### PR TITLE
 add root_instrument property

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -243,6 +243,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             else:
                 submodule.print_readable_snapshot(update, max_chars)
 
+    def get_root_instrument(self) -> InstrumentBase:
+        return self
     #
     # shortcuts to parameters & setters & getters                           #
     #

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -243,7 +243,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             else:
                 submodule.print_readable_snapshot(update, max_chars)
 
-    def get_root_instrument(self) -> 'InstrumentBase':
+    @property
+    def root_instrument(self) -> 'InstrumentBase':
         return self
     #
     # shortcuts to parameters & setters & getters                           #

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -243,7 +243,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             else:
                 submodule.print_readable_snapshot(update, max_chars)
 
-    def get_root_instrument(self) -> InstrumentBase:
+    def get_root_instrument(self) -> 'InstrumentBase':
         return self
     #
     # shortcuts to parameters & setters & getters                           #

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -59,8 +59,9 @@ class InstrumentChannel(InstrumentBase):
     def ask_raw(self, cmd):
         return self._parent.ask_raw(cmd)
 
-    def get_root_instrument(self) -> InstrumentBase:
-        return self._parent.get_root_instrument()
+    @property
+    def root_instrument(self) -> InstrumentBase:
+        return self._parent.root_instrument
 
 class MultiChannelInstrumentParameter(MultiParameter):
     """

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -59,6 +59,8 @@ class InstrumentChannel(InstrumentBase):
     def ask_raw(self, cmd):
         return self._parent.ask_raw(cmd)
 
+    def get_root_instrument(self) -> InstrumentBase:
+        return self._parent.get_root_instrument()
 
 class MultiChannelInstrumentParameter(MultiParameter):
     """

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -619,6 +619,11 @@ class _BaseParameter(Metadatable, DeferredOperations):
         else:
             raise TypeError('vals must be a Validator')
 
+    def get_root_instrument(self) -> InstrumentBase:
+        if self._instrument is not None:
+            return self._instr.get_root_instrument()
+        else:
+            return None
 
 class Parameter(_BaseParameter):
     """

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -74,7 +74,7 @@ from qcodes.instrument.sweep_values import SweepFixedValues
 from qcodes.data.data_array import DataArray
 
 if TYPE_CHECKING:
-    from .base import Instrument
+    from .base import Instrument, InstrumentBase
 
 
 class _BaseParameter(Metadatable, DeferredOperations):
@@ -619,9 +619,9 @@ class _BaseParameter(Metadatable, DeferredOperations):
         else:
             raise TypeError('vals must be a Validator')
 
-    def get_root_instrument(self) -> InstrumentBase:
+    def get_root_instrument(self) -> 'InstrumentBase':
         if self._instrument is not None:
-            return self._instr.get_root_instrument()
+            return self._instrument.get_root_instrument()
         else:
             return None
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -619,9 +619,10 @@ class _BaseParameter(Metadatable, DeferredOperations):
         else:
             raise TypeError('vals must be a Validator')
 
-    def get_root_instrument(self) -> 'InstrumentBase':
+    @property
+    def root_instrument(self) -> Optional['InstrumentBase']:
         if self._instrument is not None:
-            return self._instrument.get_root_instrument()
+            return self._instrument.root_instrument
         else:
             return None
 

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -257,5 +257,12 @@ class TestChannelsLoop(TestCase):
         self.assertIn('testchanneldummy_ChanA_temperature_set', data.arrays.keys())
         assert_array_equal(data.arrays['testchanneldummy_ChanA_temperature_set'].ndarray, np.arange(0, 10.1, 1))
 
+    def test_root_instrument(self):
+        assert self.instrument.root_instrument is self.instrument
+        for channel in self.instrument.channels:
+            assert channel.root_instrument is self.instrument
+            for parameter in channel.parameters.values():
+                assert parameter.root_instrument is self.instrument
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds a get_root_instrument method to InstrumentBase, InstrumentChannel, and _BaseParameter.
as of now channels are treated as instruments that have a parent. To find the actual instrument a parameter in a channel belongs to, one has to iterate up until one finds an instrument that is not a channel.
With this PR one simply gets this root experiment with the added function.