### PR TITLE
AssertEquals has long been deprecated and replaced by AssertEqual

### DIFF
--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -107,6 +107,6 @@ class TestInstrument(TestCase):
         snapshot = self.instrument.snapshot()
 
         self.assertIn('value', snapshot['parameters']['has_snapshot_value'])
-        self.assertEquals(42,
-                          snapshot['parameters']['has_snapshot_value']['value'])
+        self.assertEqual(42,
+                         snapshot['parameters']['has_snapshot_value']['value'])
         self.assertNotIn('value', snapshot['parameters']['no_snapshot_value'])


### PR DESCRIPTION
New versions of pytest (3.1) prints warnings per default so this allows us to get rid of some output 
from the test runner 

```
================================================================================================================ warnings summary ================================================================================================================
qcodes/tests/test_instrument.py::TestInstrument::test_snapshot_value
  /Users/jhn/src/Qcodes/qcodes/tests/test_instrument.py:111: DeprecationWarning: Please use assertEqual instead.
    snapshot['parameters']['has_snapshot_value']['value'])

-- Docs: http://doc.pytest.org/en/latest/warnings.html
```