### PR TITLE
feat: parameter snapshot_value (recreated)

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -97,11 +97,13 @@ class _BaseParameter(Metadatable, DeferredOperations):
         metadata (Optional[dict]): extra information to include with the
             JSON snapshot of the parameter
     """
-    def __init__(self, name, instrument, snapshot_get, metadata):
+    def __init__(self, name, instrument, snapshot_get, metadata,
+                 snapshot_value=True):
         super().__init__(metadata)
         self._snapshot_get = snapshot_get
         self.name = str(name)
         self._instrument = instrument
+        self._snapshot_value = snapshot_value
 
         self.has_get = hasattr(self, 'get')
         self.has_set = hasattr(self, 'set')
@@ -182,11 +184,15 @@ class _BaseParameter(Metadatable, DeferredOperations):
             dict: base snapshot
         """
 
-        if self.has_get and self._snapshot_get and update:
+        if self.has_get and self._snapshot_get and self._snapshot_value and \
+                update:
             self.get()
 
         state = self._latest()
         state['__class__'] = full_class(self)
+
+        if not self._snapshot_value:
+            state.pop('value')
 
         if isinstance(state['ts'], datetime):
             state['ts'] = state['ts'].strftime('%Y-%m-%d %H:%M:%S')
@@ -277,8 +283,9 @@ class Parameter(_BaseParameter):
     """
     def __init__(self, name, instrument=None, label=None,
                  unit=None, units=None, vals=None, docstring=None,
-                 snapshot_get=True, metadata=None):
-        super().__init__(name, instrument, snapshot_get, metadata)
+                 snapshot_get=True, snapshot_value=True, metadata=None):
+        super().__init__(name, instrument, snapshot_get, metadata,
+                         snapshot_value=snapshot_value)
 
         self._meta_attrs.extend(['label', 'unit', '_vals'])
 
@@ -451,8 +458,10 @@ class ArrayParameter(_BaseParameter):
     def __init__(self, name, shape, instrument=None,
                  label=None, unit=None, units=None,
                  setpoints=None, setpoint_names=None, setpoint_labels=None,
-                 setpoint_units=None, docstring=None, snapshot_get=True, metadata=None):
-        super().__init__(name, instrument, snapshot_get, metadata)
+                 setpoint_units=None, docstring=None,
+                 snapshot_get=True, snapshot_value=True, metadata=None):
+        super().__init__(name, instrument, snapshot_get, metadata,
+                         snapshot_value=snapshot_value)
 
         if self.has_set:  # TODO (alexcjohnson): can we support, ala Combine?
             raise AttributeError('ArrayParameters do not support set '
@@ -616,9 +625,10 @@ class MultiParameter(_BaseParameter):
     def __init__(self, name, names, shapes, instrument=None,
                  labels=None, units=None,
                  setpoints=None, setpoint_names=None, setpoint_labels=None,
-                 setpoint_units=None,
-                 docstring=None, snapshot_get=True, metadata=None):
-        super().__init__(name, instrument, snapshot_get, metadata)
+                 setpoint_units=None, docstring=None,
+                 snapshot_get=True, snapshot_value=True, metadata=None):
+        super().__init__(name, instrument, snapshot_get, metadata,
+                         snapshot_value=snapshot_value)
 
         if self.has_set:  # TODO (alexcjohnson): can we support, ala Combine?
             warnings.warn('MultiParameters do not fully support set '

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -95,16 +95,16 @@ class TestInstrument(TestCase):
                              Instrument.find_instrument(instrument.name))
 
     def test_snapshot_value(self):
-        self.source.add_parameter('has_snapshot_value',
-                            parameter_class=ManualParameter,
-                            initial_value=42,
-                            snapshot_value=True)
-        self.source.add_parameter('no_snapshot_value',
-                            parameter_class=ManualParameter,
-                            initial_value=42,
-                            snapshot_value=False)
+        self.instrument.add_parameter('has_snapshot_value',
+                                      parameter_class=ManualParameter,
+                                      initial_value=42,
+                                      snapshot_value=True)
+        self.instrument.add_parameter('no_snapshot_value',
+                                      parameter_class=ManualParameter,
+                                      initial_value=42,
+                                      snapshot_value=False)
 
-        snapshot = self.source.snapshot()
+        snapshot = self.instrument.snapshot()
 
         self.assertIn('value', snapshot['parameters']['has_snapshot_value'])
         self.assertEquals(42,

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -93,3 +93,20 @@ class TestInstrument(TestCase):
             # check that we can find this instrument from the base class
             self.assertEqual(instrument,
                              Instrument.find_instrument(instrument.name))
+
+    def test_snapshot_value(self):
+        self.source.add_parameter('has_snapshot_value',
+                            parameter_class=ManualParameter,
+                            initial_value=42,
+                            snapshot_value=True)
+        self.source.add_parameter('no_snapshot_value',
+                            parameter_class=ManualParameter,
+                            initial_value=42,
+                            snapshot_value=False)
+
+        snapshot = self.source.snapshot()
+
+        self.assertIn('value', snapshot['parameters']['has_snapshot_value'])
+        self.assertEquals(42,
+                          snapshot['parameters']['has_snapshot_value']['value'])
+        self.assertNotIn('value', snapshot['parameters']['no_snapshot_value'])


### PR DESCRIPTION
Note that this PR replaces #325 because the older branch disappeared

If a parameter contains a large amount of data, such as a trace acquisition parameter, it is often undesirable to save a full trace of data when creating a snapshot. Therefore I have added a snapshot_value kwarg to the Parameter init that can remove the parameter's 'value' from a snapshot.

Note that this is not achieved when providing the kwarg snapshot_get=False, since this only stops the parameter from performing a get when a snapshot is created.

Changes proposed in this pull request:

Add snapshot_value to the Parameter init kwargs.
If param.snapshot() is called, and param._snapshot_value==False, remove 'value' from the state dictionary.
If param.snapshot() is called and snapshot_value==False, do not perform a param.get() command, even if snapshot_get==True (since the value is not added to the snapshot).
Small update to the snapshot_get description