### PR TITLE
qcodes-1124 Add explicit flushing to avoid instability of testing

### DIFF
--- a/qcodes/tests/dataset/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/test_measurement_context_manager.py
@@ -341,6 +341,10 @@ def test_enter_and_exit_actions(experiment, DAC, words):
 
 
 def test_subscriptions(experiment, DAC, DMM):
+    """
+    Here the following is tested: subscribers should be called at the moment the data is flushed to the database,
+    i.e. after new result is added. For the purpose of testing, flush_data_to_database method is called explicitly.
+    """
 
     def subscriber1(results, length, state):
         """
@@ -383,8 +387,10 @@ def test_subscriptions(experiment, DAC, DMM):
 
             (a, b) = as_and_bs[num]
             expected_list += [c for c in (a, b) if c > 7]
-            sleep(1.2*meas.write_period)
+
             datasaver.add_result((DAC.ch1, a), (DMM.v1, b))
+            datasaver.flush_data_to_database()
+
             assert lt7s == expected_list
             assert list(res_dict.keys()) == [n for n in range(1, num+2)]
 

--- a/qcodes/tests/dataset/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/test_measurement_context_manager.py
@@ -342,8 +342,15 @@ def test_enter_and_exit_actions(experiment, DAC, words):
 
 def test_subscriptions(experiment, DAC, DMM):
     """
-    Here the following is tested: subscribers should be called at the moment the data is flushed to the database,
-    i.e. after new result is added. For the purpose of testing, flush_data_to_database method is called explicitly.
+    Test that subscribers are called at the moment that data is flushed to database
+
+    Note that for the purpose of this test, flush_data_to_database method is called explicitly instead of waiting for
+    the data to be flushed automatically after the write_period passes after a add_result call.
+
+    Args:
+        experiment (qcodes.dataset.experiment_container.Experiment) : qcodes experiment object
+        DAC (qcodes.instrument.base.Instrument) : dummy instrument object
+        DMM (qcodes.instrument.base.Instrument) : another dummy instrument object
     """
 
     def subscriber1(results, length, state):


### PR DESCRIPTION
Partially fixes #1124 

The test for subscriptions for the dataset is not stable, which means that it occasionally passes. This pull-request makes the test stable by actually making it more explicit.

The test essentially checks whether subscribers get executed at the moment the data is flushed to the database. In order to test it, two subscribers are created, data is added in a loop, and assertions are performed in the same loop. Since data is flushed to the database only once within a write_period, the original code uses sleep method next to the call to add_result, where the sleep time is set to 120% of the write_period - this way the test "ensures" that the data is flushed to the database (hence, subscribers are called) and assertions can validly be performed.

The problem of this approach is that if the sleep time is not enough for the data to be flushed to the database at some point, perhaps, due to the fact that some other system processes accidentally get higher priority, then at the moment when an assertion is performed, the expected data may not be in the database yet.

In order to make the test for subscribers more stable and explicit, the sleeping approach is substituted with an explicit call to flush_data_to_database.

@WilliamHPNielsen please have a look at the fix