### PR TITLE
Pyqtgraph automatically store ref to the last 100 plots (configurable)

### DIFF
--- a/qcodes/config/qcodesrc.json
+++ b/qcodes/config/qcodesrc.json
@@ -5,7 +5,8 @@
     },
     "gui" :{
         "notebook": true,
-        "plotlib": "matplotlib"
+        "plotlib": "matplotlib",
+        "pyqtmaxplots": 100
     },
     "user": {}
 }

--- a/qcodes/config/qcodesrc_schema.json
+++ b/qcodes/config/qcodesrc_schema.json
@@ -41,9 +41,14 @@
                     "type": "string",
                     "enum": ["QT", "matplotlib" ],
                     "default": "matplotlib"
+                },
+                "pyqtmaxplots": {
+                    "description": "Maximum number of PyQtPlots to automatically keep in memory",
+                    "type": "integer",
+                    "default": 100
                 }
             },
-            "required":[ "notebook", "plotlib" ]
+            "required":[ "notebook", "plotlib", "pyqtmaxplots" ]
         },
         "user":{
             "type" : "object",

--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -10,7 +10,7 @@ from collections import namedtuple, deque
 
 from .base import BasePlot
 from .colors import color_cycle, colorscales
-
+import qcodes.config
 
 TransformState = namedtuple('TransformState', 'translate scale revisit')
 
@@ -46,7 +46,7 @@ class QtPlot(BasePlot):
     # close event on win but this is difficult with remote proxy process
     # as the list of plots lives in the main process and the plot locally
     # in a remote process
-    plots = deque(maxlen=100)
+    plots = deque(maxlen=qcodes.config['gui']['pyqtmaxplots'])
 
     def __init__(self, *args, figsize=(1000, 600), interval=0.25,
                  window_title='', theme=((60, 60, 60), 'w'), show_window=True, remote=True, **kwargs):

--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -7,6 +7,7 @@ import pyqtgraph.multiprocess as pgmp
 from pyqtgraph.multiprocess.remoteproxy import ClosedError
 import warnings
 from collections import namedtuple
+import uuid
 
 from .base import BasePlot
 from .colors import color_cycle, colorscales
@@ -38,6 +39,7 @@ class QtPlot(BasePlot):
     """
     proc = None
     rpg = None
+    plots = {}
 
     def __init__(self, *args, figsize=(1000, 600), interval=0.25,
                  window_title='', theme=((60, 60, 60), 'w'), show_window=True, remote=True, **kwargs):
@@ -75,6 +77,17 @@ class QtPlot(BasePlot):
 
         if not show_window:
             self.win.hide()
+        self._id = uuid.uuid1()
+        self.plots[self._id] = self
+        self.win.closeEvent = self.mycloseEvent
+
+    def mycloseEvent(self, event):
+        try:
+            self.plots.pop(self._id)
+        except KeyError as e:
+            print("failed to remove plot")
+            print(e)
+            print(self.plots)
 
     @classmethod
     def _init_qt(cls):


### PR DESCRIPTION
Fixes #647 

Currently pyqt graph plots may close spontaneously if you don't keep a reference to the plot around. This creates a deque as a Class parameter in QtPlot that automatically keeps the last n (default 100) plots in reference. The number of plots to keep can be configured. In my tests 100 plots of a (100,100) heatmap is roughly 1 GB of memory so this should be safe enough

Currently on top of #661 so that should be merged first
@QCoDeS/core 
