### PR TITLE
apply get_raw recommendation SR830 driver

### DIFF
--- a/qcodes/instrument_drivers/stanford_research/SR830.py
+++ b/qcodes/instrument_drivers/stanford_research/SR830.py
@@ -84,7 +84,7 @@ class ChannelBuffer(ArrayParameter):
         else:
             self._instrument._buffer2_ready = True
 
-    def get(self):
+    def get_raw(self):
         """
         Get command. Returns numpy array
         """


### PR DESCRIPTION
... and get rid of the corresponding warning

@WilliamHPNielsen @jenshnielsen 
