### PR TITLE
Fix __str__ method in Parameter when there is no parent instrument

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -227,10 +227,10 @@ class _BaseParameter(Metadatable, DeferredOperations):
 
     def __str__(self):
         """Include the instrument name with the Parameter name if possible."""
-        inst_name = getattr(self._instrument, 'name', '')
-        if inst_name:
+        try:
+            inst_name = self._instrument.name
             return '{}_{}'.format(inst_name, self.name)
-        else:
+        except AttributeError:
             return self.name
 
     def __repr__(self):


### PR DESCRIPTION
If a parameter doesn't have a parent instrument, the __str__ method fails. This commit fix this.

@nulinspiratie @WilliamHPNielsen 