### PR TITLE
Snapshot(update=True) may fail for array parameters and such

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -161,7 +161,11 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             update = update
             if params_to_skip_update and name in params_to_skip_update:
                 update = False
-            snap['parameters'][name] = param.snapshot(update=update)
+            try:
+                snap['parameters'][name] = param.snapshot(update=update)
+            except:
+                logging.info("Snapshot: Could not update parameter: {}".format(name))
+                snap['parameters'][name] = param.snapshot(update=False)
         for attr in set(self._meta_attrs):
             if hasattr(self, attr):
                 snap[attr] = getattr(self, attr)


### PR DESCRIPTION
This log the failure and continue, fixes #691
There are lots of parameters that you may not be able to snapshot cleanly and typically it makes little sense to do so 
