### PR TITLE
Setting _VERSA_EEPROM_available to False by default

### DIFF
--- a/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -499,13 +499,19 @@ class Decadac(VisaInstrument, DacReader):
 
         # Check whether we can set startup values for the DAC.
         # This requires access to the EEPROM on each slot
+
+        # note from DV: the value never gets set to True in this driver.
+        # To avoid an error of a non existing attribute, here I set it to
+        # False by default
+        self._VERSA_EEPROM_available = False
+
         try:
             # Let's temporarily pretend to be slot 0
             self._slot = 0
             self._query_address(6, versa_eeprom=True)
             del self._slot
         except DACException:
-            self._VERSA_EEPROM_available = False
+            pass
 
         # Check whether calibration is supported
         try:


### PR DESCRIPTION
The current Decadac driver does not specify the value of _VERSA_EEPROM_available by default. It is only set to false if the feature is unavailable but never gets set to True. In this PR I set it to False by default instead of inserting the probably missing assignment of True, in order to prevent inserting a so far untested and also not missed feature.