### PR TITLE
Fix pickling of dataset

### DIFF
--- a/qcodes/config/qcodesrc.json
+++ b/qcodes/config/qcodesrc.json
@@ -7,5 +7,7 @@
         "notebook": true,
         "plotlib": "matplotlib"
     },
-    "user": {}
+    "user": {
+		"nvDataDir": "C:/Users/Laurens/Documents/Qtech/qtechData"
+	}
 }

--- a/qcodes/config/qcodesrc.json
+++ b/qcodes/config/qcodesrc.json
@@ -7,7 +7,5 @@
         "notebook": true,
         "plotlib": "matplotlib"
     },
-    "user": {
-		"nvDataDir": "C:/Users/Laurens/Documents/Qtech/qtechData"
-	}
+    "user": {}
 }

--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -301,6 +301,14 @@ class DataSet(DelegateAttributes):
         else:
             raise ValueError('unrecognized DataSet mode', mode)
 
+    def __getstate__(self):
+        """ Called when an object is pickled """
+        self.sync()
+        self.data_manager = None
+        self.background_functions = {}
+        self.formatter.close_file(self)
+        return self.__dict__
+
     def _init_local(self):
         self.mode = DataMode.LOCAL
 


### PR DESCRIPTION
After certain operations a Dataset cannot be pickled any more. This PR fixes this by making sure the dataset is cleaned when a pickle request is done.

Also see #428 

@giulioungaretti  @core
