### PR TITLE
Correctly count number of actions when updating combined measurements

### DIFF
--- a/qcodes/tests/test_combined_loop.py
+++ b/qcodes/tests/test_combined_loop.py
@@ -17,6 +17,12 @@ class TestLoopCombined(TestCase):
 
         cls.dmm.somethingelse.get = lambda: 1
 
+    @classmethod
+    def tearDownClass(cls):
+        cls.dac.close()
+        cls.dmm.close()
+        del cls.dac
+        del cls.dmm
 
     @given(npoints=hst.integers(2, 100),
            x_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),

--- a/qcodes/tests/test_combined_loop.py
+++ b/qcodes/tests/test_combined_loop.py
@@ -1,0 +1,190 @@
+from unittest import TestCase
+import numpy as np
+from unittest.mock import patch
+from hypothesis import given, settings
+import hypothesis.strategies as hst
+
+
+from .instrument_mocks import DummyInstrument
+from qcodes.instrument.parameter import combine
+from qcodes import Task, Loop
+
+class TestLoopCombined(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dac = DummyInstrument(name="dac", gates=['X', 'Y', 'Z'])
+        cls.dmm = DummyInstrument(name="dmm", gates=['voltage', 'somethingelse'])
+
+        cls.dmm.somethingelse.get = lambda: 1
+
+
+    @given(npoints=hst.integers(2, 100),
+           x_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted),
+           y_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted),
+           z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted))
+    @settings(max_examples=20)
+    def testLoopCombinedParameterPrintTask(self, npoints, x_start_stop, y_start_stop, z_start_stop):
+
+        x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints)
+        y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints)
+        z_set = np.linspace(z_start_stop[0], z_start_stop[1], npoints)
+        setpoints = np.hstack((x_set.reshape(npoints, 1),
+                               y_set.reshape(npoints, 1),
+                               z_set.reshape(npoints, 1)))
+
+        sweep_values = combine(self.dac.X, self.dac.Y, self.dac.Z,
+                               name="combined").sweep(setpoints)
+        def ataskfunc():
+            a = 1+1
+
+        def btaskfunc():
+            b = 1+2
+
+        atask = Task(ataskfunc)
+        btask = Task(btaskfunc)
+
+        loop = Loop(sweep_values).each(atask, btask)
+        data = loop.run(quiet=True)
+        np.testing.assert_array_equal(data.arrays['dac_X'].ndarray, x_set)
+        np.testing.assert_array_equal(data.arrays['dac_Y'].ndarray, y_set)
+        np.testing.assert_array_equal(data.arrays['dac_Z'].ndarray, z_set)
+
+    @given(npoints=hst.integers(2, 100),
+           x_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted),
+           y_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted),
+           z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted))
+    @settings(max_examples=20)
+    def testLoopCombinedParameterTwice(self, npoints, x_start_stop, y_start_stop, z_start_stop):
+        x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints)
+        y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints)
+        z_set = np.linspace(z_start_stop[0], z_start_stop[1], npoints)
+        setpoints = np.hstack((x_set.reshape(npoints, 1),
+                               y_set.reshape(npoints, 1),
+                               z_set.reshape(npoints, 1)))
+
+        sweep_values = combine(self.dac.X, self.dac.Y, self.dac.Z,
+                               name="combined").sweep(setpoints)
+
+        def wrapper():
+            counter = 0
+
+            def inner():
+                nonlocal counter
+                counter += 1
+                return counter
+
+            return inner
+
+        self.dmm.voltage.get = wrapper()
+        loop = Loop(sweep_values).each(self.dmm.voltage, self.dmm.voltage)
+        data = loop.run(quiet=True)
+        np.testing.assert_array_equal(data.arrays['dac_X'].ndarray, x_set)
+        np.testing.assert_array_equal(data.arrays['dac_Y'].ndarray, y_set)
+        np.testing.assert_array_equal(data.arrays['dac_Z'].ndarray, z_set)
+        np.testing.assert_array_equal(data.arrays['dmm_voltage_0'].ndarray, np.arange(1, npoints*2, 2))
+        np.testing.assert_array_equal(data.arrays['dmm_voltage_1'].ndarray, np.arange(2, npoints*2+1, 2))
+
+    @given(npoints=hst.integers(2, 100),
+           x_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted),
+           y_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted),
+           z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted))
+    @settings(max_examples=20)
+    def testLoopCombinedParameterAndMore(self, npoints, x_start_stop, y_start_stop, z_start_stop):
+        x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints)
+        y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints)
+        z_set = np.linspace(z_start_stop[0], z_start_stop[1], npoints)
+        setpoints = np.hstack((x_set.reshape(npoints, 1),
+                               y_set.reshape(npoints, 1),
+                               z_set.reshape(npoints, 1)))
+
+        sweep_values = combine(self.dac.X, self.dac.Y, self.dac.Z,
+                               name="combined").sweep(setpoints)
+
+        def wrapper():
+            counter = 0
+
+            def inner():
+                nonlocal counter
+                counter += 1
+                return counter
+
+            return inner
+
+        self.dmm.voltage.get = wrapper()
+        loop = Loop(sweep_values).each(self.dmm.voltage, self.dmm.somethingelse, self.dmm.voltage)
+        data = loop.run(quiet=True)
+        np.testing.assert_array_equal(data.arrays['dac_X'].ndarray, x_set)
+        np.testing.assert_array_equal(data.arrays['dac_Y'].ndarray, y_set)
+        np.testing.assert_array_equal(data.arrays['dac_Z'].ndarray, z_set)
+        np.testing.assert_array_equal(data.arrays['dmm_voltage_0'].ndarray, np.arange(1, npoints * 2, 2))
+        np.testing.assert_array_equal(data.arrays['dmm_somethingelse'].ndarray, np.ones(npoints))
+        np.testing.assert_array_equal(data.arrays['dmm_voltage_2'].ndarray, np.arange(2, npoints * 2 + 1, 2))
+
+    @given(npoints=hst.integers(2, 100),
+           npoints_outer=hst.integers(2,100),
+           x_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted),
+           y_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted),
+           z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
+                                  min_size=2, max_size=2, unique=True).map(sorted))
+    @settings(max_examples=20)
+    def testLoopCombinedParameterInside(self, npoints, npoints_outer, x_start_stop, y_start_stop, z_start_stop):
+        x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints_outer)
+        y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints)
+        z_set = np.linspace(z_start_stop[0], z_start_stop[1], npoints)
+        setpoints = np.hstack((y_set.reshape(npoints, 1),
+                               z_set.reshape(npoints, 1)))
+
+        sweep_values = combine(self.dac.Y, self.dac.Z,
+                               name="combined").sweep(setpoints)
+
+        def ataskfunc():
+            a = 1+1
+
+        def btaskfunc():
+            b = 1+2
+
+        atask = Task(ataskfunc)
+        btask = Task(btaskfunc)
+
+
+        def wrapper():
+            counter = 0
+
+            def inner():
+                nonlocal counter
+                counter += 1
+                return counter
+
+            return inner
+
+        self.dmm.voltage.get = wrapper()
+        loop = Loop(self.dac.X.sweep(x_start_stop[0],
+                                     x_start_stop[1],
+                                     num=npoints_outer)).loop(sweep_values).each(self.dmm.voltage,
+                                                                                 atask,
+                                                                                 self.dmm.somethingelse,
+                                                                                 self.dmm.voltage,
+                                                                                 btask)
+        data = loop.run(quiet=True)
+        np.testing.assert_array_equal(data.arrays['dac_X_set'].ndarray, x_set)
+        np.testing.assert_array_equal(data.arrays['dac_Y'].ndarray,
+                                      np.repeat(y_set.reshape(1,npoints), npoints_outer, axis=0))
+        np.testing.assert_array_equal(data.arrays['dac_Z'].ndarray,
+                                      np.repeat(z_set.reshape(1, npoints), npoints_outer, axis=0))
+
+        np.testing.assert_array_equal(data.arrays['dmm_voltage_0'].ndarray,
+                                      np.arange(1, npoints * npoints_outer* 2, 2).reshape(npoints_outer, npoints))
+        np.testing.assert_array_equal(data.arrays['dmm_voltage_3'].ndarray,
+                                      np.arange(2, npoints * npoints_outer* 2 + 1, 2).reshape(npoints_outer, npoints))
+        np.testing.assert_array_equal(data.arrays['dmm_somethingelse'].ndarray, np.ones((npoints_outer, npoints)))

