### PR TITLE
Fix incorrect inferred_from retrieval

### DIFF
--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1011,7 +1011,12 @@ def get_paramspec(conn: sqlite3.Connection,
     resp = many(c, 'layout_id', 'run_id', 'parameter', 'label', 'unit',
                 'inferred_from')
 
-    (layout_id, _, _, label, unit, inferred_from) = resp
+    (layout_id, _, _, label, unit, inferred_from_string) = resp
+
+    if inferred_from_string:
+        inferred_from = inferred_from_string.split(', ')
+    else:
+        inferred_from = []
 
     deps = get_dependencies(conn, layout_id)
     depends_on: Optional[List[str]]
@@ -1029,7 +1034,8 @@ def get_paramspec(conn: sqlite3.Connection,
             depends_on.append(one(c, 'parameter'))
 
     parspec = ParamSpec(param_name, param_type, label, unit,
-                        inferred_from, depends_on)
+                        inferred_from,
+                        depends_on)
     return parspec
 
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -103,17 +103,23 @@ def test_add_paramspec(dataset):
     assert exp.sample_name == "test-sample"
     assert exp.last_counter == 1
 
-    parameter_a = ParamSpec("a", "NUMERIC")
-    parameter_b = ParamSpec("b", "NUMERIC", key="value", number=1)
-    parameter_c = ParamSpec("c", "array")
+    parameter_a = ParamSpec("a_param", "NUMERIC")
+    parameter_b = ParamSpec("b_param", "NUMERIC", key="value", number=1)
+    parameter_c = ParamSpec("c_param", "array", inferred_from=[parameter_a,
+                                                               parameter_b])
     dataset.add_parameters([parameter_a, parameter_b, parameter_c])
+
+    # Now retrieve the paramspecs
+
     paramspecs = dataset.paramspecs
-    expected_keys = ['a', 'b', 'c']
+    expected_keys = ['a_param', 'b_param', 'c_param']
     keys = sorted(list(paramspecs.keys()))
     assert keys == expected_keys
     for expected_param_name in expected_keys:
         ps = paramspecs[expected_param_name]
         assert ps.name == expected_param_name
+
+    assert paramspecs['c_param'].inferred_from == 'a_param, b_param'
 
 
 def test_add_paramspec_one_by_one(dataset):


### PR DESCRIPTION
As pointed out by @sohailc 

Changes proposed in this pull request:
- Make paramspecs have their `inferred_from` parameters retrieved correctly
- Add a test that didn't pass before this fix


@jenshnielsen 
