### PR TITLE
feature: Signal Chain

### DIFF
--- a/docs/examples/Signal Chain Example.ipynb
+++ b/docs/examples/Signal Chain Example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import qcodes as qc\n",
     "from qcodes.instrument.parameter import StandardParameter\n",
-    "from qcodes.instrument.signalchain import addToSignalChain"
+    "from qcodes.instrument.signalchain import addToSignalChain, removeFromSignalChain"
    ]
   },
   {
@@ -71,11 +71,11 @@
      "output_type": "stream",
      "text": [
       "DataSet:\n",
-      "   location = 'data/2017-04-07/#001_testsweep_10-05-28'\n",
+      "   location = 'data/2017-04-07/#005_testsweep_10-40-42'\n",
       "   <Type>   | <array_id>      | <array.name> | <array.shape>\n",
       "   Setpoint | dac_voltage_set | voltage      | (21,)\n",
       "   Measured | dmm_voltage     | voltage      | (21,)\n",
-      "started at 2017-04-07 10:05:31\n"
+      "started at 2017-04-07 10:40:45\n"
      ]
     }
    ],
@@ -137,6 +137,32 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Value at target: 1.0484140107598805 (V)\n",
+      "Value at instrument: -0.284132921872809 (V)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# We can query the raw (instrument) value by using raw_get\n",
+    "\n",
+    "print('Value at target: {} ({})'.format(dmm.voltage(), dmm.voltage.unit))\n",
+    "print('Value at instrument: {} ({})'.format(dmm.voltage.raw_get(), dmm.voltage.unit))\n",
+    "\n",
+    "# NB: in this example, the random number generator makes these two numbers tricky to compare directly\n",
+    "# just execute this cell a few times and convince yourself that this is sane"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
     "collapsed": false,
     "scrolled": false
    },
@@ -146,11 +172,11 @@
      "output_type": "stream",
      "text": [
       "DataSet:\n",
-      "   location = 'data/2017-04-07/#002_testsweep_10-05-36'\n",
+      "   location = 'data/2017-04-07/#006_testsweep_10-40-57'\n",
       "   <Type>   | <array_id>      | <array.name> | <array.shape>\n",
       "   Setpoint | dac_voltage_set | voltage      | (21,)\n",
       "   Measured | dmm_voltage     | voltage      | (21,)\n",
-      "started at 2017-04-07 10:05:37\n"
+      "started at 2017-04-07 10:40:59\n"
      ]
     }
    ],
