### PR TITLE
fix:save scaled value, perform initial get

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -188,7 +188,7 @@ class _BaseParameter(Metadatable, DeferredOperations):
 
         # subclasses should extend this list with extra attributes they
         # want automatically included in the snapshot
-        self._meta_attrs = ['name', 'instrument', 'step', 'scale', 'raw_value',
+        self._meta_attrs = ['name', 'instrument', 'step', 'scale',
                             'inter_delay', 'post_delay', 'val_mapping', 'vals']
 
         # Specify time of last set operation, used when comparing to delay to
@@ -243,6 +243,7 @@ class _BaseParameter(Metadatable, DeferredOperations):
 
         if not self._snapshot_value:
             state.pop('value')
+            state.pop('raw_value', None)
 
         if isinstance(state['ts'], datetime):
             state['ts'] = state['ts'].strftime('%Y-%m-%d %H:%M:%S')

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -654,7 +654,8 @@ class Parameter(_BaseParameter):
                 if max_val_age is not None:
                     raise SyntaxError('Must have get method or specify get_cmd '
                                       'when max_val_age is set')
-                self.get = self.get_latest
+                self.get = lambda: self.state.get('raw_value',
+                                                  self.state['value'])
             else:
                 exec_str = instrument.ask if instrument else None
                 self.get = Command(arg_count=0, cmd=get_cmd, exec_str=exec_str)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -347,8 +347,13 @@ class _BaseParameter(Metadatable, DeferredOperations):
 
                     set_function(val, **kwargs)
                     self.raw_value = val
-                    self._save_val(val, validate=(self.val_mapping is None and
-                                                  self.set_parser is None))
+                    if self.scale is not None:
+                        scaled_val = val / self.scale
+                    else:
+                        scaled_val = val
+                    self._save_val(scaled_val,
+                                   validate=(self.val_mapping is None and
+                                             self.set_parser is None))
 
                     # Update last set time (used for calculating delays)
                     self._t_last_set = time.perf_counter()
@@ -379,7 +384,9 @@ class _BaseParameter(Metadatable, DeferredOperations):
         if step is None:
             return [value]
         else:
-            start_value = self.get_latest()
+            if self.get_latest() is None:
+                self.get()
+            start_value = self.raw_value
 
             self.validate(start_value)
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -656,7 +656,8 @@ class Parameter(_BaseParameter):
                 if max_val_age is not None:
                     raise SyntaxError('Must have get method or specify get_cmd '
                                       'when max_val_age is set')
-                self.get = lambda: self._latest.get('raw_value')
+                self.get = lambda: self._latest['value' if self.scale is None
+                                                else 'raw_value']
             else:
                 exec_str = instrument.ask if instrument else None
                 self.get = Command(arg_count=0, cmd=get_cmd, exec_str=exec_str)


### PR DESCRIPTION
Minor but important Parameter fixes I ran into after merging the latest PR.
These are related to ramping and scaling of values, and also incorporating raw_value.

Changes proposed in this pull request:
- Perform Parameter.get if get_latest returns None and a step is used. Without this, it will jump to the target value during the first .set if not .get is called first
- scale parameter value during ramping
- Remove raw_value from meta_attrs, add it to self._latest. 
    This is done for the following reasons:
    - The self.get function (previously in ManualParameter) is no longer equal to self.get_latest. Instead, it will directly get the value from self._latest ('value' if parameter doesn't have scale, 'raw_value' otherwise). This is because get_latest always returns the scaled value, while if the parameter has a scale, we want the get function to return the raw value
    - the raw value will now also be popped if snapshot_value=False


@jenshnielsen @WilliamHPNielsen