### PR TITLE
Don't snapshot array and multiparameters per default

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -884,15 +884,28 @@ class ArrayParameter(_BaseParameter):
         snapshot_get (bool): Prevent any update to the parameter, for example
             if it takes too long to update. Default True.
 
+        snapshot_value: Should the value of the parameter be stored in the
+            snapshot. Unlike Parameter this defaults to False as
+            ArrayParameters are potentially huge.
+
         metadata (Optional[dict]): extra information to include with the
             JSON snapshot of the parameter
     """
 
-    def __init__(self, name, shape, instrument=None,
-                 label=None, unit=None,
-                 setpoints=None, setpoint_names=None, setpoint_labels=None,
-                 setpoint_units=None, docstring=None,
-                 snapshot_get=True, snapshot_value=True, metadata=None):
+    def __init__(self,
+                 name: str,
+                 shape: Sequence[int],
+                 instrument: Optional['Instrument']=None,
+                 label: Optional[str]=None,
+                 unit: Optional[str]=None,
+                 setpoints: Optional[Sequence]=None,
+                 setpoint_names: Optional[Sequence[str]]=None,
+                 setpoint_labels: Optional[Sequence[str]]=None,
+                 setpoint_units: Optional[Sequence[str]]=None,
+                 docstring: Optional[str]=None,
+                 snapshot_get: bool=True,
+                 snapshot_value: bool=False,
+                 metadata: bool=None):
         super().__init__(name, instrument, snapshot_get, metadata,
                          snapshot_value=snapshot_value)
 
@@ -1046,15 +1059,29 @@ class MultiParameter(_BaseParameter):
         snapshot_get (bool): Prevent any update to the parameter, for example
             if it takes too long to update. Default True.
 
+        snapshot_value: Should the value of the parameter be stored in the
+            snapshot. Unlike Parameter this defaults to False as
+            MultiParameters are potentially huge.
+
         metadata (Optional[dict]): extra information to include with the
             JSON snapshot of the parameter
     """
 
-    def __init__(self, name, names, shapes, instrument=None,
-                 labels=None, units=None,
-                 setpoints=None, setpoint_names=None, setpoint_labels=None,
-                 setpoint_units=None, docstring=None,
-                 snapshot_get=True, snapshot_value=True, metadata=None):
+    def __init__(self,
+                 name: str,
+                 names: Sequence[str],
+                 shapes: Sequence[Sequence[Optional[int]]],
+                 instrument: Optional['Instrument']=None,
+                 labels: Optional[Sequence[str]]=None,
+                 units: Optional[Sequence[str]]=None,
+                 setpoints: Optional[Sequence[Sequence]]=None,
+                 setpoint_names: Optional[Sequence[Sequence[str]]]=None,
+                 setpoint_labels: Optional[Sequence[Sequence[str]]]=None,
+                 setpoint_units: Optional[Sequence[Sequence[str]]]=None,
+                 docstring: str=None,
+                 snapshot_get: bool=True,
+                 snapshot_value: bool=False,
+                 metadata: Optional[dict]=None):
         super().__init__(name, instrument, snapshot_get, metadata,
                          snapshot_value=snapshot_value)
 

--- a/qcodes/instrument_drivers/Keysight/Infiniium.py
+++ b/qcodes/instrument_drivers/Keysight/Infiniium.py
@@ -207,13 +207,6 @@ class InfiniiumChannel(InstrumentChannel):
                            parameter_class=RawTrace
                            )
 
-        def snapshot_base(self, update: bool=False) -> Dict:
-            skip_update = ['trace']
-            snap = super().snapshot_base(update=update,
-                                         params_to_skip_update=skip_update)
-            return snap
-
-
 class Infiniium(VisaInstrument):
     """
     This is the QCoDeS driver for the Keysight Infiniium oscilloscopes from the

--- a/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
+++ b/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
@@ -30,7 +30,8 @@ class CurrentParameter(MultiParameter):
     def __init__(self, measured_param, c_amp_ins, name='curr'):
         p_name = measured_param.name
 
-        super().__init__(name=name, names=(p_name+'_raw', name), shapes=((), ()))
+        super().__init__(name=name, names=(p_name+'_raw', name), shapes=((), ()),
+                         snapshot_value=True)
 
         self._measured_param = measured_param
         self._instrument = c_amp_ins

--- a/qcodes/instrument_drivers/oxford/mercuryiPS.py
+++ b/qcodes/instrument_drivers/oxford/mercuryiPS.py
@@ -13,7 +13,7 @@ class MercuryiPSArray(MultiParameter):
     """
     def __init__(self, name, instrument, names, units, get_cmd, set_cmd, **kwargs):
         shapes = tuple(() for i in names)
-        super().__init__(name, names, shapes, **kwargs)
+        super().__init__(name, names, shapes, snapshot_value=True, **kwargs)
         self._get = get_cmd
         self._set = set_cmd
         self._instrument = instrument

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -83,7 +83,6 @@ class FrequencySweepMagPhase(MultiParameter):
             mag_array.append(abs(complex_num))
             phase_array.append(phase(complex_num))
         self._instrument._parent.cont_meas_on()
-        self._save_val((mag_array, phase_array))
         return mag_array, phase_array
 
 
@@ -150,7 +149,6 @@ class FrequencySweep(ArrayParameter):
                         "values. Will discard the imaginary part.")
             data = data[0::2] + 1j*data[1::2]
         self._instrument._parent.cont_meas_on()
-        self._save_val(data)
         return data
 
 

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -343,13 +343,6 @@ class ZNBChannel(InstrumentChannel):
         self.trace.set_sweep(start, stop, npts)
         self.trace_mag_phase.set_sweep(start, stop, npts)
 
