### PR TITLE
Close_all catch all exceptions and log them

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -489,8 +489,8 @@ class Instrument(InstrumentBase):
                 inst = cls.find_instrument(inststr)
                 log.info(f"Closing {inststr}")
                 inst.close()
-            except KeyError:
-                log.info(f"Failed to close {inststr}, ignored")
+            except:
+                log.exception(f"Failed to close {inststr}, ignored")
                 pass
 
     @classmethod


### PR DESCRIPTION
In this special case it's better to catch catch bare exceptions since this is tear down code and any exception will stop closing the rest of the instruments

@QCoDeS/core 