--- a/qcodes/tests/test_combined_loop.py
+++ b/qcodes/tests/test_combined_loop.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 import numpy as np
-from unittest.mock import patch
 from hypothesis import given, settings
 import hypothesis.strategies as hst
 
@@ -8,20 +7,18 @@ import hypothesis.strategies as hst
 from .instrument_mocks import DummyInstrument
 from qcodes.instrument.parameter import combine
 from qcodes import Task, Loop
+from qcodes.instrument.parameter import ManualParameter
+
 
 class TestLoopCombined(TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.dac = DummyInstrument(name="dac", gates=['X', 'Y', 'Z'])
         cls.dmm = DummyInstrument(name="dmm", gates=['voltage', 'somethingelse'])
-
         cls.dmm.somethingelse.get = lambda: 1
 
     @classmethod
     def tearDownClass(cls):
-        cls.dac.close()
         cls.dmm.close()
-        del cls.dac
         del cls.dmm
 
     @given(npoints=hst.integers(2, 100),
@@ -31,7 +28,7 @@ class TestLoopCombined(TestCase):
                                   min_size=2, max_size=2, unique=True).map(sorted),
            z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
                                   min_size=2, max_size=2, unique=True).map(sorted))
-    @settings(max_examples=20)
+    @settings(max_examples=10)
     def testLoopCombinedParameterPrintTask(self, npoints, x_start_stop, y_start_stop, z_start_stop):
 
         x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints)
