### PR TITLE
add catch for network timeouts

### DIFF
--- a/qcodes/utils/slack.py
+++ b/qcodes/utils/slack.py
@@ -278,7 +278,12 @@ class Slack(threading.Thread):
                 new_tasks.append(task)
         self.tasks = new_tasks
 
-        new_messages = self.get_new_im_messages()
+        new_messages = {}
+        try:
+            new_messages = self.get_new_im_messages()
+        except Exception as ex:
+            # catch any timeouts caused by network delays
+            pass
         self.handle_messages(new_messages)
 
     def help_message(self):

--- a/qcodes/utils/slack.py
+++ b/qcodes/utils/slack.py
@@ -4,8 +4,10 @@ from functools import partial
 from time import sleep
 import inspect
 from slacker import Slacker
+import logging
 import threading
 import traceback
+from requests.exceptions import ReadTimeout
 
 from qcodes.plots.base import BasePlot
 from qcodes import config as qc_config
@@ -281,9 +283,9 @@ class Slack(threading.Thread):
         new_messages = {}
         try:
             new_messages = self.get_new_im_messages()
-        except Exception as ex:
+        except ReadTimeout as ex:
             # catch any timeouts caused by network delays
-            print(ex)
+            logging.exception(ex)
         self.handle_messages(new_messages)
 
     def help_message(self):

--- a/qcodes/utils/slack.py
+++ b/qcodes/utils/slack.py
@@ -283,7 +283,7 @@ class Slack(threading.Thread):
             new_messages = self.get_new_im_messages()
         except Exception as ex:
             # catch any timeouts caused by network delays
-            pass
+            print(ex)
         self.handle_messages(new_messages)
 
     def help_message(self):


### PR DESCRIPTION
Sometimes the slack bot generates an error due to a network timeout. This PR prevents this from happening by catching a timeout error.

@giulioungaretti @nulinspiratie 