### PR TITLE
Driver/Minicircuits variable attenuators

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,11 @@
 name: qcodes
-channels: 
+channels:
  - defaults
  - conda-forge
 dependencies:
  - h5py=2.6.0
  - matplotlib=2.0.2
- - pyqtgraph 
+ - pyqtgraph
  - python=3.6
  - jsonschema
  - pyvisa
@@ -18,3 +18,4 @@ dependencies:
  - hypothesis
  - pytest
  - pytest-runner
+ - pywinusb

--- a/qcodes/instrument_drivers/Minicircuits/USBMixin.py
+++ b/qcodes/instrument_drivers/Minicircuits/USBMixin.py
@@ -1,0 +1,158 @@
+import pywinusb.hid as hid
+from functools import partial
+from threading import Event
+from typing import Optional
+
+import logging
+log = logging.getLogger(__name__)
+
+class USBException(Exception):
+    """Base class for exceptions in this module."""
+    pass
+
+class USBMixin:
+    """
+    Mixin class to use simple raw commands.
+
+    This mixin uses the pywinusb package to enable communication with a HID-USB device.
+
+    It should be used as the first superclass of an instrument, e.g.
+    ```
+    class MyInstrument(USBMixin, Instrument):
+       ...
+       vendor_id = 0x1234
+       product_id = 0x5678
+       package_size = 64
+
+    ```
+    so that the constructor and destructor can take care of establishing and releasing the connection to the device
+
+    """
+
+    # max size of usb package in bytes
+    package_size = 0 # type: int
+
+    # These class variables have to be overridden by the subclass
+    vendor_id = 0x0000 # type: int
+    product_id = 0x0000 # type: int
+
+
+    def __init__(self, instance_id: Optional[str] = None, *args, **kwargs) -> None:
+        # as this is a mixin class it is important to call the constructor of
+        # the next in line class with the super() function.
+        # So here super() refers to the second class from which the superclass
+        # is inherited.
+        super().__init__(*args, **kwargs)
+        self.dev = None
+        self._open_USB_device(porduct_id = self.product_id,
+                              vendor_id = self.vendor_id,
+                              instance_id = instance_id)
+
+    def __del__(self) -> None:
+        if self.dev is not None:
+            self._close_USB_device
+        super().__del__()
+
+
+    def _open_USB_device(self,  **kwargs) -> None:
+        """
+        establishes the connection to an USB device.
+        
+        """
+        allDevices = hid.HidDeviceFilter(**kwargs).get_devices()
+
+        if len(allDevices) == 0:
+            raise USBException("Device not found.")
+        elif len(allDevices) > 1:
+            raise USBException("Device not unique. Supply extra keywords")
+
+        if self.dev:
+            raise USBException("Device already open")
+
+        self.dev = allDevices[0]
+        # may raise HIDError if resource already opened
+        self.dev.open()
+
+    def _close_USB_device(self):
+        if not self.dev:
+            raise USBException("trying to close device that is not open.")
+        self.dev.close()
+        self.dev = None
+
+    def write_USB_data(self, feature_id: int, data: bytes) -> None:
+        """
+        writes raw data to the usb device.
+
+        Args:
+           feature_id: specifies the data endpoint of the device. A HID can
+              offer different 'feature_id's for different purposes, similar to
+              different ports in tcp/ip
+           data: the raw data to be transferred. Has to be compatible with 'package_size'
+        """
+        if feature_id > 255 or feature_id < 0:
+            raise USBException("a feature ID has to be a single byte")
+
+        if len(data) > self.package_size:
+            raise USBException("trying to send a package bigger than {} bytes"
+                               .format(self.package_size))
+        b = bytearray(self.package_size+1)
+        b[0] = feature_id
+        for i,v in enumerate(data):
+            b[i+1] = v
+
+        # log.debug("sending {}\n".format(b))
+        feat = self.dev.send_output_report(b)
+        if feat == False:
+            raise(USBException("Error sending report"))
+
+
+    @staticmethod
+    def _usb_handler(event: Event, receiver: bytearray, data: bytes):
+        # log.debug("received {}\n".format(data))
+        receiver[:] = data
+        # break the 'wait()'-call in the mainloop by notifying that we have received
+        # data
+        event.set()
+
+    def ask_USB_data(self, feature_id: int, data: bytes, timeout: float=1) -> bytearray:
+        """
+        Queries data from the device, by registering a listener for a feature and subsequently sending data.
+
+        Args:
+           feature_id: the common feature ID for both sending the data and retrieving data. Using different IDs is not yet implemented
+           data: The raw data to be sent. Has to be compatible with 'package_size'
+           timeout: timeout in seconds for the query.
+        """
+        # We need an 'Event'-object from the threading library, because 'pywinusb'
+        # is implented with a multi threaded response queue. One has to provide a
+        # handler for the response. Here this behaviour is forced to be linear again
+        # by envoking 'Event.wait(timeout)' right after the query which waits
+        # until the timeout is reached or 'Event.set()' is called from the handler
+        event = Event()
+        # A local buffer to receive the response data
+        receiver = bytearray(USBMixin.package_size)
+        self.dev.set_raw_data_handler(
+            partial(USBMixin._usb_handler, event, receiver))
+
+        # make the query
+        self.write_USB_data(feature_id, data)
+        # wait until response from device or timeout
+        timedout = not event.wait(timeout)
+        # this is how the handler is supposed to be deactivated in this lib
+        self.dev.set_raw_data_handler(None)
+        if timedout:
+            raise USBException("request timed out {}".format(receiver))
+        # remove first byte as it indicates the feature id, which is already known
+        return receiver[1:]
+
+    @classmethod
+    def enumerate_devices(cls):
+        """
+        This method returns the 'instance_id's of all connected decives for with
+        the given product and vendor IDs.
+        """
+        allDevices = hid.HidDeviceFilter(
+            porduct_id = cls.product_id,
+            vendor_id = cls.vendor_id,).get_devices()
+        instance_ids = [dev.instance_id for dev in allDevices]
+        return instance_ids

