### PR TITLE
Fix matplotlib 2.1 compatibility

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -335,7 +335,9 @@ class MatPlot(BasePlot):
                     arr_pad += diff
                     # Ignore final value
                     arr_pad = arr_pad[:-1]
-                args.append(masked_invalid(arr_pad))
+                    # C is allowed to be masked in pcolormesh but x and y are
+                    # not so replace any empty data with nans
+                args.append(np.ma.filled(arr_pad, fill_value=np.nan))
             args.append(args_masked[-1])
         else:
             # Only the masked value of z is used as a mask


### PR DESCRIPTION
X and Y arguments to pcolormesh have never been allowed to be masked
but it worked by coincidence with older versions 

@WilliamHPNielsen @Dominik-Vogel 

