### PR TITLE
fix: Remove obj ref from metadata

### DIFF
--- a/qcodes/instrument_drivers/devices.py
+++ b/qcodes/instrument_drivers/devices.py
@@ -68,7 +68,7 @@ class VoltageDivider(Parameter):
             metadata=self.v1.metadata)
 
         # extend metadata
-        self._meta_attrs.extend(['v1', 'division_value'])
+        self._meta_attrs.extend(["division_value"])
 
     def set(self, value: Union[int, float]) -> None:
         instrument_value = value * self.division_value


### PR DESCRIPTION
Else it would crash with the metadata as the instrument object  is made no pickable by the old multiprocessing madness. 