### PR TITLE
Remove unused function in N52xx driver

### DIFF
--- a/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -407,9 +407,6 @@ class PNABase(VisaInstrument):
         """
         self.averages_enabled(False)
 
-    def _set_auto_sweep(self, val: bool) -> None:
-        self._auto_sweep = val
-
     def _set_power_limits(self,
                           min_power: Union[int, float],
                           max_power: Union[int, float]) -> None:


### PR DESCRIPTION
Remvoes an unused function `_set_auto_sweep` in N52xx driver that slipped through.

@jenshnielsen, @astafan8 