### PR TITLE
Driver: ATS upgrades & ATS9440 driver 

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -627,7 +627,7 @@ class AlazarTech_ATS(Instrument):
             (self.buffers_per_acquisition._get_byte() >
              self.allocated_buffers._get_byte())
 
-        while acquisition_controller.requires_buffer():
+        while acquisition_controller.requires_buffer(buffers_completed):
             buf = self.buffer_list[buffers_completed % allocated_buffers]
 
             self._call_dll('AlazarWaitAsyncBufferComplete',

--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -6,6 +6,7 @@ import os
 from qcodes.instrument.base import Instrument
 from qcodes.instrument.parameter import Parameter
 from qcodes.utils import validators
+from qcodes.instrument.parameter import ManualParameter
 
 # TODO(damazter) (C) logging
 
@@ -234,6 +235,18 @@ class AlazarTech_ATS(Instrument):
         # Some ATS models do not support a bwlimit. This flag defines if the
         # ATS supports a bwlimit or not. True by default.
         self._bwlimit_support = True
+
+        # get channel info
+        max_s, bps = self._get_channel_info(self._handle)
+        self.add_parameter(name='bits_per_sample',
+                           parameter_class=ManualParameter,
+                           initial_value=bps)
+        self.add_parameter(name='bytes_per_sample',
+                           parameter_class=ManualParameter,
+                           initial_value=int((bps + 7)//8))
+        self.add_parameter(name='maximum_samples',
+                           parameter_class=ManualParameter,
+                           initial_value=max_s)
 
     def get_idn(self):
         """
@@ -486,9 +499,6 @@ class AlazarTech_ATS(Instrument):
         # Abort any previous measurement
         self._call_dll('AlazarAbortAsyncRead', self._handle)
 
-        # get channel info
-        max_s, bps = self._get_channel_info(self._handle)
-
         # Set record size for NPT mode
         if mode in ['CS', 'NPT']:
             pretriggersize = 0  # pretriggersize is 0 for NPT and CS always
@@ -586,7 +596,8 @@ class AlazarTech_ATS(Instrument):
 
         for k in range(allocated_buffers):
             try:
-                self.buffer_list.append(Buffer(bps, samples_per_buffer,
+                self.buffer_list.append(Buffer(self.bits_per_sample(),
+                                               samples_per_buffer,
                                                number_of_channels))
             except:
                 self.clear_buffers()
@@ -655,10 +666,20 @@ class AlazarTech_ATS(Instrument):
         return acquisition_controller.post_acquire()
 
     def triggered(self):
+        """
+        Checks if the ATS has received at least one trigger.
+        Returns:
+            1 if there has been a trigger, 0 otherwise
+        """
         return self._call_dll('AlazarTriggered', self._handle,
                               error_check=False)
 
     def get_status(self):
+        """
+        Returns t
+        Returns:
+
+        """
         return self._call_dll('AlazarGetStatus', self._handle,
                               error_check=False)
 
@@ -988,6 +1009,9 @@ class AcquisitionController(Instrument):
                            shapes=((),),
                            snapshot_value=False)
 
+        # Save bytes_per_sample received from ATS digitizer
+        self._bytes_per_sample = self._alazar.bytes_per_sample() * 8
+
     def _get_alazar(self):
         """
         returns a reference to the alazar instrument. A call to self._alazar is
@@ -1074,7 +1098,7 @@ class AcquisitionController(Instrument):
         """
         Check if enough buffers are acquired
         Returns:
-
+            True if more buffers are needed, False otherwise
         """
         raise NotImplementedError(
             'This method should be implemented in a subclass')
@@ -1099,7 +1123,9 @@ class AcquisitionController(Instrument):
             if scale_voltages:
                 # Convert data points from an uint16 to volts
                 ch_range = self._alazar.parameters['channel_range'+ch_idx]()
-                buffer_segment = (buffer_segment - 2.**15) / 2**15 * ch_range
+                # Determine value corresponding to zero for unsigned int
+                mid_val = 2.**(self._bytes_per_sample-1)
+                buffer_segment = (buffer_segment - mid_val) / mid_val * ch_range
 
             buffer_segments[ch_idx] = buffer_segment
         return buffer_segments

--- a/qcodes/instrument_drivers/AlazarTech/ATS9440.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9440.py
@@ -1,0 +1,260 @@
+from .ATS import AlazarTech_ATS, AlazarParameter
+from qcodes.utils import validators
+
+
+class ATS9440(AlazarTech_ATS):
+    def __init__(self, name, **kwargs):
+        dll_path = 'C:\\WINDOWS\\System32\\ATSApi.dll'
+        super().__init__(name, dll_path=dll_path, **kwargs)
+
+        self._bwlimit_support = False
+
+        # add parameters
+        self.channels = ['A', 'B', 'C', 'D']
+
+        # ----- Parameters for the configuration of the board -----
+        self.add_parameter(name='clock_source',
+                           parameter_class=AlazarParameter,
+                           label='Clock Source',
+                           unit=None,
+                           value='internal_clock',
+                           byte_to_value_dict={1: 'internal_clock',
+                                               4: 'slow_external_clock',
+                                               5: 'external_clock_AC',
+                                               7: 'external_clock_10_MHz_ref'})
+        self.add_parameter(name='sample_rate',
+                           parameter_class=AlazarParameter,
+                           label='Sample Rate',
+                           unit='S/s',
+                           value=100000,
+                           byte_to_value_dict={
+                               0x1: 1000, 0x2: 2000, 0x4: 5000, 0x8: 10000,
+                               0xA: 20000, 0xC: 50000, 0xE: 100000,
+                               0x10: 200000, 0x12: 500000, 0x14: 1000000,
+                               0x18: 2000000, 0x1A: 5000000, 0x1C: 10000000,
+                               0x1E: 20000000, 0x22: 50000000, 0x24: 100000000,
+                               0x25: 125000000, 0x40: 'external_clock',
+                               1000000000: '1GHz_reference_clock'})
+        self.add_parameter(name='clock_edge',
+                           parameter_class=AlazarParameter,
+                           label='Clock Edge',
+                           unit=None,
+                           value='rising',
+                           byte_to_value_dict={0: 'rising',
+                                               1: 'falling'})
+
+        self.add_parameter(name='decimation',
+                           parameter_class=AlazarParameter,
+                           label='Decimation',
+                           unit=None,
+                           value=0,
+                           vals=validators.Ints(0, 100000))
+
+        # Acquisition channel parameters
+        for ch in self.channels:
+            self.add_parameter(name='coupling' + ch,
+                               parameter_class=AlazarParameter,
+                               label='Coupling channel ' + ch,
+                               unit=None,
+                               value='DC',
+                               byte_to_value_dict={1: 'AC', 2: 'DC'})
+            self.add_parameter(name='channel_range' + ch,
+                               parameter_class=AlazarParameter,
+                               label='Range channel ' + ch,
+                               unit='V',
+                               value=1,
+                               byte_to_value_dict={
+                                   5: 0.1, 6: 0.2, 7: 0.4,
+                                   10: 1., 11: 2., 12: 4.})
+            self.add_parameter(name='impedance' + ch,
+                               parameter_class=AlazarParameter,
+                               label='Impedance channel ' + ch,
+                               unit='Ohm',
+                               value=50,
+                               byte_to_value_dict={2: 50})
+
+        # Trigger parameters
+        self.add_parameter(name='trigger_operation',
+                           parameter_class=AlazarParameter,
+                           label='Trigger Operation',
+                           unit=None,
+                           value='J',
+                           byte_to_value_dict={
+                               0: 'J',
+                               1: 'K',
+                               2: 'J_or_K',
+                               3: 'J_and_K',
+                               4: 'J_xor_K',
+                               5: 'J_and_not_K',
+                               6: 'not_J_and_K'})
+        for i in ['1', '2']:
+            self.add_parameter(name='trigger_engine' + i,
+                               parameter_class=AlazarParameter,
+                               label='Trigger Engine ' + i,
+                               unit=None,
+                               value=('J' if i == '1' else 'K'),
+                               byte_to_value_dict={0: 'J',
+                                                   1: 'K'})
+            self.add_parameter(name='trigger_source' + i,
+                               parameter_class=AlazarParameter,
+                               label='Trigger Source ' + i,
+                               unit=None,
+                               value='disable',
+                               byte_to_value_dict={0: 'A',
+                                                   1: 'B',
+                                                   2: 'trig_in',
+                                                   3: 'disable',
+                                                   4: 'C',
+                                                   5: 'D'})
+            self.add_parameter(name='trigger_slope' + i,
+                               parameter_class=AlazarParameter,
+                               label='Trigger Slope ' + i,
+                               unit=None,
+                               value='positive',
+                               byte_to_value_dict={1: 'positive',
+                                                   2: 'negative'})
+            self.add_parameter(name='trigger_level' + i,
+                               parameter_class=AlazarParameter,
+                               label='Trigger Level ' + i,
+                               unit=None,
+                               value=150,
+                               vals=validators.Ints(0, 255))
+
+        self.add_parameter(name='external_trigger_coupling',
+                           parameter_class=AlazarParameter,
+                           label='External Trigger Coupling',
+                           unit=None,
+                           value='AC',
+                           byte_to_value_dict={1: 'AC', 2: 'DC'})
+        self.add_parameter(name='external_trigger_range',
+                           parameter_class=AlazarParameter,
+                           label='External Trigger Range',
+                           unit='V',
+                           value=5,
+                           byte_to_value_dict={0: 5, 1: 1})
+        self.add_parameter(name='trigger_delay',
+                           parameter_class=AlazarParameter,
+                           label='Trigger Delay',
+                           unit='Sample clock cycles',
+                           value=0,
+                           vals=validators.Ints(min_value=0))
+
+        # NOTE: The board will wait for a for this amount of time for a
+        # trigger event.  If a trigger event does not arrive, then the
+        # board will automatically trigger. Set the trigger timeout value
+        # to 0 to force the board to wait forever for a trigger event.
+        #
+        # IMPORTANT: The trigger timeout value should be set to zero after
+        # appropriate trigger parameters have been determined, otherwise
+        # the board may trigger if the timeout interval expires before a
+        # hardware trigger event arrives.
+        self.add_parameter(name='timeout_ticks',
+                           parameter_class=AlazarParameter,
+                           label='Timeout Ticks',
+                           unit='10 us',
+                           value=0,
+                           vals=validators.Ints(min_value=0))
+
+        # ----- Parameters for the acquire function -----
+        self.add_parameter(name='mode',
+                           parameter_class=AlazarParameter,
+                           label='Acquisition mode',
+                           unit=None,
+                           value='NPT',
+                           byte_to_value_dict={0x100: 'CS', 0x200: 'NPT',
+                                               0x400: 'TS'})
+
+        # samples_per_record must be a multiple of 32, and 256 minimum!
+        # TODO check if it is 32 or 16, manual is unclear
+        self.add_parameter(name='samples_per_record',
+                           parameter_class=AlazarParameter,
+                           label='Samples per Record',
+                           unit=None,
+                           value=1024,
+                           vals=validators.Multiples(divisor=16, min_value=16))
+
+        self.add_parameter(name='records_per_buffer',
+                           parameter_class=AlazarParameter,
+                           label='Records per Buffer',
+                           unit=None,
+                           value=10,
+                           vals=validators.Ints(min_value=0))
+        self.add_parameter(name='buffers_per_acquisition',
+                           parameter_class=AlazarParameter,
+                           label='Buffers per Acquisition',
+                           unit=None,
+                           value=10,
+                           vals=validators.Ints(min_value=0))
+        self.add_parameter(name='channel_selection',
+                           parameter_class=AlazarParameter,
+                           label='Channel Selection',
+                           unit=None,
+                           value='AB',
+                           byte_to_value_dict={1: 'A', 2: 'B', 3: 'AB', 4:'C',
+                                               5: 'AC', 6: 'BC',8:'D', 9: 'AD',
+                                               10: 'BD', 12: 'CD', 15: 'ABCD'})
+        self.add_parameter(name='transfer_offset',
+                           parameter_class=AlazarParameter,
+                           label='Transer Offset',
+                           unit='Samples',
+                           value=0,
+                           vals=validators.Ints(min_value=0))
+        self.add_parameter(name='external_startcapture',
+                           parameter_class=AlazarParameter,
+                           label='External Startcapture',
+                           unit=None,
+                           value='enabled',
+                           byte_to_value_dict={0x0: 'disabled',
+                                               0x1: 'enabled'})
+        self.add_parameter(name='enable_record_headers',
+                           parameter_class=AlazarParameter,
+                           label='Enable Record Headers',
+                           unit=None,
+                           value='disabled',
+                           byte_to_value_dict={0x0: 'disabled',
+                                               0x8: 'enabled'})
+        self.add_parameter(name='alloc_buffers',
+                           parameter_class=AlazarParameter,
+                           label='Alloc Buffers',
+                           unit=None,
+                           value='disabled',
+                           byte_to_value_dict={0x0: 'disabled',
+                                               0x20: 'enabled'})
+        self.add_parameter(name='fifo_only_streaming',
+                           parameter_class=AlazarParameter,
+                           label='Fifo Only Streaming',
+                           unit=None,
+                           value='disabled',
+                           byte_to_value_dict={0x0: 'disabled',
+                                               0x800: 'enabled'})
+        self.add_parameter(name='interleave_samples',
+                           parameter_class=AlazarParameter,
+                           label='Interleave Samples',
+                           unit=None,
+                           value='disabled',
+                           byte_to_value_dict={0x0: 'disabled',
+                                               0x1000: 'enabled'})
+        self.add_parameter(name='get_processed_data',
+                           parameter_class=AlazarParameter,
+                           label='Get Processed Data',
+                           unit=None,
+                           value='disabled',
+                           byte_to_value_dict={0x0: 'disabled',
+                                               0x2000: 'enabled'})
+
+        self.add_parameter(name='allocated_buffers',
+                           parameter_class=AlazarParameter,
+                           label='Allocated Buffers',
+                           unit=None,
+                           value=2,
+                           vals=validators.Ints(min_value=0))
+        self.add_parameter(name='buffer_timeout',
+                           parameter_class=AlazarParameter,
+                           label='Buffer Timeout',
+                           unit='ms',
+                           value=1000,
+                           vals=validators.Ints(min_value=0))
+
+        # TODO (M) make parameter for board type
+
+        # TODO (M) check board kind

--- a/qcodes/instrument_drivers/AlazarTech/ATS9870.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9870.py
@@ -12,7 +12,9 @@ class AlazarTech_ATS9870(AlazarTech_ATS):
     def __init__(self, name, **kwargs):
         dll_path = 'C:\\WINDOWS\\System32\\ATSApi.dll'
         super().__init__(name, dll_path=dll_path, **kwargs)
+
         # add parameters
+        self.channels = ['A', 'B', 'C', 'D']
 
         # ----- Parameters for the configuration of the board -----
         self.add_parameter(name='clock_source',
@@ -53,30 +55,30 @@ class AlazarTech_ATS9870(AlazarTech_ATS):
                            value=0,
                            vals=validators.Ints(0, 100000))
 
-        for i in ['1', '2']:
-            self.add_parameter(name='coupling' + i,
+        for ch in self.channels:
+            self.add_parameter(name='coupling' + ch,
                                parameter_class=AlazarParameter,
-                               label='Coupling channel ' + i,
+                               label='Coupling channel ' + ch,
                                unit=None,
                                value='AC',
                                byte_to_value_dict={1: 'AC', 2: 'DC'})
-            self.add_parameter(name='channel_range' + i,
+            self.add_parameter(name='channel_range' + ch,
                                parameter_class=AlazarParameter,
-                               label='Range channel ' + i,
+                               label='Range channel ' + ch,
                                unit='V',
                                value=4,
                                byte_to_value_dict={
                                    2: 0.04, 5: 0.1, 6: 0.2, 7: 0.4,
                                    10: 1., 11: 2., 12: 4.})
-            self.add_parameter(name='impedance' + i,
+            self.add_parameter(name='impedance' + ch,
                                parameter_class=AlazarParameter,
-                               label='Impedance channel ' + i,
+                               label='Impedance channel ' + ch,
                                unit='Ohm',
                                value=50,
                                byte_to_value_dict={1: 1000000, 2: 50})
-            self.add_parameter(name='bwlimit' + i,
+            self.add_parameter(name='bwlimit' + ch,
                                parameter_class=AlazarParameter,
-                               label='Bandwidth limit channel ' + i,
+                               label='Bandwidth limit channel ' + ch,
                                unit=None,
                                value='DISABLED',
                                byte_to_value_dict={0: 'DISABLED',

--- a/qcodes/instrument_drivers/AlazarTech/ATS9870.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9870.py
@@ -100,7 +100,7 @@ class AlazarTech_ATS9870(AlazarTech_ATS):
                                parameter_class=AlazarParameter,
                                label='Trigger Engine ' + i,
                                unit=None,
-                               value='TRIG_ENGINE_' + ('J' if i == 0 else 'K'),
+                               value='TRIG_ENGINE_'+('J' if i == '1' else 'K'),
                                byte_to_value_dict={0: 'TRIG_ENGINE_J',
                                                    1: 'TRIG_ENGINE_K'})
             self.add_parameter(name='trigger_source' + i,

--- a/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -1,6 +1,474 @@
-from .ATS import AcquisitionController
 import math
 import numpy as np
+import logging
+import time
+
+from qcodes.instrument.parameter import ManualParameter
+from qcodes.utils import validators as vals
+from .ATS import AcquisitionController
+
+
+class Triggered_AcquisitionController(AcquisitionController):
+    """Basic AcquisitionController tested on ATS9360
+    returns unprocessed data averaged by record with 2 channels
+    """
+    def __init__(self, name, alazar_name, **kwargs):
+        super().__init__(name, alazar_name, **kwargs)
+        self.samples_per_record = None
+        self.records_per_buffer = None
+        self.buffers_per_acquisition = None
+        self.buffer = None
+        self.buffer_idx = 0
+
+        self._fixed_acquisition_settings = {
+            'mode': 'NPT'
+        }
+
+        self.add_parameter(name='average_mode',
+                           parameter_class=ManualParameter,
+                           initial_value='trace',
+                           vals=vals.Enum('none', 'trace', 'point'))
+
+    def setup(self, **kwargs):
+        """
+        Setup the ATS controller by updating most current ATS values and setting
+        the acquisition parameter metadata
+
+        Returns:
+            None
+        """
+        # Update acquisition parameter values. These depend on the average mode
+        for attr in ['channel_selection', 'samples_per_record',
+                     'records_per_buffer', 'buffers_per_acquisition']:
+            setattr(self, attr, self.get_acquisition_setting(attr))
+        self.samples_per_buffer = self.samples_per_record * \
+                                  self.records_per_buffer
+        self.number_of_channels = len(self.channel_selection)
+        self.traces_per_acquisition = self.buffers_per_acquisition * \
+                                       self.records_per_buffer
+
+        if self.samples_per_record % 16:
+            raise SyntaxError('Samples per record {} is not multiple of '
+                              '16'.format(self.samples_per_record))
+
+        # Set acquisition parameter metadata
+        self.acquisition.names = tuple(['ch{}_signal'.format(ch) for ch in
+                                        self.channel_selection])
+        self.acquisition.labels = self.acquisition.names
+        self.acquisition.units = ['V'] * self.number_of_channels
+
+        if self.average_mode() == 'point':
+            shape = ()
+        elif self.average_mode() == 'trace':
+            shape = (self.samples_per_record,)
+        else:
+            shape = (self.traces_per_acquisition, self.samples_per_record)
+        self.acquisition.shapes = tuple([shape] * self.number_of_channels)
+
+    def _requires_buffer(self):
+        return self.buffer_idx < self.buffers_per_acquisition
+
+    def pre_start_capture(self):
+        """
+        Initializes buffers before capturing
+        """
+        self.buffer_idx = 0
+        self.buffers = [np.zeros((self.traces_per_acquisition,
+                                  self.samples_per_record))
+                        for ch in self.channel_selection]
+
+    def pre_acquire(self):
+        # gets called after 'AlazarStartCapture'
+        pass
+
+    def handle_buffer(self, buffer):
+        if self.buffer_idx < self.buffers_per_acquisition:
+            # Segment the buffer into buffers for each channel
+            segmented_buffer = self.segment_buffer(buffer, scale_voltages=True)
+
+            # Save buffer components into each channel dataset
+            for ch, ch_name in enumerate(self.channel_selection):
+                buffer_slice = slice(
+                    self.buffer_idx * self.records_per_buffer,
+                    (self.buffer_idx + 1) * self.records_per_buffer)
+                self.buffers[ch][buffer_slice] = segmented_buffer.pop(ch_name)
+        else:
+            logging.warning('Ignoring extra ATS buffer')
+
+        self.buffer_idx += 1
+
+    def post_acquire(self):
+        # average over records in buffer:
+        # for ATS9360 samples are arranged in the buffer as follows:
+        # S0A, S0B, ..., S1A, S1B, ...
+        # with SXY the sample number X of channel Y.
+
+        if self.average_mode() == 'none':
+            data = self.buffers
+        elif self.average_mode() == 'trace':
+            data = [np.mean(buffer, axis=0) for buffer in self.buffers]
+        elif self.average_mode() == 'point':
+            data = [np.mean(buffer) for buffer in self.buffers]
+
+        return data
+
+
+class Continuous_AcquisitionController(AcquisitionController):
+    def __init__(self, name, alazar_name, **kwargs):
+        super().__init__(name, alazar_name, **kwargs)
+
+        # buffers_per_acquisition=0x7FFFFFFF results in buffers being collected
+        # indefinitely until aborted.
+        # Records_per_buffer must equal 1 for CS or TS
+        self._fixed_acquisition_settings = {
+            'mode': 'CS',
+            'buffers_per_acquisition': 0x7FFFFFFF,
+            'records_per_buffer': 1}
+        self._acquisition_settings = self._fixed_acquisition_settings.copy()
+
+        self.add_parameter(name='average_mode',
+                           parameter_class=ManualParameter,
+                           initial_value='trace',
+                           vals=vals.Enum('none', 'trace', 'point'))
+        self.add_parameter(name='samples_per_trace',
+                           parameter_class=ManualParameter,
+                           vals=vals.Multiples(divisor=16))
+        self.add_parameter(name='traces_per_acquisition',
+                           parameter_class=ManualParameter,
+                           vals=vals.Ints())
+
+        self.buffer_idx = None
+        self.trace_idx = None
+        self.buffer_start_idx = None
+
+    def setup(self, **kwargs):
+        """
+        Setup the ATS controller by updating most current ATS values and setting
+        the acquisition parameter metadata
+
+        Returns:
+            None
+        """
+
+        # Update acquisition parameter values. These depend on the average mode
+        for attr in ['channel_selection', 'samples_per_record']:
+            setattr(self, attr, self.get_acquisition_setting(attr))
+        self.number_of_channels = len(self.channel_selection)
+        self.buffers_per_trace = round(self.samples_per_trace() / \
+                                       self.samples_per_record)
+
+        if self.samples_per_record % 16:
+            raise SyntaxError('Samples per record {} is not multiple of '
+                              '16'.format(self.samples_per_record))
+
+        # Set acquisition parameter metadata
+        self.acquisition.names = tuple(['ch{}_signal'.format(ch) for ch in
+                                        self.channel_selection])
+        self.acquisition.labels = self.acquisition.names
+        self.acquisition.units = ['V'] * self.number_of_channels
+
+        if self.average_mode() == 'point':
+            shape = ()
+        elif self.average_mode() == 'trace':
+            shape = (self.samples_per_trace(),)
+        else:
+            shape = (self.traces_per_acquisition(), self.samples_per_record)
+        self.acquisition.shapes = tuple([shape] * self.number_of_channels)
+
+    def _requires_buffer(self):
+        return self.trace_idx < self.traces_per_acquisition()
+
+    def pre_start_capture(self):
+        """
+        Initializes buffers before capturing
+        """
+        self.buffer_idx = 0
+        self.trace_idx = 0
+        self.buffer_start_idx = 0
+        self.buffers = [np.zeros((self.traces_per_acquisition(),
+                                  self.samples_per_trace()))
+                        for ch in self.channel_selection]
+
+    def pre_acquire(self):
+        # gets called after 'AlazarStartCapture'
+        pass
+
+    def handle_buffer(self, buffer):
+
+        if self.buffer_idx >= self.buffers_per_trace * \
+                             self.traces_per_acquisition():
+            print('Ignoring extra ATS buffer {}'.format(self.buffer_idx))
+            return None
+
+        # Segment the buffer into buffers for each channel
+        segmented_buffer = self.segment_buffer(buffer, scale_voltages=True)
+
+        # Determine the slice where the buffer segments should go in the traces,
+        # and possibly cut the segments if they start at nonzero idx,
+        # or if they don't fit completely in a trace
+        if self.buffer_idx == -1:
+            # This is the first (incomplete) buffer, whose starting idx is
+            # buffer_start_idx, add it to the beginning of the segmented buffer
+            buffer_slice = slice(None, self.samples_per_record -
+                                 self.buffer_start_idx)
+            for ch_name, buffer_segment in segmented_buffer.items():
+                # Shorten each of the segments to start from buffer_start_idx
+                segmented_buffer[ch_name] = \
+                    buffer_segment[self.buffer_start_idx:]
+        else:
+            # Determine the buffer idx offset in the trace
+            trace_offset = self.samples_per_record - self.buffer_start_idx + \
+                           self.samples_per_record * \
+                           (self.buffer_idx % self.buffers_per_trace)
+
+            if trace_offset+self.samples_per_record > self.samples_per_trace():
+                # Buffer does not fit completely in a trace, cutting buffer
+                buffer_slice = slice(trace_offset, None)
+                for ch_name, buffer_segment in segmented_buffer.items():
+                    # Shorten each of the segments to stop at samples_per_trace
+                    max_idx = self.samples_per_trace() - trace_offset
+                    segmented_buffer[ch_name] = buffer_segment[:max_idx]
+            else:
+               buffer_slice = slice(trace_offset,
+                                    trace_offset + self.samples_per_record)
+
+        # Save buffer components into each channel dataset
+        for ch, ch_name in enumerate(self.channel_selection):
+            self.buffers[ch][self.trace_idx, buffer_slice] = \
+                segmented_buffer[ch_name]
+
+        self.buffer_idx += 1
+        if self.buffer_idx and not self.buffer_idx % self.buffers_per_trace:
+            # Filled a trace
+            self.trace_idx += 1
+
+    def post_acquire(self):
+        # average over records in buffer:
+        # for ATS9360 samples are arranged in the buffer as follows:
+        # S0A, S0B, ..., S1A, S1B, ...
+        # with SXY the sample number X of channel Y.
+
+        if self.average_mode() == 'none':
+            data = self.buffers
+        elif self.average_mode() == 'trace':
+            data = [np.mean(buffer, axis=0) for buffer in self.buffers]
+        elif self.average_mode() == 'point':
+            data = [np.mean(buffer) for buffer in self.buffers]
+
+        return data
+
+
+class SteeredInitialization_AcquisitionController(Continuous_AcquisitionController):
+    shared_kwargs = ['target_instrument']
+
+    def __init__(self, name, alazar_name, target_instrument, **kwargs):
+        super().__init__(name, alazar_name, **kwargs)
+
+        self._target_instrument = target_instrument
+
+        self.add_parameter(name='t_no_blip',
+                           parameter_class=ManualParameter,
+                           units='ms',
+                           initial_value=40)
+        self.add_parameter(name='t_max_wait',
+                           parameter_class=ManualParameter,
+                           units='ms',
+                           initial_value=500)
+        self.add_parameter(name='max_wait_action',
+                           parameter_class=ManualParameter,
+                           units='ms',
+                           initial_value='start',
+                           vals=vals.Enum('start', 'error'))
+
+        self.add_parameter(name='silent',
+                           parameter_class=ManualParameter,
+                           initial_value=True,
+                           vals=vals.Bool())
+        self.add_parameter(name='stage',
+                           parameter_class=ManualParameter,
+                           vals=vals.Enum('initialization', 'active', 'read'))
+        self.add_parameter(name='record_initialization_traces',
+                           parameter_class=ManualParameter,
+                           initial_value=False,
+                           vals=vals.Bool())
+
+        # Parameters for the target instrument and command after initialization
+        self.add_parameter(name='target_instrument',
+                           get_cmd=lambda: self._target_instrument.name)
+        self.add_parameter(name='target_command',
+                           parameter_class=ManualParameter,
+                           initial_value='start',
+                           vals=vals.Strings())
+
+
+        self.add_parameter(name='readout_channel',
+                           parameter_class=ManualParameter,
+                           vals=vals.Enum('A', 'B', 'C', 'D'))
+        self.add_parameter(name='trigger_channel',
+                           parameter_class=ManualParameter,
+                           vals=vals.Enum('A', 'B', 'C', 'D'))
+        self.add_parameter(name='trigger_threshold_voltage',
+                           parameter_class=ManualParameter)
+        self.add_parameter(name='readout_threshold_voltage',
+                           parameter_class=ManualParameter)
+
+        self.add_parameter(name='initialization_traces',
+                           get_cmd=lambda: self._initialization_traces)
+        self.add_parameter(name='post_initialization_traces',
+                           get_cmd=lambda: self._post_initialization_traces)
+
+        self.number_of_buffers_no_blip = None
+        self.number_of_buffers_max_wait = None
+        self._target_command = None
+        self.buffer_no_blip_idx = None
+        self.trace_idx = None
+        self.t_start_list = None
+
+    def setup(self, readout_threshold_voltage=None,
+              trigger_threshold_voltage=None, **kwargs):
+        if readout_threshold_voltage is not None:
+            self.readout_threshold_voltage(readout_threshold_voltage)
+        if trigger_threshold_voltage is not None:
+            self.trigger_threshold_voltage(trigger_threshold_voltage)
+        super().setup()
+
+        # Convert t_no_blip and t_max_wait to equivalent number of buffers
+        sample_rate = self._alazar.get_sample_rate()
+        samples_per_ms = sample_rate * 1e-3
+        buffers_per_ms = samples_per_ms / self.samples_per_record
+        self.ms_per_buffer = 1 / buffers_per_ms
+        self.number_of_buffers_max_wait = \
+            int(np.ceil(self.t_max_wait() * buffers_per_ms))
+        self.number_of_buffers_no_blip = \
+            int(np.ceil(self.t_no_blip() * buffers_per_ms))
+
+        # Setup target command when t_no_blip is reached
+        self._target_command = getattr(self._target_instrument,
+                                       self.target_command())
+
+        self.t_start_list = np.zeros(self.traces_per_acquisition())
+
+        if self.record_initialization_traces():
+            self._initialization_traces = np.zeros(
+                (self.traces_per_acquisition(),
+                 self.samples_per_record * self.number_of_buffers_max_wait))
+            self._post_initialization_traces = {
+                'ch' + str(ch_idx): np.zeros((self.traces_per_acquisition(),
+                                  self.samples_per_record))
+                for ch_idx in self.channel_selection}
+
+    def pre_start_capture(self):
+        """
+        Initializes buffers before capturing
+        """
+        self.t0 = time.time()
+
+        super().pre_start_capture()
+        self.stage('initialization')
+        self.buffer_no_blip_idx = 0
+
+    def handle_buffer(self, buffer):
+        if self.stage() == 'initialization':
+            self.buffer_idx += 1
+            # increase no_blip_idx, if there was a blip it will be reset
+            self.buffer_no_blip_idx += 1
+
+            segmented_buffers = self.segment_buffer(buffer, scale_voltages=True)
+            readout_buffer = segmented_buffers[self.readout_channel()]
+
+            if self.record_initialization_traces():
+                # Store buffer into initialization trace
+                buffer_slice = (
+                    self.trace_idx, slice(
+                        (self.buffer_idx-1) * self.samples_per_record,
+                        self.buffer_idx * self.samples_per_record))
+                self._initialization_traces[buffer_slice] = readout_buffer
+
+            if max(readout_buffer) > self.readout_threshold_voltage():
+                # A blip occurred, reset counter for buffers without blips
+                self.buffer_no_blip_idx = 0
+
+            if self.buffer_no_blip_idx >= self.number_of_buffers_no_blip:
+                # Sufficient successive buffers without blips, starting
+                self.stage('active')
+                # Perform target command (e.g. starting an instrument)
+                self._target_command()
+                self.t_start_list[self.trace_idx] = self.buffer_idx * \
+                                                    self.ms_per_buffer
+                if not self.silent():
+                    print('Starting active {:.2f} s'.format(
+                        time.time() - self.t0))
+                self.buffer_idx = 0
+            elif self.buffer_idx >= self.number_of_buffers_max_wait:
+                # Max waiting time has been reached, but no sufficient
+                # period of time without blips occurred. Either start or error
+                if self.max_wait_action() == 'start':
+                    self.stage('active')
+                    self._target_command()
+                    self.t_start_list[self.trace_idx] = self.buffer_idx * \
+                                                        self.ms_per_buffer
+                    if not self.silent():
+                        print('Starting active {:.2f} s'.format(
+                            time.time()-self.t0))
+                    self.buffer_idx = 0
+
+                    if not self.silent():
+                        logging.warning('Max wait time reached, but no '
+                                        'period without blips occurred, '
+                                        'starting')
+                else: # self.max_wait_action() == 'error':
+                    raise RuntimeError('Max wait time reached but no period'
+                                       ' without blips occurred, stopping')
+
+        elif self.stage() == 'active':
+            # Keep acquiring buffers until acquisition trigger is measured
+            segmented_buffers = self.segment_buffer(buffer, scale_voltages=True)
+
+            if self.buffer_idx == 0 and self.record_initialization_traces():
+                # Store first stage after initialization
+                for ch_idx in self.channel_selection:
+                    ch_name = 'ch{}'.format(ch_idx)
+                    self._post_initialization_traces[ch_name][self.trace_idx] = \
+                        segmented_buffers[ch_idx]
+
+            trigger_buffer = segmented_buffers[self.trigger_channel()]
+            if max(trigger_buffer) > self.trigger_threshold_voltage():
+                # Acquisition trigger measured
+                self.stage('read')
+
+                # Find first index of acquisition trigger
+                self.buffer_idx = -1
+                self.buffer_start_idx = \
+                    np.argmax(trigger_buffer > self.trigger_threshold_voltage())
+
+                # Add first (partial) segment to traces
+                super().handle_buffer(buffer)
+
+                if not self.silent():
+                    print('starting readout after {:.2f} s, buffers {}'.format(
+                        time.time()-self.t0, self.buffer_idx))
+            else:
+                self.buffer_idx += 1
+
+
+        elif self.stage() == 'read':
+            # Add buffer to data
+            super().handle_buffer(buffer)
+            if not self.buffer_idx % self.buffers_per_trace:
+
+                if not self.silent():
+                    print('finished trace after {:.2f} s'.format(
+                        time.time()-self.t0))
+                self.t0 = time.time()
+                # Trace filled, go back to initialization
+                self.stage('initialization')
+                # Reset buffer idx
+                self.buffer_idx = 0
+                self.buffer_start_idx
+                self.buffer_no_blip_idx = 0
+
+        else:
+            raise ValueError('Acquisition stage {} unknown'.format(self.stage))
 
 
 # DFT AcquisitionController

--- a/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -77,8 +77,10 @@ class Triggered_AcquisitionController(AcquisitionController):
             shape = (self.traces_per_acquisition, self.samples_per_record)
         self.acquisition.shapes = tuple([shape] * self.number_of_channels)
 
-    def requires_buffer(self):
-        return self.buffer_idx < self.buffers_per_acquisition
+    def requires_buffer(self, buffers_completed):
+        # Using buffers_completed instead of self.buffer_idx because the
+        # buffers may all be passed on to handle_buffer after all are filled
+        return buffers_completed < self.buffers_per_acquisition
 
     def pre_start_capture(self):
         """
@@ -206,7 +208,7 @@ class Continuous_AcquisitionController(AcquisitionController):
             shape = (self.traces_per_acquisition(), self.samples_per_record)
         self.acquisition.shapes = tuple([shape] * self.number_of_channels)
 
-    def requires_buffer(self):
+    def requires_buffer(self, buffers_completed):
         return self.trace_idx < self.traces_per_acquisition()
 
     def pre_start_capture(self):

--- a/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -77,7 +77,7 @@ class Triggered_AcquisitionController(AcquisitionController):
             shape = (self.traces_per_acquisition, self.samples_per_record)
         self.acquisition.shapes = tuple([shape] * self.number_of_channels)
 
-    def _requires_buffer(self):
+    def requires_buffer(self):
         return self.buffer_idx < self.buffers_per_acquisition
 
     def pre_start_capture(self):
@@ -206,7 +206,7 @@ class Continuous_AcquisitionController(AcquisitionController):
             shape = (self.traces_per_acquisition(), self.samples_per_record)
         self.acquisition.shapes = tuple([shape] * self.number_of_channels)
 
-    def _requires_buffer(self):
+    def requires_buffer(self):
         return self.trace_idx < self.traces_per_acquisition()
 
     def pre_start_capture(self):

--- a/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -225,7 +225,20 @@ class Continuous_AcquisitionController(AcquisitionController):
         pass
 
     def handle_buffer(self, buffer):
+        """
+        Adds buffers to fill up the data traces.
+        Because a trace can consist of multiple buffers, the 'trace_idx' and
+        'buffer_idx' determine the relevant trace/buffer within a trace,
+        respectively.
+        Note that 'buffer_start_idx' set to nonzero if the first buffer should
+        be added from a nonzero starting idx. In this case, the first buffer
+        must have 'buffer_idx = -1'.
+        Args:
+            buffer: Buffer to add to trace
 
+        Returns:
+            None
+        """
         if self.buffer_idx >= self.buffers_per_trace * \
                              self.traces_per_acquisition():
             print('Ignoring extra ATS buffer {}'.format(self.buffer_idx))


### PR DESCRIPTION
Changes proposed in this pull request
- Addition of the ATS9440 driver
- Updates to ATS driver
    - Added Continuous Streaming mode
    - Added support for four channels
    - Added fix for drivers that do not have bw_limit support
    - Standardized channel names (Channels used to be called 'A', 'chA', or 1, resulting in conversion headaches. Now it is always referred to as 'A', 'B' etc.)
    - Added triggered function
    - Added get_status function
    - _set_list_if_present also accepts a single value, in which case it sets this value for each channel.
    - Added option to turn off error_check in call_dll, since some dll commands return a value
- Update to Buffer
    - Now also accepts digitizers that have bits_per_sample != 8
- Updates to AcquisitionController
    - Changed acquisition_kwargs to acquisition_settings (felt easier to read/understand)
    - Added get/update/set functionality for acquisition_settings
    - Added fixed acquisition settings (these cannot be changed via get/set/update)
    - Added requires_buffer function (this is called from ATS during acquisition, allowing an indefinite number of buffers to be acquired until a condition is met)
    - Added segment_buffer, which segments a single buffer into segments for each channel. These are returned as dictionary keys.
    - Added option to scale data through segment_buffer
    - Added two basic acquisition controllers, which have averaging funcitonalities
        - Added Triggered_AcquisitionController, which records a record per triggered. This is based on the Basic_AcquisitionController from @nataliejpg
        - Added Continuous_AcquisitionController, which continuously acquires buffers, filling up traces
- Fix small bug in ATS9870, and changed format to adhere to standardized channel names

Note that the Demodulation_AcquisitionController is now not working, since it still needs an implementation for requires_buffer. Furthermore, errors will occur if users have not updated their code to adhere to the standardized channel names. Also acquisition_kwargs has changed to acquisition_settings

Finally, I have only tested it out on the ATS9440, it would be good if someone who has a different driver (@damazter @nataliejpg) could see if everything works for them as well