### PR TITLE
Feature / rescale ticks and units in plot_by_id

### DIFF
--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -31,7 +31,34 @@ def flatten_1D_data_for_plot(rawdata: Sequence[Sequence[Any]]) -> np.ndarray:
 def get_data_by_id(run_id: int) -> List:
     """
     Load data from database and reshapes into 1D arrays with minimal
-    name, unit and label metadata.
+    name, unit and label metadata (see `get_layout` function).
+
+    Args:
+        run_id: run ID from the database
+
+    Returns:
+        a list of lists of dictionaries like this:
+
+        [
+          # each element in this list refers
+          # to one dependent (aka measured) parameter
+            [
+              # each element in this list refers
+              # to one independent (aka setpoint) parameter
+              # that the dependent parameter depends on;
+              # a dictionary with the data and metadata of the dependent
+              # parameter is in the *last* element in this list
+                ...
+                {
+                    'data': <1D numpy array of points>,
+                    'name': <name of the parameter>,
+                    'label': <label of the parameter or ''>,
+                    'unit': <unit of the parameter or ''>
+                },
+                ...
+            ],
+            ...
+        ]
     """
 
     data = load_by_id(run_id)

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -62,28 +62,37 @@ def get_data_by_id(run_id: int) -> List:
     """
 
     data = load_by_id(run_id)
+
     conn = data.conn
     deps = get_dependents(conn, run_id)
+
     output = []
     for dep in deps:
 
         dependencies = get_dependencies(conn, dep)
+
         data_axis: Dict[str, Union[str, np.ndarray]] = get_layout(conn, dep)
+
         rawdata = data.get_values(data_axis['name'])
         data_axis['data'] = flatten_1D_data_for_plot(rawdata)
+
         raw_setpoint_data = data.get_setpoints(data_axis['name'])
+
         my_output = []
+
         max_size = 0
         for i, dependency in enumerate(dependencies):
             axis: Dict[str, Union[str, np.ndarray]] = get_layout(conn,
                                                                  dependency[0])
+
             mydata = flatten_1D_data_for_plot(raw_setpoint_data[i])
             axis['data'] = mydata
+
             size = mydata.size
             if size > max_size:
                 max_size = size
-            my_output.append(axis)
 
+            my_output.append(axis)
 
         for i, dependency in enumerate(dependencies):
             axis = my_output[i]
@@ -96,6 +105,7 @@ def get_data_by_id(run_id: int) -> List:
                 axis['data'] = np.repeat(axis['data'], max_size//size)
 
         my_output.append(data_axis)
+
         output.append(my_output)
     return output
 

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -270,12 +270,12 @@ _THRESHOLDS = OrderedDict(
     {10**(scale + 3): scale for scale in _ENGINEERING_PREFIXES.keys()})
 
 
-def _scale_formatter(tick_value, pos, scale):
+def _scale_formatter(tick_value, pos, factor):
     """
     Function for matplotlib.ticker.FuncFormatter that scales the tick values
     according to the given `scale` value.
     """
-    return "{0:g}".format(tick_value * scale)
+    return "{0:g}".format(tick_value*factor)
 
 
 def _make_rescaled_ticks_and_units(data_dict):
@@ -321,8 +321,9 @@ def _make_rescaled_ticks_and_units(data_dict):
         label = data_dict['label']
         new_label = _make_axis_label(label, new_unit)
 
+        scale_factor = 10**(-selected_scale)
         ticks_formatter = FuncFormatter(
-            partial(_scale_formatter, scale=selected_scale))
+            partial(_scale_formatter, factor=scale_factor))
 
     return ticks_formatter, new_label
 

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -46,43 +46,9 @@ def plot_by_id(run_id: int,
         The colorbar axes may be None if no colorbar is created (e.g. for
         1D plots)
     """
-
-    def set_axis_labels(ax, data, cax=None):
-        if data[0]['label'] == '':
-            lbl = data[0]['name']
-        else:
-            lbl = data[0]['label']
-        if data[0]['unit'] == '':
-            unit = ''
-        else:
-            unit = data[0]['unit']
-            unit = f"({unit})"
-        ax.set_xlabel(f'{lbl} {unit}')
-
-        if data[1]['label'] == '':
-            lbl = data[1]['name']
-        else:
-            lbl = data[1]['label']
-        if data[1]['unit'] == '':
-            unit = ''
-        else:
-            unit = data[1]['unit']
-            unit = f'({unit})'
-        ax.set_ylabel(f'{lbl} {unit}')
-        if cax is not None and len(data) > 2:
-            if data[2]['label'] == '':
-                lbl = data[2]['name']
-            else:
-                lbl = data[2]['label']
-            if data[2]['unit'] == '':
-                unit = ''
-            else:
-                unit = data[2]['unit']
-                unit = f'({unit})'
-            cax.set_label(f'{lbl} {unit}')
-
     alldata = get_data_by_id(run_id)
     nplots = len(alldata)
+
     if isinstance(axes, matplotlib.axes.Axes):
         axes = [axes]
     if isinstance(colorbars, matplotlib.colorbar.Colorbar):
