### PR TITLE
Unpin coverage

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-coverage==4.4.2
+coverage!=4.5.0
 pytest-cov
 pytest
 codacy-coverage


### PR DESCRIPTION
The bug in coverage 4.5.0 should be fixed in 4.5.1, see https://bitbucket.org/ned/coveragepy/issues/638/run-omit-is-ignored-since-45

@QCoDeS/core 