### PR TITLE
Make ATS instrument serializable

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -793,7 +793,8 @@ class AlazarParameter(Parameter):
                 # TODO(damazter) (S) test this validator
                 vals = validators.Enum(*byte_to_value_dict.values())
 
-        super().__init__(name=name, label=label, units=unit, vals=vals)
+        super().__init__(name=name, label=label, units=unit, vals=vals,
+                         instrument=instrument)
         self.instrument = instrument
         self._byte = None
         self._uptodate_flag = False


### PR DESCRIPTION
The AlazarParameter were non serializable because an explicit reference was stored.
The way that baseparameter works, now only the name is stored.

Fixes #503 

@giulioungaretti 
@jenshnielsen 
