### PR TITLE
fix: Fix Decadac output off problem

### DIFF
--- a/docs/examples/Qcodes example with Decadac.ipynb
+++ b/docs/examples/Qcodes example with Decadac.ipynb
@@ -10,24 +10,17 @@
    "source": [
     "%matplotlib nbagg\n",
     "\n",
-    "import qcodes as qc"
+    "import qcodes as qc\n",
+    "from qcodes.instrument_drivers.Harvard.Decadac import Decadac"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "hello\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "deca = Decadac('Decadac', port=4, slot=0)"
    ]
@@ -36,7 +29,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This created four parameters corresponding to the channels, i.e. deca.volt0, deca.volt1, deca.volt2, deca.volt3."
+    "The most used feature of the Decadac is its voltage output capability.\n",
+    "There are four parameters corresponding to the channels, i.e. deca.ch0_voltage, deca.ch1_voltage, etc."
    ]
   },
   {
@@ -47,8 +41,8 @@
    },
    "outputs": [],
    "source": [
-    "deca.volt0.set(1)\n",
-    "deca.volt0.get()"
+    "deca.ch0_voltage.set(1)\n",
+    "deca.ch0_voltage.get()"
    ]
   },
   {
@@ -66,10 +60,57 @@
    },
    "outputs": [],
    "source": [
-    "deca.set_ramping(True, time=1000)\n",
-    "deca.volt0.set(0)\n",
+    "deca.set_ramping(True, time=1000)  # time in ms\n",
+    "deca.ch0_voltage.set(0)\n",
     "deca.set_ramping(False)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The precision of the Decadac may be rather poor, so one might want to apply a correctional offset to each channel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "deca.ch0_offset.set(-0.1)\n",
+    "deca.ch0_voltage.set(1)\n",
+    "deca.ch0_voltage.get()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is possible to toggle the Decadac output ON/OFF without changing anything else."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "deca.mode.set(0)  # 0: output off, 1: output on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -60,11 +60,6 @@ class Decadac(VisaInstrument):
         self._voltranges = [1, 1, 1, 1]
         self._offsets = [0, 0, 0, 0]
 
-        self.add_parameter('mode',
-                           label='Output mode',
-                           set_cmd='B {}; M {};'.format(self.slot, '{}'),
-                           vals=vals.Enum(0, 1))
-
         # channels
         for channelno in range(4):
             self.add_parameter('ch{}_voltage'.format(channelno),

--- a/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -21,9 +21,9 @@ class Decadac(VisaInstrument):
 
     Attributes:
 
-        ramp_state (bool): If True, ramp state is ON. Default False.
+        _ramp_state (bool): If True, ramp state is ON. Default False.
 
-        ramp_time (int): The ramp time in ms. Default 100 ms.
+        _ramp_time (int): The ramp time in ms. Default 100 ms.
     """
 
     def __init__(self, name, port, slot, timeout=2, baudrate=9600,
@@ -139,7 +139,7 @@ class Decadac(VisaInstrument):
 
     def _setvoltage(self, voltage, channel):
         """
-        Function to set the voltage. Depending on whether self.ramp_state is
+        Function to set the voltage. Depending on whether self._ramp_state is
         True or False, this function either ramps from the current voltage to
         the specified voltage or directly makes the voltage jump there.
 
@@ -152,7 +152,7 @@ class Decadac(VisaInstrument):
 
         mssg = 'B {:d}; C {:d};'.format(self.slot, channel)
 
-        if not self.ramp_state:
+        if not self._ramp_state:
             mssg += 'D ' + code + ';'
 
             self.visa_handle.write(mssg)
@@ -162,15 +162,15 @@ class Decadac(VisaInstrument):
             try:
                 self.visa_handle.read()
             except UnicodeDecodeError:
-                log.warning(" Decadac returned nothing and did nothing. " +
+                log.warning(" Decadac returned nothing and possibly did nothing. " +
                             "Please re-run the command")
                 pass
 
-        if self.ramp_state:
+        if self._ramp_state:
             currentcode = self._voltage2code(self._getvoltage(channel),
                                              channel)
             slope = int((float(code)-float(currentcode)) /
-                        (10*self.ramp_time)*2**16)
+                        (10*self._ramp_time)*2**16)
             if slope < 0:
                 limit = 'L'
             else:
@@ -187,7 +187,7 @@ class Decadac(VisaInstrument):
             runcmd = 'X 1;'
             mssg += ''.join(script) + runcmd
             self.visa_handle.write(mssg)
-            sleep(0.0015*self.ramp_time)  # Required sleep.
+            sleep(0.0015*self._ramp_time)  # Required sleep.
             self.visa_handle.read()
 
             # reset channel voltage ranges
@@ -200,7 +200,7 @@ class Decadac(VisaInstrument):
 
     def set_ramping(self, state, time=None):
         """
-        Function to set ramp_state and ramp_time.
+        Function to set _ramp_state and _ramp_time.
 
         Args:
             state (bool): True sets ramping ON.
@@ -213,7 +213,7 @@ class Decadac(VisaInstrument):
 
     def get_ramping(self):
         """
-        Queries the value of self.ramp_state and self.ramp_time.
+        Queries the value of self._ramp_state and self._ramp_time.
 
         Returns:
             str: ramp state information


### PR DESCRIPTION
Add a parameter to control the Decadac output mode and set its default to ON. Add offset parameters for each channel.

Breaking changes: rename the voltage parameters from volt0, volt1, ... to ch0_voltage, ch1_voltage, ...

Fixes Decadac output mode problem.

Changes proposed in this pull request:
- Add important Decadac parameters.


@nataliejpg @giulioungaretti 
