### PR TITLE
feat: make gnuplot dataset writing more flexible

### DIFF
--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -486,13 +486,20 @@ class DataSet(DelegateAttributes):
         if self.location is False:
             return
 
-        # NB: Only the gnuplot formatter has a "filename" kwarg
-        self.formatter.write(self,
-                             self.io,
-                             self.location,
-                             write_metadata=write_metadata,
-                             only_complete=only_complete,
-                             filename=filename)
+        # Only the gnuplot formatter has a "filename" kwarg
+        if isinstance(self.formatter, GNUPlotFormat):
+            self.formatter.write(self,
+                                 self.io,
+                                 self.location,
+                                 write_metadata=write_metadata,
+                                 only_complete=only_complete,
+                                 filename=filename)
+        else:
+            self.formatter.write(self,
+                                 self.io,
+                                 self.location,
+                                 write_metadata=write_metadata,
+                                 only_complete=only_complete)
 
     def write_copy(self, path=None, io_manager=None, location=None):
         """

--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -469,7 +469,7 @@ class DataSet(DelegateAttributes):
             return
         self.formatter.read_metadata(self)
 
-    def write(self, write_metadata=False, only_complete=True):
+    def write(self, write_metadata=False, only_complete=True, filename=None):
         """
         Writes updates to the DataSet to storage.
         N.B. it is recommended to call data_set.finalize() when a DataSet is
@@ -480,15 +480,19 @@ class DataSet(DelegateAttributes):
             only_complete (bool): passed on to the match_save_range inside
                 self.formatter.write. Used to ensure that all new data gets
                 saved even when some columns are strange.
+            filename (Optional[str]): The filename (minus extension) to use.
+                The file gets saved in the usual location.
         """
         if self.location is False:
             return
 
+        # NB: Only the gnuplot formatter has a "filename" kwarg
         self.formatter.write(self,
                              self.io,
                              self.location,
                              write_metadata=write_metadata,
-                             only_complete=only_complete)
+                             only_complete=only_complete,
+                             filename=filename)
 
     def write_copy(self, path=None, io_manager=None, location=None):
         """
@@ -562,21 +566,28 @@ class DataSet(DelegateAttributes):
             self.snapshot()
             self.formatter.write_metadata(self, self.io, self.location)
 
-    def finalize(self):
+    def finalize(self, filename=None, write_metadata=True):
         """
         Mark the DataSet complete and write any remaining modifications.
 
         Also closes the data file(s), if the ``Formatter`` we're using
         supports that.
+
+        Args:
+            filename (Optional[str]): The file name (minus extension) to
+                write to. The location of the file is the usual one.
+            write_metadata (bool): Whether to save a snapshot. For e.g. dumping
+                raw data inside a loop, a snapshot is not wanted.
         """
         log.debug('Finalising the DataSet. Writing.')
         # write all new data, not only (to?) complete columns
-        self.write(only_complete=False)
+        self.write(only_complete=False, filename=filename)
 
         if hasattr(self.formatter, 'close_file'):
             self.formatter.close_file(self)
 
-        self.save_metadata()
+        if write_metadata:
+            self.save_metadata()
 
     def snapshot(self, update=False):
         """JSON state of the DataSet."""

--- a/qcodes/data/gnuplot_format.py
+++ b/qcodes/data/gnuplot_format.py
@@ -244,7 +244,7 @@ class GNUPlotFormat(Formatter):
             return [l.replace('\\"', '"').replace('\\\\', '\\') for l in parts]
 
     def write(self, data_set, io_manager, location, force_write=False,
-              write_metadata=True, only_complete=True):
+              write_metadata=True, only_complete=True, filename=None):
         """
         Write updates in this DataSet to storage.
 
@@ -259,7 +259,11 @@ class GNUPlotFormat(Formatter):
                 or only complete rows? Is used to make sure that everything
                 gets written when the DataSet is finalised, even if some
                 dataarrays are strange (like, full of nans)
+            filename (Optional[str]): Filename to save to. Will override
+                the usual naming scheme and possibly overwrite files, so
+                use with care. The file will be saved in the normal location.
         """
+        print('DEBUG: received location: {}'.format(location))
         arrays = data_set.arrays
 
         # puts everything with same dimensions together
@@ -271,7 +275,11 @@ class GNUPlotFormat(Formatter):
         for group in groups:
             log.debug('Attempting to write the following '
                       'group: {}'.format(group))
-            fn = io_manager.join(location, group.name + self.extension)
+
+            if filename:
+                fn = io_manager.join(location, filename + self.extension)
+            else:
+                fn = io_manager.join(location, group.name + self.extension)
 
             written_files.add(fn)
 

--- a/qcodes/data/gnuplot_format.py
+++ b/qcodes/data/gnuplot_format.py
@@ -263,7 +263,6 @@ class GNUPlotFormat(Formatter):
                 the usual naming scheme and possibly overwrite files, so
                 use with care. The file will be saved in the normal location.
         """
-        print('DEBUG: received location: {}'.format(location))
         arrays = data_set.arrays
 
         # puts everything with same dimensions together


### PR DESCRIPTION
Allow users to save multiple files with a custom filename to a single
folder containing no snapshots

Changes proposed in this pull request:
- Hack in kwargs `filename` and `write_metadata` 

@jenshnielsen 
