### PR TITLE
Travis only upgrade if needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ branches:
 install:
     - pip install --upgrade pip
     - pip install -r requirements.txt
-    - pip install -r test_requirements.txt --upgrade
+    - pip install -r test_requirements.txt --upgrade --upgrade-strategy only-if-needed
     - pip install -r docs_requirements.txt
 # Install a new version of Sphinx that correctly handles forward refs once 1.7.0 is out that should
 # be used instead


### PR DESCRIPTION
This prevents the dependency on pyvisa-sim in test_requirements.txt from upgrading pyvisa regardless of the fact that we pinned the version in requirements.txt