### PR TITLE
Fix AttributeError in remove_instance for IPInstruments

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -535,7 +535,7 @@ class Instrument(InstrumentBase):
             The instance to remove
         """
         wr = weakref.ref(instance)
-        if wr in cls._instances:
+        if wr in getattr(cls, "_instances", []):
             cls._instances.remove(wr)
 
         # remove from all_instruments too, but don't depend on the


### PR DESCRIPTION
IPInstrument base class does not have an _instance
attribute.

Fixes #948.

Changes proposed in this pull request:
- Add getattr to remove_instance to provide an empty list for instruments that don't supply a _instance attribute

@jenshnielsen 
