### PR TITLE
fix: rescale also works for a dataset that is not completed

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -421,7 +421,8 @@ class MatPlot(BasePlot):
                 if self.traces[i]['config'].get(axis):
                     unit = self.traces[i]['config'][axis].unit
                     label = self.traces[i]['config'][axis].label
-                    maxval = abs(self.traces[i]['config'][axis].ndarray).max()
+                    maxval = np.nanmax(
+                        abs(self.traces[i]['config'][axis].ndarray))
                     units_to_scale = self.standardunits
 
                     # allow values up to a <1000. i.e. nV is used up to 1000 nV


### PR DESCRIPTION
Currently, MatPlot's `rescale_axis` does not work if the data array contains nan's. Therefore, it doesn't work if you prematurely stop a loop.

Changes proposed in this pull request:
- Use `np.nanmax` instead of `np.array.max`, which ignores nans

@jenshnielsen @WilliamHPNielsen 