--- a/qcodes/instrument_drivers/Minicircuits/USBMixin.py
+++ b/qcodes/instrument_drivers/Minicircuits/USBMixin.py
@@ -47,7 +47,7 @@ class USBMixin:
             **kwargs) -> None:
         # as this is a mixin class it is important to call the constructor of
         # the next in line class with the super() function.
-        # So here super() refers to the second class from which the superclass
+        # So here super() refers to the second class from which the subclass
         # is inherited.
         super().__init__(*args, **kwargs)
         self.dev = None

--- a/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
+++ b/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
@@ -128,7 +128,8 @@ class RCDAT_6000_60(qcodes.instrument.base.Instrument):
                            })
         self.connect_message()
 
-    def string_to_float(self, time_string):
+    @staticmethod
+    def string_to_float(time_string):
         value, prefix = time_string.split(maxsplit=1)
         if prefix == 'Sec':
             value = float(value)

--- a/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
+++ b/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
@@ -25,7 +25,7 @@ class RCDAT_6000_60(qcodes.instrument.base.Instrument):
 
         self.add_parameter(name='hop_points',
                            label='number of points',
-                           unit='#',
+                           unit='',
                            get_cmd=':HOP:POINTS?',
                            set_cmd=':HOP:POINTS:{}',
                            get_parser=int,

--- a/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
+++ b/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
@@ -146,14 +146,14 @@ class RCDAT_6000_60(qcodes.instrument.base.Instrument):
                 'serial': self.ask('*SN?'),
                 'firmware': self.ask('*FIRMWARE?')}
 
-    def ask_raw(self, command):
-        command = command + '\n\r'
+    def ask_raw(self, cmd):
+        command = cmd + '\n\r'
         self.telnet.write(command.encode('ASCII'))
         data = self.telnet.read_until(b"\n\r", timeout=1).decode('ASCII').strip()
         return data
 
-    def write_raw(self, command):
-        command = command + '\n\r'
+    def write_raw(self, cmd):
+        command = cmd + '\n\r'
         self.telnet.write(command.encode('ASCII'))
         data = self.telnet.read_until(b"\n\r", timeout=1).strip()
         if data in [b'1']:

