### PR TITLE
limit numpy to 1.13.x until h5py is compatible with 1.14

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
  - QtPy
  - sip
  - pyqt=5.6.0
- - numpy==1.13.3
+ - numpy=1.13.3
  - jupyter=1.0.0
  - hypothesis
  - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
  - QtPy
  - sip
  - pyqt=5.6.0
- - numpy
+ - numpy==1.13.3
  - jupyter=1.0.0
  - hypothesis
  - pytest

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(name='qcodes',
       package_data={'qcodes': ['monitor/dist/*', 'monitor/dist/js/*',
                                'monitor/dist/css/*', 'config/*.json']},
       install_requires=[
-          'numpy>=1.10',
+          'numpy>=1.10,<1.14',
           'pyvisa>=1.8',
           'h5py>=2.6',
           'websockets>=3.2,<3.4',


### PR DESCRIPTION
Fixes annoying warning at the start of qcodes sessions