### PR TITLE
do not load notebook elements when no notebook is running

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -33,7 +33,6 @@ if in_notebook():  # pragma: no cover
 
     # only load the show_subprocess_widget when running jupyter notebook
     if frontend()=='notebook':
-        print('load show_subprocess_widget')
         from qcodes.widgets.widgets import show_subprocess_widget
 
 from qcodes.station import Station

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -2,13 +2,16 @@
 
 # flake8: noqa (we don't need the "<...> imported but unused" error)
 
+import os
 # just for convenience in debugging, so we don't have to
 # separately import multiprocessing
 from multiprocessing import active_children
 
 from qcodes.version import __version__
 from qcodes.process.helpers import set_mp_method
-from qcodes.utils.helpers import in_notebook
+from qcodes.utils.helpers import in_notebook, frontend
+
+
 
 # code that should only be imported into the main (notebook) thread
 # in particular, importing matplotlib in the side processes takes a long
@@ -28,7 +31,10 @@ if in_notebook():  # pragma: no cover
               'try "from qcodes.plots.pyqtgraph import QtPlot" '
               'to see the full error')
 
-    from qcodes.widgets.widgets import show_subprocess_widget
+    # only load the show_subprocess_widget when running jupyter notebook
+    if frontend()=='notebook':
+        print('load show_subprocess_widget')
+        from qcodes.widgets.widgets import show_subprocess_widget
 
 from qcodes.station import Station
 from qcodes.loops import get_bg, halt_bg, Loop

--- a/qcodes/plots/base.py
+++ b/qcodes/plots/base.py
@@ -3,8 +3,12 @@ Live plotting in Jupyter notebooks
 '''
 from IPython.display import display
 
-from qcodes.widgets.widgets import HiddenUpdateWidget
+from qcodes.utils.helpers import frontend
 
+if frontend()=='notebook':
+    from qcodes.widgets.widgets import HiddenUpdateWidget
+else:
+    HiddenUpdateWidget=None
 
 class BasePlot:
 
@@ -26,7 +30,7 @@ class BasePlot:
         self.data_updaters = set()
 
         self.interval = interval
-        if interval:
+        if interval and HiddenUpdateWidget:
             self.update_widget = HiddenUpdateWidget(self.update, interval)
             display(self.update_widget)
 

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -10,7 +10,6 @@ from collections import Mapping
 
 from .base import BasePlot
 
-
 class MatPlot(BasePlot):
     '''
     Plot x/y lines or x/y/z heatmap data. The first trace may be included

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -4,6 +4,7 @@ import time
 import logging
 import math
 import sys
+import os
 import io
 import numpy as np
 import json
@@ -35,6 +36,13 @@ def tprint(string, dt=1, tag='default'):
         print(string)
         _tprint_times[tag] = time.time()
 
+def frontend():
+    """ Return frontend used
+
+    Returns
+        frontend (string): frontend used. Default is notebook    
+    """
+    return os.environ.get('QCODESFRONTEND', 'notebook')
 
 def in_notebook():
     """


### PR DESCRIPTION
When the user is not running a jupyter notebook as a frontend then the graphical elements based on the notebook should not be loaded.

It is not possible to detemine from python itself whether the user is running a notebook (or just an ipython terminal), so the function `frontend` uses an enviroment variable to overrule the default setting. The default setting is still notebook.

Changes proposed in this pull request:
- Add `frontend()` function
- Do not load HiddenUpdateWidget when the frontend is not `notebook`


@giulioungaretti @alexcjohnson 

