### PR TITLE
added timestamp instrument

### DIFF
--- a/docs/examples/example_timestamps.py
+++ b/docs/examples/example_timestamps.py
@@ -6,24 +6,22 @@ import numpy as np
 import logging
 
 import qcodes as qc
-import qcodes.instrument_drivers.TimeStamp
-#os.chdir('/home/eendebakpt/develop/Qcodes/docs/examples')
+import qcodes.instrument_drivers.QuTech.TimeStamp
 
-#%% Create dummy instruments
+#%% Create dummy instruments and model
 
 from toymodel import AModel, MockGates, MockSource, MockMeter
 
 # now create this "experiment"
 model = AModel()
-gates = MockGates('gates', model)
-source = MockSource('source', model)
-meter = MockMeter('meter', model)
+gates = MockGates('gates', model=model)
+meter = MockMeter('meter', model=model)
 
-station = qc.Station(gates, source, meter)
+station = qc.Station(gates, meter)
 
-c0, c1, c2, vsd = gates.chan0, gates.chan1, gates.chan2, source.amplitude
+c0, c1, c2 = gates.chan0, gates.chan1, gates.chan2
 
-ts = qcodes.instrument_drivers.TimeStamp.TimeStampInstrument(name='TimeStamp')
+ts = qcodes.instrument_drivers.QuTech.TimeStamp.TimeStampInstrument(name='TimeStamp')
 
 # could measure any number of things by adding arguments to this
 station.set_measurement(ts.timestamp, meter.amplitude)
@@ -41,6 +39,8 @@ def progress(data):
     tt=data.arrays['timestamp']
     vv=~np.isnan(tt)        
     ttx=tt[vv]
+    if ttx.size==0:
+        return 0, np.Inf
     t0=ttx[0]
     t1=ttx[-1]
     

--- a/docs/examples/example_timestamps.py
+++ b/docs/examples/example_timestamps.py
@@ -10,7 +10,7 @@ import qcodes.instrument_drivers.QuTech.TimeStamp
 
 #%% Create dummy instruments and model
 
-from toymodel import AModel, MockGates, MockSource, MockMeter
+from toymodel import AModel, MockGates, MockMeter
 
 # now create this "experiment"
 model = AModel()
@@ -18,9 +18,6 @@ gates = MockGates('gates', model=model)
 meter = MockMeter('meter', model=model)
 
 station = qc.Station(gates, meter)
-
-c0, c1, c2 = gates.chan0, gates.chan1, gates.chan2
-
 ts = qcodes.instrument_drivers.QuTech.TimeStamp.TimeStampInstrument(name='TimeStamp')
 
 # could measure any number of things by adding arguments to this
@@ -36,7 +33,7 @@ station.measure()
 def progress(data):
     ''' Simpe progress meter, should be integrated with either loop or data object '''
     data.sync()
-    tt=data.arrays['timestamp']
+    tt=data.arrays['TimeStamp_timestamp']
     vv=~np.isnan(tt)        
     ttx=tt[vv]
     if ttx.size==0:
@@ -46,14 +43,14 @@ def progress(data):
     
     logging.info('t0 %f t1 %f' % (t0, t1))
 
-    fraction = ttx.size / tt.size[0]
+    fraction = ttx.size / tt.shape[0]
     remaining = (t1-t0)*(1-fraction)/fraction
     return fraction, remaining
 
 
 #%% Go!
     
-data = qc.Loop(c0[-20:20:0.1], 0.1).run(location='testsweep', overwrite=True)
+data = qc.Loop(gates.chan0[-20:20:0.1], 0.1).run(location='testsweep', overwrite=True)
 
 for ii in range(10):
     print('progress: fraction %.2f, %.1f seconds remaining' % progress(data) )

--- a/docs/examples/example_timestamps.py
+++ b/docs/examples/example_timestamps.py
@@ -1,0 +1,61 @@
+# code for example notebook
+
+#%% Load packages
+import time
+import numpy as np
+import logging
+
+import qcodes as qc
+import qcodes.instrument_drivers.TimeStamp
+#os.chdir('/home/eendebakpt/develop/Qcodes/docs/examples')
+
+#%% Create dummy instruments
+
+from toymodel import AModel, MockGates, MockSource, MockMeter
+
+# now create this "experiment"
+model = AModel()
+gates = MockGates('gates', model)
+source = MockSource('source', model)
+meter = MockMeter('meter', model)
+
+station = qc.Station(gates, source, meter)
+
+c0, c1, c2, vsd = gates.chan0, gates.chan1, gates.chan2, source.amplitude
+
+ts = qcodes.instrument_drivers.TimeStamp.TimeStampInstrument(name='TimeStamp')
+
+# could measure any number of things by adding arguments to this
+station.set_measurement(ts.timestamp, meter.amplitude)
+
+#%% Test measurement
+
+station.measure()
+
+#%% Define process function
+
+
+def progress(data):
+    ''' Simpe progress meter, should be integrated with either loop or data object '''
+    data.sync()
+    tt=data.arrays['timestamp']
+    vv=~np.isnan(tt)        
+    ttx=tt[vv]
+    t0=ttx[0]
+    t1=ttx[-1]
+    
+    logging.info('t0 %f t1 %f' % (t0, t1))
+
+    fraction = ttx.size / tt.size[0]
+    remaining = (t1-t0)*(1-fraction)/fraction
+    return fraction, remaining
+
+
+#%% Go!
+    
+data = qc.Loop(c0[-20:20:0.1], 0.1).run(location='testsweep', overwrite=True)
+
+for ii in range(10):
+    print('progress: fraction %.2f, %.1f seconds remaining' % progress(data) )
+    time.sleep(5)
+