@@ -169,7 +195,7 @@
    "source": [
     "## Metadata\n",
     "\n",
-    "In the `snapshot.json` metadata, the sinhave the following entry:\n",
+    "In the `snapshot.json` metadata, the `dmm.voltage` parameter has the following entry:\n",
     "\n",
     "```\n",
     "        \"dmm_voltage\": {\n",
@@ -212,9 +238,91 @@
     "collapsed": true
    },
    "source": [
-    "## NB: \n",
+    "### Remove from signal chain\n",
     "\n",
-    "It is currently only possible to remove from the signal chain be restarting the notebook, but an update is coming soon."
+    "Elements can be removed from the signal chain by using `removeFromSignalChain`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('offset', 48), ('multiplier', 0.001), ('offset', 1)]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.voltage.signalchain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Enter the 1-indexed number of the element to remove, counting from the instrument.\n",
+    "# In our case, that means\n",
+    "\n",
+    "# removeFromSignalChain(dmm.voltage, 1)  # remove the offset of 48 \n",
+    "# removeFromSignalChain(dmm.voltage, 2)  # remover the multiplier of 0.001\n",
+    "removeFromSignalChain(dmm.voltage, 3)  # remove the offset of 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('offset', 48), ('multiplier', 0.001)]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.voltage.signalchain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.04904794618130652"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dmm.voltage()"
    ]
   },
   {

--- a/docs/examples/Signal Chain Example.ipynb
+++ b/docs/examples/Signal Chain Example.ipynb
@@ -1,0 +1,208 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Signal Chain in QCoDeS\n",
+    "\n",
+    "The purpose of the signal chain is to eventually make it possible to account for modifications made to the instrument output after the signal leaves the instrument, e.g. attenuation along the signal line.\n",
+    "\n",
+    "This notebook shows how to add a signal chain to a StandardParameter of a dummy instrument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import qcodes as qc\n",
+    "from qcodes.instrument.parameter import StandardParameter\n",
+    "from qcodes.instrument.signalchain import addToSignalChain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from qcodes.tests.instrument_mocks import DummyInstrument\n",
+    "import numpy as np\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Set up two dummy instruments and give them a parameter each\n",
+    "dac = DummyInstrument(name='dac')\n",
+    "dmm = DummyInstrument(name='dmm')\n",
+    "\n",
+    "dmm.add_parameter('voltage',\n",
+    "                  set_cmd=lambda x: x,\n",
+    "                  get_cmd=lambda : np.random.randn(),  # random return values for good looks\n",
+    "                  unit='V')\n",
+    "\n",
+    "\n",
+    "dac.add_parameter('voltage',\n",
+    "                  set_cmd=lambda x: x,\n",
+    "                  unit='V')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataSet:\n",
+      "   location = 'data/2017-04-06/#024_testsweep_15-55-01'\n",
+      "   <Type>   | <array_id>      | <array.name> | <array.shape>\n",
+      "   Setpoint | dac_voltage_set | voltage      | (21,)\n",
+      "   Measured | dmm_voltage     | voltage      | (21,)\n",
+      "started at 2017-04-06 15:55:02\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A loop of the 'dac' voltage whilst reading from the 'dmm' will return noise centred on zero with an std of 1\n",
+    "loop = qc.Loop(dac.voltage.sweep(0, 1, 0.05), delay=0.01).each(dmm.voltage)\n",
+    "data = loop.get_data_set(name='testsweep')\n",
+    "plot = qc.QtPlot()\n",
+    "plot.add(data.dmm_voltage)\n",
+    "_ = loop.with_bg_task(plot.update, plot.save).run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add to signal chain\n",
+    "\n",
+    "We now add an offset, a multiplier, and a second offset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "addToSignalChain(dmm.voltage, 'offset', 48)\n",
+    "addToSignalChain(dmm.voltage, 'multiplier', 1e-3)\n",
+    "addToSignalChain(dmm.voltage, 'offset', 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('offset', 48), ('multiplier', 0.001), ('offset', 1)]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# we can see the signal chain in the 'signalchain' attribute\n",
+    "dmm.voltage.signalchain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DataSet:\n",
+      "   location = 'data/2017-04-06/#025_testsweep_16-20-23'\n",
+      "   <Type>   | <array_id>      | <array.name> | <array.shape>\n",
+      "   Setpoint | dac_voltage_set | voltage      | (21,)\n",
+      "   Measured | dmm_voltage     | voltage      | (21,)\n",
+      "started at 2017-04-06 16:20:29\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Performing the same loop again will return noise centred on 1.048 with an std of 1e-3\n",
+    "loop = qc.Loop(dac.voltage.sweep(0, 1, 0.05), delay=0.01).each(dmm.voltage)\n",
+    "data = loop.get_data_set(name='testsweep')\n",
+    "plot = qc.QtPlot()\n",
+    "plot.add(data.dmm_voltage)\n",
+    "_ = loop.with_bg_task(plot.update, plot.save).run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "## NB: \n",
+    "\n",
+    "It is currently only possible to remove from the signal chain be restarting the notebook, but an update is coming soon."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/Signal Chain Example.ipynb
+++ b/docs/examples/Signal Chain Example.ipynb
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -71,11 +71,11 @@
      "output_type": "stream",
      "text": [
       "DataSet:\n",
-      "   location = 'data/2017-04-06/#024_testsweep_15-55-01'\n",
+      "   location = 'data/2017-04-07/#001_testsweep_10-05-28'\n",
       "   <Type>   | <array_id>      | <array.name> | <array.shape>\n",
       "   Setpoint | dac_voltage_set | voltage      | (21,)\n",
       "   Measured | dmm_voltage     | voltage      | (21,)\n",
-      "started at 2017-04-06 15:55:02\n"
+      "started at 2017-04-07 10:05:31\n"
      ]
     }
    ],
