### PR TITLE
`is_function` has moved so don't import from deprecated module

### DIFF
--- a/qcodes/actions.py
+++ b/qcodes/actions.py
@@ -1,7 +1,7 @@
 """Actions, mainly to be executed in measurement Loops."""
 import time
 
-from qcodes.utils.deferred_operations import is_function
+from qcodes.utils.helpers import is_function
 from qcodes.utils.threading import thread_map
 
 


### PR DESCRIPTION
Otherwise this triggers the warning because it's at Class level so the warning is displayed as soon as this module is imported. @QCoDeS/core 

