### PR TITLE
unpin h5py dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
  - defaults
  - conda-forge
 dependencies:
- - h5py=2.6.0
+ - h5py
  - matplotlib=2.0.2
  - pyqtgraph 
  - python=3.6


### PR DESCRIPTION
The h5py dependency was pinned to a fixed version. Thus numpy won't update as it depends on it.

found by
@jenshnielsen 