--- a/qcodes/instrument_drivers/QuTech/TimeStamp.py
+++ b/qcodes/instrument_drivers/QuTech/TimeStamp.py
@@ -2,17 +2,28 @@
 #
 
 import time
+import datetime
 from qcodes import Instrument
 
 
 class TimeStampInstrument(Instrument):
     '''
-    Instrument that generates a timestamp
+    Instrument that generates timestamps
+    
+    Currently available are:
+    
+        * timestamp: Time in seconds sich epoch
+        * timestr: String representation of the current time
     '''
     def __init__(self, name, **kwargs):
         super().__init__(name, **kwargs)
-        # we need this to be a parameter (a function does not work with measure)
         self.add_parameter('timestamp', units='s', get_cmd=time.time, docstring='Timestamp based on number of seconds since epoch.')
-        _ = self.timestamp.get()
+        self.add_parameter('timestring', get_cmd=self.get_timestring, docstring='Time string based on number of seconds since epoch.')
         
-    
+        _ = self.timestamp.get()
+        _ = self.timestring.get()
+        
+
+    def get_timestring(self):
+        """ Return string representation of current time """
+        return str(datetime.datetime.now())

--- a/qcodes/instrument_drivers/QuTech/TimeStamp.py
+++ b/qcodes/instrument_drivers/QuTech/TimeStamp.py
@@ -9,13 +9,10 @@ class TimeStampInstrument(Instrument):
     '''
     Instrument that generates a timestamp
     '''
-    def __init__(self, name):
-        super().__init__(name)
-
+    def __init__(self, name, **kwargs):
+        super().__init__(name, **kwargs)
         # we need this to be a parameter (a function does not work with measure)
-        self.add_parameter('timestamp', units='s', get_cmd=time.time)
-        #self.add_function('timestamp', units='s', call_cmd=time.time, return_parser=float)
-
+        self.add_parameter('timestamp', units='s', get_cmd=time.time, docstring='Timestamp based on number of seconds since epoch.')
         _ = self.timestamp.get()
         
     

--- a/qcodes/instrument_drivers/TimeStamp.py
+++ b/qcodes/instrument_drivers/TimeStamp.py
@@ -1,0 +1,21 @@
+# Instrument generating a timestamp
+#
+
+import time
+from qcodes import Instrument
+
+
+class TimeStampInstrument(Instrument):
+    '''
+    Instrument that generates a timestamp
+    '''
+    def __init__(self, name):
+        super().__init__(name)
+
+        # we need this to be a parameter (a function does not work with measure)
+        self.add_parameter('timestamp', units='s', get_cmd=time.time)
+        #self.add_function('timestamp', units='s', call_cmd=time.time, return_parser=float)
+
+        _ = self.timestamp.get()
+        
+    

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -19,6 +19,8 @@ from .instrument_mocks import (AMockModel, MockInstTester,
                                MockGates, MockSource, MockMeter, DummyInstrument)
 from .common import strip_qc
 
+from qcodes.instrument_drivers.QuTech.TimeStamp import TimeStampInstrument
+
 
 class TestParamConstructor(TestCase):
 
@@ -1015,3 +1017,14 @@ class TestInstrument2(TestCase):
 
         # make sure the gate is removed
         self.assertEqual(hasattr(instrument, 'dac1'), False)
+
+
+class TestTimeStampInstrument(TestCase):
+
+    def test_instrument(self):
+        instrument = TimeStampInstrument(name='timekeeper')
+        t0=instrument.timestamp.get()
+        tstr=instrument.timestring.get()
+        
+        
+


### PR DESCRIPTION
This PR adds a virtual instrument that provides a timestamp. Currently it uses `time.time`, but we could use any other timestamp as well (as long as it as a `float`)

The timestamp is used to provide a simple progress function for a `DataSet` object. I would like to integrate the progress functionality with either the `station` or `DataSet` object. An example is in  `docs/examples/example_timestamps.py`.

PR is not ready for merging, but meant for discussion.
