### PR TITLE
Support mypy 0.590

### DIFF
--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -90,7 +90,8 @@ CREATE TABLE IF NOT EXISTS dependencies (
 _unicode_categories = ('Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nd', 'Pc', 'Pd', 'Zs')
 # utility function to allow sqlite/numpy type
 
-def _adapt_array(arr: ndarray) -> sqlite3.Binary:
+
+def _adapt_array(arr: ndarray) -> Any: # this should really be sqlite3.Binary but there seems to be a bug in mypy 0.590
     """
     See this:
     https://stackoverflow.com/questions/3425320/sqlite3-programmingerror-you-must-not-use-8-bit-bytestrings-unless-you-use-a-te

--- a/qcodes/instrument_drivers/Spectrum/pyspcm.py
+++ b/qcodes/instrument_drivers/Spectrum/pyspcm.py
@@ -55,7 +55,7 @@ if os.name == 'nt':
         # for unknown reasons c_void_p gets messed up on Win7/64bit, but this works:
         drv_handle = POINTER(c_uint64)
     else:
-        drv_handle = c_void_p
+        drv_handle = c_void_p # type: ignore
 
     # Load DLL into memory.
     # use windll because all driver access functions use _stdcall calling convention under windows
@@ -157,7 +157,7 @@ elif os.name == 'posix':
     sys.stdout.write("Linux found")
 
     # define card handle type
-    drv_handle = c_void_p
+    drv_handle = c_void_p # type: ignore
 
     # Load DLL into memory.
     # use cdll because all driver access functions use cdecl calling convention under linux 

--- a/qcodes/instrument_drivers/Spectrum/pyspcm.py
+++ b/qcodes/instrument_drivers/Spectrum/pyspcm.py
@@ -161,7 +161,7 @@ elif os.name == 'posix':
 
     # Load DLL into memory.
     # use cdll because all driver access functions use cdecl calling convention under linux 
-    spcmDll = cdll.LoadLibrary ("libspcm_linux.so")
+    spcmDll = cdll.LoadLibrary ("libspcm_linux.so") # type: ignore
 
     # load spcm_hOpen
     spcm_hOpen = getattr (spcmDll, "spcm_hOpen")


### PR DESCRIPTION
Ignore an issue in the bundled pyscm code and work around an issue with typing of sqlite3
See https://github.com/python/mypy/issues/4916

@QCoDeS/core 
