### PR TITLE
Docs fix link to json shema

### DIFF
--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -25,7 +25,7 @@ Default config
 --------------
 The following  table explains the default configuration of qcodes.
 
-.. jsonschema:: ../qcodes/config/qcodesrc_schema.json
+.. jsonschema:: ../../qcodes/config/qcodesrc_schema.json
 
 
 Using the config


### PR DESCRIPTION
It should be relative to the location of the rst file, Currently missing here http://qcodes.github.io/Qcodes/user/configuration.html#default-config