--- a/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
+++ b/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
@@ -1,0 +1,162 @@
+
+import telnetlib
+import qcodes.instrument.base
+from qcodes.utils.validators import Numbers, Ints, Enum, MultiType
+
+class RCDAT_6000_60(qcodes.instrument.base.Instrument):
+
+    def __init__(self, name, address, port=23, **kwargs):
+        self.telnet = telnetlib.Telnet(address)
+        super().__init__(name, **kwargs)
+        # do a read until command here
+        self.telnet.read_until(b"\n\r", timeout=1)
+
+# General Reference commands
+
+        self.add_parameter(name='attenuation',
+                           label='attenuation',
+                           unit='dB',
+                           get_cmd='SETATT?',
+                           set_cmd='SETATT={}',
+                           get_parser=float,
+                           vals=Numbers(min_value=0, max_value=60))
+
+# Attenuation hopping commands
+
+        self.add_parameter(name='hop_points',
+                           label='number of points',
+                           unit='#',
+                           get_cmd=':HOP:POINTS?',
+                           set_cmd=':HOP:POINTS:{}',
+                           get_parser=int,
+                           vals=Numbers(min_value=1, max_value=100))
+
+        self.add_parameter(name='hop_direction',
+                           get_cmd=':HOP:DIRECTION?',
+                           set_cmd=':HOP:DIRECTION:{}',
+                           val_mapping={
+                               'forward': 0,
+                               'backward': 1,
+                               'bi': 2
+                           })
+
+        self.add_parameter(name='hop_index',
+                           get_cmd=':HOP:POINT?',
+                           set_cmd=':HOP:POINT:{}',
+                           get_parser=int,
+                           vals=Numbers(min_value=1, max_value=100))
+
+        self.add_parameter(name='hop_time_unit',
+                           set_cmd=':HOP:DWELL_UNIT:{}',
+                           val_mapping={
+                               'micros': 'U',
+                               'millis': 'M',
+                               's': 'S'
+                           })
+
+        self.add_parameter(name='hop_time',
+                           unit='s',
+                           label='hop time',
+                           get_cmd=':HOP:DWELL?',
+                           set_cmd=':HOP:DWELL:{}',
+                           get_parser=self.string_to_float,
+                           vals=Numbers(min_value=5e-3, max_value=1e10))
+
+        self.add_parameter(name='attenuation_hop',
+                           get_cmd=':HOP:ATT?',
+                           set_cmd=':HOP:ATT:{}',
+                           get_parser=float,
+                           vals=Numbers(min_value=0, max_value=60))
+
+        self.add_parameter(name='hop_mode',
+                           set_cmd=':HOP:MODE:{}',
+                           val_mapping={
+                               'on': 'ON',
+                               'off': 'OFF'
+                           })
+
+# Attenuation sweeping commands
+
+        self.add_parameter(name='sweep_direction',
+                           get_cmd=':SWEEP:DIRECTION?',
+                           set_cmd=':SWEEP:DIRECTION:{}',
+                           val_mapping={
+                               'forward': 0,
+                               'back': 1,
+                               'bi': 2
+                           })
+
+        self.add_parameter(name='sweep_time_unit',
+                           set_cmd=':SWEEP:DWELL_UNIT:{}',
+                           val_mapping={
+                               'micros': 'U',
+                               'millis': 'M',
+                               's': 'S'
+                           })
+
+        self.add_parameter(name='sweep_time',
+                           get_cmd=':SWEEP:DWELL?',
+                           set_cmd=':SWEEP:DWELL:{}',
+                           unit='s',
+                           label='sweep time',
+                           get_parser=self.string_to_float,
+                           vals=Numbers(min_value=5e-3, max_value=1e10))
+
+        self.add_parameter(name='sweep_start',
+                           get_cmd=':SWEEP:START?',
+                           set_cmd=':SWEEP:START:{}',
+                           get_parser=float,
+                           vals=Numbers(min_value=0, max_value=60))
+
+        self.add_parameter(name='sweep_stop',
+                           get_cmd=':SWEEP:STOP?',
+                           set_cmd=':SWEEP:STOP:{}',
+                           get_parser=float,
+                           vals=Numbers(min_value=0, max_value=60))
+
+        self.add_parameter(name='sweep_stepsize',
+                           get_cmd=':SWEEP:STEPSIZE?',
+                           set_cmd=':SWEEP:STEPSIZE:{}',
+                           get_parser=float,
+                           vals=Numbers(min_value=0.25, max_value=60))
+
+        self.add_parameter(name='sweep_mode',
+                           set_cmd=':SWEEP:MODE:{}',
+                           val_mapping={
+                               'on': 'ON',
+                               'off': 'OFF'
+                           })
+        self.connect_message()
+
+    def string_to_float(self, time_string):
+        value, prefix = time_string.split(maxsplit=1)
+        if prefix == 'Sec':
+            value = float(value)
+            return value
+        elif prefix == 'mSec':
+            value = float(value)*1e-3
+            return value
+        elif prefix == 'uSec':
+            value = float(value)*1e-6
+            return value
+
+    def get_idn(self):
+        return {'vendor': 'Mini-Circuits',
+                'model': self.ask('*MN?'),
+                'serial': self.ask('*SN?'),
+                'firmware': self.ask('*FIRMWARE?')}
+
+    def ask_raw(self, command):
+        command = command + '\n\r'
+        self.telnet.write(command.encode('ASCII'))
+        data = self.telnet.read_until(b"\n\r", timeout=1).decode('ASCII').strip()
+        return data
+
+    def write_raw(self, command):
+        command = command + '\n\r'
+        self.telnet.write(command.encode('ASCII'))
+        data = self.telnet.read_until(b"\n\r", timeout=1).strip()
+        if data in [b'1']:
+            pass
+        elif data in [b'0']:
+            raise ValueError('Command failed')

