### PR TITLE
Add feature to allow subselection of data with an sqlite where clause

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -565,7 +565,8 @@ class DataSet(Sized):
     def get_data(self,
                  *params: Union[str, ParamSpec, _BaseParameter],
                  start: Optional[int] = None,
-                 end: Optional[int] = None) -> List[List[Any]]:
+                 end: Optional[int] = None,
+                 select_condition: Optional[str] = None) -> List[List[Any]]:
         """ Returns the values stored in the DataSet for the specified parameters.
         The values are returned as a list of lists, SQL rows by SQL columns,
         e.g. datapoints by parameters. The data type of each element is based on
@@ -578,6 +579,13 @@ class DataSet(Sized):
         equal to the start, or if start is after the current end of the
         DataSet – then a list of empty arrays is returned.
 
+
+        You can also use the select_condition to subselect data according
+        to a SQLite where clause See http://www.sqlitetutorial.net/sqlite-where/
+        for examples. Note that as this is automatically combined with the
+        start end end conditions the where keyword is inserted automatically
+        and should be omitted from the string.
+
         For a more type independent and easier to work with view of the data
         you may want to consider using
         :py:meth:`qcodes.dataset.data_export.get_data_by_id`
@@ -588,6 +596,8 @@ class DataSet(Sized):
                ParamSpec objects
             - start:
             - end:
+            - select_condition: SQlite Where clause that is used to
+               subselect data e.g. 'my_column > 10'
 
         Returns:
             - list of lists SQL rows of data by SQL columns. Each SQL row
@@ -608,7 +618,7 @@ class DataSet(Sized):
                         "This parameter does not have  a name") from e
             valid_param_names.append(maybeParam)
         data = get_data(self.conn, self.table_name, valid_param_names,
-                        start, end)
+                        start, end, select_condition)
         return data
 
     def get_values(self, param_name: str) -> List[List[Any]]:

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -549,10 +549,12 @@ def get_data(conn: sqlite3.Connection,
              columns: List[str],
              start: int = None,
              end: int = None,
+             select_condition: str = None
              ) -> List[List[Any]]:
     """
     Get data from the columns of a table.
-    Allows to specfiy a range.
+    Allows to specfiy a range and selection
+    condition.
 
     Args:
         conn: database connection
@@ -560,11 +562,21 @@ def get_data(conn: sqlite3.Connection,
         columns: list of columns
         start: start of range (1 indedex)
         end: start of range (1 indedex)
+        select_condition: Subselect data according to this condition.
 
     Returns:
         the data requested
     """
     _columns = ",".join(columns)
+    if select_condition is not None:
+        if start or end:
+            select_condition = f"and {select_condition}"
+        else:
+            select_condition = f"where {select_condition}"
+    else:
+        select_condition = ''
+
+
     if start and end:
         query = f"""
         SELECT {_columns}
@@ -573,6 +585,7 @@ def get_data(conn: sqlite3.Connection,
             > {start} and
               rowid
             <= {end}
+            {select_condition}
         """
     elif start:
         query = f"""
@@ -580,6 +593,7 @@ def get_data(conn: sqlite3.Connection,
         FROM "{table_name}"
         WHERE rowid
             >= {start}
+            {select_condition}
         """
     elif end:
         query = f"""
@@ -587,11 +601,13 @@ def get_data(conn: sqlite3.Connection,
         FROM "{table_name}"
         WHERE rowid
             <= {end}
+            {select_condition}
         """
     else:
         query = f"""
         SELECT {_columns}
         FROM "{table_name}"
+        {select_condition}
         """
     c = atomic_transaction(conn, query)
     res = many_many(c, *columns)


### PR DESCRIPTION
We need better tools for customizing the data selection from the database. A simple way could be to 
allow the user to inject a sqlite where clause into get_data as done here. But it's perhaps not the most pure solution? 

Never the less this allows you to do something like the following:

```python
from qcodes.dataset.data_set import  load_by_id
load_by_id(dataid).get_data('dac_ch1', 'dmm_v1', select_condition='dmm_v1 > 0.5')
```

If we want to go this way this needs:

- [ ] Examples
- [ ] A proper test 

before merge

@nataliejpg 

