### PR TITLE
SR86x lockin: get values of many parameters at once

### DIFF
--- a/docs/examples/driver_examples/QCodes_example_with_SR86x_with_buffered_readout.ipynb
+++ b/docs/examples/driver_examples/QCodes_example_with_SR86x_with_buffered_readout.ipynb
@@ -37,6 +37,7 @@
     "import time\n",
     "import matplotlib.pyplot as plt \n",
     "import numpy\n",
+    "from pprint import pprint  # for pretty printing lists and dictionaries\n",
     "\n",
     "# QCoDeS\n",
     "import qcodes\n",
@@ -57,19 +58,297 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to: Stanford_Research_Systems SR860 (serial:003230, firmware:V1.47) in 0.23s\n"
+      "Connected to: Stanford_Research_Systems SR860 (serial:003223, firmware:V1.47) in 0.25s\n"
      ]
     }
    ],
    "source": [
     "lockin = SR860(\"lockin\", \"GPIB0::4::INSTR\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Basics of reading values from the lock-in\n",
+    "\n",
+    "Lock-in amplifier measures a number of values. The most frequently used ones are available in the driver directly as QCODES parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "X = 3.1690581181e-07\n",
+      "Y = 2.9734803775e-07\n",
+      "R = 4.2155235747e-07\n",
+      "P = 45.936515808\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'X = { lockin.X() }')\n",
+    "print(f'Y = { lockin.Y() }')\n",
+    "print(f'R = { lockin.R() }')\n",
+    "print(f'P = { lockin.P() }')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Actually, the full list of values (or 'parameters', not to be confused with QCODES parameters) that the lock-in amplifier measures is available in the following dictionary (refer to the page 132 of the instrument's manual for more information):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['X',\n",
+      " 'Y',\n",
+      " 'R',\n",
+      " 'P',\n",
+      " 'aux_in1',\n",
+      " 'aux_in2',\n",
+      " 'aux_in3',\n",
+      " 'aux_in4',\n",
+      " 'Xnoise',\n",
+      " 'Ynoise',\n",
+      " 'aux_out1',\n",
+      " 'aux_out2',\n",
+      " 'phase',\n",
+      " 'amplitude',\n",
+      " 'sine_outdc',\n",
+      " 'frequency',\n",
+      " 'frequency_ext']\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(list(lockin.PARAMETER_NAMES.keys()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the `get_values` method of the driver to obtain values of 2 or 3 of those parameters. The values that are returned by this method are guaranteed to be coming from the same measurement, as opposed to requesting values sequentially by calling `lockin.X()` and then `lockin.Y()`. The method returns a tuple of values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-2.1813903572e-07, 1.6225968125e-07, 3.1462531069e-07)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lockin.get_values('X', 'Y', 'Xnoise')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2.696416459e-07, 152.20687866)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lockin.get_values('R', 'P')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data channels\n",
+    "\n",
+    "Lock-in amplifier has a notion of data channels. Each data channel can be assigned to a measured parameter mentioned above. Each data channel is being displayed on the insturment's screen, and has a corresponding color.\n",
+    "\n",
+    "Let's list the data channels using the `data_channels` list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lock-in amplifier has the following data channels:\n",
+      "DAT1 (green)\n",
+      "DAT2 (blue)\n",
+      "DAT3 (yellow)\n",
+      "DAT4 (orange)\n"
+     ]
+    }
+   ],
+   "source": [
+    "msg = f'Lock-in amplifier has the following data channels:\\n'\n",
+    "msg += '\\n'.join([f'{dch.cmd_id_name} ({dch.color})' for dch in lockin.data_channels])\n",
+    "print(msg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These channels are also accessible individually from the lock-in amplifier driver instance with `data_channel_<i>` attributes.\n",
+    "\n",
+    "Each of the channels has a `color`, `cmd_id` that is used in VISA commands, and `cmd_id_name` that can be (but is not) used in VISA commands, and is just there for reference.\n",
+    "\n",
+    "Most importantly, each data channel has an `assigned_parameter` to it. The available parameter are coming from the same list of parameters from above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'aux_in3'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lockin.data_channel_3.assigned_parameter('aux_in3')\n",
+    "lockin.data_channel_3.assigned_parameter()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The main feature of the data channels is that the lock-in amplifier has commands to retrieve all of their values at once. This feature is similar to `get_values` method, but instead of specifying the parameter names, the values of the data channels are returned.\n",
+    "\n",
+    "`get_data_channels_values` method returns a tuple of the values of the data channels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-1.3243408148e-07, -1.4647376645e-07, -0.00053787231445, -132.11825562)"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lockin.get_data_channels_values()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to see which are the assigned parameters for all the data channels, `get_data_channels_parameters` method can be used. Note that this method has a keyword argument `query_instrument` that allows you to choose not to query the values from the instrument in order to save time on VISA communication."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('X', 'Y', 'aux_in3', 'P')"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lockin.get_data_channels_parameters()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, a convenience method available that returns a dictionary of data channels assigned parameters with the associated values. Note that this method also has a keyword argument `requery_names` that allows you to choose whether the assigned parameter names are queried from the instrument. In this case, by default the names are not queried."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'P': -95.362594604,\n",
+       " 'X': -3.9464794099e-08,\n",
+       " 'Y': -4.204223103e-07,\n",
+       " 'aux_in3': -0.00045776367188}"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lockin.get_data_channels_dict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setting up for the buffer readout examples"
    ]
   },
   {

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -1028,7 +1028,7 @@ class SR86x(VisaInstrument):
         Args:
             *parameter_names
                 2 or 3 names of parameters for which the values are
-                requested; valid names can be found in `_PARAMETER_NAMES`
+                requested; valid names can be found in `PARAMETER_NAMES`
                 attribute of the driver class
 
         Returns:

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -1037,7 +1037,7 @@ class SR86x(VisaInstrument):
         """
         if not 2 <= len(parameter_names) <= 3:
             raise KeyError(
-                'It is possible to request values of only 2 or 3 parameters '
+                'It is only possible to request values of 2 or 3 parameters '
                 'at a time.')
 
         for name in parameter_names:

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -1018,7 +1018,7 @@ class SR86x(VisaInstrument):
         else:
             return self._CURR_TO_N[s]
 
-    def get_values(self, *parameter_names: str) -> Tuple[float]:
+    def get_values(self, *parameter_names: str) -> Tuple[float, ...]:
         """
         Get values of 2 or 3 parameters that are measured by the lock-in
         amplifier. These values are guaranteed to come from the same

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -1043,7 +1043,7 @@ class SR86x(VisaInstrument):
         for name in parameter_names:
             if name not in self.PARAMETER_NAMES:
                 raise KeyError(f'{name} is not a valid parameter name. Refer '
-                               f'to `_PARAMETER_NAMES` for a list of valid '
+                               f'to `PARAMETER_NAMES` for a list of valid '
                                f'parameter names')
 
         p_ids = [self.PARAMETER_NAMES[name] for name in parameter_names]

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -589,7 +589,7 @@ class SR86xDataChannel(InstrumentChannel):
             reference
     """
     def __init__(self, parent: 'SR86x', name: str, cmd_id: str,
-                 cmd_id_name: str=None, color: str=None):
+                 cmd_id_name: str=None, color: str=None) -> None:
         super().__init__(parent, name)
 
         self._cmd_id = cmd_id

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -3,7 +3,7 @@ import logging
 from typing import Sequence, Dict, Callable, Tuple
 
 from qcodes import VisaInstrument
-from qcodes.instrument.channel import InstrumentChannel
+from qcodes.instrument.channel import InstrumentChannel, ChannelList
 from qcodes.utils.validators import Numbers, Ints, Enum
 from qcodes.instrument.parameter import ArrayParameter
 from qcodes.utils.workarounds import visa_query_binary_values_fix_for
@@ -561,6 +561,64 @@ class SR86xBuffer(InstrumentChannel):
         return self.get_capture_data(sample_count)
 
 
+class SR86xDataChannel(InstrumentChannel):
+    """
+    Implements a data channel of SR86x lock-in amplifier. Parameters that are
+    assigned to these channels get plotted on the display of the instrument.
+    Moreover, there are commands that allow to conveniently retrieve the values
+    of the parameters that are currently assigned to the data channels.
+
+    This class relies on the available parameter names that should be
+    mentioned in the lock-in amplifier class in `PARAMETER_NAMES` attribute.
+
+    Args:
+        parent
+            an instance of SR86x driver
+        name
+            data channel name that is to be used to refernce it from the parent
+        cmd_id
+            this ID is used in VISA commands to refer to this data channel,
+            usually is an integer number
+        channel_name
+            this name can also be used in VISA commands along with
+            channel_id; it is not used in this implementation, but is added
+            for reference
+        channel_color
+            every data channel is also referred to by the color with which it
+            is being plotted on the instrument's screen; added here only for
+            reference
+    """
+    def __init__(self, parent: 'SR86x', name: str, cmd_id: str,
+                 cmd_id_name: str=None, color: str=None):
+        super().__init__(parent, name)
+
+        self._cmd_id = cmd_id
+        self._cmd_id_name = cmd_id_name
+        self._color = color
+
+        self.add_parameter(f'assigned_parameter',
+                           label=f'Data channel {cmd_id} parameter',
+                           docstring=f'Allows to set and get the '
+                                     f'parameter that is assigned to data '
+                                     f'channel {cmd_id}',
+                           set_cmd=f'CDSP {cmd_id}, {{}}',
+                           get_cmd=f'CDSP? {cmd_id}',
+                           val_mapping=self.parent.PARAMETER_NAMES
+                           )
+
+    @property
+    def cmd_id(self):
+        return self._cmd_id
+
+    @property
+    def cmd_id_name(self):
+        return self._cmd_id_name
+
+    @property
+    def color(self):
+        return self._color
+
+
 class SR86x(VisaInstrument):
     """
     This is the code for Stanford_SR865 Lock-in Amplifier
@@ -598,7 +656,7 @@ class SR86x(VisaInstrument):
     }
     _N_TO_INPUT_SIGNAL = {v: k for k, v in _INPUT_SIGNAL_TO_N.items()}
 
