### PR TITLE
add missing channel to keithley 2600 resistance 

### DIFF
--- a/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
@@ -118,7 +118,7 @@ class KeithleyChannel(InstrumentChannel):
                            unit='A')
 
         self.add_parameter('res',
-                           get_cmd='measure.r()',
+                           get_cmd='{}.measure.r()'.format(channel),
                            get_parser=float,
                            set_cmd=False,
                            label='Resistance',


### PR DESCRIPTION
This was missed when converting from non channel version that injects this in  a different way. Matches V and I 
