### PR TITLE
feat: Snapshot value

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -142,6 +142,7 @@ class Parameter(Metadatable, DeferredOperations):
 
         snapshot_get (bool): Update the parameter before a snapshot.
             Set to false if it takes too long to update the parameter.
+            Note that snapshot_get is ignored if snapshot_value=False
 
         snapshot_value (bool): Store the parameter value in a snapshot.
             Set to false if the value is a large array.

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -548,18 +548,16 @@ class TestInstrument(TestCase):
         self.assertGreater(noise_ts, datetime.now() - timedelta(seconds=1.1))
 
     def test_snapshot_value(self):
-        gates = self.gates
-
-        gates.add_parameter('has_snapshot_value',
+        self.source.add_parameter('has_snapshot_value',
                             parameter_class=ManualParameter,
                             initial_value=42,
                             snapshot_value=True)
-        gates.add_parameter('no_snapshot_value',
+        self.source.add_parameter('no_snapshot_value',
                             parameter_class=ManualParameter,
                             initial_value=42,
                             snapshot_value=False)
 
-        snapshot = gates.snapshot()
+        snapshot = self.source.snapshot()
 
         self.assertIn('value', snapshot['parameters']['has_snapshot_value'])
         self.assertEquals(42,

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -547,6 +547,23 @@ class TestInstrument(TestCase):
         self.assertLessEqual(noise_ts, datetime.now())
         self.assertGreater(noise_ts, datetime.now() - timedelta(seconds=1.1))
 
+    def test_snapshot_value(self):
+        gates = self.gates
+
+        gates.add_parameter('has_snapshot_value',
+                            initial_value=42,
+                            snapshot_value=True)
+        gates.add_parameter('no_snapshot_value',
+                            initial_value=42,
+                            snapshot_value=False)
+
+        snapshot = gates.snapshot()
+
+        self.assertIn('value', snapshot['parameters']['has_snapshot_value'])
+        self.assertEquals(42,
+                          snapshot['parameters']['has_snapshot_value']['value'])
+        self.assertNotIn('value', snapshot['parameters']['no_snapshot_value'])
+
     def tests_get_latest(self):
         self.source.add_parameter('noise', parameter_class=ManualParameter)
         noise = self.source.noise

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -551,9 +551,11 @@ class TestInstrument(TestCase):
         gates = self.gates
 
         gates.add_parameter('has_snapshot_value',
+                            parameter_class=ManualParameter,
                             initial_value=42,
                             snapshot_value=True)
         gates.add_parameter('no_snapshot_value',
+                            parameter_class=ManualParameter,
                             initial_value=42,
                             snapshot_value=False)
 


### PR DESCRIPTION
If a parameter contains a large amount of data, such as a trace acquisition parameter, it is often undesirable to save a full trace of data when creating a snapshot. Therefore I have added a snapshot_value kwarg to the Parameter init that can remove the parameter's 'value' from a snapshot.

Note that this is not achieved when providing the kwarg snapshot_get=False, since this only stops the parameter from performing a get when a snapshot is created.

Changes proposed in this pull request:
- Add snapshot_value to the Parameter init kwargs.
- If param.snapshot() is called, and param._snapshot_value==False, remove 'value' from the state dictionary.
- If param.snapshot() is called and snapshot_value==False, do not perform a param.get() command, even if snapshot_get==True (since the value is not added to the snapshot).
- Small update to the snapshot_get description
