### PR TITLE
fix IVVI driver

### DIFF
--- a/qcodes/instrument_drivers/QuTech/IVVI.py
+++ b/qcodes/instrument_drivers/QuTech/IVVI.py
@@ -510,15 +510,15 @@ class IVVI(VisaInstrument):
         Args:
             param (Parameter): a dac of the IVVI instrument
         """
-        if not isinstance(param._vals, Numbers):
+        if not isinstance(param.vals, Numbers):
             raise Exception('Only the Numbers validator is supported.')
-        min_val = param._vals._min_value
-        max_val = param._vals._max_value
+        min_val = param.vals._min_value
+        max_val = param.vals._max_value
 
         min_val_upd = self.round_dac(min_val, param.name)
         max_val_upd = self.round_dac(max_val, param.name)
 
-        param._vals = Numbers(min_val_upd, max_val_upd)
+        param.vals = Numbers(min_val_upd, max_val_upd)
 
 
 '''


### PR DESCRIPTION
 @AdriaanRol @CJvanDiepen 

With the new Parameter updates in qcodes the IVVI driver `adjust_parameter_validator` function stopped working.

@jenshnielsen @WilliamHPNielsen You might want to check other drivers on the usage of `_vals` as well.

