### PR TITLE
allow config to update based on specified path

### DIFF
--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -125,10 +125,10 @@ class Config():
         self.current_schema = copy.deepcopy(self.defaults_schema)
         self.config_file_path = path or self.config_file_path
         if self.config_file_path is not None:
-            config_file = "{}/{}".format(path, config_file_name)
-            schema_file = config_file.replace(config_file_name,
-                                              schema_file_name)
-            path_config = self.load_config(path)
+            config_file = "{}/{}".format(self.config_file_path, self.config_file_name)
+            schema_file = config_file.replace(self.config_file_name,
+                                              self.schema_file_name)
+            path_config = self.load_config(config_file)
             config = update(config, path_config)
             self.validate(config, self.current_schema,
                           schema_file)
@@ -151,7 +151,7 @@ class Config():
                 self.validate(config, self.current_schema,
                               self.schema_cwd_file_name)
 
-        self._current_config = config
+        self.current_config = config
 
     def validate(self, json_config=None, schema=None, extra_schema_path=None):
         """

--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -69,7 +69,7 @@ class Config():
                                                       schema_file_name)
 
     # home dir, os independent
-    home_file_name = expanduser("~/{}".format(config_file_name))
+    home_file_name = expanduser(os.path.join("~", config_file_name))
     schema_home_file_name = home_file_name.replace(config_file_name,
                                                    schema_file_name)
 
@@ -78,7 +78,7 @@ class Config():
     schema_env_file_name = env_file_name.replace(config_file_name,
                                                  schema_file_name)
     # current working dir
-    cwd_file_name = "{}/{}".format(Path.cwd(), config_file_name)
+    cwd_file_name = os.path.join(Path.cwd(), config_file_name)
     schema_cwd_file_name = cwd_file_name.replace(config_file_name,
                                                  schema_file_name)
 
@@ -125,7 +125,7 @@ class Config():
         self.current_schema = copy.deepcopy(self.defaults_schema)
         self.config_file_path = path or self.config_file_path
         if self.config_file_path is not None:
-            config_file = "{}/{}".format(self.config_file_path, self.config_file_name)
+            config_file = os.path.join(self.config_file_path, self.config_file_name)
             schema_file = config_file.replace(self.config_file_name,
                                               self.schema_file_name)
             path_config = self.load_config(config_file)

--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -94,7 +94,7 @@ class Config():
     def __init__(self, path=None):
         self.config_file_path = path
         self.defaults, self.defaults_schema = self.load_default()
-        self.update_config(path=path)
+        self.update_config()
 
     def load_default(self):
         defaults = self.load_config(self.default_file_name)

--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -92,6 +92,7 @@ class Config():
     _diff_schema: Dict[str, dict] = {}
 
     def __init__(self, path=None):
+        self.config_file_path = path
         self.defaults, self.defaults_schema = self.load_default()
         self.update_config(path=path)
 
@@ -122,7 +123,7 @@ class Config():
         """
         config = copy.deepcopy(self.defaults)
         self.current_schema = copy.deepcopy(self.defaults_schema)
-
+        path = path or self.config_file_path
         if path is not None:
             config_file = "{}/{}".format(path, config_file_name)
             schema_file = config_file.replace(config_file_name,

--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -153,6 +153,8 @@ class Config():
 
         self.current_config = config
 
+        return config
+
     def validate(self, json_config=None, schema=None, extra_schema_path=None):
         """
         Validate configuration, if no arguments are passed, the default

--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -123,8 +123,8 @@ class Config():
         """
         config = copy.deepcopy(self.defaults)
         self.current_schema = copy.deepcopy(self.defaults_schema)
-        path = path or self.config_file_path
-        if path is not None:
+        self.config_file_path = path or self.config_file_path
+        if self.config_file_path is not None:
             config_file = "{}/{}".format(path, config_file_name)
             schema_file = config_file.replace(config_file_name,
                                               schema_file_name)


### PR DESCRIPTION
Fixes #1223 .

allows a config file path to be specified either in initialisation of the Config object or when running update. This path is then used for future updates.

How's this @jenshnielsen? I haven't tested it yet.