### PR TITLE
IVVI add missing underscore in parameter name

### DIFF
--- a/qcodes/instrument_drivers/QuTech/IVVI.py
+++ b/qcodes/instrument_drivers/QuTech/IVVI.py
@@ -110,7 +110,7 @@ class IVVI(VisaInstrument):
                                       'value. Change to a lower value for '
                                       'a shorter minimum time to wait.'))
 
-        self.add_parameter('dac voltages',
+        self.add_parameter('dac_voltages',
                            label='Dac voltages',
                            get_cmd=self._get_dacs)
 


### PR DESCRIPTION
parameters can't have white spaces