### PR TITLE
Added support for N5183B Signal Generator

### DIFF
--- a/qcodes/instrument_drivers/Keysight/Keysight_N5183B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N5183B.py
@@ -1,0 +1,3 @@
+from qcodes.instrument_drivers.Keysight.N51x1 import N51x1 as N5183B
+# N5183B has the same interface as N51x1 devices
+# This file is to allow for improved device labeling.

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -42,8 +42,8 @@ class N51x1(VisaInstrument):
 
         self.add_parameter('rf_output',
                            get_cmd='OUTP:STAT?',
-                           set_cmd='OUTP:STAT ' + '{:s}',
-                           val_mapping={'on': '1', 'off': '0'})
+                           set_cmd='OUTP:STAT {}',
+                           val_mapping={'on': 1, 'off': 0})
                             
         self.connect_message()
         

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -6,7 +6,7 @@ from qcodes.utils.validators import Numbers
 class N51x1(VisaInstrument):
     """
     This is the qcodes driver for Keysight/Agilent scalar RF sources.
-    It has been tested with N5171B, N5181A, N5171B
+    It has been tested with N5171B, N5181A, N5171B, N5183B
     """
 
     def __init__(self, name, address, **kwargs):
@@ -21,7 +21,8 @@ class N51x1(VisaInstrument):
                            vals=Numbers(min_value=-144,max_value=19))
 
         # Query the instrument to see what frequency range was purchased
-        freq_dict = {'501':1e9, '503':3e9, '505':6e9}
+        freq_dict = {'501':1e9, '503':3e9, '505':6e9, '520':20e9}
+
         max_freq = freq_dict[self.ask('*OPT?')]
         self.add_parameter('frequency',
                            label='Frequency',
@@ -42,7 +43,7 @@ class N51x1(VisaInstrument):
         self.add_parameter('rf_output',
                            get_cmd='OUTP:STAT?',
                            set_cmd='OUTP:STAT ' + '{:s}',
-                           val_mapping={'on': 1, 'off': 0})
+                           val_mapping={'on': '1', 'off': '0'})
                             
         self.connect_message()
         


### PR DESCRIPTION
Added support for the Agilent/Keysight N5183B Signal Generator.

Fixed a string type error as well in val_mapping.
The set_cmd has the formatting of a string, so I changed the val_mapping to a string.
```
set_cmd='OUTP:STAT ' + '{:s}'
```

Additionally this device doesn't really match the model number of the previous devices, but it's effectively the same.  I leaned toward adding it despite the name not matching exactly vs creating a whole new driver which would just be a copy of the original with a very slight name change.