### PR TITLE
Datasaver save speed

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -405,8 +405,6 @@ class DataSet(Sized):
         len_before_add = length(self.conn, self.table_name)
         insert_many_values(self.conn, self.table_name, list(expected_keys),
                            values)
-        # TODO: should this not be made atomic?
-        self.conn.commit()
         return len_before_add
 
     def modify_result(self, index: int, results: Dict[str, VALUES]) -> None:

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -8,6 +8,7 @@ import numpy as np
 import io
 from typing import Any, List, Optional, Tuple, Union, Dict, cast
 from distutils.version import LooseVersion
+import itertools
 
 import qcodes as qc
 import unicodedata
@@ -456,8 +457,8 @@ def insert_many_values(conn: sqlite3.Connection,
                      """
             stop += chunk
             # we need to make values a flat list from a list of list
-            flattened_values = [item for sublist in values[start:stop]
-                                for item in sublist]
+            flattened_values = list(
+                itertools.chain.from_iterable(values[start:stop]))
 
             c = transaction(conn, query, *flattened_values)
 

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -445,24 +445,25 @@ def insert_many_values(conn: sqlite3.Connection,
     start = 0
     stop = 0
 
-    for ii, chunk in enumerate(chunks):
-        _values_x_params = ",".join([_values] * chunk)
+    with atomic(conn):
+        for ii, chunk in enumerate(chunks):
+            _values_x_params = ",".join([_values] * chunk)
 
-        query = f"""INSERT INTO "{formatted_name}"
-                    ({_columns})
-                    VALUES
-                    {_values_x_params}
-                 """
-        stop += chunk
-        # we need to make values a flat list from a list of list
-        flattened_values = [item for sublist in values[start:stop]
-                            for item in sublist]
+            query = f"""INSERT INTO "{formatted_name}"
+                        ({_columns})
+                        VALUES
+                        {_values_x_params}
+                     """
+            stop += chunk
+            # we need to make values a flat list from a list of list
+            flattened_values = [item for sublist in values[start:stop]
+                                for item in sublist]
 
-        c = atomic_transaction(conn, query, *flattened_values)
+            c = transaction(conn, query, *flattened_values)
 
-        if ii == 0:
-            return_value = c.lastrowid
-        start += chunk
+            if ii == 0:
+                return_value = c.lastrowid
+            start += chunk
 
     return return_value
 

--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -1,6 +1,7 @@
 from typing import Callable, Type
 from functools import wraps
 from time import sleep
+import cProfile
 
 
 def strip_qc(d, keys=('instrument', '__class__')):
@@ -67,3 +68,24 @@ def retry_until_does_not_throw(
         return func_retry
 
     return retry_until_passes_decorator
+
+
+def profile(func):
+    """
+    Decorator that profiles the wrapped function with cProfile.
+
+    It produces a '.prof' file in the current working directory
+    that has the name of the executed function.
+
+    Use the 'Stats' class from the 'pstats' module to read the file,
+    analyze the profile data (for example, 'p.sort_stats('tottime')'
+    where 'p' is an instance of the 'Stats' class), and print the data
+    (for example, 'p.print_stats()').
+    """
+    def wrapper(*args, **kwargs):
+        profile_filename = func.__name__ + '.prof'
+        profiler = cProfile.Profile()
+        result = profiler.runcall(func, *args, **kwargs)
+        profiler.dump_stats(profile_filename)
+        return result
+    return wrapper


### PR DESCRIPTION
Recently, two users have reported that it takes too much time to save data to the database during the experiment. In particular, saving 10,000 points for 5 parameters (2 dependent, and 3 independent) is reported to take 5-10s.

After investigating the `DataSaver` `add_results` method using `cProfile` profiler, I could improve the saving speed by a factor of ~2. Hence, this pull-request.

The fix is in the `insert_many_values` method. The data is split into chunks in order to pass as many values as possible within a single `INSERT` call. The problem was that each of these `INSERT` calls had a `commit` which was decreasing the performance. As it is suggested everywhere on the web, in this situation, all the `INSERT` calls should happen within one transaction, meaning there should be a single `COMMIT` for all of them. This way the performance is improved.

Changes in this PR:
- one `COMMIT` per all `INSERT`s
- remove unnecessary commit after the `insert_many_values` call, because commit is done within that function
- use `itertools` instead of list comprehension for flattening a list of lists (advised on StackOverflow)
- add convenient profile decorator function

Note that the users would like to have this amount of data saved within ~0.1s which raises a question whether sqlite is the right backend. But let's keep this discussion aside of this pull-request.