### PR TITLE
fix: use latest value instead of raw value in ramp

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -437,7 +437,7 @@ class _BaseParameter(Metadatable, DeferredOperations):
                 raise RuntimeError("Don't know how to step a parameter with more than one value")
             if self.get_latest() is None:
                 self.get()
-            start_value = self.raw_value
+            start_value = self.get_latest()
 
             if not (isinstance(start_value, (int, float)) and
                     isinstance(value, (int, float))):


### PR DESCRIPTION
Changes proposed in this pull request:
- Use latest value in get_ramp_value as starting value

After switching the order of scaling and ramping (#788), the starting value should no longer be the raw value, but the scaled value.

@jenshnielsen @WilliamHPNielsen 