### PR TITLE
Measure: get_data_set

### DIFF
--- a/qcodes/measure.py
+++ b/qcodes/measure.py
@@ -32,6 +32,9 @@ class Measure(Metadatable):
         """
         return self.run(quiet=True, location=False, **kwargs)
 
+    def get_data_set(self, *args, **kwargs):
+        return self._dummyLoop.get_data_set(*args, **kwargs)
+
     def run(self, use_threads=False, quiet=False, station=None, **kwargs):
         """
         Run the actions in this measurement and return their data as a DataSet


### PR DESCRIPTION
This is a convenience function to get the data set directly from a Measure object, without going through the dummy loop. It is needed to remove the qcodes-dk dependencies


