### PR TITLE
perf: Improve Tektronix_AWG5014 performance

### DIFF
--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -1432,7 +1432,7 @@ class Tektronix_AWG5014(VisaInstrument):
         if not np.all(np.in1d(m1, np.array([0, 1]))):
             raise TypeError('Marker 1 contains invalid values.' +
                             ' Only 0 and 1 are allowed')
-        if not np.all(np.in1d(m1, np.array([0, 1]))):
+        if not np.all(np.in1d(m2, np.array([0, 1]))):
             raise TypeError('Marker 2 contains invalid values.' +
                             ' Only 0 and 1 are allowed')
 

--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -1426,13 +1426,13 @@ class Tektronix_AWG5014(VisaInstrument):
         # Input validation
         if (not((len(wf) == len(m1)) and ((len(m1) == len(m2))))):
             raise Exception('error: sizes of the waveforms do not match')
-        if min(wf) < -1 or max(wf) > 1:
+        if np.min(wf) < -1 or np.max(wf) > 1:
             raise TypeError('Waveform values out of bonds.' +
                             ' Allowed values: -1 to 1 (inclusive)')
-        if (list(m1).count(0)+list(m1).count(1)) != len(m1):
+        if not np.all(np.in1d(m1, np.array([0, 1]))):
             raise TypeError('Marker 1 contains invalid values.' +
                             ' Only 0 and 1 are allowed')
-        if (list(m2).count(0)+list(m2).count(1)) != len(m2):
+        if not np.all(np.in1d(m1, np.array([0, 1]))):
             raise TypeError('Marker 2 contains invalid values.' +
                             ' Only 0 and 1 are allowed')
 


### PR DESCRIPTION
`pack_waveform` in `Tektronix_AWG5014` uses Python native functions like `min`, `max` and `count`,
which are slow compared to the numpy alternatives. This update replaces the Python function calls
with numpy alternatives considerably improving the speed of programming the Tektronix AWG5014
while leaving the functionality the same.

As an example, on my machine:
```
> data = np.random.choice([0, 1], 10000)

> %timeit list(data).count(0) + list(data).count(1) == len(data)
100 loops, best of 3: 5.23 ms per loop

> %timeit np.all(np.in1d(data, np.array([0, 1])))
The slowest run took 9.76 times longer than the fastest. This could mean that an intermediate result is being cached.
10000 loops, best of 3: 70.3 µs per loop
```

Changes proposed in this pull request:
- Change native Python functions in `Tektronix_AWG5014.pack_waveform` to numpy versions.

@giulioungaretti 
