### PR TITLE
add simple config system

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -10,6 +10,19 @@ from qcodes.version import __version__
 from qcodes.process.helpers import set_mp_method
 from qcodes.utils.helpers import in_notebook
 
+from qcodes.utils.config import HorseConfig
+config = HorseConfig()
+
+# add default config values
+config.add_entry('general.verbosity', 1)
+config.add_entry('logging.useZMQ', 0)
+config.add_entry('logging.zmq_port', 5502)
+config.add_entry('general.frontend', 0)
+
+# load user-defined options from file
+config.load_defaults()
+
+
 # code that should only be imported into the main (notebook) thread
 # in particular, importing matplotlib in the side processes takes a long
 # time and spins up other processes in order to try and get a front end

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -10,8 +10,8 @@ from qcodes.version import __version__
 from qcodes.process.helpers import set_mp_method
 from qcodes.utils.helpers import in_notebook
 
-from qcodes.utils.config import HorseConfig
-config = HorseConfig()
+from qcodes.utils.config import QCodesConfig
+config = QCodesConfig()
 
 # add default config values
 config.add_entry('general.verbosity', 1)

--- a/qcodes/utils/config.py
+++ b/qcodes/utils/config.py
@@ -1,0 +1,69 @@
+import configparser
+import os
+import six
+
+
+class HorseConfig(configparser.ConfigParser):
+
+    def show(self):
+        """ Show all the entries in the config object """
+        for each_section in self.sections():
+            for (each_key, each_val) in self.items(each_section):
+                print('%s.%s: %s' % (each_section, each_key, each_val))
+
+    def load_defaults(self, cfile=None):
+        """ Load settings from file
+
+        Arguments:
+            cfile (string or None): file to load from. If None, then use config_filename()
+        """
+        if cfile is None:
+            cfile = self.config_filename()
+        self.read(cfile)
+
+    def add_entry(self, combined_key: str, value):
+        """ Add an entry to the config system 
+        
+        Arguments:
+            combined_key (string): a key of the form bar.foo
+            value: value to be set for the key
+        """
+        kk = combined_key.split('.')
+
+        p = self
+        for k in kk[:-1]:
+            try:
+                p[k]
+            except:
+                p[k] = dict()
+            p = self[k]
+        k = kk[-1]
+        p[k] = str(value)
+
+    @staticmethod
+    def config_filename(horserc='horse.config'):
+        """
+        Get the location of the config file.
+
+        The file location is determined in the following order
+
+        - `$PWD/qcodesrc`
+
+        - `$QCODESRC/qcodesrc`
+
+        If no file is found, None is returned
+        """
+
+        if 'HORSERC' in os.environ:
+            path = os.environ['HORSERC']
+            if os.path.exists(path):
+                fname = os.path.join(path, horserc)
+                if os.path.exists(fname):
+                    return fname
+
+        if six.PY2:
+            cwd = os.getcwdu()
+        else:
+            cwd = os.getcwd()
+        fname = os.path.join(cwd, horserc)
+        return fname

--- a/qcodes/utils/config.py
+++ b/qcodes/utils/config.py
@@ -3,7 +3,7 @@ import os
 import six
 
 
-class HorseConfig(configparser.ConfigParser):
+class QCodesConfig(configparser.ConfigParser):
 
     def show(self):
         """ Show all the entries in the config object """


### PR DESCRIPTION
This is a small wrapper over the default python `configparser`

Changes proposed in this pull request:
- Create config object in qcodes 
- Set some default values in the config object

@giulioungaretti @alexcjohnson 
