### PR TITLE
feat: return plot handle

### DIFF
--- a/qcodes/plots/base.py
+++ b/qcodes/plots/base.py
@@ -88,8 +88,10 @@ class BasePlot:
         """
         # TODO(giulioungaretti): replace with an explicit version, see expand trace
         self.expand_trace(args, kwargs)
-        self.add_to_plot(**kwargs)
+        plot_object = self.add_to_plot(**kwargs)
         self.add_updater(updater, kwargs)
+
+        return plot_object
 
     def add_to_plot(self, **kwargs):
         """

--- a/qcodes/plots/base.py
+++ b/qcodes/plots/base.py
@@ -83,6 +83,9 @@ class BasePlot:
                              ylabel= "Amplitude",
                              yunit ="V")
 
+        Returns:
+            Plot handle for trace
+
         Array shapes for 2D plots:
             x:(1D-length m), y:(1D-length n), z: (2D- n*m array)
         """

--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -175,6 +175,8 @@ class QtPlot(BasePlot):
             self.win.setWindowTitle(self.get_default_title())
         self.fixUnitScaling()
 
+        return plot_object
+
     def _draw_plot(self, subplot_object, y, x=None, color=None, width=None,
                    antialias=None, **kwargs):
         if 'pen' not in kwargs:

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -143,6 +143,9 @@ class MatPlot(BasePlot):
                 without `z` we draw a scatter/lines plot (ax.plot):
                     `x`, `y`, and `fmt` (if present) are passed as positional
                     args
+        
+        Returns:
+            Plot handle for trace
         """
         # TODO some way to specify overlaid axes?
         # Note that there is a conversion from subplot kwarg, which is

--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -168,6 +168,8 @@ class MatPlot(BasePlot):
             # in case the user has updated title, don't change it anymore
             self.title.set_text(self.get_default_title())
 
+        return plot_object
+
     def _update_labels(self, ax, config):
         for axletter in ("x", "y"):
             if axletter+'label' in config:

--- a/qcodes/tests/test_plots.py
+++ b/qcodes/tests/test_plots.py
@@ -63,6 +63,10 @@ class TestQtPlot(TestCase):
                             ylabel='Amplitude', yunit='V',
                             subplot=j+1,
                             symbol='o', symbolSize=5)
+    def test_return_handle(self):
+        plotQ = QtPlot(remote=False)
+        return_handle = plotQ.add([1, 2, 3])
+        self.assertIs(return_handle, plotQ.subplots[0].items[0])
 
 
 @skipIf(noMatPlot, '***matplotlib plotting cannot be tested***')
@@ -80,3 +84,9 @@ class TestMatPlot(TestCase):
         """
         plotM = MatPlot(interval=0)
         plt.close(plotM.fig)
+
+    def test_return_handle(self):
+        plotM = MatPlot(interval=0)
+        returned_handle = plotM.add([1,2,3])
+        line_handle = plotM[0].get_lines()[0]
+        self.assertIs(returned_handle, line_handle)


### PR DESCRIPTION
Changes proposed in this pull request:
- Return plot handle for `MatPlot` and `QTPlot`. This can then be used for changes later on, such as legends.

@WilliamHPNielsen @jenshnielsen 
