### PR TITLE
Fix ZNB space in setpoint names

### DIFF
--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -113,7 +113,7 @@ class FrequencySweep(ArrayParameter):
                          unit='dB',
                          label='{} magnitude'.format(instrument._vna_parameter),
                          setpoint_units=('Hz',),
-                         setpoint_names=('{}_frequency'.forgit mat(instrument._vna_parameter),))
+                         setpoint_names=('{}_frequency'.format(instrument._vna_parameter),))
         self.set_sweep(start, stop, npts)
         self._channel = channel
 

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -113,7 +113,7 @@ class FrequencySweep(ArrayParameter):
                          unit='dB',
                          label='{} magnitude'.format(instrument._vna_parameter),
                          setpoint_units=('Hz',),
-                         setpoint_names=('{} frequency'.format(instrument._vna_parameter),))
+                         setpoint_names=('{}_frequency'.forgit mat(instrument._vna_parameter),))
         self.set_sweep(start, stop, npts)
         self._channel = channel
 


### PR DESCRIPTION
Changes proposed in this pull request:
-  makes setpoint_names of FrequencySweep parameter not have any spaces in because this prevents ability to load back datasets (among other things)

@jenshnielsen 