### PR TITLE
Fix: print dataset before removing dataset

### DIFF
--- a/qcodes/loops.py
+++ b/qcodes/loops.py
@@ -757,7 +757,6 @@ class ActiveLoop(Metadatable):
         returns:
             a DataSet object that we can use to plot
         """
-        print(USE_MP)
         if progress_interval is not False:
             self.progress_interval = progress_interval
 
@@ -824,15 +823,16 @@ class ActiveLoop(Metadatable):
             ds = self.data_set
 
         finally:
+            if not quiet:
+                print(repr(self.data_set))
+                print(datetime.now().strftime('started at %Y-%m-%d %H:%M:%S'))
+
             # After normal loop execution we clear the data_set so we can run
             # again. But also if something went wrong during the loop execution
             # we want to clear the data_set attribute so we don't try to reuse
             # this one later.
             self.data_set = None
 
-        if not quiet:
-            print(repr(self.data_set))
-            print(datetime.now().strftime('started at %Y-%m-%d %H:%M:%S'))
 
         return ds
 


### PR DESCRIPTION
Previously, when running a loop, the dataset was always set to None before its results were printed. As a result, it always prints None.

Changes proposed in this pull request:
- Print dataset before clearing
- Remove print(USE_MP), seems unnecessary