--- a/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
+++ b/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60.py
@@ -1,7 +1,7 @@
 
 import telnetlib
 import qcodes.instrument.base
-from qcodes.utils.validators import Numbers, Ints, Enum, MultiType
+from qcodes.utils.validators import Numbers
 
 class RCDAT_6000_60(qcodes.instrument.base.Instrument):
 

--- a/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60_usb.py
+++ b/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60_usb.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 
 log = logging.getLogger(__name__)
 
+
 class RCDAT_6000_60_usb(USBMixin, Instrument):
     """
     Driver for the Minicircuits RCDAT-6000-60 programmable attenuator.
@@ -40,12 +41,12 @@ class RCDAT_6000_60_usb(USBMixin, Instrument):
 
     # To identify the USB device. If there are multiple connected the serial
     # number has to be supplied as well
-    vendor_id = 0x20ce # type: int
-    product_id = 0x0023 # type: int
-    
+    vendor_id = 0x20ce  # type: int
+    product_id = 0x0023  # type: int
+
     # the feature_id identifies the usb enpoint to and from which the data is
     # sent. There is only one endpoint for this simple device
-    feature_id = 0 # type: int
+    feature_id = 0  # type: int
 
     # a list of commands taken from the manual for programmable attenuators
     # p.104. Every command consists of 64 bytes. The first byte given here
@@ -55,23 +56,31 @@ class RCDAT_6000_60_usb(USBMixin, Instrument):
                                   'send_visa': bytes([1]),
                                   'get_device_model_name': bytes([40]),
                                   'get_device_serial_number': bytes([41]),
-                                  'get_firmware': bytes([99]),}
+                                  'get_firmware': bytes([99]), }
 
     # size of usb package in bytes
     package_size = 64
 
-    def __init__(self, name: str, instance_id: Optional[str] = None, **kwargs) -> None:
+    def __init__(
+            self,
+            name: str,
+            instance_id: Optional[str] = None,
+            **kwargs) -> None:
         """
         Instantiates the instrument.
 
         Args:
             name: The instrument name used by qcodes
