### PR TITLE
Fix tests for pyvisa19

### DIFF
--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -15,6 +15,9 @@ log = logging.getLogger(__name__)
 class AMI430Exception(Exception):
     pass
 
+class AMI430Warning(UserWarning):
+    pass
+
 class AMI430SwitchHeater(InstrumentChannel):
     class _Decorators:
         @classmethod
@@ -360,7 +363,7 @@ class AMI430(IPInstrument):
                                " any magnet. Change this value at your own "
                                "responsibility after consulting the specs of "
                                "your particular magnet")
-            warn(warning_message)
+            warn(warning_message, category=AMI430Warning)
 
         # Update ramp limit
         self._current_ramp_limit = new_current_rate_limit

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -8,7 +8,7 @@ import logging
 from typing import List, Dict
 
 import qcodes.instrument.sims as sims
-from qcodes.instrument_drivers.american_magnetics.AMI430 import AMI430_3D
+from qcodes.instrument_drivers.american_magnetics.AMI430 import AMI430_3D, AMI430Warning
 from qcodes.instrument.ip_to_visa import AMI430_VISA
 from qcodes.math.field_vector import FieldVector
 
@@ -389,14 +389,12 @@ def test_warning_increased_max_ramp_rate():
     # Increasing the maximum ramp rate should raise a warning
     target_ramp_rate = max_ramp_rate + 0.01
 
-    with pytest.warns(Warning) as excinfo:
+    with pytest.warns(AMI430Warning, match="Increasing maximum ramp rate") as excinfo:
         AMI430_VISA("testing_increased_max_ramp_rate",
                     address='GPIB::4::65535::INSTR', visalib=visalib,
                     terminator='\n', port=1,
                     current_ramp_limit=target_ramp_rate)
-
-        assert len(excinfo) == 1 # Check we onlt saw one warning
-        assert "Increasing maximum ramp rate" in excinfo[0].message.args[0]
+        assert len(excinfo) >= 1 # Check we at least one warning.
 
 
 def test_ramp_rate_exception(current_driver):


### PR DESCRIPTION
Hopefully fixes Travis failing 

We change the warning to be ami specific and only capture that
We have to rewrite the checking code because exeinfo will contain data for all warnings
not just the captured ones so use the context manager instead to to the check