### PR TITLE
Use uuid over homegrown function

### DIFF
--- a/docs/examples/DataSet/subscriber json exporter.ipynb
+++ b/docs/examples/DataSet/subscriber json exporter.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qcodes.dataset.data_set import new_data_set, ParamSpec, hash_from_parts\n",
+    "from qcodes.dataset.data_set import new_data_set, ParamSpec\n",
     "from qcodes.dataset.json_exporter import json_template_heatmap, json_template_linear\n",
     "from qcodes.dataset.json_exporter import export_data_as_json_heatmap, export_data_as_json_linear\n",
     "from qcodes.dataset.sqlite_base import new_experiment, connect, length"
@@ -471,7 +471,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -12,6 +12,7 @@ from threading import Thread
 import time
 import logging
 import hashlib
+import uuid
 from queue import Queue, Empty
 
 import qcodes.config
@@ -547,7 +548,7 @@ class DataSet(Sized):
                   state: Optional[Any] = None,
                   callback_kwargs: Optional[Dict[str, Any]] = None,
                   subscriber_class=Subscriber) -> str:
-        sub_id = hash_from_parts(str(time.time()))
+        sub_id = uuid.uuid4().hex
         sub = Subscriber(self, sub_id, callback, state, min_wait, min_count,
                          callback_kwargs)
         self.subscribers[sub_id] = sub

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -14,6 +14,7 @@ import logging
 import hashlib
 import uuid
 from queue import Queue, Empty
+import warnings
 
 import qcodes.config
 from qcodes.dataset.param_spec import ParamSpec
@@ -678,5 +679,8 @@ def hash_from_parts(*parts: str) -> str:
     Returns:
         hash created with the given parts
     """
+    warnings.warn("hash_from_parts has been deprecated and will be removed. "
+                  "Use stdlib uuid4 instead",
+                  stacklevel=2)
     combined = "".join(parts)
     return hashlib.sha1(combined.encode("utf-8")).hexdigest()


### PR DESCRIPTION
Fixes https://github.com/QCoDeS/Qcodes/issues/1057

the hash function may return the same hash for two subs created just after each other due to the low resolution of time.time. Rather than fixing this by adding extra entropy from a random number i suggest using the python uuid module 
@WilliamHPNielsen 
