### PR TITLE
fix: Don't append if file does not exist.

### DIFF
--- a/qcodes/tests/test_format.py
+++ b/qcodes/tests/test_format.py
@@ -282,10 +282,18 @@ class TestGNUPlotFormat(TestCase):
             self.assertEqual(f.read(), odd_format)
 
     def add_star(self, path):
-        try:
+        """
+        Args:
+            path(str): path to gnu plot data file
+
+        Write a start to file at path if exists.  Else record that the file
+        does not exist, in the obscure counter self.stars_before_write, starts
+        are written only if a file exists, i.e. "after_write"
+        """
+        if os.path.isfile(path):
             with open(path, 'a') as f:
                 f.write('*')
-        except FileNotFoundError:
+        else:
             self.stars_before_write += 1
 
     def test_incremental_write(self):


### PR DESCRIPTION
FileNotFoundError is not raised, if the directory exists (very much like Linux).
So safer to check for the file we actually want to check for existence.

Closes #407