### PR TITLE
Small tweaks to docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,14 @@ script:
 
 after_success:
     # install dependencies for docs build
-    - pip install -r docs_requirements.txt
+    - pip install -r ../docs_requirements.txt
     - python-codacy-coverage -r coverage.xml
     - cd ..
     # build the docs
-    - make -f docs/Makefile gh-pages
+    - |
+      if [[ $TRAVIS_REPO_SLUG == "qcodes/qcodes" && $TRAVIS_BRANCH == 'master' ]]; then
+        make -f docs/Makefile gh-pages
+      else
+        cd docs
+        make html-api
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 install:
     - pip install --upgrade pip
     - pip install -r requirements.txt
-    - pip install coverage pytest-cov pytest --upgrade
+    - pip install -r test_requirements.txt --upgrade
     - pip install -e .
 # command to run tests
 script:
@@ -36,8 +36,8 @@ script:
     - py.test --cov=qcodes --cov-report xml --cov-config=.coveragerc
 
 after_success:
-    # install codacy coverage plugin and sphinx only on traivs
-    - pip install codacy-coverage sphinx sphinx_rtd_theme jsonschema sphinxcontrib-jsonschema
+    # install dependencies for docs build
+    - pip install -r docs_requirements.txt
     - python-codacy-coverage -r coverage.xml
     - cd ..
     # build the docs

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx_rtd_theme
+jsonschema
+sphinxcontrib-jsonschema

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,4 @@
+coverage
+pytest-cov
+pytest
+codacy-coverage


### PR DESCRIPTION
* Split dependencies out from travis file so they are easier to install locally
* When building from a pr build the actual pr docs rather than the master docs so we can verify these from the travis logs 