### PR TITLE
Fix: ip instrument log empty responce and ensure all data is send

### DIFF
--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -1,8 +1,10 @@
 """Ethernet instrument driver class based on sockets."""
 import socket
+import logging
 
 from .base import Instrument
 
+log = logging.getLogger(__name__)
 
 class IPInstrument(Instrument):
 
@@ -142,7 +144,11 @@ class IPInstrument(Instrument):
         self._socket.send(data.encode())
 
     def _recv(self):
-        return self._socket.recv(self._buffer_size).decode()
+        result = self._socket.recv(self._buffer_size)
+        if result == b'':
+            log.warning("Got empty response from Socket recv() "
+                        "Connection broken.")
+        return result.decode()
 
     def close(self):
         """Disconnect and irreversibly tear down the instrument."""

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -141,7 +141,7 @@ class IPInstrument(Instrument):
 
     def _send(self, cmd):
         data = cmd + self._terminator
-        self._socket.send(data.encode())
+        self._socket.sendall(data.encode())
 
     def _recv(self):
         result = self._socket.recv(self._buffer_size)


### PR DESCRIPTION
As I understand it that is a sign of a closed socket
This should probably be an error in the future

Also use sendall to ensure that we dont drop data. Fixes #748 