### PR TITLE
MyPy: We don't cleanly pass strict optional so disable that for now

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,6 +31,6 @@ test_script:
   - cd tests
   - pytest
   - cd ..\..
-  - mypy qcodes --ignore-missing-imports
+  - mypy qcodes --ignore-missing-imports --no-strict-optional
   - cd docs
   - execute_notebooks.cmd

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ script:
     # build docs with warnings as errors
     - |
       cd ..
-      mypy qcodes --ignore-missing-imports
+      mypy qcodes --ignore-missing-imports --no-strict-optional
+
     - |
       cd docs
       make SPHINXOPTS="-W" html-api


### PR DESCRIPTION
This is an issue with the new MyPy 0.600 
