### PR TITLE
ZI: clear history when reusing scope

### DIFF
--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -391,7 +391,7 @@ class Scope(MultiParameter):
             self._instrument.daq.sync()
 
             scope = self._instrument.scope # There are issues reusing the scope.
-
+            scope.set('scopeModule/clearhistory', 1)
             # Subscribe to the relevant... publisher?
             scope.subscribe('/{}/scopes/0/wave'.format(self._instrument.device))
 


### PR DESCRIPTION
The issue with changing number of segments seems to be that old data may be returned along with the new data. Clear data to ensure that this can not happen.
