### PR TITLE
make docstring be formatted as rich text

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -176,7 +176,7 @@ class Parameter(Metadatable, DeferredOperations):
 
             self.set_validator(vals or Anything())
             self.__doc__ = os.linesep.join((
-                'Parameter class:',
+                'Parameter class:' + os.linesep,
                 '* `names` %s' % ', '.join(self.names),
                 '* `labels` %s' % ', '.join(self.labels),
                 '* `units` %s' % ', '.join(self.units)))
@@ -191,7 +191,7 @@ class Parameter(Metadatable, DeferredOperations):
 
             # generate default docstring
             self.__doc__ = os.linesep.join((
-                'Parameter class:',
+                'Parameter class:' + os.linesep,
                 '* `name` %s' % self.name,
                 '* `label` %s' % self.label,
                 # TODO is this unit s a typo? shouldnt that be unit?
@@ -246,7 +246,7 @@ class Parameter(Metadatable, DeferredOperations):
         self._latest_ts = None
 
         if docstring is not None:
-            self.__doc__ = docstring + os.linesep + self.__doc__
+            self.__doc__ = docstring + os.linesep + os.linesep + self.__doc__
 
         self.get_latest = GetLatest(self)
 


### PR DESCRIPTION
In spyder the formatting of the generated `__doc__` of a `Parameter` is not according to rich text formatting. This commits fixes that, so that the docstring is renderer as rich text (tested with Spyder).

Changes proposed in this pull request:
-  Add some newlines in the generated docstrings


@core