-            instanc_id: The identification string for the instrument. If there are multiple instruments of the same type connected, an additional 'instance_id' has to be provided to identify the desired instance. Use the enumerate_devices() function to get a list of all 'instance_id's of the connected devices.
+            instanc_id: The identification string for the instrument. If there
+               are multiple instruments of the same type connected, an
+               additional 'instance_id' has to be provided to identify the
+               desired instance. Use the enumerate_devices() function to get a
+               list of all 'instance_id's of the connected devices.
         """
 
         # super refers to mixin, mixin calls super().__init__() to
         # refer to Instrument
-        super().__init__(instance_id = instance_id, name = name, **kwargs)
+        super().__init__(instance_id=instance_id, name=name, **kwargs)
 
         self.connect_message()
 
@@ -96,25 +105,31 @@ class RCDAT_6000_60_usb(USBMixin, Instrument):
 
     def ask_cmd(self, cmd: str, data: bytes = None) -> bytearray:
         # clip the first byte off because it reflects the command
-        ret  = self.ask_USB_data(self.feature_id, self._prepare_package(cmd, data))
+        ret = self.ask_USB_data(
+            self.feature_id,
+            self._prepare_package(
+                cmd,
+                data))
         return ret[1:]
 
     def get_attenuation(self) -> float:
         ret = self.ask_cmd('get_attenuation')
-        return ret[2] + float(ret[3])/4
+        return ret[2] + float(ret[3]) / 4
 
     def set_attenuation(self, attenuation: float) -> None:
         data = bytearray(2)
         data[0] = int(attenuation)
-        data[1] = int((attenuation-data[0])*4)
+        data[1] = int((attenuation - data[0]) * 4)
         self.write_cmd('set_attenuation', data)
 
     def get_idn(self) -> Dict[str, str]:
         """
         overides get_idn from 'Instrument'
         """
-        model = self._bytearray_to_string(self.ask_cmd('get_device_model_name' ))
-        serial = self._bytearray_to_string(self.ask_cmd('get_device_serial_number'))
+        model = self._bytearray_to_string(
+            self.ask_cmd('get_device_model_name'))
+        serial = self._bytearray_to_string(
+            self.ask_cmd('get_device_serial_number'))
         firmware = self._bytearray_to_string(self.ask_cmd('get_firmware'))
         return {'vendor': 'Mini-Circuits',
                 'model': model,
@@ -123,7 +138,8 @@ class RCDAT_6000_60_usb(USBMixin, Instrument):
 
     # this does not work for this instrument for no apparent reason
     def ask_visa(self, cmd: str) -> str:
-        log.error('Trying to call unimplemented function: ask_visa for RCDAT-6000-60')
+        log.error(
+            'Trying to call unimplemented function: ask_visa for RCDAT-6000-60')
         data = cmd.encode('ascii')
         return self.ask_cmd('send_visa', data)
 
@@ -137,8 +153,8 @@ class RCDAT_6000_60_usb(USBMixin, Instrument):
 
     @staticmethod
     def round_to_nearest_attenuation_value(val: float) -> float:
-        return float(round(val*4)/4)
+        return float(round(val * 4) / 4)
 
     @staticmethod
     def round_to_nearest_attenuation_value(val: float) -> float:
-        return float(round(val*4)/4)
+        return float(round(val * 4) / 4)

--- a/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60_usb.py
+++ b/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60_usb.py
@@ -1,0 +1,144 @@
+import logging
+from qcodes.instrument_drivers.Minicircuits.USBMixin import USBMixin
+
+
+from qcodes.instrument.base import Instrument
+from typing import Dict, Optional
+
+log = logging.getLogger(__name__)
+
+class RCDAT_6000_60_usb(USBMixin, Instrument):
+    """
+    Driver for the Minicircuits RCDAT-6000-60 programmable attenuator.
+
+    This driver is implements the attenuator for a connection through raw USB.
+    No drivers are needed but only the basic functionality of setting the
+    attenuation is provided. For using the sweep and fast table hopping mode
+    another driver has to be implemented.
+    For implementing this other functionality there have been the following
+    difficulties:
+     * using the device in VISA USB-raw mode:
+       To do this one can use the NI-VISA Driver Wizard with the PID and VID
+       as provided in this file, to generate an .inf file. The trouble for
+       installing the .inf file is that it is not signed. To install it anyways
+       driver signatures have to be temporily disabled and the computer rebooted
+       To avoid this, this reduced driver uses the windows inbuildt USB
+       functions
+     * An alternative approach is to use the dlls provided by Minicircuits.
+       The functions prodided can be called from python using the ctypes library
+       This requires to install the dll files on every computer to use the
+       device
+     * Yet another option is to extend this driver by reverse engineering the
+       raw and binary USB commands for this functionality by analyzing the usb
+       packages send by the supplied Minicircuits GUI.
+
+    For the ethernet version use the driver RCDAT_6000_60_telnet.
+
+    Depednecies:
+     - pywinusb
+    """
+
+    # To identify the USB device. If there are multiple connected the serial
+    # number has to be supplied as well
+    vendor_id = 0x20ce # type: int
+    product_id = 0x0023 # type: int
+    
+    # the feature_id identifies the usb enpoint to and from which the data is
+    # sent. There is only one endpoint for this simple device
+    feature_id = 0 # type: int
+
+    # a list of commands taken from the manual for programmable attenuators
+    # p.104. Every command consists of 64 bytes. The first byte given here
+    # specifies the type of command followed by 63 bytes payload.
+    commands: Dict[str, bytes] = {'read_attenuation': bytes([18]),
+                                  'set_attenuation': bytes([19]),
+                                  'send_visa': bytes([1]),
+                                  'get_device_model_name': bytes([40]),
+                                  'get_device_serial_number': bytes([41]),
+                                  'get_firmware': bytes([99]),}
+
+    # size of usb package in bytes
+    package_size = 64
+
+    def __init__(self, name: str, instance_id: Optional[str] = None, **kwargs) -> None:
+        """
+        Instantiates the instrument.
+
+        Args:
+            name: The instrument name used by qcodes
+            instanc_id: The identification string for the instrument. If there are multiple instruments of the same type connected, an additional 'instance_id' has to be provided to identify the desired instance. Use the enumerate_devices() function to get a list of all 'instance_id's of the connected devices.
+        """
+
+        # super refers to mixin, mixin calls super().__init__() to
+        # refer to Instrument
+        super().__init__(instance_id = instance_id, name = name, **kwargs)
+
+        self.connect_message()
+
+        self.add_parameter(name='attenuation',
+                           label='attenuation',
+                           unit='dB',
+                           get_cmd=self.get_attenuation,
+                           set_cmd=self.set_attenuation,)
+        # TODO: add validator
+
+    @staticmethod
+    def _prepare_package(cmd: str, data: bytes = None) -> bytearray:
+        bCmd = RCDAT_6000_60_usb.commands[cmd]
+        if data:
+            package = bCmd + data
+        else:
+            package = bCmd
+        return package
+
+    def write_cmd(self, cmd: str, data: bytes = None) -> None:
+        self.write_USB_data(self.feature_id, self._prepare_package(cmd, data))
+
+    def ask_cmd(self, cmd: str, data: bytes = None) -> bytearray:
+        # clip the first byte off because it reflects the command
+        ret  = self.ask_USB_data(self.feature_id, self._prepare_package(cmd, data))
+        return ret[1:]
+
+    def get_attenuation(self) -> float:
+        ret = self.ask_cmd('get_attenuation')
+        return ret[2] + float(ret[3])/4
+
+    def set_attenuation(self, attenuation: float) -> None:
+        data = bytearray(2)
+        data[0] = int(attenuation)
+        data[1] = int((attenuation-data[0])*4)
+        self.write_cmd('set_attenuation', data)
+
+    def get_idn(self) -> Dict[str, str]:
+        """
+        overides get_idn from 'Instrument'
+        """
+        model = self._bytearray_to_string(self.ask_cmd('get_device_model_name' ))
+        serial = self._bytearray_to_string(self.ask_cmd('get_device_serial_number'))
+        firmware = self._bytearray_to_string(self.ask_cmd('get_firmware'))
+        return {'vendor': 'Mini-Circuits',
+                'model': model,
+                'serial': serial,
+                'firmware': firmware}
+
+    # this does not work for this instrument for no apparent reason
+    def ask_visa(self, cmd: str) -> str:
+        log.error('Trying to call unimplemented function: ask_visa for RCDAT-6000-60')
+        data = cmd.encode('ascii')
+        return self.ask_cmd('send_visa', data)
+
+    @staticmethod
+    def _bytearray_to_string(b: bytes) -> bytearray:
+        i = 0
+        while i < len(b) and b[i] != 0:
+            i += 1
+        ret = b[0:i]
+        return ret.decode('ascii')
+
+    @staticmethod
+    def round_to_nearest_attenuation_value(val: float) -> float:
+        return float(round(val*4)/4)
+
+    @staticmethod
+    def round_to_nearest_attenuation_value(val: float) -> float:
+        return float(round(val*4)/4)

--- a/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60_usb.py
+++ b/qcodes/instrument_drivers/Minicircuits/rcdat_6000_60_usb.py
@@ -136,7 +136,8 @@ class RCDAT_6000_60_usb(USBMixin, Instrument):
                 'serial': serial,
                 'firmware': firmware}
 
-    # this does not work for this instrument for no apparent reason
+    # NOTE: the following command silently failed when tested with firmware C9-2
+    # according to the manual, it should work exactly as the other commands.
     def ask_visa(self, cmd: str) -> str:
         log.error(
             'Trying to call unimplemented function: ask_visa for RCDAT-6000-60')


### PR DESCRIPTION
This is the driver for the Minicircuits RCDAT-6000-60 variable attenuator. The PR includes the implementation over Telnet(Ethernet) by @euchas and my additional implementation of a version that communicates via USB.
The USB part is general and is supposed to build the basis for other Minicircuit devices that do not have an ethernet interface such as the  RUDAT-13G-90 variable attenuator (#703)

@jenshnielsen , @WilliamHPNielsen:
 - may I assume that no one is using the telnet version yet and chnage the name of the class?
 - What is your opinion for a location of the USBMixin within the qcodes source tree?

Fixes #703.

Todos
 * implement incremental validator
 * change name, to something more general
 * make example notebook
 * test with RUDAT-13G-90 

