### PR TITLE
docs: Give TPS2012 example a headline

### DIFF
--- a/docs/examples/driver_examples/Qcodes example with TPS2012.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with TPS2012.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# QCoDeS Example with Tektronix TPS2012"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {


### PR DESCRIPTION
Make the headers in the TPS2012 example notebook more uniform.

Changes proposed in this pull request:
- Add a headline to the example notebook. This should make the autgenerated docs more readable.

@jenshnielsen 
