### PR TITLE
Do not use sphinx 1.7.7 due to possible sphinx bug with type annotations

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=1.7.2
+sphinx>=1.7.2,!=1.7.7
 sphinx_rtd_theme
 sphinxcontrib-jsonschema
 nbconvert


### PR DESCRIPTION
Most probably the reason is in this sphinx issue:
https://github.com/sphinx-doc/sphinx/issues/5291

Warnings that sphinx 1.7.7 gives look like this:
`WARNING: error while formatting arguments for xxx.xxx.xxx: '_Any' object has no attribute '__origin__'`

I could not understand why it happens. It also seems that more and more people are getting the same error, so just falling back to other sphinx versions should a good workaround, so that it does not block our work.