-    def snapshot_base(self, update=False, params_to_skip_update=None):
-        if params_to_skip_update is None:
-            params_to_skip_update = ('trace', 'trace_mag_phase')
-        snap = super().snapshot_base(update=update,
-                                     params_to_skip_update=params_to_skip_update)
-        return snap
-
 class ZNB(VisaInstrument):
     """
     qcodes driver for the Rohde & Schwarz ZNB8 and ZNB20

--- a/qcodes/instrument_drivers/stanford_research/SR560.py
+++ b/qcodes/instrument_drivers/stanford_research/SR560.py
@@ -29,7 +29,8 @@ class VoltageParameter(MultiParameter):
         name (str): the name of the current output. Default 'curr'.
             Also used as the name of the whole parameter.
     """
-    def __init__(self, measured_param, v_amp_ins, name='volt'):
+    def __init__(self, measured_param, v_amp_ins, name='volt',
+                 snapshot_value=True):
         p_name = measured_param.name
 
         super().__init__(name=name, names=(p_name+'_raw', name), shapes=((), ()))

--- a/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
@@ -194,13 +194,6 @@ class KeithleyChannel(InstrumentChannel):
 
         self.channel = channel
 
-    # We need to avoid updating the sweep parameter
-    def snapshot_base(self, update: bool=False) -> Dict:
-        params_to_skip_update = ['fastsweep']
-        dct = super().snapshot_base(update=update,
-                                    params_to_skip_update=params_to_skip_update)
-        return dct
-
     def reset(self):
         """
         Reset instrument to factory defaults.

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -260,7 +260,7 @@ class TestArrayParameter(TestCase):
 
         self.assertEqual(p._get_count, 0)
         snap = p.snapshot(update=True)
-        self.assertEqual(p._get_count, 1)
+        self.assertEqual(p._get_count, 0)
         snap_expected = {
             'name': name,
             'label': name,
@@ -272,7 +272,7 @@ class TestArrayParameter(TestCase):
 
         self.assertIn(name, p.__doc__)
 
-    def test_explicit_attrbutes(self):
+    def test_explicit_attributes(self):
         name = 'tiny_array'
         shape = (2,)
         label = 'it takes two to tango'
@@ -286,7 +286,7 @@ class TestArrayParameter(TestCase):
                              setpoints=setpoints,
                              setpoint_names=setpoint_names,
                              setpoint_labels=setpoint_labels,
-                             docstring=docstring, snapshot_get=False,
+                             docstring=docstring, snapshot_value=True,
                              metadata=metadata)
 
         self.assertEqual(p.name, name)
@@ -299,7 +299,7 @@ class TestArrayParameter(TestCase):
 
         self.assertEqual(p._get_count, 0)
         snap = p.snapshot(update=True)
-        self.assertEqual(p._get_count, 0)
+        self.assertEqual(p._get_count, 1)
         snap_expected = {
             'name': name,
             'label': label,
@@ -396,7 +396,7 @@ class TestMultiParameter(TestCase):
 
         self.assertEqual(p._get_count, 0)
         snap = p.snapshot(update=True)
-        self.assertEqual(p._get_count, 1)
+        self.assertEqual(p._get_count, 0)
         snap_expected = {
             'name': name,
             'names': names,
@@ -429,7 +429,7 @@ class TestMultiParameter(TestCase):
                              setpoints=setpoints,
                              setpoint_names=setpoint_names,
                              setpoint_labels=setpoint_labels,
-                             docstring=docstring, snapshot_get=False,
+                             docstring=docstring, snapshot_value=True,
                              metadata=metadata)
 
         self.assertEqual(p.name, name)
@@ -444,7 +444,7 @@ class TestMultiParameter(TestCase):
 
         self.assertEqual(p._get_count, 0)
         snap = p.snapshot(update=True)
-        self.assertEqual(p._get_count, 0)
+        self.assertEqual(p._get_count, 1)
         snap_expected = {
             'name': name,
             'names': names,

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -264,8 +264,7 @@ class TestArrayParameter(TestCase):
         snap_expected = {
             'name': name,
             'label': name,
-            'unit': '',
-            'value': [[1, 2, 3], [4, 5, 6]]
+            'unit': ''
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
@@ -306,7 +305,8 @@ class TestArrayParameter(TestCase):
             'unit': unit,
             'setpoint_names': setpoint_names,
             'setpoint_labels': setpoint_labels,
-            'metadata': metadata
+            'metadata': metadata,
+            'value': [6, 7]
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
@@ -401,8 +401,7 @@ class TestMultiParameter(TestCase):
             'name': name,
             'names': names,
             'labels': names,
-            'units': [''] * 3,
-            'value': [0, [1, 2, 3], [[4, 5], [6, 7]]]
+            'units': [''] * 3
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
@@ -452,7 +451,8 @@ class TestMultiParameter(TestCase):
             'units': units,
             'setpoint_names': setpoint_names,
             'setpoint_labels': setpoint_labels,
-            'metadata': metadata
+            'metadata': metadata,
+            'value': [0, [1, 2, 3], [[4, 5], [6, 7]]]
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)


### PR DESCRIPTION
This is an alternative to #797 works by disabling snapshot storage for Array and Multiparamters by default

Pro this 

* we retain the wrappers including delays etc for all parameters:

Against

* This is an still an api break. (Array/Multi)Parameters that used to do explicit _saveval will no longer  be snapshotted unless they explicitly pass snapshot_value=True to the super class constructor, I have verified that this is the case for all current QCoDeS drivers.
* If you don't want the wrappers in any _BaseParameter subclass you will have to replace them in your subclass with a noop

@WilliamHPNielsen  @nulinspiratie 