### PR TITLE
Consistent names

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -45,6 +45,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
     def __init__(self, name: str,
                  metadata: Optional[Dict]=None, **kwargs) -> None:
         self.name = str(name)
+        self.short_name = str(name)
 
         self.parameters = {} # type: Dict[str, _BaseParameter]
         self.functions = {} # type: Dict[str, Function]

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -46,6 +46,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
                  metadata: Optional[Dict]=None, **kwargs) -> None:
         self.name = str(name)
         self.short_name = str(name)
+        self.full_name = str(name)
 
         self.parameters = {} # type: Dict[str, _BaseParameter]
         self.functions = {} # type: Dict[str, Function]

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -35,6 +35,7 @@ class InstrumentChannel(InstrumentBase):
 
         self.name = "{}_{}".format(parent.name, str(name))
         self.short_name = str(name)
+        self.full_name = self.name
         self._meta_attrs = ['name']
 
         self._parent = parent

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -200,6 +200,7 @@ class _BaseParameter(Metadatable):
                  delay: Optional[Union[int, float]]=None) -> None:
         super().__init__(metadata)
         self.name = str(name)
+        self.short_name = str(name)
         self._instrument = instrument
         self._snapshot_get = snapshot_get
         self._snapshot_value = snapshot_value

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -155,6 +155,41 @@ class TestChannels(TestCase):
             assert chan.name == f'testchanneldummy_Chan{names[chanindex]}'
 
 
+    def test_names(self):
+        ex_inst_name = 'testchanneldummy'
+        for channel in self.instrument.channels:
+            sub_channel = DummyChannel(channel, 'subchannel', 'subchannel')
+            channel.add_submodule('somesubchannel', sub_channel)
+        assert self.instrument.name == ex_inst_name
+        assert self.instrument.full_name == ex_inst_name
+        assert self.instrument.short_name == ex_inst_name
+        # Parameters directly on instrument
+        assert self.instrument.IDN.name == 'IDN'
+        assert self.instrument.IDN.full_name == f"{ex_inst_name}_IDN"
+        for chan, name in zip(self.instrument.channels,
+                              ['A', 'B', 'C', 'D', 'E', 'F']):
+            ex_chan_name = f"Chan{name}"
+            ex_chan_full_name = f"{ex_inst_name}_{ex_chan_name}"
+            assert chan.short_name == ex_chan_name
+            assert chan.name == ex_chan_full_name
+            assert chan.full_name == ex_chan_full_name
+
+            ex_param_name = 'temperature'
+            assert chan.temperature.name == ex_param_name
+            assert chan.temperature.full_name == f'{ex_chan_full_name}_{ex_param_name}'
+            assert chan.temperature.short_name == ex_param_name
+
+            ex_subchan_name = f"subchannel"
+            ex_subchan_full_name = f"{ex_chan_full_name}_{ex_subchan_name}"
+
+            assert chan.somesubchannel.short_name == ex_subchan_name
+            assert chan.somesubchannel.name == ex_subchan_full_name
+            assert chan.somesubchannel.full_name == ex_subchan_full_name
+
+            assert chan.somesubchannel.temperature.name == ex_param_name
+            assert chan.somesubchannel.temperature.full_name == f'{ex_subchan_full_name}_{ex_param_name}'
+            assert chan.somesubchannel.temperature.short_name == ex_param_name
+
 class TestChannelsLoop(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Fixes #1140 .

This tries to fix #1140 by making instrument, channel and paramters have consistent full_name and short_name. `name` is still behaving different. Adds tests for the behavior too

@QCoDeS/core 