### PR TITLE
Travis failures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ matplotlib==1.5.3
 pyqtgraph==0.10.0
 PyVISA==1.8
 PyQt5==5.7
+sip==4.18.1
 QtPy==1.1.2
 h5py==2.6.0


### PR DESCRIPTION
Trying to figure out whats wrong with travis here https://travis-ci.org/QCoDeS/Qcodes/builds/188466963

seqfault during `setup.py develop`

I can reproduce it locally on OSX and it looks like 
the upgrade of sip from 4.18.1 to 4.19 causes it

So I guess that either sip 4.19 isn’t compatible with pyqt 5.7 but requires pyqt 5.71 but thats not reflected in the dependencies. It may also just be an abi compatibility issues with the binary wheels between the 2 packages. 

This is just restoring previous behaviour. We could also just upgrade pyqt to 5.7.1