### PR TITLE
Speedup qdac snapshot

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -4,6 +4,7 @@ import numpy as np
 import time
 import warnings
 import weakref
+from typing import Sequence
 
 from qcodes.utils.metadata import Metadatable
 from qcodes.utils.helpers import DelegateAttributes, strip_attrs, full_class
@@ -133,25 +134,34 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             raise TypeError('Submodules must be metadatable.')
         self.submodules[name] = submodule
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update: bool=False,
+                      params_to_skip_update: Sequence[str]=None):
         """
         State of the instrument as a JSON-compatible dict.
 
         Args:
             update (bool): If True, update the state by querying the
                 instrument. If False, just use the latest values in memory.
+            params_to_skip_update: List of parameter names that will be skipped
+                in update even if update is True. This is useful if you have
+                parameters that are slow to update but can be updated in a
+                different way (as in the qdac)
 
         Returns:
             dict: base snapshot
         """
-        snap = {'parameters': dict((name, param.snapshot(update=update))
-                                   for name, param in self.parameters.items()),
-                'functions': dict((name, func.snapshot(update=update))
+        snap = {'functions': dict((name, func.snapshot(update=update))
                                   for name, func in self.functions.items()),
                 'submodules': dict((name, subm.snapshot(update=update))
                                    for name, subm in self.submodules.items()),
                 '__class__': full_class(self),
                 }
+        snap['parameters'] = {}
+        for name, param in self.parameters.items():
+            update = True
+            if params_to_skip_update and name in params_to_skip_update:
+                update = False
+            snap['parameters'][name] = param.snapshot(update=update)
         for attr in set(self._meta_attrs):
             if hasattr(self, attr):
                 snap[attr] = getattr(self, attr)

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -1,4 +1,6 @@
 """Visa instrument driver based on pyvisa."""
+from typing import Sequence
+
 import visa
 import pyvisa.constants as vi_const
 import pyvisa.resources
@@ -157,18 +159,23 @@ class VisaInstrument(Instrument):
         """
         return self.visa_handle.ask(cmd)
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update: bool=False,
+                      params_to_skip_update: Sequence[str] = None):
         """
         State of the instrument as a JSON-compatible dict.
 
         Args:
             update (bool): If True, update the state by querying the
                 instrument. If False, just use the latest values in memory.
-
+            params_to_skip_update: List of parameter names that will be skipped
+                in update even if update is True. This is useful if you have
+                parameters that are slow to update but can be updated in a
+                different way (as in the qdac)
         Returns:
             dict: base snapshot
         """
-        snap = super().snapshot_base(update=update)
+        snap = super().snapshot_base(update=update,
+                                     params_to_skip_update=params_to_skip_update)
 
         snap['address'] = self._address
         snap['terminator'] = self._terminator

--- a/qcodes/instrument_drivers/QDev/QDac.py
+++ b/qcodes/instrument_drivers/QDev/QDac.py
@@ -163,6 +163,19 @@ class QDac(VisaInstrument):
         self._get_status(readcurrents=update_currents)
         log.info('[+] Done')
 
+    def snapshot_base(self, update=False, params_to_skip_update=None):
+        # call get_status here if updates are requested
+        # this is much faster than updating the individual channels
+        update_currents = self._update_currents and update
+        if update:
+            self._get_status(readcurrents=update_currents)
+        if params_to_skip_update is None:
+            params_to_skip_update = ('v', 'vrange', 'i', 'irange')
+        supfun = super().snapshot_base
+        snap = supfun(update=update,
+                      params_to_skip_update=params_to_skip_update)
+        return snap
+
     #########################
     # Channel gets/sets
     #########################

--- a/qcodes/instrument_drivers/QDev/QDac.py
+++ b/qcodes/instrument_drivers/QDev/QDac.py
@@ -69,7 +69,7 @@ class QDac(VisaInstrument):
                                QCoDeS only supports version 0.170202 or newer.
                                Contact rikke.lutge@nbi.ku.dk for an update.
                                ''')
-
+        self._update_currents = update_currents
         self.num_chans = num_chans
 
         # Assigned slopes. Entries will eventually be [chan, slope]
@@ -82,8 +82,12 @@ class QDac(VisaInstrument):
 
         self.chan_range = range(1, 1 + self.num_chans)
         self.channel_validator = vals.Ints(1, self.num_chans)
-
+        self._params_to_skip_update = []
         for i in self.chan_range:
+            self._params_to_skip_update.append('ch{:02}_v'.format(i))
+            self._params_to_skip_update.append('ch{:02}_i'.format(i))
+            self._params_to_skip_update.append('ch{:02}_vrange'.format(i))
+            self._params_to_skip_update.append('ch{:02}_irange'.format(i))
             stri = str(i)
             self.add_parameter(name='ch{:02}_v'.format(i),
                                label='Channel ' + stri,
@@ -170,7 +174,7 @@ class QDac(VisaInstrument):
         if update:
             self._get_status(readcurrents=update_currents)
         if params_to_skip_update is None:
-            params_to_skip_update = ('v', 'vrange', 'i', 'irange')
+            params_to_skip_update = self._params_to_skip_update
         supfun = super().snapshot_base
         snap = supfun(update=update,
                       params_to_skip_update=params_to_skip_update)

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -10,7 +10,6 @@ from functools import partial
 from operator import xor
 from collections import OrderedDict
 
-from qcodes.utils.helpers import full_class
 from qcodes.instrument.channel import InstrumentChannel, ChannelList
 from qcodes.instrument.channel import MultiChannelInstrumentParameter
 from qcodes.instrument.parameter import ManualParameter

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -163,6 +163,7 @@ class QDac(VisaInstrument):
             QDac object
         """
         super().__init__(name, address)
+        self._output_n_lines = 50
         handle = self.visa_handle
 
         # This is the baud rate on power-up. It can be changed later but
@@ -240,7 +241,6 @@ class QDac(VisaInstrument):
         self._get_status(readcurrents=update_currents)
         log.info('[+] Done')
 
-        self._output_n_lines = 50
     #########################
     # Channel gets/sets
     #########################

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -264,12 +264,9 @@ class QDac(VisaInstrument):
         self._update_currents = update_currents
         log.info('[+] Done')
 
-    #########################
-    # Channel gets/sets
-    #########################
     def snapshot_base(self, update=False):
         # call get_status here if updates are requested
-        # this is much faster than updateing the individual channels
+        # this is much faster than updating the individual channels
         # We take care of not updating the matching parameters (i, v, vrange,
         # irange) in the channel.
         update_currents = self._update_currents and update
@@ -277,6 +274,10 @@ class QDac(VisaInstrument):
             self._get_status(readcurrents=update_currents)
         snap = super().snapshot_base(update=update)
         return snap
+
+    #########################
+    # Channel gets/sets
+    #########################
 
     def _set_voltage(self, chan, v_set):
         """

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -106,24 +106,8 @@ class QDacChannel(InstrumentChannel):
                            )
 
     def snapshot_base(self, update=False):
-        # we special case this to not update a few parameters
-        # that are both slow to update and can be updated faster`
-        # by calling _get_status of the instrument which is done below
-        snap = {'functions': dict((name, func.snapshot(update=update))
-                                  for name, func in self.functions.items()),
-                'submodules': dict((name, subm.snapshot(update=update))
-                                   for name, subm in self.submodules.items()),
-                '__class__': full_class(self),
-                }
-        snap['parameters'] = {}
-        for name, param in self.parameters.items():
-            update = True
-            if name in ['v', 'vrange', 'i', 'irange']:
-                update = False
-            snap['parameters'][name] = param.snapshot(update=update)
-        for attr in set(self._meta_attrs):
-            if hasattr(self, attr):
-                snap[attr] = getattr(self, attr)
+        params = ('v', 'i', 'irange', 'vrange')
+        snap = super().snapshot_base(update=update, params_to_skip_update=params)
         return snap
 
 

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -104,18 +104,18 @@ class QDacChannel(InstrumentChannel):
                            initial_value=0.01
                            )
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update=False, params_to_skip_update=None):
         update_currents = self._parent._update_currents and update
-        if update:
+        if update and not self._parent._get_status_performed:
             self._parent._get_status(readcurrents=update_currents)
         # call get_status rather than getting the status individually for
-        # each paramter. This is slower than it needs to be when getting
-        # all channels because _get_status is called once per channel
-        # Need to find a good way to ensure that _get_status is called exactly
-        # once per shapshot
-        params = ('v', 'i', 'irange', 'vrange')
+        # each parameter. This is only done if _get_status_performed is False
+        # this is used to signal that the parent has already called it and
+        # no need to repeat.
+        if params_to_skip_update is None:
+            params_to_skip_update = ('v', 'i', 'irange', 'vrange')
         snap = super().snapshot_base(update=update,
-                                     params_to_skip_update=params)
+                                     params_to_skip_update=params_to_skip_update)
         return snap
 
 
@@ -179,7 +179,7 @@ class QDac(VisaInstrument):
         super().__init__(name, address)
         self._output_n_lines = 50
         handle = self.visa_handle
-
+        self._get_status_performed = False
         # This is the baud rate on power-up. It can be changed later but
         # you must start out with this value.
         handle.baud_rate = 480600
@@ -255,6 +255,21 @@ class QDac(VisaInstrument):
         self._get_status(readcurrents=update_currents)
         self._update_currents = update_currents
         log.info('[+] Done')
+
+    def snapshot_base(self, update=False, params_to_skip_update=None):
+        update_currents = self._parent._update_currents and update
+        if update:
+            self._parent._get_status(readcurrents=update_currents)
+        self._get_status_performed = True
+        # call get_status rather than getting the status individually for
+        # each parameter. We set _get_status_performed to True
+        # to indicate that each update channel does not need to call this
+        # function as opposed to when snapshot is called on an individual
+        # channel
+        snap = super().snapshot_base(update=update,
+                                     params_to_skip_update=params_to_skip_update)
+        self._get_status_performed = False
+        return snap
 
     #########################
     # Channel gets/sets

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -257,9 +257,9 @@ class QDac(VisaInstrument):
         log.info('[+] Done')
 
     def snapshot_base(self, update=False, params_to_skip_update=None):
-        update_currents = self._parent._update_currents and update
+        update_currents = self._update_currents and update
         if update:
-            self._parent._get_status(readcurrents=update_currents)
+            self._get_status(readcurrents=update_currents)
         self._get_status_performed = True
         # call get_status rather than getting the status individually for
         # each parameter. We set _get_status_performed to True

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -106,8 +106,17 @@ class QDacChannel(InstrumentChannel):
                            )
 
     def snapshot_base(self, update=False):
+        update_currents = self._parent._update_currents and update
+        if update:
+            self._parent._get_status(readcurrents=update_currents)
+        # call get_status rather than getting the status individually for
+        # each paramter. This is slower than it needs to be when getting
+        # all channels because _get_status is called once per channel
+        # Need to find a good way to ensure that _get_status is called exactly
+        # once per shapshot
         params = ('v', 'i', 'irange', 'vrange')
-        snap = super().snapshot_base(update=update, params_to_skip_update=params)
+        snap = super().snapshot_base(update=update,
+                                     params_to_skip_update=params)
         return snap
 
 
@@ -247,17 +256,6 @@ class QDac(VisaInstrument):
         self._get_status(readcurrents=update_currents)
         self._update_currents = update_currents
         log.info('[+] Done')
-
-    def snapshot_base(self, update=False):
-        # call get_status here if updates are requested
-        # this is much faster than updating the individual channels
-        # We take care of not updating the matching parameters (i, v, vrange,
-        # irange) in the channel.
-        update_currents = self._update_currents and update
-        if update:
-            self._get_status(readcurrents=update_currents)
-        snap = super().snapshot_base(update=update)
-        return snap
 
     #########################
     # Channel gets/sets

--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from .helpers import deep_update
 
 
@@ -35,7 +36,8 @@ class Metadatable:
 
         return snap
 
-    def snapshot_base(self, update=False, params_to_skip_update=None):
+    def snapshot_base(self, update: bool=False,
+                      params_to_skip_update: Sequence[str]=None):
         """
         override this with the primary information for a subclass
         """

--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -35,7 +35,7 @@ class Metadatable:
 
         return snap
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update=False, params_to_skip_update=None):
         """
         override this with the primary information for a subclass
         """


### PR DESCRIPTION
This significantly speeds up the qdac snapshotting such as when adding it to a station. This is done by using _get_status to read parameters at once rather than one by one. 

My benchmark shows 

Creating a station with a QDac. Before 30 s, with this change 0.5 s without updating currents.

Updating currents adds about another 11 seconds both to the instrument creation and snapshot

