### PR TITLE
Allow tuple selection for ChannelLists

### DIFF
--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -187,7 +187,7 @@ class ChannelList(Metadatable):
                 raise TypeError("All items in this channel list must be of "
                                 "type {}.".format(chan_type.__name__))
 
-    def __getitem__(self, i: Union[int, slice]):
+    def __getitem__(self, i: Union[int, slice, tuple]):
         """
         Return either a single channel, or a new ChannelList containing only
         the specified channels
@@ -199,6 +199,10 @@ class ChannelList(Metadatable):
         if isinstance(i, slice):
             return ChannelList(self._parent, self._name, self._chan_type,
                                self._channels[i],
+                               multichan_paramclass=self._paramclass)
+        elif isinstance(i, tuple):
+            return ChannelList(self._parent, self._name, self._chan_type,
+                               [self._channels[j] for j in i],
                                multichan_paramclass=self._paramclass)
         return self._channels[i]
 


### PR DESCRIPTION
We are currently calling channellists for measurements with alazar and VNA. Sometimes one wants to take data from only a subset of the channels in the channellists however currently one can only choose slices or a single channel.
This PR allows one to take data from a subset of a channellist defined by a tuple (e.g. alazar_ctrl.channels[2,4,6].data).

Changes proposed in this pull request:
- Add functionality for channellist __getitem__ to allow for a tuple in addition to int and slice.

@jenshnielsen 
