### PR TITLE
Make data saver accept numpy type floats/ints 

### DIFF
--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -124,7 +124,7 @@ class DataSaver:
                                      f'and {array_size}')
                 else:
                     input_size = array_size
-            elif is_number(value):
+            elif is_number(value) or isinstance(value, str):
                 pass
             else:
                 raise ValueError('Wrong value type received. '

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -3,7 +3,7 @@ import logging
 from time import monotonic
 from collections import OrderedDict
 from typing import (Callable, Union, Dict, Tuple, List, Sequence, cast,
-                    MutableMapping, MutableSequence, Optional)
+                    MutableMapping, MutableSequence, Optional, Any)
 from inspect import signature
 from numbers import Number
 
@@ -19,11 +19,21 @@ from qcodes.dataset.data_set import DataSet
 log = logging.getLogger(__name__)
 
 array_like_types = (tuple, list, np.ndarray)
-non_array_like_types = (int, float, str)
 
 
 class ParameterTypeError(Exception):
     pass
+
+
+def is_number(thing: Any) -> bool:
+    """
+    Test if an object can be converted to a number
+    """
+    try:
+        float(thing)
+        return True
+    except (ValueError, TypeError):
+        return False
 
 
 class DataSaver:
@@ -114,7 +124,7 @@ class DataSaver:
                                      f'and {array_size}')
                 else:
                     input_size = array_size
-            elif any(isinstance(value, t) for t in non_array_like_types):
+            elif is_number(value):
                 pass
             else:
                 raise ValueError('Wrong value type received. '

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -66,7 +66,7 @@ class DataSaver:
 
     def add_result(self,
                    *res_tuple: Tuple[Union[_BaseParameter, str],
-                                     Union[str, int, float, np.ndarray]])-> None:
+                                     Union[str, int, float, np.dtype, np.ndarray]])-> None:
         """
         Add a result to the measurement results. Represents a measurement
         point in the space of measurement parameters, e.g. in an experiment

--- a/qcodes/tests/dataset/test_datasaver.py
+++ b/qcodes/tests/dataset/test_datasaver.py
@@ -78,7 +78,7 @@ def test_default_callback(experiment):
 
 def test_numpy_types(experiment):
     """
-    Test that we can save numpy types in the dataset
+    Test that we can save numpy types in the data set
     """
 
     p = ParamSpec("p", "numeric")
@@ -91,3 +91,16 @@ def test_numpy_types(experiment):
 
     for dtype in dtypes:
         data_saver.add_result(("p", dtype(2)))
+
+
+def test_string(experiment):
+    """
+    Test that we can save text in the data set
+    """
+    p = ParamSpec("p", "text")
+
+    test_set = qc.new_data_set("test-dataset")
+    data_saver = DataSaver(
+        dataset=test_set, write_period=0, parameters={"p": p})
+
+    data_saver.add_result(("p", "some text"))

--- a/qcodes/tests/dataset/test_datasaver.py
+++ b/qcodes/tests/dataset/test_datasaver.py
@@ -83,6 +83,8 @@ def test_numpy_types(experiment):
 
     p = ParamSpec("p", "numeric")
     test_set = qc.new_data_set("test-dataset")
+    test_set.add_parameter(p)
+
     data_saver = DataSaver(
         dataset=test_set, write_period=0, parameters={"p": p})
 
@@ -92,6 +94,10 @@ def test_numpy_types(experiment):
     for dtype in dtypes:
         data_saver.add_result(("p", dtype(2)))
 
+    data_saver.flush_data_to_database()
+    data = test_set.get_data("p")
+    assert data == [[2] for _ in range(len(dtypes))]
+
 
 def test_string(experiment):
     """
@@ -100,7 +106,12 @@ def test_string(experiment):
     p = ParamSpec("p", "text")
 
     test_set = qc.new_data_set("test-dataset")
+    test_set.add_parameter(p)
     data_saver = DataSaver(
         dataset=test_set, write_period=0, parameters={"p": p})
 
     data_saver.add_result(("p", "some text"))
+    test_set.mark_complete()
+
+    data_saver.flush_data_to_database()
+    assert test_set.get_data("p") == [["some text"]]

--- a/qcodes/tests/dataset/test_datasaver.py
+++ b/qcodes/tests/dataset/test_datasaver.py
@@ -111,7 +111,5 @@ def test_string(experiment):
         dataset=test_set, write_period=0, parameters={"p": p})
 
     data_saver.add_result(("p", "some text"))
-    test_set.mark_complete()
-
     data_saver.flush_data_to_database()
     assert test_set.get_data("p") == [["some text"]]

--- a/qcodes/tests/dataset/test_datasaver.py
+++ b/qcodes/tests/dataset/test_datasaver.py
@@ -1,8 +1,11 @@
 import pytest
 import os
 import tempfile
+import numpy as np
+
 import qcodes as qc
 from qcodes.dataset.measurements import DataSaver
+from qcodes.dataset.param_spec import ParamSpec
 from qcodes.dataset.sqlite_base import connect, init_db
 from qcodes.dataset.database import initialise_database
 
@@ -71,3 +74,20 @@ def test_default_callback(experiment):
         DataSaver.default_callback = None
         if test_set is not None:
             test_set.conn.close()
+
+
+def test_numpy_types(experiment):
+    """
+    Test that we can save numpy types in the dataset
+    """
+
+    p = ParamSpec("p", "numeric")
+    test_set = qc.new_data_set("test-dataset")
+    data_saver = DataSaver(
+        dataset=test_set, write_period=0, parameters={"p": p})
+
+    dtypes = [np.int8, np.int16, np.int32, np.int64, np.float16, np.float32,
+              np.float64]
+
+    for dtype in dtypes:
+        data_saver.add_result(("p", dtype(2)))


### PR DESCRIPTION
Fixes #1224

We test if a value is a "non-array-type" by our ability to recast it to a float. This is more robust than having a list of acceptable types as we can always miss types. 