### PR TITLE
make print_readable_snapshot work with value-less parameters

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -228,12 +228,10 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             name = snapshot['parameters'][par]['name']
             msg = '{0:<{1}}:'.format(name, par_field_len)
 
-            # in case of e.g. ArrayParameters, the parameter may not have
+            # in case of e.g. ArrayParameters, that usually have
+            # snapshot_value == False, the parameter may not have
             # a value in the snapshot
-            try:
-                val = snapshot['parameters'][par]['value']
-            except KeyError:
-                val = 'Not available'
+            val = snapshot['parameters'][par].get('value', 'Not available')
 
             unit = snapshot['parameters'][par].get('unit', None)
             if unit is None:

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -227,7 +227,14 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         for par in sorted(snapshot['parameters']):
             name = snapshot['parameters'][par]['name']
             msg = '{0:<{1}}:'.format(name, par_field_len)
-            val = snapshot['parameters'][par]['value']
+
+            # in case of e.g. ArrayParameters, the parameter may not have
+            # a value in the snapshot
+            try:
+                val = snapshot['parameters'][par]['value']
+            except KeyError:
+                val = 'Not available'
+
             unit = snapshot['parameters'][par].get('unit', None)
             if unit is None:
                 # this may be a multi parameter


### PR DESCRIPTION
If a parameter does not have a value in the snapshot (e.g. because it is an ArrayParameter), the `print_readable_snapshot` function can not iterate through all parameters and values. This PR fixes that.

Changes proposed in this pull request:
- Make `print_readable_snapshot` handle missing values

@jenshnielsen @AdriaanRol 
