### PR TITLE
Fix: make voltage divider take an instrument

### DIFF
--- a/qcodes/instrument_drivers/devices.py
+++ b/qcodes/instrument_drivers/devices.py
@@ -61,7 +61,7 @@ class VoltageDivider(Parameter):
         else:
             self.name = "{}_attenuated".format(self.v1.name)
         if not instrument:
-            getattr(self.v1, "_instrument", None)
+            instrument = getattr(self.v1, "_instrument", None)
         super().__init__(
             name=self.name,
             instrument=instrument,

--- a/qcodes/instrument_drivers/devices.py
+++ b/qcodes/instrument_drivers/devices.py
@@ -1,6 +1,6 @@
 from typing import Union
 
-from qcodes import Parameter, StandardParameter
+from qcodes import Parameter, StandardParameter, Instrument
 
 
 class VoltageDivider(Parameter):
@@ -47,7 +47,8 @@ class VoltageDivider(Parameter):
                  v1: StandardParameter,
                  division_value: Union[int, float],
                  name: str=None,
-                 label: str=None) -> None:
+                 label: str=None,
+                 instrument: Union[None, Instrument]=None) -> None:
         self.v1 = v1
         self.division_value = division_value
         if label:
@@ -59,10 +60,11 @@ class VoltageDivider(Parameter):
             self.name = name
         else:
             self.name = "{}_attenuated".format(self.v1.name)
-
+        if not instrument:
+            getattr(self.v1, "_instrument", None)
         super().__init__(
             name=self.name,
-            instrument=getattr(self.v1, "_instrument", None),
+            instrument=instrument,
             label=self.label,
             unit=self.v1.unit,
             metadata=self.v1.metadata)


### PR DESCRIPTION
This makes it possible to add a voltage divider to an instrument (subclass)
with `add_parameter` and then get snapshotted correctly as in 

```
class DUMMYDACVD(DummyInstrument):
    """
    A DummyDac with a voltage divider
    """
    def __init__(self, name, gates, **kwargs):
        super().__init__(name, gates, **kwargs)

        # Define the named channels

        topo_channel = self.parameters['ch1']

        self.add_parameter('topo_bias',
                           parameter_class=VoltageDivider,
                           v1=topo_channel,
                           division_value=10)

```
which includes the VoltageDivider in the snapshot of the instrument
rather than the current pattern on t10

```
class DUMMYDACVD(DummyInstrument):
    """
    A DummyDac with a voltage divider
    """
    def __init__(self, name, gates, **kwargs):
        super().__init__(name, gates, **kwargs)

        # Define the named channels

        topo_channel = self.parameters['ch1']

        self.topo_bias = VoltageDivider(v1=topo_channel, division_value=10)

```
which does not automatically snapshot the voltage divider
