### PR TITLE
Make comparison of parameters not deferred

### DIFF
--- a/qcodes/utils/deferred_operations.py
+++ b/qcodes/utils/deferred_operations.py
@@ -147,6 +147,8 @@ class DeferredOperations:
                 '{}, type {}'.format(repr(other), repr(type(other))))
 
     def __eq__(self, other):
+        if id(self) == id(other):
+            return True
         return self._binary(operator.eq, other)
 
     def __ne__(self, other):


### PR DESCRIPTION
The `DeferredOperations` allow to postpone the calculation with parameters to a later stage, so that expressions that depend on parameters can be formed and evaluated with the value of the parameter at evaluation time.
This is problematic especially for the __eq__ operator. With a deferred identity comparison, parameters can e.g. not be removed from a list.
Here we remove the creation of a deferred operation on identity comparison. I cannot think of any application, but this PR has to be taken with caution as it affects the code in so many places.