### PR TITLE
make register_parameter match add_result for array_parameter

### DIFF
--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -422,8 +422,8 @@ class Measurement:
         if isinstance(parameter, ArrayParameter):
             parameter = cast(ArrayParameter, parameter)
             spname_parts = []
-            if parameter.root_instrument is not None:
-                inst_name = parameter.root_instrument.name
+            if parameter._instrument is not None:
+                inst_name = parameter._instrument.name
                 if inst_name is not None:
                     spname_parts.append(inst_name)
             if parameter.setpoint_names is not None:

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -422,8 +422,8 @@ class Measurement:
         if isinstance(parameter, ArrayParameter):
             parameter = cast(ArrayParameter, parameter)
             spname_parts = []
-            if parameter._instrument is not None:
-                inst_name = parameter._instrument.name
+            if parameter.instrument is not None:
+                inst_name = parameter.instrument.name
                 if inst_name is not None:
                     spname_parts.append(inst_name)
             if parameter.setpoint_names is not None:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -660,7 +660,10 @@ class _BaseParameter(Metadatable):
     @property
     def instrument(self) -> Optional['InstrumentBase']:
         """
-        Return the first instrument that this parameter is bound to
+        Return the first instrument that this parameter is bound to.
+        E.g if this is bound to a channel it will return the channel
+        and not the instrument that the channel is bound too. Use
+        :meth:`root_instrument` to get the real instrument.
         """
         return self._instrument
 
@@ -669,8 +672,8 @@ class _BaseParameter(Metadatable):
         """
         Return the fundamental instrument that this parameter belongs too.
         E.g if the parameter is bound to a channel this will return the
-        fundamental instrument that that channel belongs to.
-
+        fundamental instrument that that channel belongs to. Use
+        :meth:`instrument` to get the channel.
         """
         if self._instrument is not None:
             return self._instrument.root_instrument

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -658,7 +658,20 @@ class _BaseParameter(Metadatable):
             raise TypeError('vals must be a Validator')
 
     @property
+    def instument(self) -> Optional['InstrumentBase']:
+        """
+        Return the first instrument that this parameter is bound to
+        """
+        return self._instrument
+
+    @property
     def root_instrument(self) -> Optional['InstrumentBase']:
+        """
+        Return the fundamental instrument that this parameter belongs too.
+        E.g if the parameter is bound to a channel this will return the
+        fundamental instrument that that channel belongs to.
+
+        """
         if self._instrument is not None:
             return self._instrument.root_instrument
         else:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -658,7 +658,7 @@ class _BaseParameter(Metadatable):
             raise TypeError('vals must be a Validator')
 
     @property
-    def instument(self) -> Optional['InstrumentBase']:
+    def instrument(self) -> Optional['InstrumentBase']:
         """
         Return the first instrument that this parameter is bound to
         """


### PR DESCRIPTION
@WilliamHPNielsen Fixes an inconsistency between add_parameter and the register_parameter for ArrayParameters. At the one uses the name of the root instrument but the other users the full name. This fails for an arrayparameter inside a channel since one name will contain the name of the channel but the other one does not. 
