### PR TITLE
Fix write_copy

### DIFF
--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -759,7 +759,7 @@ class DataSet(DelegateAttributes):
             array.modified_range = (0, array.ndarray.size - 1)
 
         try:
-            self.formatter.write(self, io_manager, location)
+            self.formatter.write(self, io_manager, location, force_write=True)
             self.snapshot()
             self.formatter.write_metadata(self, io_manager, location,
                                           read_first=False)

--- a/qcodes/data/format.py
+++ b/qcodes/data/format.py
@@ -47,7 +47,8 @@ class Formatter:
     """
     ArrayGroup = namedtuple('ArrayGroup', 'shape set_arrays data name')
 
-    def write(self, data_set, io_manager, location, write_metadata=True):
+    def write(self, data_set, io_manager, location, write_metadata=True,
+              force_write=False):
         """
         Write the DataSet to storage.
 
@@ -61,6 +62,7 @@ class Formatter:
             io_manager (io_manager): base physical location to write to.
             location (str): the file location within the io_manager.
             write_metadata (bool): if True, then the metadata is written to disk
+            force_write (bool): if True, then the data is written to disk
         """
         raise NotImplementedError
 

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -624,10 +624,10 @@ class Instrument(Metadatable, DelegateAttributes, NestedAttrAccess,
     def __getstate__(self):
         """Prevent pickling instruments, and give a nice error message."""
         raise RuntimeError(
-            'qcodes Instruments should not be pickled. Likely this means you '
+            'Pickling %s. qcodes Instruments should not be pickled. Likely this means you '
             'were trying to use a local instrument (defined with '
             'server_name=None) in a background Loop. Local instruments can '
-            'only be used in Loops with background=False.')
+            'only be used in Loops with background=False.' % self.name)
 
     def validate_status(self, verbose=False):
         """ Validate the values of all gettable parameters

--- a/qcodes/tests/data_mocks.py
+++ b/qcodes/tests/data_mocks.py
@@ -50,7 +50,7 @@ class RecordingMockFormatter:
         self.last_saved_indices = []
         self.write_metadata_calls = []
 
-    def write(self, data_set, io_manager, location):
+    def write(self, data_set, io_manager, location, force_write=False):
         self.write_calls.append((io_manager.base_location, location))
 
         self.modified_ranges.append({


### PR DESCRIPTION
- For the `write_copy` function the formatter should always write the data.
- Better debugging output for instruments being pickled

@unga @core
