### PR TITLE
add first qcodes performance test

### DIFF
--- a/qcodes/tests/test_performance.py
+++ b/qcodes/tests/test_performance.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+import time
+
+from qcodes.tests.instrument_mocks import DummyInstrument
+
+
+class TestInstrumentGet(TestCase):
+
+    def test_get_overhead(self, verbose=0):
+        # test overhead of local and remote parameter
+        local = DummyInstrument(name='local', server_name=None)
+        remote = DummyInstrument(name='remote')
+
+        gettime = 1e-3
+        t0 = time.time()
+        for ii in range(1000):
+            time.sleep(gettime)
+        dt = time.time() - t0
+
+        t0 = time.time()
+        for ii in range(1000):
+            local.dac1.get()
+            time.sleep(gettime)
+        dtlocal = time.time() - t0
+
+        t0 = time.time()
+        for ii in range(1000):
+            remote.dac1.get()
+            time.sleep(gettime)
+        dtremote = time.time() - t0
+        overheadlocal = dtlocal / dt
+        overheadremote = dtremote / dt
+
+        if verbose:
+            print('test_get_overhead: local %f, remote %f: overhead %.2f %.2f' %
+                  (dtlocal, dtremote, overheadlocal, overheadremote))
+
+        self.assertLess(overheadlocal, 1.2)
+                        # at most 20% overhead for local measurement
+        self.assertLess(overheadremote, 1.4)
+                        # at most 40% overhead for remote measurement


### PR DESCRIPTION
This does not solve #187, but gives a method of monitoring

Changes proposed in this pull request:
- Add performance test for the `.get` of a `Parameter` 

@giulioungaretti @alexcjohnson 
