### PR TITLE
Log the instrument that a failed parameter update comes from.

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -179,9 +179,9 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             except:
                 # really log this twice. Once verbose for the UI and once
                 # at lower level with more info for file based loggers
-                log.warning("Snapshot: Could not update parameter:"
-                            "{}".format(name))
-                log.info("Details for Snapshot of {}:".format(name),
+                log.warning(f"Snapshot: Could not update parameter: "
+                            f"{name} on {self.full_name}")
+                log.info(f"Details for Snapshot of {name}:",
                          exec_info=True)
 
                 snap['parameters'][name] = param.snapshot(update=False)


### PR DESCRIPTION
This makes it much easier to identify the relevant parameter when adding multiple instruments in a startup script.
