### PR TITLE
Fix/nognuplotsorting

### DIFF
--- a/qcodes/data/gnuplot_format.py
+++ b/qcodes/data/gnuplot_format.py
@@ -350,7 +350,7 @@ class GNUPlotFormat(Formatter):
 
         fn = io_manager.join(location, self.metadata_file)
         with io_manager.open(fn, 'w', encoding='utf8') as snap_file:
-            json.dump(data_set.metadata, snap_file, sort_keys=True,
+            json.dump(data_set.metadata, snap_file, sort_keys=False,
                       indent=4, ensure_ascii=False, cls=NumpyJSONEncoder)
 
     def read_metadata(self, data_set):

--- a/qcodes/tests/test_generic_formatter.py
+++ b/qcodes/tests/test_generic_formatter.py
@@ -31,3 +31,19 @@ class TestFormatters(TestCase):
             # strings should be read and written identically
             self.assertEqual(dataset.metadata['string'],
                              dataset2.metadata['string'])
+
+
+class TestNoSorting(TestCase):
+    """
+    (WilliamHPNielsen): I'm not too sure where this test belongs... It tests
+    that parameters with non-sortable keys can be saved using the gnuplot
+    formatter, so I guess it goes here.
+    """
+
+    param = qcodes.Parameter(name='mixed_val_mapping_param',
+                             get_cmd=lambda: np.random.randint(1, 3),
+                             val_mapping={1: 1, '2': 2}
+                             )
+
+    def test_can_measure(self):
+        qcodes.Measure(self.gparam).run()

--- a/qcodes/tests/test_generic_formatter.py
+++ b/qcodes/tests/test_generic_formatter.py
@@ -46,4 +46,4 @@ class TestNoSorting(TestCase):
                              )
 
     def test_can_measure(self):
-        qcodes.Measure(self.gparam).run()
+        qcodes.Measure(self.param).run()


### PR DESCRIPTION
Fixes #775.

Changes proposed in this pull request:
- Make the `json.dump` of metadata not sort the keys
- Add a little test that this works

@jenshnielsen @nulinspiratie @peendebak