-    _PARAMETER_NAMES = {
+    PARAMETER_NAMES = {
                 'X': '0',   # X output, 'X'
                 'Y': '1',   # Y output, 'Y'
                 'R': '2',   # R output, 'R'
@@ -617,6 +675,8 @@ class SR86x(VisaInstrument):
         'frequency': '15',  # Int. Ref. Frequency, 'FInt'
     'frequency_ext': '16',  # Ext. Ref. Frequency, 'FExt'
     }
+
+    _N_DATA_CHANNELS = 4
 
     def __init__(self, name, address, max_frequency, reset=False, **kwargs):
         super().__init__(name, address, terminator='\n', **kwargs)
@@ -889,6 +949,25 @@ class SR86x(VisaInstrument):
                                set_cmd='AUXV {0}, {{}}'.format(i),
                                unit='V')
 
+        # Data channels:
+        # 'DAT1' (green), 'DAT2' (blue), 'DAT3' (yellow), 'DAT4' (orange)
+        data_channels = ChannelList(self, "data_channels", SR86xDataChannel,
+                                    snapshotable=False)
+        for num, color in zip(range(self._N_DATA_CHANNELS),
+                              ('green', 'blue', 'yellow', 'orange')):
+            cmd_id = f"{num}"
+            cmd_id_name = f"DAT{num + 1}"
+            ch_name = f"data_channel_{num + 1}"
+
+            data_channel = SR86xDataChannel(
+                self, ch_name, cmd_id, cmd_id_name, color)
+
+            data_channels.append(data_channel)
+            self.add_submodule(ch_name, data_channel)
+
+        data_channels.lock()
+        self.add_submodule("data_channels", data_channels)
+
         # Interface
         self.add_function('reset', call_cmd='*RST')
 
