### PR TITLE
Feat: Jsonencoder addition

### DIFF
--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -34,6 +34,7 @@ class NumpyJSONEncoder(json.JSONEncoder):
                 'im': float(obj.imag)
             }
         elif hasattr(obj, '_JSONEncoder'):
+            # Use object's custom JSON encoder
             return obj._JSONEncoder()
         else:
             try:

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -33,6 +33,8 @@ class NumpyJSONEncoder(json.JSONEncoder):
                 're': float(obj.real),
                 'im': float(obj.imag)
             }
+        elif hasattr(obj, '_JSONEncoder'):
+            return obj._JSONEncoder()
         else:
             try:
                 s = super(NumpyJSONEncoder, self).default(obj)


### PR DESCRIPTION
Changes proposed in this pull request
- Adds optionality for an object to have a custom JSON encoder. The encoder checks if the object has a method _JSONencoder. If it does, this method is used to generate a JSON dict.