### PR TITLE
Quick fix for mypy 0.620 behavior

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -59,7 +59,8 @@ import logging
 import os
 import collections
 import warnings
-from typing import Optional, Sequence, TYPE_CHECKING, Union, Callable, List, Dict, Any, Sized, Iterable
+from typing import Optional, Sequence, TYPE_CHECKING, Union, Callable, List, \
+    Dict, Any, Sized, Iterable, Type
 from functools import partial, wraps
 import numpy
 
@@ -1033,7 +1034,7 @@ class ArrayParameter(_BaseParameter):
         self.label = name if label is None else label
         self.unit = unit if unit is not None else ''
 
-        nt = type(None)
+        nt: Type[Any] = type(None)
 
         if not is_sequence_of(shape, int):
             raise ValueError('shapes must be a tuple of ints, not ' +
@@ -1213,7 +1214,7 @@ class MultiParameter(_BaseParameter):
         self.labels = labels if labels is not None else names
         self.units = units if units is not None else [''] * len(names)
 
-        nt = type(None)
+        nt: Type[Any] = type(None)
 
         if (not is_sequence_of(shapes, int, depth=2) or
                 len(shapes) != len(names)):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ pytest-cov
 pytest
 codacy-coverage
 hypothesis==3.61.0 # type annotation failures with mypy for 3.62.0 and later
-mypy!=0.570,!=0.620 # 0.570 - due to https://github.com/python/mypy/issues/4674, 0.620 due to https://github.com/python/mypy/issues/5354
+mypy!=0.570 # due to https://github.com/python/mypy/issues/4674
 git+https://github.com/QCoDeS/pyvisa-sim.git
 git+https://github.com/QCoDeS/broadbean
 lxml

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ pytest-cov
 pytest
 codacy-coverage
 hypothesis==3.61.0 # type annotation failures with mypy for 3.62.0 and later
-mypy!=0.570 # due to https://github.com/python/mypy/issues/4674
+mypy!=0.570,!=0.620 # 0.570 - due to https://github.com/python/mypy/issues/4674, 0.620 due to https://github.com/python/mypy/issues/5354
 git+https://github.com/QCoDeS/pyvisa-sim.git
 git+https://github.com/QCoDeS/broadbean
 lxml


### PR DESCRIPTION
With the new release of mypy 0.620, the mypy part of the test started failing ([an example here](https://travis-ci.org/QCoDeS/Qcodes/builds/404452622?utm_source=github_status&utm_medium=notification)):
```
qcodes/instrument/parameter.py:1046: error: The type alias is invalid in runtime context
qcodes/instrument/parameter.py:1052: error: The type alias is invalid in runtime context
qcodes/instrument/parameter.py:1055: error: The type alias is invalid in runtime context
qcodes/instrument/parameter.py:1059: error: The type alias is invalid in runtime context
qcodes/instrument/parameter.py:1224: error: The type alias is invalid in runtime context
qcodes/instrument/parameter.py:1229: error: The type alias is invalid in runtime context
qcodes/instrument/parameter.py:1233: error: The type alias is invalid in runtime context
qcodes/instrument/parameter.py:1237: error: The type alias is invalid in runtime context
```

~I did not want to spend a time on figuring out why, so here is the fix that disables this new version.~

See more on mypy github https://github.com/python/mypy/issues/5354 - it might be related.

The edits in the code make the type objects be type-annotated which makes the new mypy 0.620 happy 😄 👍 🥇 