@@ -41,7 +38,9 @@ class TestLoopCombined(TestCase):
                                y_set.reshape(npoints, 1),
                                z_set.reshape(npoints, 1)))
 
-        sweep_values = combine(self.dac.X, self.dac.Y, self.dac.Z,
+        parameters = [ManualParameter(name) for name in ["X", "Y", "Z"]]
+
+        sweep_values = combine(*parameters,
                                name="combined").sweep(setpoints)
         def ataskfunc():
             a = 1+1
@@ -54,9 +53,9 @@ class TestLoopCombined(TestCase):
 
         loop = Loop(sweep_values).each(atask, btask)
         data = loop.run(quiet=True)
-        np.testing.assert_array_equal(data.arrays['dac_X'].ndarray, x_set)
-        np.testing.assert_array_equal(data.arrays['dac_Y'].ndarray, y_set)
-        np.testing.assert_array_equal(data.arrays['dac_Z'].ndarray, z_set)
+        np.testing.assert_array_equal(data.arrays['X'].ndarray, x_set)
+        np.testing.assert_array_equal(data.arrays['Y'].ndarray, y_set)
+        np.testing.assert_array_equal(data.arrays['Z'].ndarray, z_set)
 
     @given(npoints=hst.integers(2, 100),
            x_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
@@ -65,7 +64,7 @@ class TestLoopCombined(TestCase):
                                   min_size=2, max_size=2, unique=True).map(sorted),
            z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
                                   min_size=2, max_size=2, unique=True).map(sorted))
-    @settings(max_examples=20)
+    @settings(max_examples=10)
     def testLoopCombinedParameterTwice(self, npoints, x_start_stop, y_start_stop, z_start_stop):
         x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints)
         y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints)
@@ -73,8 +72,8 @@ class TestLoopCombined(TestCase):
         setpoints = np.hstack((x_set.reshape(npoints, 1),
                                y_set.reshape(npoints, 1),
                                z_set.reshape(npoints, 1)))
