### PR TITLE
Change loglevel for send/recv in ip.py

### DIFF
--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -145,12 +145,12 @@ class IPInstrument(Instrument):
 
     def _send(self, cmd):
         data = cmd + self._terminator
-        log.info(f"Writing {data} to instrument {self.name}")
+        log.debug(f"Writing {data} to instrument {self.name}")
         self._socket.sendall(data.encode())
 
     def _recv(self):
         result = self._socket.recv(self._buffer_size)
-        log.info(f"Got {result} from instrument {self.name}")
+        log.debug(f"Got {result} from instrument {self.name}")
         if result == b'':
             log.warning("Got empty response from Socket recv() "
                         "Connection broken.")


### PR DESCRIPTION
Loglevel `info` for send/recv commands completely floods logfile when using ip instruments. Propose to change level to debug.

Changes proposed in this pull request:
- Change loglevel for send/recv of ip instruments from info to debug.


@Dominik-Vogel 