@@ -962,11 +1041,71 @@ class SR86x(VisaInstrument):
                 'at a time.')
 
         for name in parameter_names:
-            if name not in self._PARAMETER_NAMES:
+            if name not in self.PARAMETER_NAMES:
                 raise KeyError(f'{name} is not a valid parameter name. Refer '
                                f'to `_PARAMETER_NAMES` for a list of valid '
                                f'parameter names')
 
-        p_ids = [self._PARAMETER_NAMES[name] for name in parameter_names]
+        p_ids = [self.PARAMETER_NAMES[name] for name in parameter_names]
         output = self.ask(f'SNAP? {",".join(p_ids)}')
         return tuple(float(val) for val in output.split(','))
+
+    def get_data_channels_values(self) -> Tuple[float, ...]:
+        """
+        Queries the current values of the data channels
+
+        Returns:
+            tuple of 4 values of the data channels
+        """
+        output = self.ask('SNAPD?')
+        return tuple(float(val) for val in output.split(','))
+
+    def get_data_channels_parameters(self, query_instrument: bool=True
+                                     ) -> Tuple[str, ...]:
+        """
+        Convenience method to query a list of parameters which the data
+        channels are currently assigned to.
+
+        Args:
+            query_instrument
+                If set to False, the internally cashed names of the parameters
+                will be returned; if True, then the names will be queried
+                through the instrument
+
+        Returns:
+            a tuple of 4 strings of parameter names
+        """
+        if query_instrument:
+            method_name = 'get'
+        else:
+            method_name = 'get_latest'
+
+        return tuple(
+            getattr(getattr(self.data_channels[i], 'assigned_parameter'),
+                    method_name)()
+            for i in range(self._N_DATA_CHANNELS)
+        )
+
+    def get_data_channels_dict(self, requery_names: bool=False
+                               ) -> Dict[str, float]:
+        """
+        Returns a dictionary where the keys are parameter names currently
+        assigned to the data channels, and values are the values of those
+        parameters.
+
+        Args:
+            requery_names
+                if False, the currently assigned parameter names will not be
+                queries from the instrument in order to save time on
+                communication, in this case the cached assigned parameter
+                names will be used for the keys of the dicitonary; if True,
+                the assigned parameter names will be queried from the
+                instrument
+
+        Returns:
+            a dictionary where keys are names of parameters assigned to the
+            data channels, and values are the values of those parameters
+        """
+        parameter_names = self.get_data_channels_parameters(requery_names)
+        parameter_values = self.get_data_channels_values()
+        return dict(zip(parameter_names, parameter_values))


### PR DESCRIPTION
Adds the possibility to return multiple measured values at the same time, `get_values` by implementing corresponding visa commands. Also, add data channels, `data_channels`, which also allow to return 4 values of parameters assigned to them at once.

ToDo:
- [x] final testing on device
- [x] update example notebook
