### PR TITLE
Use beta release of sphinx rather than a custom tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
     - pip install -r docs_requirements.txt
 # Install a new version of Sphinx that correctly handles forward refs once 1.7.0 is out that should
 # be used instead
-    - pip install git+https://github.com/jenshnielsen/sphinx.git@working_forward_ref --upgrade
+    - pip install sphinx --upgrade --pre
     - pip install -e .
 
 before_script: # configure a headless display to test plot generation

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-coverage
+coverage==4.4.2
 pytest-cov
 pytest
 codacy-coverage


### PR DESCRIPTION
We need 1.7 to fix issues with forward references 
