### PR TITLE
Spectrum M4i: improve blockavg functionality and add acquisition functions

### DIFF
--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -711,7 +711,7 @@ class M4i(Instrument):
         self.data_memory_size(memsize)
         self.segment_size(seg_size)
         self.posttrigger_memory_size(posttrigger_size)
-        numch = bin(self.enable_channels()).count("1")
+        numch = self._num_channels()
 
         self.general_command(pyspcm.M2CMD_CARD_START |
                              pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
@@ -744,7 +744,7 @@ class M4i(Instrument):
         # set memsize and posttrigger
         self.data_memory_size(memsize)
         self.posttrigger_memory_size(posttrigger_size)
-        numch = bin(self.enable_channels()).count("1")
+        numch = self._num_channels()
 
         self.general_command(pyspcm.M2CMD_CARD_START |
                              pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
@@ -782,7 +782,7 @@ class M4i(Instrument):
         self.data_memory_size(memsize)
         self.pretrigger_memory_size(pretrigger_size)
         self.posttrigger_memory_size(posttrigger_size)
-        numch = bin(self.enable_channels()).count("1")
+        numch = self._num_channels()
 
         self.general_command(pyspcm.M2CMD_CARD_START |
                              pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
@@ -822,7 +822,7 @@ class M4i(Instrument):
 
         self.data_memory_size(memsize)
         self.posttrigger_memory_size(posttrigger_size)
-        numch = bin(self.enable_channels()).count("1")
+        numch = self._num_channels()
 
         # start/enable trigger/wait ready
         self.trigger_or_mask(pyspcm.SPC_TMASK_SOFTWARE)  # software trigger
@@ -860,6 +860,10 @@ class M4i(Instrument):
         if pretrigger > 2**13:
             raise Exception('value of SPC_PRETRIGGER is invalid')
 
+    def _num_channels(self):
+        """ Return number of channels that is enabled """
+        return bin(self.enable_channels()).count("1")
+    
     def blockavg_hardware_trigger_acquisition(self, mV_range, nr_averages=10,
                                               verbose=0, post_trigger=None):
         """ Acquire data using block averaging and hardware triggering
@@ -892,7 +896,7 @@ class M4i(Instrument):
         self._check_buffers()
 
         self._set_param32bit(pyspcm.SPC_AVERAGES, nr_averages)
-        numch = bin(self.enable_channels()).count("1")
+        numch = self._num_channels()
 
         if verbose:
             print('blockavg_hardware_trigger_acquisition: errors %s' %

--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -763,7 +763,7 @@ class M4i(Instrument):
         self.general_command(pyspcm.M2CMD_CARD_START |
                              pyspcm.M2CMD_CARD_ENABLETRIGGER)
 
-        return {'memsize': memsize, 'numch': numch}
+        return {'memsize': memsize, 'numch': numch, 'mV_range': mV_range}
 
     def _transfer_buffer_numpy(self, memsize, numch):
         """ Transfer buffer to numpy array """
@@ -797,6 +797,7 @@ class M4i(Instrument):
 
         memsize = trace['memsize']
         numch = trace['numch']
+        mV_range = trace['mV_range']
 
         self.general_command(pyspcm.M2CMD_CARD_WAITREADY)
         output = self._transfer_buffer_numpy(memsize, numch)

--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -764,6 +764,24 @@ class M4i(Instrument):
                              pyspcm.M2CMD_CARD_ENABLETRIGGER)
 
         return  {'memsize': memsize, 'numch': numch}
+
+    def _transfer_buffer_numpy(self, memsize, numch):
+        """ Transfer buffer to numpy array """
+        # setup software buffer
+        buffer_size = ct.c_int16 * memsize * numch
+        data_buffer = (buffer_size)()
+        data_pointer = ct.cast(data_buffer, ct.c_void_p)
+
+        # data acquisition
+        self._def_transfer64bit(
+            pyspcm.SPCM_BUF_DATA, pyspcm.SPCM_DIR_CARDTOPC, 0, data_pointer, 0, 2 * memsize * numch)
+        self.general_command(pyspcm.M2CMD_DATA_STARTDMA |
+                             pyspcm.M2CMD_DATA_WAITDMA)
+
+        # convert buffer to numpy array
+        data = ct.cast(data_pointer, ct.POINTER(buffer_size))
+        output = np.frombuffer(data.contents, dtype=ct.c_int16)
+        return output
     
     def retrieve_data(self, trace):
         """ Retrieve data from the digitizer
@@ -781,22 +799,7 @@ class M4i(Instrument):
         numch = trace['numch']
         
         self.general_command(pyspcm.M2CMD_CARD_WAITREADY)
-        logger.info('data acquisition complete %.3f' % (time.time()-t0))
-
-        # setup software buffer
-        buffer_size = ct.c_int16 * memsize * numch
-        data_buffer = (buffer_size)()
-        data_pointer = ct.cast(data_buffer, ct.c_void_p)
-
-        # data acquisition
-        self._def_transfer64bit(
-            pyspcm.SPCM_BUF_DATA, pyspcm.SPCM_DIR_CARDTOPC, 0, data_pointer, 0, 2 * memsize * numch)
-        self.general_command(pyspcm.M2CMD_DATA_STARTDMA |
-                             pyspcm.M2CMD_DATA_WAITDMA)
-
-        # convert buffer to numpy array
-        data = ct.cast(data_pointer, ct.POINTER(buffer_size))
-        output = np.frombuffer(data.contents, dtype=ct.c_int16)
+        output = self._transfer_buffer_numpy(memsize, numch)
         self._debug = output
         self._stop_acquisition()
 
@@ -816,21 +819,7 @@ class M4i(Instrument):
         self.general_command(pyspcm.M2CMD_CARD_START |
                              pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
 
-        # setup software buffer
-        buffer_size = ct.c_int16 * memsize * numch
-        data_buffer = (buffer_size)()
-        data_pointer = ct.cast(data_buffer, ct.c_void_p)
-
-        # data acquisition
-        self._def_transfer64bit(
-            pyspcm.SPCM_BUF_DATA, pyspcm.SPCM_DIR_CARDTOPC, 0, data_pointer, 0, 2 * memsize * numch)
-        self.general_command(pyspcm.M2CMD_DATA_STARTDMA |
-                             pyspcm.M2CMD_DATA_WAITDMA)
-
-        # convert buffer to numpy array
-        data = ct.cast(data_pointer, ct.POINTER(buffer_size))
-        output = np.frombuffer(data.contents, dtype=ct.c_int16)
-
+        output = self._transfer_buffer_numpy(memsize, numch)
         self._stop_acquisition()
 
         voltages = self.convert_to_voltage(output, mV_range / 1000)
@@ -854,20 +843,7 @@ class M4i(Instrument):
         self.general_command(pyspcm.M2CMD_CARD_START |
                              pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
 
-        # setup software buffer
-        buffer_size = ct.c_int16 * memsize * numch
-        data_buffer = (buffer_size)()
-        data_pointer = ct.cast(data_buffer, ct.c_void_p)
-
-        # data acquisition
-        self._def_transfer64bit(
-            pyspcm.SPCM_BUF_DATA, pyspcm.SPCM_DIR_CARDTOPC, 0, data_pointer, 0, 2 * memsize * numch)
-        self.general_command(pyspcm.M2CMD_DATA_STARTDMA |
-                             pyspcm.M2CMD_DATA_WAITDMA)
-
-        # convert buffer to numpy array
-        data = ct.cast(data_pointer, ct.POINTER(buffer_size))
-        output = np.frombuffer(data.contents, dtype=ct.c_int16)
+        output = self._transfer_buffer_numpy(memsize, numch)
 
         self._stop_acquisition()
 
@@ -896,20 +872,7 @@ class M4i(Instrument):
         self.general_command(pyspcm.M2CMD_CARD_START |
                              pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
 
-        # setup software buffer
-        buffer_size = ct.c_int16 * memsize * numch
-        data_buffer = (buffer_size)()
-        data_pointer = ct.cast(data_buffer, ct.c_void_p)
-
-        # data acquisition
-        self._def_transfer64bit(
-            pyspcm.SPCM_BUF_DATA, pyspcm.SPCM_DIR_CARDTOPC, 0, data_pointer, 0, 2 * memsize * numch)
-        self.general_command(pyspcm.M2CMD_DATA_STARTDMA |
-                             pyspcm.M2CMD_DATA_WAITDMA)
-
-        # convert buffer to numpy array
-        data = ct.cast(data_pointer, ct.POINTER(buffer_size))
-        output = np.frombuffer(data.contents, dtype=ct.c_int16)
+        output = self._transfer_buffer_numpy(memsize, numch)
         self._debug = output
         self._stop_acquisition()
 

--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -315,7 +315,7 @@ class M4i(Instrument):
                                    pyspcm, 'SPC_AMP{}'.format(i))),
                                vals=Enum(200, 500, 1000, 2000,
                                          2500, 5000, 10000),
-                               unit = 'mV',
+                               unit='mV',
                                docstring='Set and get input range of channel {} (in mV)'.format(i))
 
             # input termination functions
@@ -738,11 +738,11 @@ class M4i(Instrument):
 
         return voltages
 
-    def start_acquisition(self, mV_range, memsize, posttrigger_size = None, verbose=0):
+    def start_acquisition(self, mV_range, memsize, posttrigger_size=None, verbose=0):
         """ Start data acquisition of a single data trace
 
         The resulting data can be acquired with the function retrieve_data.
-        
+
         Args:
             mV_range (float): range in mV
             memsize (int): size of data trace
@@ -754,7 +754,7 @@ class M4i(Instrument):
 
         self.data_memory_size(memsize)
         if posttrigger_size is None:
-            posttrigger_size = memsize-16
+            posttrigger_size = memsize - 16
         self.posttrigger_memory_size(posttrigger_size)
         numch = self._num_channels()
 
@@ -763,7 +763,7 @@ class M4i(Instrument):
         self.general_command(pyspcm.M2CMD_CARD_START |
                              pyspcm.M2CMD_CARD_ENABLETRIGGER)
 
-        return  {'memsize': memsize, 'numch': numch}
+        return {'memsize': memsize, 'numch': numch}
 
     def _transfer_buffer_numpy(self, memsize, numch):
         """ Transfer buffer to numpy array """
@@ -782,22 +782,22 @@ class M4i(Instrument):
         data = ct.cast(data_pointer, ct.POINTER(buffer_size))
         output = np.frombuffer(data.contents, dtype=ct.c_int16)
         return output
-    
+
     def retrieve_data(self, trace):
         """ Retrieve data from the digitizer
-        
+
         The data acquisition must have been started by start_acquisition.
-        
+
         Args:
-            
-        
+
+
         Returns:
             voltages (array)
         """
 
         memsize = trace['memsize']
         numch = trace['numch']
-        
+
         self.general_command(pyspcm.M2CMD_CARD_WAITREADY)
         output = self._transfer_buffer_numpy(memsize, numch)
         self._debug = output
@@ -806,7 +806,7 @@ class M4i(Instrument):
         voltages = self.convert_to_voltage(output, mV_range / 1000)
 
         return voltages
-    
+
     def single_trigger_acquisition(self, mV_range, memsize, posttrigger_size):
 
         self.card_mode(pyspcm.SPC_REC_STD_SINGLE)  # single
@@ -893,7 +893,7 @@ class M4i(Instrument):
     def _num_channels(self):
         """ Return number of channels that is enabled """
         return bin(self.enable_channels()).count("1")
-    
+
     def blockavg_hardware_trigger_acquisition(self, mV_range, nr_averages=10,
                                               verbose=0, post_trigger=None):
         """ Acquire data using block averaging and hardware triggering
@@ -931,10 +931,11 @@ class M4i(Instrument):
         if nr_averages == 1:
             # special case since SPC_AVERAGES cannot handle 1
             if verbose:
-                print('blockavg_hardware_trigger_acquisition: pass to single_trigger_acquisition')
+                print(
+                    'blockavg_hardware_trigger_acquisition: pass to single_trigger_acquisition')
             return self.single_trigger_acquisition(mV_range=mV_range, memsize=memsize, posttrigger_size=post_trigger)
 
-        self.card_mode(pyspcm.SPC_REC_STD_AVERAGE)  
+        self.card_mode(pyspcm.SPC_REC_STD_AVERAGE)
         self._set_param32bit(pyspcm.SPC_AVERAGES, nr_averages)
         numch = self._num_channels()
 


### PR DESCRIPTION
This PR does the following:

- Allows the `blockavg_hardware_trigger_acquisition` to use `naverages=1`
- Add functions to start data acquisition and retrieve data independently (all functions so far combined these two). Any suggestions for the names `start_acquisition` and `retrieve_data` are welcome.
- Put common code into `_transfer_buffer_numpy`

@jenshnielsen @WilliamHPNielsen 