### PR TITLE
Keithley 2400 protect read commands

### DIFF
--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -38,14 +38,27 @@ class Keithley_2400(VisaInstrument):
                            get_parser=self._volt_parser,
                            set_cmd=':SOUR:VOLT:LEV {:.8f}',
                            label='Voltage',
-                           unit='V')
+                           unit='V',
+                           docstring="Sets voltage in 'VOLT' mode. "
+                                     "Get returns measured voltage if "
+                                     "sensing 'VOLT' otherwise it returns "
+                                     "setpoint value. "
+                                     "Note that it is an error to read voltage with "
+                                     "output off")
 
         self.add_parameter('curr',
                            get_cmd=self._get_read_output_protected,
                            get_parser=self._curr_parser,
                            set_cmd=':SOUR:CURR:LEV {:.8f}',
                            label='Current',
-                           unit='A')
+                           unit='A',
+                           docstring = "Sets current in 'CURR' mode. "
+                                        "Get returns measured current if "
+                                        "sensing 'CURR' otherwise it returns "
+                                        "setpoint value. "
+                                        "Note that it is an error to read current with "
+                                        "output off")
+
 
         self.add_parameter('mode',
                            vals=Enum('VOLT', 'CURR'),
@@ -80,7 +93,10 @@ class Keithley_2400(VisaInstrument):
                            get_cmd=self._get_read_output_protected,
                            get_parser=self._resistance_parser,
                            label='Resistance',
-                           unit='Ohm')
+                           unit='Ohm',
+                           docstring="Measure resistance from current and voltage "
+                                     "Note that it is an error to read current "
+                                     "and voltage with output off")
 
     def _get_read_output_protected(self) -> str:
         """

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -98,7 +98,7 @@ class Keithley_2400(VisaInstrument):
         if output == 1:
             msg = self.ask(':READ?')
         else:
-            msg = "nan,nan,nan,nan"
+            msg = "nan,nan,nan,nan,nan"
         return msg
 
     def _set_mode_and_sense(self, msg):

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -150,8 +150,5 @@ class Keithley_2400(VisaInstrument):
 
     def _resistance_parser(self, msg):
         fields = [float(x) for x in msg.split(',')]
-        try:
-            res = fields[0] / fields[1]
-        except ZeroDivisionError:
-            res = float('NaN')
+        res = fields[0] / fields[1]
         return res

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -98,7 +98,7 @@ class Keithley_2400(VisaInstrument):
         if output == 1:
             msg = self.ask(':READ?')
         else:
-            msg = "nan,nan,nan,nan,nan"
+            raise RuntimeError("Cannot perform read with output off")
         return msg
 
     def _set_mode_and_sense(self, msg):

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -34,14 +34,14 @@ class Keithley_2400(VisaInstrument):
                            label='Current Compliance')
 
         self.add_parameter('volt',
-                           get_cmd=self._get_volt_and_curr,
+                           get_cmd=self._get_read_output_protected,
                            get_parser=self._volt_parser,
                            set_cmd=':SOUR:VOLT:LEV {:.8f}',
                            label='Voltage',
                            unit='V')
 
         self.add_parameter('curr',
-                           get_cmd=self._get_volt_and_curr,
+                           get_cmd=self._get_read_output_protected,
                            get_parser=self._curr_parser,
                            set_cmd=':SOUR:CURR:LEV {:.8f}',
                            label='Current',
@@ -77,12 +77,12 @@ class Keithley_2400(VisaInstrument):
                            label='Current integration time')
 
         self.add_parameter('resistance',
-                           get_cmd=self._get_volt_and_curr,
+                           get_cmd=self._get_read_output_protected,
                            get_parser=self._resistance_parser,
                            label='Resistance',
                            unit='Ohm')
 
-    def _get_volt_and_curr(self) -> str:
+    def _get_read_output_protected(self) -> str:
         """
         This wrapper function around ":READ?" exists because calling
         ":READ?" on an instrument with output disabled is an error.


### PR DESCRIPTION
In the Keithley 2400 doing a read with output disabled is an error that leaves the instrument in a state where no commands can be sent to it without restart

To overcome this we check that output is on before doing a read. If not we return 'nan' as a result
Fixes #1149 

