### PR TITLE
Upgrade matplotlib to 2.2.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
  - conda-forge
 dependencies:
  - h5py
- - matplotlib=2.0.2
+ - matplotlib=2.2.3
  - pyqtgraph 
  - python=3.6
  - jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.13.3
-matplotlib==2.0.2
+matplotlib==2.2.3
 pyqtgraph==0.10.0
 PyVISA==1.8
 PyQt5==5.9

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def readme():
         return f.read()
 
 extras = {
-    'MatPlot': ('matplotlib', '2.0.2'),
+    'MatPlot': ('matplotlib', '2.2.3'),
     'QtPlot': ('pyqtgraph', '0.10.0'),
     'coverage tests': ('coverage', '4.0'),
     'Slack': ('slacker', '0.9.42')


### PR DESCRIPTION
This upgrade was pending for a long time already. It is especially necessary for https://github.com/QCoDeS/Qcodes/pull/1248 because `matplotlib > 2.1.x` supports plotting categorical (i.e. string-valued) data out-of-the-box.

Other relevant updates to dependency requirements are performed in https://github.com/QCoDeS/Qcodes/pull/1120 PR.