### PR TITLE
Remove references to deprecated set_validator in SRS instruments

### DIFF
--- a/qcodes/instrument_drivers/stanford_research/SR830.py
+++ b/qcodes/instrument_drivers/stanford_research/SR830.py
@@ -550,20 +550,20 @@ class SR830(VisaInstrument):
         mode = self._N_TO_INPUT_CONFIG[int(s)]
 
         if mode in ['a', 'a-b']:
-            self.sensitivity.set_validator(self._VOLT_ENUM)
+            self.sensitivity.vals = self._VOLT_ENUM
             self._set_units('V')
         else:
-            self.sensitivity.set_validator(self._CURR_ENUM)
+            self.sensitivity.vals = self._CURR_ENUM
             self._set_units('A')
 
         return mode
 
     def _set_input_config(self, s):
         if s in ['a', 'a-b']:
-            self.sensitivity.set_validator(self._VOLT_ENUM)
+            self.sensitivity.vals = self._VOLT_ENUM
             self._set_units('V')
         else:
-            self.sensitivity.set_validator(self._CURR_ENUM)
+            self.sensitivity.vals = self._CURR_ENUM
             self._set_units('A')
 
         return self._INPUT_CONFIG_TO_N[s]

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -539,20 +539,20 @@ class SR86x(VisaInstrument):
         mode = self._N_TO_INPUT_SIGNAL[int(s)]
 
         if mode == 'voltage':
-            self.sensitivity.set_validator(self._VOLT_ENUM)
+            self.sensitivity.vals = self._VOLT_ENUM
             self._set_units('V')
         else:
-            self.sensitivity.set_validator(self._CURR_ENUM)
+            self.sensitivity.vals = self._CURR_ENUM
             self._set_units('A')
 
         return mode
 
     def _set_input_config(self, s):
         if s == 'voltage':
-            self.sensitivity.set_validator(self._VOLT_ENUM)
+            self.sensitivity.vals = self._VOLT_ENUM
             self._set_units('V')
         else:
-            self.sensitivity.set_validator(self._CURR_ENUM)
+            self.sensitivity.vals = self._CURR_ENUM
             self._set_units('A')
 
         return self._INPUT_SIGNAL_TO_N[s]


### PR DESCRIPTION
Replaces all set_validator calls in the SRS instruments with directs sets of self.vals

Fixes #950.

Changes proposed in this pull request:
- Replace references to `set_validator` with direct sets of `self.vals`

@jenshnielsen 
