### PR TITLE
Fixes to AMI430 driver, write confirmation

### DIFF
--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -42,7 +42,8 @@ class AMI430(IPInstrument):
     def __init__(self, name, address, port, coil_constant, current_rating,
                  current_ramp_limit, persistent_switch=True,
                  reset=False, terminator='\r\n', **kwargs):
-        super().__init__(name, address, port, terminator=terminator, **kwargs)
+        super().__init__(name, address, port, terminator=terminator,
+                         write_confirmation=False, **kwargs)
 
         self._parent_instrument = None
 


### PR DESCRIPTION
pause not working suspected target is write_confirmation
By removing the write_confirmation, pausing the magnet now works.
The magnet does not seem to give a confirmation after a write

@giulioungaretti 
@Rubenknex 