### PR TITLE
fix: Triton: Don't read existing channel

### DIFF
--- a/qcodes/instrument_drivers/oxford/triton.py
+++ b/qcodes/instrument_drivers/oxford/triton.py
@@ -5,7 +5,7 @@ import logging
 from traceback import format_exc
 
 from qcodes import IPInstrument
-from qcodes.utils.validators import Enum
+from qcodes.utils.validators import Enum, Ints
 
 
 class Triton(IPInstrument):
@@ -53,7 +53,8 @@ class Triton(IPInstrument):
         self.add_parameter(name='pid_control_channel',
                            label='PID control channel',
                            get_cmd=self._get_control_channel,
-                           set_cmd=self._set_control_channel)
+                           set_cmd=self._set_control_channel,
+                           vals=Ints(1,16))
 
         self.add_parameter(name='pid_mode',
                            label='PID Mode',

--- a/qcodes/instrument_drivers/oxford/triton.py
+++ b/qcodes/instrument_drivers/oxford/triton.py
@@ -136,8 +136,7 @@ class Triton(IPInstrument):
 
     def _set_control_channel(self, channel):
         self._control_channel = channel
-        self.write('SET:DEV:T%s:TEMP:LOOP:HTR:H1' %
-                   self._get_control_channel())
+        self.write('SET:DEV:T{}:TEMP:LOOP:HTR:H1'.format(channel))
 
     def _get_control_param(self, param):
         chan = self._get_control_channel()

--- a/qcodes/instrument_drivers/oxford/triton.py
+++ b/qcodes/instrument_drivers/oxford/triton.py
@@ -139,6 +139,7 @@ class Triton(IPInstrument):
             tempval = self.ask('READ:DEV:T{}:TEMP:LOOP:MODE'.format(i))
             if not tempval.endswith('NOT_FOUND'):
                 self._control_channel = i
+                break
 
         return self._control_channel
 

--- a/qcodes/instrument_drivers/oxford/triton.py
+++ b/qcodes/instrument_drivers/oxford/triton.py
@@ -126,12 +126,19 @@ class Triton(IPInstrument):
 
         return dict(zip(('vendor', 'model', 'serial', 'firmware'), idparts))
 
-    def _get_control_channel(self, force_get=True):
-        if force_get or (not self._control_channel):
-            for i in range(1,17):
-                tempval = self.ask('READ:DEV:T%s:TEMP:LOOP:MODE' % (i))
-                if not tempval.endswith('NOT_FOUND'):
-                    self._control_channel = i
+    def _get_control_channel(self):
+
+        # verify current channel
+        if self._control_channel:
+            tempval = self.ask('READ:DEV:T{}:TEMP:LOOP:MODE'.format(self._control_channel))
+            if not tempval.endswith('NOT_FOUND'):
+                return self._control_channel
+
+        # either _control_channel is not set or wrong
+        for i in range(1,17):
+            tempval = self.ask('READ:DEV:T{}:TEMP:LOOP:MODE'.format(i))
+            if not tempval.endswith('NOT_FOUND'):
+                self._control_channel = i
 
         return self._control_channel
 

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -134,7 +134,7 @@ class Strings(Validator):
 class Numbers(Validator):
     """
     Args:
-        min_value (Optional[Union[float, int]):  Min value allowed, default inf
+        min_value (Optional[Union[float, int]):  Min value allowed, default -inf
         max_value:  (Optional[Union[float, int]): Max  value allowed, default inf
 
     Raises:


### PR DESCRIPTION
@MerlinSmiles  As far as I can see this call to `_get_control_channel` would always return the previous channel (since force defaults to True now) We can either do like this or explicitly call `_get_control_channel`  with `Force=False` Does this make sense to you? 