### PR TITLE
pin hypothesis to less than 3.62 which adds problematic typehints

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,7 @@ coverage!=4.5.0
 pytest-cov
 pytest
 codacy-coverage
-hypothesis
+hypothesis==3.61.0 # type annotation failures with mypy for 3.62.0 and later
 mypy!=0.570 # due to https://github.com/python/mypy/issues/4674
 git+https://github.com/QCoDeS/pyvisa-sim.git
 git+https://github.com/QCoDeS/broadbean


### PR DESCRIPTION
@QCoDeS/core this should unbreak travis and appveyor 