### PR TITLE
Matplotlib updates

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -13,7 +13,8 @@ from .base import BasePlot
 
 
 class MatPlot(BasePlot):
-    plot_kwargs = {}
+    plot_kwargs_1D = {}
+    plot_kwargs_2D = {}
     """
     Plot x/y lines or x/y/z heatmap data. The first trace may be included
     in the constructor, other traces can be added with MatPlot.add()
@@ -174,7 +175,9 @@ class MatPlot(BasePlot):
         # didn't want to strip it out of kwargs earlier because it should stay
         # part of trace['config'].
         args = [arg for arg in [x, y, fmt] if arg is not None]
-        line, = ax.plot(*args, **kwargs)
+
+        full_kwargs = {**self.plot_kwargs_1D, **kwargs}
+        line, = ax.plot(*args, **full_kwargs)
         return line
 
     def _draw_pcolormesh(self, ax, z, x=None, y=None, subplot=1,
@@ -252,7 +255,7 @@ class MatPlot(BasePlot):
 
         # Include default plotting kwargs, which can be overwritten by given
         # kwargs
-        full_kwargs = {**self.plot_kwargs, **kwargs}
+        full_kwargs = {**self.plot_kwargs_2D, **kwargs}
         pc = ax.pcolormesh(*args, **full_kwargs)
 
         # Set x and y limits if arrays are provided

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -203,7 +203,6 @@ class MatPlot(BasePlot):
         # described by ax, and it's not a kwarg to matplotlib's ax.plot. But I
         # didn't want to strip it out of kwargs earlier because it should stay
         # part of trace['config'].
-
         args_masked = [masked_invalid(arg) for arg in [x, y, z]
                       if arg is not None]
 
@@ -226,7 +225,7 @@ class MatPlot(BasePlot):
                 if arr.ndim > 1:
                     arr = arr[0] if k == 0 else arr[:,0]
 
-                if np.isnan(arr[1]):
+                if np.ma.is_masked(arr[1]):
                     # Only the first element is not nan, in this case pad with
                     # a value, and separate their values by 1
                     arr_pad = np.pad(arr, (1, 0), mode='symmetric')
@@ -246,8 +245,7 @@ class MatPlot(BasePlot):
                     arr_pad += diff
                     # Ignore final value
                     arr_pad = arr_pad[:-1]
-
-                args.append(arr_pad)
+                args.append(masked_invalid(arr_pad))
             args.append(args_masked[-1])
         else:
             # Only the masked value of z is used as a mask
@@ -287,9 +285,9 @@ class MatPlot(BasePlot):
             # put this where it belongs.
             ax.qcodes_colorbar.set_label(self.get_label(z))
 
-        # Scale colors
-        cmin = np.nanmin(z)
-        cmax = np.nanmax(z)
+        # Scale colors if z has elements
+        cmin = np.nanmin(args_masked[-1])
+        cmax = np.nanmax(args_masked[-1])
         ax.qcodes_colorbar.set_clim(cmin, cmax)
 
         return pc

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -179,6 +179,23 @@ class MatPlot(BasePlot):
 
     def _draw_pcolormesh(self, ax, z, x=None, y=None, subplot=1,
                          nticks=None, use_offset=False, **kwargs):
+        """
+        Draws a 2D color plot
+
+        Args:
+            ax (Axis): Matplotlib axis object to plot in
+            z: 2D array of data values
+            x (Array, Optional): Array of values along x-axis. Dimensions should
+                be either same as z, or equal to length along x-axis.
+            y (Array, Optional): Array of values along y-axis. Dimensions should
+                be either same as z, or equal to length along y-axis.
+            subplot (int, Optional): Deprecated, see alexj notes below
+            nticks (int, Optional): preferred number of ticks along axes
+            use_offset (bool, Optional): Whether or not axes can have an offset
+            **kwargs: Optional list of kwargs to be passed on to pcolormesh.
+                These will overwrite any of the default kwargs in plot_kwargs.
+        """
+
         # NOTE(alexj)stripping out subplot because which subplot we're in is already
         # described by ax, and it's not a kwarg to matplotlib's ax.plot. But I
         # didn't want to strip it out of kwargs earlier because it should stay

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -13,8 +13,8 @@ from .base import BasePlot
 
 
 class MatPlot(BasePlot):
-    plot_kwargs_1D = {}
-    plot_kwargs_2D = {}
+    plot_1D_kwargs = {}
+    plot_2D_kwargs = {}
     """
     Plot x/y lines or x/y/z heatmap data. The first trace may be included
     in the constructor, other traces can be added with MatPlot.add()
@@ -176,7 +176,7 @@ class MatPlot(BasePlot):
         # part of trace['config'].
         args = [arg for arg in [x, y, fmt] if arg is not None]
 
-        full_kwargs = {**self.plot_kwargs_1D, **kwargs}
+        full_kwargs = {**self.plot_1D_kwargs, **kwargs}
         line, = ax.plot(*args, **full_kwargs)
         return line
 
@@ -255,7 +255,7 @@ class MatPlot(BasePlot):
 
         # Include default plotting kwargs, which can be overwritten by given
         # kwargs
-        full_kwargs = {**self.plot_kwargs_2D, **kwargs}
+        full_kwargs = {**self.plot_2D_kwargs, **kwargs}
         pc = ax.pcolormesh(*args, **full_kwargs)
 
         # Set x and y limits if arrays are provided


### PR DESCRIPTION
This pull request fixes some of the issues for plotting with MatPlot. One of the fixes solves issue #257.

Changes proposed in this pull request:
- add a point to x- and y-axes such that datapoints are centered around their x and y values. This also stops the colorplot from ignoring the edge row and column.
- Add possibility of working with a 2D array of subplots. This can be used with the kwarg subplots=(nrows, ncols) upon instantiation. The subplots are flattened such that you always need a single int to be able to specify any subplot.
- Add default plot_kwargs_1D and plot_kwargs_2D to class. These are default kwargs that are always passed on when plotting, and can be overwritten by custom kwargs.
- Actually pass kwargs as kwargs to function _get_axes. I don't know why this was not done before
- Add nticks kwarg to _pcolormesh, which specifies preferred number of ticks. I did this because I sometimes ran into issues that for small ranges, there was only a single tick with label. Note that matplotlib actually refers to nbins, but nticks seems like a more suitable name in this case
- add use_offset for axes, default to False. When a range is reasonably small, matplotlib sometimes has a fixed offset, and only displays differences w.r.t. that offset as ticks. This can be quite confusing at times, so I have set the default behaviour to off.
- Scale the colors to the minimum and maximum data values.

Solving the x- and y-axes was not trivial, and so better solutions might well be possible. The biggest problem I ran into was that it had to deal with nan values as well. This method does deal with it correctly, but changes any 2D arrays into 1D arrays. There might be a way that would retain the 2D array, but I have not found one. Also, the current way that the function is called, it makes no difference.