@@ -101,6 +67,7 @@ def plot_by_id(run_id: int,
     if colorbars is None:
         colorbars = len(axes)*[None]
     new_colorbars: List[matplotlib.colorbar.Colorbar] = []
+
     for data, ax, colorbar in zip(alldata, axes, colorbars):
 
         if len(data) == 2:  # 1D PLOTTING
@@ -120,7 +87,7 @@ def plot_by_id(run_id: int,
             else:
                 raise ValueError('Unknown plottype. Something is way wrong.')
 
-            set_axis_labels(ax, data)
+            _set_axis_labels(ax, data)
             new_colorbars.append(None)
 
         elif len(data) == 3:  # 2D PLOTTING
@@ -145,7 +112,7 @@ def plot_by_id(run_id: int,
             zpoints = flatten_1D_data_for_plot(data[2]['data'])
             plot_func = how_to_plot[plottype]
             ax, colorbar = plot_func(xpoints, ypoints, zpoints, ax, colorbar)
-            set_axis_labels(ax, data, colorbar)
+            _set_axis_labels(ax, data, colorbar)
             new_colorbars.append(colorbar)
 
         else:
@@ -159,6 +126,28 @@ def plot_by_id(run_id: int,
         raise RuntimeError("Non equal number of axes. Perhaps colorbar is "
                            "missing from one of the cases above")
     return axes, new_colorbars
+
+
+def _make_label_for_data_axis(data, axis_index):
+    if data[axis_index]['label'] == '':
+        lbl = data[axis_index]['name']
+    else:
+        lbl = data[axis_index]['label']
+
+    if data[axis_index]['unit'] == '':
+        unit = ''
+    else:
+        unit = data[axis_index]['unit']
+
+    return f'{lbl} ({unit})'
+
+
+def _set_axis_labels(ax, data, cax=None):
+    ax.set_xlabel(_make_label_for_data_axis(data, 0))
+    ax.set_ylabel(_make_label_for_data_axis(data, 1))
+
+    if cax is not None and len(data) > 2:
+        cax.set_label(_make_label_for_data_axis(data, 2))
 
 
 def plot_2d_scatterplot(x: np.ndarray, y: np.ndarray, z: np.ndarray,

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -306,7 +306,7 @@ def _make_rescaled_ticks_and_units(data_dict):
     if unit in _SI_UNITS:
         maxval = np.nanmax(data_dict['data'])
 
-        for threshold, scale in _THRESHOLDS:
+        for threshold, scale in _THRESHOLDS.items():
             if maxval < threshold:
                 selected_scale = scale
                 prefix = _ENGINEERING_PREFIXES[scale]

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -87,7 +87,8 @@ def plot_by_id(run_id: int,
             else:
                 raise ValueError('Unknown plottype. Something is way wrong.')
 
-            _set_axis_labels(ax, data)
+            _set_data_axes_labels(ax, data)
+
             new_colorbars.append(None)
 
         elif len(data) == 3:  # 2D PLOTTING
@@ -112,7 +113,9 @@ def plot_by_id(run_id: int,
             zpoints = flatten_1D_data_for_plot(data[2]['data'])
             plot_func = how_to_plot[plottype]
             ax, colorbar = plot_func(xpoints, ypoints, zpoints, ax, colorbar)
-            _set_axis_labels(ax, data, colorbar)
+
+            _set_data_axes_labels(ax, data, colorbar)
+
             new_colorbars.append(colorbar)
 
         else:
@@ -130,19 +133,23 @@ def plot_by_id(run_id: int,
 
 def _make_label_for_data_axis(data, axis_index):
     if data[axis_index]['label'] == '':
-        lbl = data[axis_index]['name']
+        label = data[axis_index]['name']
     else:
-        lbl = data[axis_index]['label']
+        label = data[axis_index]['label']
 
     if data[axis_index]['unit'] == '':
         unit = ''
     else:
         unit = data[axis_index]['unit']
 
-    return f'{lbl} ({unit})'
+    return _make_axis_label(label, unit)
 
 
-def _set_axis_labels(ax, data, cax=None):
+def _make_axis_label(label, unit):
+    return f'{label} ({unit})'
+
+
+def _set_data_axes_labels(ax, data, cax=None):
     ax.set_xlabel(_make_label_for_data_axis(data, 0))
     ax.set_ylabel(_make_label_for_data_axis(data, 1))
 

--- a/qcodes/tests/dataset/test_plotting.py
+++ b/qcodes/tests/dataset/test_plotting.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from qcodes.dataset.plotting import _make_rescaled_ticks_and_units, \
+    _ENGINEERING_PREFIXES
+
+
+def test_rescaled_ticks_and_units():
+    scale = 6
+    data = {
+        'name': 'param',
+        'label': 'Parameter',
+        'unit': 'V',
+        'data': np.array(np.arange(0, 10, 1)*10**scale)
+    }
+    expected_prefix = _ENGINEERING_PREFIXES[scale]
+
+    ticks_formatter, label = _make_rescaled_ticks_and_units(data)
+
+    assert f"{data['label']} ({expected_prefix}{data['unit']})" == label
+
+    assert '5' == ticks_formatter(5/(10**(-scale)))
+    assert '2.12346' == ticks_formatter(2.123456789 / (10 ** (-scale)))
+    assert '1' == ticks_formatter(1/(10 ** (-scale)))


### PR DESCRIPTION
Request along with #1200. This brings the "rescale_axis" feature of plotting functionality of the old dataset to the `plot_by_id` of the new dataset. The feature scale the ticks and the units (on the axes labels) to engineering units (`k`, `M`, `m`, `n`, etc.) so that the plots are more readable. For example, `2.000.000.000` in `V` becomes `2` in `GV` if all the numbers on this axis are not larger than 1.000.000.000.000 volts. The feature can be turned of by using a corresponding kwarg.

ToDo:
- [ ] more tests
- [ ] update "offline plotting tutorial"