@@ -99,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -112,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -123,7 +123,7 @@
        "[('offset', 48), ('multiplier', 0.001), ('offset', 1)]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -135,7 +135,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false,
     "scrolled": false
@@ -146,11 +146,11 @@
      "output_type": "stream",
      "text": [
       "DataSet:\n",
-      "   location = 'data/2017-04-06/#025_testsweep_16-20-23'\n",
+      "   location = 'data/2017-04-07/#002_testsweep_10-05-36'\n",
       "   <Type>   | <array_id>      | <array.name> | <array.shape>\n",
       "   Setpoint | dac_voltage_set | voltage      | (21,)\n",
       "   Measured | dmm_voltage     | voltage      | (21,)\n",
-      "started at 2017-04-06 16:20:29\n"
+      "started at 2017-04-07 10:05:37\n"
      ]
     }
    ],
@@ -161,6 +161,49 @@
     "plot = qc.QtPlot()\n",
     "plot.add(data.dmm_voltage)\n",
     "_ = loop.with_bg_task(plot.update, plot.save).run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Metadata\n",
+    "\n",
+    "In the `snapshot.json` metadata, the sinhave the following entry:\n",
+    "\n",
+    "```\n",
+    "        \"dmm_voltage\": {\n",
+    "            \"__class__\": \"qcodes.data.data_array.DataArray\",\n",
+    "            \"action_indices\": [\n",
+    "                0\n",
+    "            ],\n",
+    "            \"array_id\": \"dmm_voltage\",\n",
+    "            \"instrument\": \"qcodes.tests.instrument_mocks.DummyInstrument\",\n",
+    "            \"instrument_name\": \"dmm\",\n",
+    "            \"is_setpoint\": false,\n",
+    "            \"label\": \"voltage\",\n",
+    "            \"name\": \"voltage\",\n",
+    "            \"shape\": [\n",
+    "                21\n",
+    "            ],\n",
+    "            \"signalchain\": [\n",
+    "                [\n",
+    "                    \"offset\",\n",
+    "                    48\n",
+    "                ],\n",
+    "                [\n",
+    "                    \"multiplier\",\n",
+    "                    0.001\n",
+    "                ],\n",
+    "                [\n",
+    "                    \"offset\",\n",
+    "                    1\n",
+    "                ]\n",
+    "            ],\n",
+    "            \"unit\": \"V\",\n",
+    "            \"vals\": \"<Numbers>\"\n",
+    "        }\n",
+    "```"
    ]
   },
   {

--- a/qcodes/instrument/signalchain.py
+++ b/qcodes/instrument/signalchain.py
@@ -15,6 +15,9 @@ def addToSignalChain(param, mapping, value):
         mapping (str): A string describing the mapping. Must be either
             'offset' or 'multiplier'.
         value (Union[float, int]): The numerical parameter of the mapping.
+
+    Raises:
+        NotImplementedError: If param is not a StandardParameter.
     """
 
     if not isinstance(param, StandardParameter):
@@ -31,7 +34,10 @@ def addToSignalChain(param, mapping, value):
     if not hasattr(param, 'signalchain'):
         param._meta_attrs.append('signalchain')
         param.signalchain = [(mapping, value)]
-        # TODO: save original/raw set/get
+
+        # The original (raw/instrument) set/get functions
+        param.raw_get = param._get
+        param.raw_set = param._set
     else:
         param.signalchain.append((mapping, value))
 

--- a/qcodes/instrument/signalchain.py
+++ b/qcodes/instrument/signalchain.py
@@ -1,0 +1,55 @@
+# A minimal implementation of the signal chain idea.
+# It is up to the user to ensure that the signal chain is applied to
+# parameters for which it makes sense to apply it.
+
+from qcodes.instrument.parameter import StandardParameter
+
+
+def addToSignalChain(param, mapping, value):
+    """
+    Add a mapping to the signalchain of a parameter.
+
+    Args:
+        param (StandardParameter): A QCoDeS StandardParameter. The signal
+            chain will probably not make sense for other things than voltages.
+        mapping (str): A string describing the mapping. Must be either
+            'offset' or 'multiplier'.
+        value (Union[float, int]): The numerical parameter of the mapping.
+    """
+
+    if not isinstance(param, StandardParameter):
+        raise NotImplementedError('Signal Chain only supports '
+                                  'StandardParameters. Recieved an instance '
+                                  'of {}.'.format(param.__class__))
+
+    maps = {'offset': {'get': lambda x, a: x + a,
+                       'set': lambda x, a: x - a},
+            'multiplier': {'get': lambda x, a: x * a,
+                           'set': lambda x, a: x / a}}
+
+    # set up a signal chain "inside" the parameter
+    if not hasattr(param, 'signalchain'):
+        param._meta_attrs.append('signalchain')
+        param.signalchain = [(mapping, value)]
+        # TODO: save original/raw set/get
+    else:
+        param.signalchain.append((mapping, value))
+
+    # Daisy-chain gets and sets
+
+    old_get = param._get
+    old_set = param._set
+
+    def new_get():
+        inst_val = old_get()
+        new_val = maps[mapping]['get'](inst_val, value)
+        param._save_val(new_val)  # will overwrite previous links in the chain
+        return new_val
+
+    def new_set(set_val):
+        new_val = maps[mapping]['set'](set_val, value)
+        param._save_val(new_val)  # will overwrite previous links in the chain
+        old_set(new_val)  # pipes value back through chain
+
+    param._get = new_get
+    param._set = new_set

--- a/qcodes/instrument/signalchain.py
+++ b/qcodes/instrument/signalchain.py
@@ -59,3 +59,37 @@ def addToSignalChain(param, mapping, value):
 
     param._get = new_get
     param._set = new_set
+
+
+def removeFromSignalChain(param, element_number):
+    """
+    Remove an element from the signal chain of a parameter.
+
+    Args:
+        param (StandardParameter): A QCoDeS StandardParameter with a signal
+            chain.
+        element_number (int): The (1-indexed) number of the element to remove,
+            counting from the instrument.
+    """
+
+    if not hasattr(param, 'signalchain'):
+        raise ValueError('{} has no assigned signalchain'.format(param))
+
+    if element_number > len(param.signalchain):
+        raise ValueError('Can not remove element {} '.format(element_number) +
+                         'from signal chain. Only contains '
+                         '{} elements'.format(len(param.signalchain)))
+
+    # remove the element by removing everything and then reapplying everything
+    # BUT the specific element
+
+    to_apply = param.signalchain.copy()
+    to_apply.remove(to_apply[element_number-1])
+
+    # reset the param to be "virgin"
+    del param.signalchain
+    param._meta_attrs.remove('signalchain')
+
+    # and reapply the chain
+    for (mapping, value) in to_apply:
+        addToSignalChain(param, mapping, value)

--- a/qcodes/instrument/signalchain.py
+++ b/qcodes/instrument/signalchain.py
@@ -89,6 +89,8 @@ def removeFromSignalChain(param, element_number):
     # reset the param to be "virgin"
     del param.signalchain
     param._meta_attrs.remove('signalchain')
+    param._get = param.raw_get
+    param._set = param.raw_set
 
     # and reapply the chain
     for (mapping, value) in to_apply:


### PR DESCRIPTION
It is considered useful to be able to absorb passive elements along a transmission line such as attenuators into a QCoDeS parameter. This PR enables a minimal version of that functionality. We call it a "signal chain" to mimic the notion of a voltage propagating through INSTRUMENT -> ATTENUATOR -> OFFSET -> SAMPLE.  One is usually interested in setting the voltage on SAMPLE directly from the instrument parameter.

Add a signal chain for StandardParameters and a notebook on using them.

Still pending
- [x] Make signal chain elements removable
- [ ] Add more than an offset and a scale factor?

@giulioungaretti 
