### PR TITLE
Make a folder for unsupported code

### DIFF
--- a/qcodes/unsupported/README.rst
+++ b/qcodes/unsupported/README.rst
@@ -1,0 +1,12 @@
+Unsupported
+===========
+
+Welcome to the unsupported part of QCoDeS. Entrance at own risk.
+
+This folder - which might eventually become its own repository - is for user-contributed code that
+the core developer team can not support or maintain.
+
+Examples of code that belongs in here include (but are not limited to):
+- Instrument drivers for instruments that the core team does not have access to
+- Legacy code that is incompatible with newer versions of QCoDeS
+


### PR DESCRIPTION
Okay, so let's talk a bit about restructuring the code base.

This PR introduces a new folder, `qcodes/unsupported` which is meant for code that the core team will not maintain. Whereas the rest of QCoDeS comes with some promise of not being intentionally broken and having known bugs fixed as soon as the core team can get around to it, the code in `unsupported` does not. 

What I envision is that drivers for instruments that we (the core team) do not have access to should go there, because we can not give any guarantees about whether they work or not. Also, I would like to see the `Loop` and its associated (old) dataset go in there, since that will give us the much needed freedom to change how `Parameters` work.

I think perhaps it's good to have some discussion about this?

@QCoDeS/core-contributors 

The way I see it, we can can not make promises about the drivers below (just listed by vendor for easy overview). I am not too sure about all of them and I may have missed some. What do you think?

- Advantech
- QuTech
- Spectrum
- cryocon
- cryogenic
- signal_hound