### PR TITLE
Add locking to IVVI driver

### DIFF
--- a/qcodes/instrument_drivers/QuTech/IVVI.py
+++ b/qcodes/instrument_drivers/QuTech/IVVI.py
@@ -44,11 +44,16 @@ class IVVI(VisaInstrument):
             polarity (string[4]) : list of polarities of each set of 4 dacs
                                    choose from 'BIP', 'POS', 'NEG',
                                    default=['BIP', 'BIP', 'BIP', 'BIP']
-            dac_step (float)     : max step size for dac parameter
-            dac_delay (float)    : delay (in seconds) for dac
-            dac_max_delay (float): maximum delay before emitting a warning
-            safe_version (bool)  : if True then do not send version commands
-                                   to the IVVI controller
+            dac_step (float)         : max step size for dac parameter
+            dac_delay (float)        : delay (in seconds) for dac
+            dac_max_delay (float)    : maximum delay before emitting a warning
+            safe_version (bool)    : if True then do not send version commands
+                                     to the IVVI controller
+            use_locks (bool) : if True then locks are used in the `ask`
+                              function of the driver. The IVVI driver is not
+                              thread safe, this locking mechanism makes it
+                              thread safe at the cost of making the call to ask
+                              blocking.
         '''
         t0 = time.time()
         super().__init__(name, address, **kwargs)

--- a/qcodes/instrument_drivers/QuTech/IVVI.py
+++ b/qcodes/instrument_drivers/QuTech/IVVI.py
@@ -329,11 +329,6 @@ class IVVI(VisaInstrument):
         Raises an error if one occurred
         Returns a list of bytes
         '''
-        '''
-        Send <message> to the device and read answer.
-        Raises an error if one occurred
-        Returns a list of bytes
-        '''
         if self.lock:
             max_tries = 10
             for i in range(max_tries):

--- a/qcodes/instrument_drivers/QuTech/IVVI.py
+++ b/qcodes/instrument_drivers/QuTech/IVVI.py
@@ -32,7 +32,7 @@ class IVVI(VisaInstrument):
     def __init__(self, name, address, reset=False, numdacs=16, dac_step=10,
                  dac_delay=.1, dac_max_delay=0.2, safe_version=True,
                  polarity=['BIP', 'BIP', 'BIP', 'BIP'],
-                 use_locks = False, **kwargs):
+                 use_locks=False, **kwargs):
         '''
         Initialzes the IVVI, and communicates with the wrapper
 
@@ -116,10 +116,10 @@ class IVVI(VisaInstrument):
                            label='Dac voltages',
                            get_cmd=self._get_dacs)
 
-        #initialize pol_num, the voltage offset due to the polarity
+        # initialize pol_num, the voltage offset due to the polarity
         self.pol_num = np.zeros(self._numdacs)
-        for i in range(int(self._numdacs/4)):
-            self.set_pol_dacrack(polarity[i], np.arange(1+i*4,1+(i+1)*4),
+        for i in range(int(self._numdacs / 4)):
+            self.set_pol_dacrack(polarity[i], np.arange(1 + i * 4, 1 + (i + 1) * 4),
                                  get_all=False)
 
         for i in range(1, numdacs + 1):
@@ -129,8 +129,8 @@ class IVVI(VisaInstrument):
                 unit='mV',
                 get_cmd=self._gen_ch_get_func(self._get_dac, i),
                 set_cmd=self._gen_ch_set_func(self._set_dac, i),
-                vals=vals.Numbers(self.pol_num[i-1],
-                                  self.pol_num[i-1]+self.Fullrange),
+                vals=vals.Numbers(self.pol_num[i - 1],
+                                  self.pol_num[i - 1] + self.Fullrange),
                 step=dac_step,
                 delay=dac_delay,
                 max_delay=dac_max_delay,
@@ -186,7 +186,7 @@ class IVVI(VisaInstrument):
 
     def set_dacs_zero(self):
         for i in range(self._numdacs):
-            self.set('dac{}'.format(i+1),0)
+            self.set('dac{}'.format(i + 1), 0)
 
     # Conversion of data
     def _mvoltage_to_bytes(self, mvoltage):


### PR DESCRIPTION

Changes proposed in this pull request:
- Add locks to the IVVI driver

The locking is optional, so without enabling them the behaviour of the driver is unchanged. The locks are needed for safety of our systems (otherwise we could have set random values to the DACs).

@giulioungaretti @AdriaanRol @WilliamHPNielsen @jenshnielsen 
