### PR TITLE
fix: make sync a no-opt on local data

### DIFF
--- a/docs/examples/Measure without a Loop.ipynb
+++ b/docs/examples/Measure without a Loop.ipynb
@@ -379,7 +379,8 @@
    },
    "outputs": [],
    "source": [
-    "from toymodel import AModel, MockGates, MockSource, MockMeter, AverageAndRaw, ArrayGetter\n",
+    "from toymodel import AModel, MockGates, MockSource, MockMeter, AverageAndRaw\n",
+    "from qcodes.instrument.mock import ArrayGetter\n",
     "\n",
     "# now create this \"experiment\", note that all these are instruments \n",
     "model = AModel()\n",

--- a/docs/examples/toymodel.py
+++ b/docs/examples/toymodel.py
@@ -4,7 +4,7 @@ import math
 
 from qcodes import MockInstrument, MockModel, Parameter, Loop, DataArray
 from qcodes.utils.validators import Numbers
-
+from qcodes.instrument.mock import ArrayGetter
 
 class AModel(MockModel):
     def __init__(self):
@@ -147,36 +147,3 @@ class AverageAndRaw(Parameter):
         array = data.arrays[self.measured_param.full_name]
         return (array, array.mean())
 
-
-class ArrayGetter(Parameter):
-    """
-    Example parameter that just returns a single array
-
-    TODO: in theory you can make this same Parameter with
-    name, label & shape (instead of names, labels & shapes) and altered
-    setpoints (not wrapped in an extra tuple) and this mostly works,
-    but when run in a loop it doesn't propagate setpoints to the
-    DataSet. We could track down this bug, but perhaps a better solution
-    would be to only support the simplest and the most complex Parameter
-    forms (ie cases 1 and 5 in the Parameter docstring) and do away with
-    the intermediate forms that make everything more confusing.
-    """
-    def __init__(self, measured_param, sweep_values, delay):
-        name = measured_param.name
-        super().__init__(names=(name,))
-        self._instrument = getattr(measured_param, '_instrument', None)
-        self.measured_param = measured_param
-        self.sweep_values = sweep_values
-        self.delay = delay
-        self.shapes = ((len(sweep_values),),)
-        set_array = DataArray(parameter=sweep_values.parameter,
-                              preset_data=sweep_values)
-        self.setpoints = ((set_array,),)
-        if hasattr(measured_param, 'label'):
-            self.labels = (measured_param.label,)
-
-    def get(self):
-        loop = Loop(self.sweep_values, self.delay).each(self.measured_param)
-        data = loop.run_temp()
-        array = data.arrays[self.measured_param.full_name]
-        return (array,)

--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -386,15 +386,7 @@ class DataSet(DelegateAttributes):
         # could find a robust and intuitive way to make modifications to the
         # version on the DataServer from the main copy)
         if not self.is_live_mode:
-            # LOCAL DataSet - just read it in
-            # Compare timestamps to avoid overwriting unsaved data
-            if self.last_store > self.last_write:
-                return True
-            try:
-                self.read()
-            except IOError:
-                # if no files exist, they probably haven't been created yet.
-                pass
+            # LOCAL DataSet - no need to sync just use local data
             return False
             # TODO - for remote live plotting, maybe set some timestamp
             # threshold and call it static after it's been dormant a long time?

--- a/qcodes/instrument/mock.py
+++ b/qcodes/instrument/mock.py
@@ -3,6 +3,9 @@ import time
 from datetime import datetime
 
 from .base import Instrument
+from .parameter import Parameter
+from qcodes import Loop
+from qcodes.data.data_array import DataArray
 from qcodes.process.server import ServerManager, BaseServer
 from qcodes.utils.nested_attrs import _NoDefault
 
@@ -279,3 +282,36 @@ class MockModel(ServerManager, BaseServer):  # pragma: no cover
         See NestedAttrAccess for details.
         """
         self.ask('method_call', 'delattr', attr)
+
+class ArrayGetter(Parameter):
+    """
+    Example parameter that just returns a single array
+
+    TODO: in theory you can make this same Parameter with
+    name, label & shape (instead of names, labels & shapes) and altered
+    setpoints (not wrapped in an extra tuple) and this mostly works,
+    but when run in a loop it doesn't propagate setpoints to the
+    DataSet. We could track down this bug, but perhaps a better solution
+    would be to only support the simplest and the most complex Parameter
+    forms (ie cases 1 and 5 in the Parameter docstring) and do away with
+    the intermediate forms that make everything more confusing.
+    """
+    def __init__(self, measured_param, sweep_values, delay):
+        name = measured_param.name
+        super().__init__(names=(name,))
+        self._instrument = getattr(measured_param, '_instrument', None)
+        self.measured_param = measured_param
+        self.sweep_values = sweep_values
+        self.delay = delay
+        self.shapes = ((len(sweep_values),),)
+        set_array = DataArray(parameter=sweep_values.parameter,
+                              preset_data=sweep_values)
+        self.setpoints = ((set_array,),)
+        if hasattr(measured_param, 'label'):
+            self.labels = (measured_param.label,)
+
+    def get(self):
+        loop = Loop(self.sweep_values, self.delay).each(self.measured_param)
+        data = loop.run_temp()
+        array = data.arrays[self.measured_param.full_name]
+        return (array,)

--- a/qcodes/tests/test_loop.py
+++ b/qcodes/tests/test_loop.py
@@ -118,6 +118,9 @@ class TestMockInstLoop(TestCase):
         self.check_loop_data(data)
 
     def test_background_no_datamanager(self):
+        # We don't support syncing data from a background process
+        # if not using a datamanager. See warning in ActiveLoop.run()
+        # So we expect the data to be empty even after running.
         data = self.loop.run(location=self.location,
                              background=True,
                              data_manager=False,
@@ -127,7 +130,7 @@ class TestMockInstLoop(TestCase):
         self.loop.process.join()
 
         data.sync()
-        self.check_loop_data(data)
+        self.check_empty_data(data)
 
     def test_foreground_and_datamanager(self):
         data = self.loop.run(location=self.location, background=False,

--- a/qcodes/tests/test_loop.py
+++ b/qcodes/tests/test_loop.py
@@ -79,7 +79,7 @@ class TestMockInstLoop(TestCase):
         # you can only do in-memory loops if you set data_manager=False
         # TODO: this is the one place we don't do quiet=True - test that we
         # really print stuff?
-        data = self.loop.run(location=self.location, background=True)
+        data = self.loop.run(location=self.location, background=True, data_manager=True)
         self.check_empty_data(data)
 
         # wait for process to finish (ensures that this was run in the bg,


### PR DESCRIPTION
fixes #380 by avoiding to overwrite data
with partial data from disk

Changes proposed in this pull request:
- Make sync a no opt in local mode rather than read data from disc

I don't think that sync has any function in local mode but if that is too intrusive https://github.com/jenshnielsen/Qcodes/commit/fd2b0d3859627d882a9986f7aa453b980e60a9c6 is a less intrusive fix

@giulioungaretti @nataliejpg 
