### PR TITLE
Fix: Handle 2d subplot arrays from pyplot.subplots

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -53,12 +53,16 @@ class MatPlot(BasePlot):
 
         if isinstance(subplots, Mapping):
             self.fig, self.subplots = plt.subplots(figsize=figsize, num=num,
-                                                   **subplots)
+                                                   **subplots, squeeze=False)
         else:
             self.fig, self.subplots = plt.subplots(*subplots, num=num,
-                                                   figsize=figsize)
-        if not hasattr(self.subplots, '__len__'):
-            self.subplots = (self.subplots,)
+                                                   figsize=figsize, squeeze=False)
+
+        # squeeze=False ensures that subplots is always a 2D array independent of the number
+        # of subplots.
+        # However the qcodes api assumes that subplots is always a 1D array
+        # so flatten here
+        self.subplots = self.subplots.flatten()
 
         self.title = self.fig.suptitle('')
 


### PR DESCRIPTION
Fixes #609.

The add plot api assumes that `self.subplots` is always a 1d array, However the array returned from `plt.subplots` dimensionality depends of the number of subplots (unless squeeze=False) The code correctly handled the 1d case but not the 2d. This should handle all 3 cases