-
-        sweep_values = combine(self.dac.X, self.dac.Y, self.dac.Z,
+        parameters = [ManualParameter(name) for name in ["X", "Y", "Z"]]
+        sweep_values = combine(*parameters,
                                name="combined").sweep(setpoints)
 
         def wrapper():
@@ -90,9 +89,9 @@ class TestLoopCombined(TestCase):
         self.dmm.voltage.get = wrapper()
         loop = Loop(sweep_values).each(self.dmm.voltage, self.dmm.voltage)
         data = loop.run(quiet=True)
-        np.testing.assert_array_equal(data.arrays['dac_X'].ndarray, x_set)
-        np.testing.assert_array_equal(data.arrays['dac_Y'].ndarray, y_set)
-        np.testing.assert_array_equal(data.arrays['dac_Z'].ndarray, z_set)
+        np.testing.assert_array_equal(data.arrays['X'].ndarray, x_set)
+        np.testing.assert_array_equal(data.arrays['Y'].ndarray, y_set)
+        np.testing.assert_array_equal(data.arrays['Z'].ndarray, z_set)
         np.testing.assert_array_equal(data.arrays['dmm_voltage_0'].ndarray, np.arange(1, npoints*2, 2))
         np.testing.assert_array_equal(data.arrays['dmm_voltage_1'].ndarray, np.arange(2, npoints*2+1, 2))
 
@@ -103,7 +102,7 @@ class TestLoopCombined(TestCase):
                                   min_size=2, max_size=2, unique=True).map(sorted),
            z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
                                   min_size=2, max_size=2, unique=True).map(sorted))
-    @settings(max_examples=20)
+    @settings(max_examples=10)
     def testLoopCombinedParameterAndMore(self, npoints, x_start_stop, y_start_stop, z_start_stop):
         x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints)
         y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints)
@@ -111,8 +110,8 @@ class TestLoopCombined(TestCase):
         setpoints = np.hstack((x_set.reshape(npoints, 1),
                                y_set.reshape(npoints, 1),
                                z_set.reshape(npoints, 1)))
-
-        sweep_values = combine(self.dac.X, self.dac.Y, self.dac.Z,
+        parameters = [ManualParameter(name) for name in ["X", "Y", "Z"]]
+        sweep_values = combine(*parameters,
                                name="combined").sweep(setpoints)
 
         def wrapper():
@@ -128,9 +127,9 @@ class TestLoopCombined(TestCase):
         self.dmm.voltage.get = wrapper()
         loop = Loop(sweep_values).each(self.dmm.voltage, self.dmm.somethingelse, self.dmm.voltage)
         data = loop.run(quiet=True)
-        np.testing.assert_array_equal(data.arrays['dac_X'].ndarray, x_set)
-        np.testing.assert_array_equal(data.arrays['dac_Y'].ndarray, y_set)
-        np.testing.assert_array_equal(data.arrays['dac_Z'].ndarray, z_set)
+        np.testing.assert_array_equal(data.arrays['X'].ndarray, x_set)
+        np.testing.assert_array_equal(data.arrays['Y'].ndarray, y_set)
+        np.testing.assert_array_equal(data.arrays['Z'].ndarray, z_set)
         np.testing.assert_array_equal(data.arrays['dmm_voltage_0'].ndarray, np.arange(1, npoints * 2, 2))
         np.testing.assert_array_equal(data.arrays['dmm_somethingelse'].ndarray, np.ones(npoints))
         np.testing.assert_array_equal(data.arrays['dmm_voltage_2'].ndarray, np.arange(2, npoints * 2 + 1, 2))
@@ -143,15 +142,17 @@ class TestLoopCombined(TestCase):
                                   min_size=2, max_size=2, unique=True).map(sorted),
            z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
                                   min_size=2, max_size=2, unique=True).map(sorted))
-    @settings(max_examples=20)
+    @settings(max_examples=10)
     def testLoopCombinedParameterInside(self, npoints, npoints_outer, x_start_stop, y_start_stop, z_start_stop):
         x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints_outer)
         y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints)
         z_set = np.linspace(z_start_stop[0], z_start_stop[1], npoints)
