### PR TITLE
Added print human readable snapshot to base instrument class

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -435,7 +435,7 @@ class Instrument(Metadatable, DelegateAttributes, NestedAttrAccess,
                 snap[attr] = getattr(self, attr)
         return snap
 
-    def print_readable_snapshot(self, update=False):
+    def print_readable_snapshot(self, update=False, max_chars=80):
         """
         Prints a readable version of the snapshot.
         The readable snapshot includes the name, value and unit of each
@@ -449,11 +449,18 @@ class Instrument(Metadatable, DelegateAttributes, NestedAttrAccess,
         """
         floating_types = (float, np.integer, np.floating)
         snapshot = self.snapshot(update=update)
+
+        par_lengths = [len(p) for p in snapshot['parameters']]
+
+        # Min of 50 is to prevent a super long parameter name to break this
+        # function
+        par_field_len = min(max(par_lengths)+1, 50)
+
         print(self.name + ':')
-        print('{: >21}'.format('parameter ') + '\tvalue')
+        print('{0:<{1}}'.format('\tparameter ', par_field_len) + 'value')
         print('-'*80)
         for par in sorted(snapshot['parameters']):
-            msg = '{: >21}:'.format(snapshot['parameters'][par]['name'])
+            msg = '{0:<{1}}:'.format(snapshot['parameters'][par]['name'], par_field_len)
             val = snapshot['parameters'][par]['value']
             unit = snapshot['parameters'][par]['unit']
             if isinstance(val, floating_types):
@@ -462,6 +469,9 @@ class Instrument(Metadatable, DelegateAttributes, NestedAttrAccess,
                 msg += '\t{} '.format(val)
             if unit is not '':  # corresponds to no unit
                 msg += '({})'.format(unit)
+            # Truncate the message if it is longer than max length
+            if len(msg) > max_chars and not max_chars==-1:
+                msg = msg[0:max_chars-3] + '...'
             print(msg)
 
     # `write_raw` and `ask_raw` are the interface to hardware                #

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -442,7 +442,7 @@ class Instrument(Metadatable, DelegateAttributes, NestedAttrAccess,
             print('{0:25}: \t{1}\t ({2})'.format(
                   snapshot['parameters'][par]['name'],
                   snapshot['parameters'][par]['value'],
-                  snapshot['parameters'][par]['units']))
+                  snapshot['parameters'][par]['unit']))
     #
     # `write_raw` and `ask_raw` are the interface to hardware                #
     # `write` and `ask` are standard wrappers to help with error reporting   #

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -3,6 +3,7 @@ import logging
 import time
 import warnings
 import weakref
+import numpy as np
 
 from qcodes.utils.metadata import Metadatable
 from qcodes.utils.helpers import DelegateAttributes, strip_attrs, full_class
@@ -435,15 +436,34 @@ class Instrument(Metadatable, DelegateAttributes, NestedAttrAccess,
         return snap
 
     def print_readable_snapshot(self, update=False):
+        """
+        Prints a readable version of the snapshot.
+        The readable snapshot includes the name, value and unit of each
+        parameter.
+        A convenience function to quickly get an overview of the status of an instrument.
+
+        Args:
+            update (bool): If True, update the state by querying the
+                instrument. If False, just use the latest values in memory.
+                This argument gets passed to the snapshot function.
+        """
+        floating_types = (float, np.integer, np.floating)
         snapshot = self.snapshot(update=update)
-        print('{0:23} {1} \t ({2})'.format('\t parameter ', 'value', 'units'))
+        print(self.name + ':')
+        print('{: >21}'.format('parameter ') + '\tvalue')
         print('-'*80)
         for par in sorted(snapshot['parameters']):
-            print('{0:25}: \t{1}\t ({2})'.format(
-                  snapshot['parameters'][par]['name'],
-                  snapshot['parameters'][par]['value'],
-                  snapshot['parameters'][par]['unit']))
-    #
+            msg = '{: >21}:'.format(snapshot['parameters'][par]['name'])
+            val = snapshot['parameters'][par]['value']
+            unit = snapshot['parameters'][par]['unit']
+            if isinstance(val, floating_types):
+                msg += '\t{:.5g} '.format(val)
+            else:
+                msg += '\t{} '.format(val)
+            if unit is not '':  # corresponds to no unit
+                msg += '({})'.format(unit)
+            print(msg)
+
     # `write_raw` and `ask_raw` are the interface to hardware                #
     # `write` and `ask` are standard wrappers to help with error reporting   #
     #

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -443,9 +443,12 @@ class Instrument(Metadatable, DelegateAttributes, NestedAttrAccess,
         A convenience function to quickly get an overview of the status of an instrument.
 
         Args:
-            update (bool): If True, update the state by querying the
+            update (bool)  : If True, update the state by querying the
                 instrument. If False, just use the latest values in memory.
                 This argument gets passed to the snapshot function.
+            max_chars (int) : the maximum number of characters per line. The
+                readable snapshot will be cropped if this value is exceeded.
+                Defaults to 80 to be consistent with default terminal width.
         """
         floating_types = (float, np.integer, np.floating)
         snapshot = self.snapshot(update=update)

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -434,6 +434,15 @@ class Instrument(Metadatable, DelegateAttributes, NestedAttrAccess,
                 snap[attr] = getattr(self, attr)
         return snap
 
+    def print_readable_snapshot(self, update=False):
+        snapshot = self.snapshot(update=update)
+        print('{0:23} {1} \t ({2})'.format('\t parameter ', 'value', 'units'))
+        print('-'*80)
+        for par in sorted(snapshot['parameters']):
+            print('{0:25}: \t{1}\t ({2})'.format(
+                  snapshot['parameters'][par]['name'],
+                  snapshot['parameters'][par]['value'],
+                  snapshot['parameters'][par]['units']))
     #
     # `write_raw` and `ask_raw` are the interface to hardware                #
     # `write` and `ask` are standard wrappers to help with error reporting   #


### PR DESCRIPTION
Fixes #391 

Changes proposed in this pull request:
- Add a print_readable_snapshot to the base instrument class 


@giulioungaretti 
@nulinspiratie, I think you said you liked this. 

Below two pictures to compare the conventional snapshot and the readable version. 
Note that the readable snapshot is not intended to replace the existing snapshot function. 

## Readable snapshot:
![screenshot 2016-12-20 13 21 20](https://cloud.githubusercontent.com/assets/6142932/21350380/52a2388a-c6b7-11e6-8605-b1b0cdd835ee.png)

## Conventional snapshot: 
![screenshot 2016-12-20 13 21 31](https://cloud.githubusercontent.com/assets/6142932/21350378/4f70d3b0-c6b7-11e6-9d5b-1afa70b7834f.png)


