### PR TITLE
Pin sphinx to 1.7.0b2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
     - pip install -r docs_requirements.txt
 # Install a new version of Sphinx that correctly handles forward refs once 1.7.0 is out that should
 # be used instead
-    - pip install sphinx --upgrade --pre
+    - pip install sphinx==1.7.0b2
     - pip install -e .
 
 before_script: # configure a headless display to test plot generation


### PR DESCRIPTION
there seems to be issues with 1.7.0 and apidoc not working correctly see #968 