### PR TITLE
Add tests for Keysight_33XXX 

### DIFF
--- a/qcodes/.coveragerc
+++ b/qcodes/.coveragerc
@@ -4,6 +4,41 @@ omit =
     */__init__.py
     test.py
     tests/*
-    instrument_drivers/*
-    instrument_drivers/*/*
     utils/reload_code.py
+    instrument_drivers/Advantech/*
+    instrument_drivers/QuTech/*
+    instrument_drivers/cryogenic/*
+    instrument_drivers/rigol/*
+    instrument_drivers/tektronix/*
+    instrument_drivers/AlazarTech/*
+    instrument_drivers/Lakeshore/*
+    instrument_drivers/Spectrum/*
+    instrument_drivers/agilent/*
+    instrument_drivers/devices.py/*
+    instrument_drivers/test.py
+    instrument_drivers/HP/*
+    instrument_drivers/Minicircuits/*
+    instrument_drivers/ZI/*
+    instrument_drivers/ithaco/*
+    instrument_drivers/signal_hound/*
+    instrument_drivers/weinschel/*
+    instrument_drivers/Harvard/*
+    instrument_drivers/QDev/*
+    instrument_drivers/cryocon/*
+    instrument_drivers/oxford/*
+    instrument_drivers/stanford_research/*
+    instrument_drivers/yokogawa/*
+    instrument_drivers/devices.py
+    instrument_drivers/rohde_schwarz/ZNB*
+    instrument_drivers/rohde_schwarz/SMR40.py
+    instrument_drivers/rohde_schwarz/SGS100A.py
+    instrument_drivers/Keysight/Infiniium.py
+    instrument_drivers/Keysight/Keysight_33500B.py
+    instrument_drivers/Keysight/Keysight_33500B_channels.py
+    instrument_drivers/Keysight/Keysight_34465A.py
+    instrument_drivers/Keysight/Keysight_E8267D.py
+    instrument_drivers/Keysight/M3201A.py
+    instrument_drivers/Keysight/M3300A.py
+    instrument_drivers/Keysight/N51x1.py
+    instrument_drivers/Keysight/SD_common/*
+    instrument_drivers/Keysight/test_suite.py

--- a/qcodes/instrument/sims/Keysight_33xxx.yaml
+++ b/qcodes/instrument/sims/Keysight_33xxx.yaml
@@ -31,6 +31,24 @@ devices:
           q: "OUTPut:SYNC:SOURce {}"
           r: "OK"
 
+      chan1 function type:
+        default: SIN
+        getter:
+          q: "SOURce1:FUNCtion?"
+          r: "{}"
+        setter:
+          q: "SOURce1:FUNCtion {}"
+          r: "OK"
+
+      chan1 burst ncycles:
+        default: 1
+        getter:
+          q: "SOURce1:BURSt:NCYCLes?"
+          r: "{}"
+        setter:
+          q: "SOURce1:BURSt:NCYCles {}"
+          r: "OK"
+
 resources:
   GPIB::1::INSTR:
     device: device 1

--- a/qcodes/instrument/sims/Keysight_33xxx.yaml
+++ b/qcodes/instrument/sims/Keysight_33xxx.yaml
@@ -1,0 +1,36 @@
+# SIMULATED INSTRUMENT FOR Keysight 33xxx series function generator
+spec: "1.0"
+devices:
+  device 1:
+    eom:
+      GPIB INSTR:
+        q: "\n"
+        r: "\n"
+    error: ERROR
+    dialogues:
+      - q: "*IDN?"
+        r: "QCoDeS, 33522B, 1, 0.1"
+
+    properties:
+
+      sync output:
+        default: 0
+        getter:
+          q: "OUTPut:SYNC?"
+          r: "{}"
+        setter:
+          q: "OUTPut:SYNC {}"
+          r: OK
+
+      sync output source:
+        default: CH1
+        getter:
+          q: "OUTPut:SYNC:SOURce?"
+          r: "{}"
+        setter:
+          q: "OUTPut:SYNC:SOURce {}"
+          r: "OK"
+
+resources:
+  GPIB::1::INSTR:
+    device: device 1

--- a/qcodes/instrument/sims/RTO_1000.yaml
+++ b/qcodes/instrument/sims/RTO_1000.yaml
@@ -19,6 +19,39 @@ devices:
           q: "TIMebase:DIVisions?"
           r: "{}"
 
+      trigger source:
+        default: CHAN1
+        getter:
+          q: "TRIGger1:SOURce?"
+          r: "{}"
+        setter:
+          q: "TRIGger1:SOURce? {}"
+          r: "OK"
+
+      trigger level 1:
+        default: 0
+        getter:
+          q: "TRIGger1:LEVel1?"
+          r: "{}"
+        setter:
+          q: "TRIGger1:LEVel1 {}"
+          r: "OK"
+
+      channel range 1:
+        default: 5
+        getter:
+          q: "CHANnel1:RANGe?"
+          r: "{}"
+
+      channel offset 1:
+        default: 0
+        getter:
+          q: "CHANnel1:OFFSet?"
+          r: "{}"
+        setter:
+          q: "CHANnel1:OFFSet {}"
+          r: "OK"
+
 resources:
   GPIB::1::INSTR:
     device: device 1

--- a/qcodes/tests/drivers/test_Keysight_33XXX.py
+++ b/qcodes/tests/drivers/test_Keysight_33XXX.py
@@ -32,5 +32,23 @@ def test_sync(driver):
     assert driver.sync.output() == 'ON'
 
     assert driver.sync.source() == 1
-    # driver.sync.source(2)
-    # assert driver.sync.source() == 2
+    driver.sync.source(2)
+    assert driver.sync.source() == 2
+
+def test_channel(driver):
+    assert driver.ch1.function_type() == 'SIN'
+    driver.ch1.function_type('SQU')
+    assert driver.ch1.function_type() == 'SQU'
+
+
+def test_burst(driver):
+    assert driver.ch1.burst_ncycles() == 1
+    driver.ch1.burst_ncycles(10)
+    assert driver.ch1.burst_ncycles() == 10
+    # the following does not actually work because
+    # val parser cannot handle INF being returned.
+    # not clear if this is a bug or the instrument get
+    # set to something else?
+    # driver.ch1.burst_ncycles('INF')
+    # assert driver.ch1.burst_ncycles() == 'INF'
+

--- a/qcodes/tests/drivers/test_Keysight_33XXX.py
+++ b/qcodes/tests/drivers/test_Keysight_33XXX.py
@@ -1,0 +1,36 @@
+import pytest
+
+from qcodes.instrument_drivers.Keysight.KeysightAgilent_33XXX import WaveformGenerator_33XXX
+import qcodes.instrument.sims as sims
+visalib = sims.__file__.replace('__init__.py', 'Keysight_33xxx.yaml@sim')
+
+
+@pytest.fixture(scope='module')
+def driver():
+    kw_sim = WaveformGenerator_33XXX('kw_sim',
+                                      address='GPIB::1::65535::INSTR',
+                                      visalib=visalib)
+    yield kw_sim
+
+    kw_sim.close()
+
+
+def test_init(driver):
+
+    idn_dict = driver.IDN()
+
+    assert idn_dict['vendor'] == 'QCoDeS'
+
+    assert driver.model == '33522B'
+    assert driver.num_channels == 2
+
+
+def test_sync(driver):
+
+    assert driver.sync.output() == 'OFF'
+    driver.sync.output('ON')
+    assert driver.sync.output() == 'ON'
+
+    assert driver.sync.source() == 1
+    # driver.sync.source(2)
+    # assert driver.sync.source() == 2

--- a/qcodes/tests/drivers/test_rto_1000.py
+++ b/qcodes/tests/drivers/test_rto_1000.py
@@ -22,3 +22,11 @@ def test_init(driver):
     idn_dict = driver.IDN()
 
     assert idn_dict['vendor'] == 'QCoDeS'
+
+
+def test_trigger_source_level(driver):
+    assert driver.trigger_source() == 'CH1'
+    assert driver.trigger_level() == 0
+    driver.trigger_level(1.0)
+    assert driver.trigger_level() == 1
+


### PR DESCRIPTION
Mainly because I wanted to experiment with the pyvisa sim backend


This also changes the blacklisting of driver from code coverage to not include the drivers that actually have tests