### PR TITLE
driver / add block_during_ramp parameter to AMI430_3D

### DIFF
--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -330,10 +330,12 @@ class AMI430(IPInstrument):
             return
 
         # Otherwise, wait until no longer ramping
+        log.debug(f'Starting blocking ramp of {self.name} to {value}')
         while self.ramping_state() == 'ramping':
             self._sleep(0.3)
         self._sleep(2.0)
         state = self.ramping_state()
+        log.debug(f'Finished blocking ramp')
         # If we are now holding, it was successful
         if state != 'holding':
             msg = '_set_field({}) failed with state: {}'

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -656,6 +656,14 @@ class AMI430_3D(Instrument):
             vals=Numbers()
         )
 
+        self.add_parameter(
+            'block_during_ramp',
+            set_cmd=None,
+            initial_value=True,
+            unit='',
+            vals=Bool()
+        )
+
     def _verify_safe_setpoint(self, setpoint_values):
 
         if repr(self._field_limit).isnumeric():
@@ -710,7 +718,8 @@ class AMI430_3D(Instrument):
                 if not operator(abs(value), abs(current_actual)):
                     continue
 
-                instrument.set_field(value, perform_safety_check=False)
+                instrument.set_field(value, perform_safety_check=False,
+                                     block=self.block_during_ramp.get())
 
     def _request_field_change(self, instrument, value):
         """

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -391,11 +391,12 @@ def test_warning_increased_max_ramp_rate():
     target_ramp_rate = max_ramp_rate + 0.01
 
     with pytest.warns(AMI430Warning, match="Increasing maximum ramp rate") as excinfo:
-        AMI430_VISA("testing_increased_max_ramp_rate",
-                    address='GPIB::4::65535::INSTR', visalib=visalib,
-                    terminator='\n', port=1,
-                    current_ramp_limit=target_ramp_rate)
+        inst = AMI430_VISA("testing_increased_max_ramp_rate",
+                           address='GPIB::4::65535::INSTR', visalib=visalib,
+                           terminator='\n', port=1,
+                           current_ramp_limit=target_ramp_rate)
         assert len(excinfo) >= 1 # Check we at least one warning.
+        inst.close()
 
 
 def test_ramp_rate_exception(current_driver):


### PR DESCRIPTION
@WilliamHPNielsen 

The AMI430_3D magnet does not currently support non-blocking field ramps. A linear field ramp between two safe points is always safe if the ramp rates are safe, so this should be possible.

The new block_during_ramp parameter (default True), if set to False, will call the set_field methods of the children with the argument block=False, so that they get ramped in a non-blocking way.