### PR TITLE
Mypy/channel typing fixes

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -7,7 +7,7 @@ from typing import Sequence, Optional, Dict, Union, Callable, Any, List, TYPE_CH
 
 import numpy as np
 if TYPE_CHECKING:
-    from qcodes.instrumet.channel import ChannelList
+    from qcodes.instrument.channel import ChannelList
 from qcodes.utils.helpers import DelegateAttributes, strip_attrs, full_class
 from qcodes.utils.metadata import Metadatable
 from qcodes.utils.validators import Anything
@@ -46,9 +46,10 @@ class InstrumentBase(Metadatable, DelegateAttributes):
                  metadata: Optional[Dict]=None, **kwargs) -> None:
         self.name = str(name)
 
-        self.parameters = {} # type: Dict[str, _BaseParameter]
-        self.functions = {} # type: Dict[str, Function]
-        self.submodules = {} # type: Dict[str, Union['InstrumentBase', 'ChannelList']]
+        self.parameters: Dict[str, _BaseParameter] = {}
+        self.functions: Dict[str, Function] = {}
+        self.submodules: Dict[str, Union['InstrumentBase',
+                                         'ChannelList']] = {}
         super().__init__(**kwargs)
 
     def add_parameter(self, name: str,
@@ -243,6 +244,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
 
         for submodule in self.submodules.values():
             if hasattr(submodule, '_channels'):
+                submodule = cast('ChannelList', submodule)
                 if submodule._snapshotable:
                     for channel in submodule._channels:
                         channel.print_readable_snapshot()

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -77,7 +77,7 @@ class MultiChannelInstrumentParameter(MultiParameter):
         param_name(str): Name of the multichannel parameter
     """
     def __init__(self,
-                 channels: Union[List, Tuple],
+                 channels: Sequence[InstrumentChannel],
                  param_name: str,
                  *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -175,15 +175,21 @@ class ChannelList(Metadatable):
         # provide lookup of channels by name
         # If a list of channels is not provided, define a list to store
         # channels. This will eventually become a locked tuple.
+        self._channels: Sequence[InstrumentChannel]
         if chan_list is None:
             self._locked = False
-            self._channels: Union[List[InstrumentChannel],Tuple[InstrumentChannel, ...]] = []
+            self._channels = []
         else:
             self._locked = True
             self._channels = tuple(chan_list)
+            # At this stage mypy (0.610) is convinced that self._channels is
+            # None. Creating a local variable seems to resolve this
+            channels = cast(Tuple[InstrumentChannel, ...], self._channels)
+            if channels is None:
+                raise RuntimeError("Empty channel list")
             self._channel_mapping = {channel.short_name: channel
-                                     for channel in self._channels}
-            if not all(isinstance(chan, chan_type) for chan in self._channels):
+                                     for channel in channels}
+            if not all(isinstance(chan, chan_type) for chan in channels):
                 raise TypeError("All items in this channel list must be of "
                                 "type {}.".format(chan_type.__name__))
 
@@ -257,9 +263,10 @@ class ChannelList(Metadatable):
                             ".".format(type(obj).__name__,
                                        self._chan_type.__name__))
         self._channel_mapping[obj.short_name] = obj
+        self._channels = cast(List[InstrumentChannel], self._channels)
         return self._channels.append(obj)
 
-    def extend(self, objects):
+    def extend(self, objects: Sequence[InstrumentChannel]):
         """
         Insert an iterable of objects into the list of channels.
 
@@ -269,13 +276,15 @@ class ChannelList(Metadatable):
         """
         # objects may be a generator but we need to iterate over it twice
         # below so copy it into a tuple just in case.
-        objects = tuple(objects)
+        objects_tuple = tuple(objects)
         if self._locked:
             raise AttributeError("Cannot extend a locked channel list")
-        if not all(isinstance(obj, self._chan_type) for obj in objects):
+        if not all(isinstance(obj, self._chan_type) for obj in objects_tuple):
             raise TypeError("All items in a channel list must be of the same "
                             "type.")
-        return self._channels.extend(objects)
+        channels = cast(List[InstrumentChannel], self._channels)
+        channels.extend(objects_tuple)
+        self._channels = channels
 
     def index(self, obj: InstrumentChannel):
         """
@@ -286,7 +295,7 @@ class ChannelList(Metadatable):
         """
         return self._channels.index(obj)
 
-    def insert(self, index: int, obj: InstrumentChannel):
+    def insert(self, index: int, obj: InstrumentChannel) -> None:
         """
         Insert an object into the channel list at a specific index.
 
@@ -302,8 +311,8 @@ class ChannelList(Metadatable):
                             "type. Adding {} to a list of {}"
                             ".".format(type(obj).__name__,
                                        self._chan_type.__name__))
-
-        return self._channels.insert(index, obj)
+        self._channels = cast(List[InstrumentChannel], self._channels)
+        self._channels.insert(index, obj)
 
     def get_validator(self):
         """
@@ -314,7 +323,7 @@ class ChannelList(Metadatable):
             raise AttributeError("Cannot create a validator for an unlocked channel list")
         return ChannelListValidator(self)
 
-    def lock(self):
+    def lock(self) -> None:
         """
         Lock the channel list. Once this is done, the channel list is
         converted to a tuple and any future changes to the list are prevented.
@@ -461,7 +470,7 @@ class ChannelListValidator(Validator):
                 "to create a validator")
         self._channel_list = channel_list
 
-    def validate(self, value, context=''):
+    def validate(self, value, context: str='') -> None:
         """
         Checks to see that value is a member of the channel list referenced by this
         validator


### PR DESCRIPTION
Some small fixes to typing of channels lifted from a feature branch

* Correct a typo that was unnoticed because it was guarded by TYPE_CHECKING
* Correctly use sequence
* Correct signature of various methods that actually never return anything

@QCoDeS/core 