### PR TITLE
Fix: Import config

### DIFF
--- a/qcodes/plots/base.py
+++ b/qcodes/plots/base.py
@@ -3,6 +3,7 @@ Live plotting in Jupyter notebooks
 """
 from IPython.display import display
 
+from qcodes import config
 from qcodes.widgets.widgets import HiddenUpdateWidget
 
 


### PR DESCRIPTION
The config isn't loaded in plots/base.py, resulting in an error upon initialization

Changes proposed in this pull request:
- from qcodes import config