+
         setpoints = np.hstack((y_set.reshape(npoints, 1),
                                z_set.reshape(npoints, 1)))
 
-        sweep_values = combine(self.dac.Y, self.dac.Z,
+        parameters = [ManualParameter(name) for name in ["X", "Y", "Z"]]
+        sweep_values = combine(parameters[1], parameters[2],
                                name="combined").sweep(setpoints)
 
         def ataskfunc():
@@ -175,7 +176,7 @@ class TestLoopCombined(TestCase):
             return inner
 
         self.dmm.voltage.get = wrapper()
-        loop = Loop(self.dac.X.sweep(x_start_stop[0],
+        loop = Loop(parameters[0].sweep(x_start_stop[0],
                                      x_start_stop[1],
                                      num=npoints_outer)).loop(sweep_values).each(self.dmm.voltage,
                                                                                  atask,
@@ -183,10 +184,10 @@ class TestLoopCombined(TestCase):
                                                                                  self.dmm.voltage,
                                                                                  btask)
         data = loop.run(quiet=True)
-        np.testing.assert_array_equal(data.arrays['dac_X_set'].ndarray, x_set)
-        np.testing.assert_array_equal(data.arrays['dac_Y'].ndarray,
+        np.testing.assert_array_equal(data.arrays['X_set'].ndarray, x_set)
+        np.testing.assert_array_equal(data.arrays['Y'].ndarray,
                                       np.repeat(y_set.reshape(1,npoints), npoints_outer, axis=0))
-        np.testing.assert_array_equal(data.arrays['dac_Z'].ndarray,
+        np.testing.assert_array_equal(data.arrays['Z'].ndarray,
                                       np.repeat(z_set.reshape(1, npoints), npoints_outer, axis=0))
 
         np.testing.assert_array_equal(data.arrays['dmm_voltage_0'].ndarray,

--- a/qcodes/tests/test_combined_par.py
+++ b/qcodes/tests/test_combined_par.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 from unittest.mock import call
 
-from hypothesis import given, settings
+from hypothesis import given
 import hypothesis.strategies as hst
 
 import numpy as np

--- a/qcodes/tests/test_combined_par.py
+++ b/qcodes/tests/test_combined_par.py
@@ -4,6 +4,9 @@ import unittest
 from unittest.mock import patch
 from unittest.mock import call
 
+from hypothesis import given, settings
+import hypothesis.strategies as hst
+
 import numpy as np
 
 from qcodes.instrument.parameter import combine
@@ -72,8 +75,17 @@ class TestMultiPar(unittest.TestCase):
                 ]
             )
 
-    def testAggregator(self):
-        setpoints = np.array([[1, 1, 1], [1, 1, 1]])
+
+    @given(npoints=hst.integers(1, 100),
+           x_start_stop=hst.lists(hst.integers(), min_size=2, max_size=2).map(sorted),
+           y_start_stop=hst.lists(hst.integers(), min_size=2, max_size=2).map(sorted),
+           z_start_stop=hst.lists(hst.integers(), min_size=2, max_size=2).map(sorted))
+    def testAggregator(self, npoints, x_start_stop, y_start_stop, z_start_stop):
+
+        x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints).reshape(npoints, 1)
+        y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints).reshape(npoints, 1)
+        z_set = np.linspace(z_start_stop[0], z_start_stop[1], npoints).reshape(npoints, 1)
+        setpoints = np.hstack((x_set, y_set, z_set))
         expected_results = [linear(*set) for set in setpoints]
         sweep_values = combine(*self.parameters,
                                name="combined",


### PR DESCRIPTION
Fixes #669 

The issue is that the base parameters within the combined parameter were being looked up from an index that always starts at 1. This is only true if there is only one parameter/task being measured/executed within the loop. This corrects the counting


- [ ] Print/log warning in case data is dropped
- [ ] Tests! 
