### PR TITLE
Fix deprecation warnings

### DIFF
--- a/qcodes/data/format.py
+++ b/qcodes/data/format.py
@@ -13,7 +13,7 @@ class Formatter:
 
     Each Formatter is expected to implement writing methods:
 
-    - ``write``: to write the ``DataArray``\s
+    - ``write``: to write the ``DataArrays``
     - ``write_metadata``: to write the metadata structure
 
     Optionally, if this Formatter keeps the data file(s) open
@@ -24,7 +24,7 @@ class Formatter:
 
     and reading methods:
 
-    - ``read`` or ``read_one_file`` to reconstruct the ``DataArray``\s, either
+    - ``read`` or ``read_one_file`` to reconstruct the ``DataArrays``, either
       all at once (``read``) or one file at a time, supplied by the base class
       ``read`` method that loops over all data files at the correct location.
 
@@ -150,7 +150,7 @@ class Formatter:
             f (file-like): a file-like object to read from, as provided by
                 ``io_manager.open``.
 
-            ids_read (set): ``array_id``\s that we have already read.
+            ids_read (set): ``array_ids`` that we have already read.
                 When you read an array, check that it's not in this set (except
                 setpoints, which can be in several files with different inner
                 loops) then add it to the set so other files know it should not

--- a/qcodes/data/gnuplot_format.py
+++ b/qcodes/data/gnuplot_format.py
@@ -240,7 +240,7 @@ class GNUPlotFormat(Formatter):
             return labelstr.split()
         else:
             # fields *are* quoted (and escaped)
-            parts = re.split('"\s+"', labelstr[1:-1])
+            parts = re.split('"\\s+"', labelstr[1:-1])
             return [l.replace('\\"', '"').replace('\\\\', '\\') for l in parts]
 
     def write(self, data_set, io_manager, location, force_write=False,

--- a/qcodes/data/io.py
+++ b/qcodes/data/io.py
@@ -34,7 +34,7 @@ The main thing these managers need to implement is the open context manager:
 
 IO managers should also implement:
 
-- a join method, ala os.path.join(\*args).
+- a join method, ala ``os.path.join(*args)``.
 - a list method, that returns all objects matching location
 - a remove method, ala os.remove(path) except that it will remove directories
   as well as files, since we're allowing "locations" to be directories

--- a/qcodes/dataset/database.py
+++ b/qcodes/dataset/database.py
@@ -38,7 +38,7 @@ def initialise_or_create_database_at(db_file_with_abs_path: str) -> None:
     Args:
         db_file_with_abs_path
             Database file name with absolute path, for example
-            "C:\mydata\majorana_experiments.db"
+            ``C:\\mydata\\majorana_experiments.db``
     """
     qcodes.config.core.db_location = db_file_with_abs_path
     initialise_database()

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -95,7 +95,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         for every real function of the instrument.
 
         This functionality is meant for simple cases, principally things that
-        map to simple commands like '\*RST' (reset) or those with just a few
+        map to simple commands like ``*RST`` (reset) or those with just a few
         arguments. It requires a fixed argument count, and positional args
         only. If your case is more complicated, you're probably better off
         simply making a new method in your ``Instrument`` subclass definition.
@@ -404,13 +404,13 @@ class Instrument(InstrumentBase):
 
     def get_idn(self) -> Dict[str, Optional[str]]:
         """
-        Parse a standard VISA '\*IDN?' response into an ID dict.
+        Parse a standard VISA ``*IDN?`` response into an ID dict.
 
         Even though this is the VISA standard, it applies to various other
         types as well, such as IPInstruments, so it is included here in the
         Instrument base class.
 
-        Override this if your instrument does not support '\*IDN?' or
+        Override this if your instrument does not support ``*IDN?`` or
         returns a nonstandard IDN string. This string is supposed to be a
         comma-separated list of vendor, model, serial, and firmware, but
         semicolon and colon are also common separators so we accept them here

--- a/qcodes/instrument/function.py
+++ b/qcodes/instrument/function.py
@@ -8,7 +8,7 @@ class Function(Metadatable):
     Defines a function  that an instrument can execute.
 
     This class is meant for simple cases, principally things that
-    map to simple commands like '\*RST' (reset) or those with just a few
+    map to simple commands like ``*RST`` (reset) or those with just a few
     arguments.
     It requires a fixed argument count, and positional args
     only. If your case is more complicated, you're probably better off

--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -1184,7 +1184,7 @@ class Tektronix_AWG5014(VisaInstrument):
         """
         if verbose:
             print('Writing to:',
-                  self.ask('MMEMory:CDIRectory?').replace('\n', '\ '),
+                  self.ask('MMEMory:CDIRectory?').replace('\n', '\\ '),
                   filename)
         # Header indicating the name and size of the file being send
         name_str = 'MMEMory:DATA "{}",'.format(filename).encode('ASCII')

--- a/qcodes/instrument_drivers/tektronix/AWG70000A.py
+++ b/qcodes/instrument_drivers/tektronix/AWG70000A.py
@@ -449,7 +449,7 @@ class AWG70000A(VisaInstrument):
 
         # Folder on the AWG where to files are uplaoded by default
         self.wfmxFileFolder = "\\Users\\OEM\\Documents"
-        self.seqxFileFolder = "\\Users\\OEM\Documents"
+        self.seqxFileFolder = "\\Users\\OEM\\Documents"
 
         self.current_directory(self.wfmxFileFolder)
 

--- a/qcodes/loops.py
+++ b/qcodes/loops.py
@@ -268,7 +268,7 @@ class Loop(Metadatable):
 
         This is more naturally done to an ActiveLoop (ie after .each())
         and can also be done there, but it's allowed at this stage too so that
-        you can define final actions and share them among several *Loop*\s that
+        you can define final actions and share them among several ``Loops`` that
         have different loop actions, or attach final actions to a Loop run
 
         TODO:

--- a/qcodes/loops.py
+++ b/qcodes/loops.py
@@ -90,17 +90,18 @@ class Loop(Metadatable):
         progress_interval: should progress of the loop every x seconds. Default
             is None (no output)
 
-    After creating a Loop, you attach ``action``\s to it, making an ``ActiveLoop``
+    After creating a Loop, you attach one or more ``actions`` to it, making an
+    ``ActiveLoop``
 
     TODO:
         how? Maybe obvious but not specified! that you can ``.run()``,
         or you can ``.run()`` a ``Loop`` directly, in which
-        case it takes the default ``action``\s from the default ``Station``
+        case it takes the default ``actions`` from the default ``Station``
 
-    ``actions`` are a sequence of things to do at each ``Loop`` step: they can be
-    ``Parameter``\s to measure, ``Task``\s to do (any callable that does not yield
-    data), ``Wait`` times, or other ``ActiveLoop``\s or ``Loop``\s to nest inside
-    this one.
+    ``actions`` is a sequence of things to do at each ``Loop`` step: that can be
+    a ``Parameter`` to measure, a ``Task`` to do (any callable that does not
+    yield data), ``Wait`` times, or another ``ActiveLoop`` or ``Loop`` to nest
+    inside this one.
     """
     def __init__(self, sweep_values, delay=0, station=None,
                  progress_interval=None):
@@ -260,7 +261,7 @@ class Loop(Metadatable):
         """
         Attach actions to be performed after the loop completes.
 
-        These can only be *Task* and *Wait* actions, as they may not generate
+        These can only be ``Task`` and ``Wait`` actions, as they may not generate
         any data.
 
         returns a new Loop object - the original is untouched
@@ -274,7 +275,7 @@ class Loop(Metadatable):
             examples of this ? with default actions.
 
         Args:
-            \*actions: *Task* and *Wait* objects to execute in order
+            *actions: ``Task`` and ``Wait`` objects to execute in order
 
             overwrite: (default False) whether subsequent .then() calls (including
                 calls in an ActiveLoop after .then() has already been called on
@@ -336,12 +337,13 @@ def _attach_bg_task(loop, task, bg_final_task, min_delay):
 
 class ActiveLoop(Metadatable):
     """
-    Created by attaching actions to a *Loop*, this is the object that actually
-    runs a measurement loop. An *ActiveLoop* can no longer be nested, only run,
-    or used as an action inside another `Loop` which will run the whole thing.
+    Created by attaching ``actions`` to a ``Loop``, this is the object that
+    actually runs a measurement loop. An ``ActiveLoop`` can no longer be nested,
+    only run, or used as an action inside another ``Loop`` which will run the
+    whole thing.
 
-    The *ActiveLoop* determines what *DataArray*\s it will need to hold the data
-    it collects, and it creates a *DataSet* holding these *DataArray*\s
+    The ``ActiveLoop`` determines what ``DataArrays`` it will need to hold the
+    data it collects, and it creates a ``DataSet`` holding these ``DataArrays``
     """
 
     # Currently active loop, is set when calling loop.run(set_active=True)
@@ -383,14 +385,16 @@ class ActiveLoop(Metadatable):
         """
         Attach actions to be performed after the loop completes.
 
-        These can only be `Task` and `Wait` actions, as they may not generate
-        any data.
+        These can only be ``Task`` and ``Wait`` actions, as they may not
+        generate any data.
 
         returns a new ActiveLoop object - the original is untouched
 
-        \*actions: `Task` and `Wait` objects to execute in order
+
 
         Args:
+            *actions: ``Task`` and ``Wait`` objects to execute in order
+
             overwrite: (default False) whether subsequent .then() calls (including
                 calls in an ActiveLoop after .then() has already been called on
                 the Loop) will add to each other or overwrite the earlier ones.

--- a/qcodes/plots/base.py
+++ b/qcodes/plots/base.py
@@ -189,29 +189,32 @@ class BasePlot:
         """
         Complete the x, y (and possibly z) data definition for a trace.
 
-        Also modifies kwargs in place so that all the data needed to fully specify the
-        trace is present (ie either x and y or x and y and z)
+        Also modifies kwargs in place so that all the data needed to fully
+        specify the trace is present (ie either x and y or x and y and z)
 
-        Both ``__init__`` (for the first trace) and the ``add`` method support multiple
-        ways to specify the data in the trace:
+        Both ``__init__`` (for the first trace) and the ``add`` method support
+        multiple ways to specify the data in the trace:
 
-        As \*args:
-            - ``add(y)`` or ``add(z)`` specify just the main 1D or 2D data, with the setpoint
-              axis or axes implied.
+        As ``*args``:
+            - ``add(y)`` or ``add(z)`` specify just the main 1D or 2D data, with
+              the setpoint axis or axes implied.
             - ``add(x, y)`` or ``add(x, y, z)`` specify all axes of the data.
-        And as \*\*kwargs:
-            - ``add(x=x, y=y, z=z)`` you specify exactly the data you want on each axis.
-              Any but the last (y or z) can be omitted, which allows for all of the same
-              forms as with \*args, plus x and z or y and z, with just one axis implied from
-              the setpoints of the z data.
+        And as ``**kwargs``:
+            - ``add(x=x, y=y, z=z)`` you specify exactly the data you want on
+              each axis. Any but the last (y or z) can be omitted, which allows
+              for all of the same forms as with ``*args``, plus x and z or y and
+              z, with just one axis implied from the setpoints of the z data.
 
-        This method takes any of those forms and converts them into a complete set of
-        kwargs, containing all of the explicit or implied data to be used in plotting this trace.
+        This method takes any of those forms and converts them into a complete
+        set of kwargs, containing all of the explicit or implied data to be used
+        in plotting this trace.
 
         Args:
-            args (Tuple[DataArray]): positional args, as passed to either ``__init__`` or ``add``
-            kwargs (Dict(DataArray]): keyword args, as passed to either ``__init__`` or ``add``.
-                kwargs may contain non-data items in keys other than x, y, and z.
+            args (Tuple[DataArray]): positional args, as passed to either
+                ``__init__`` or ``add``
+            kwargs (Dict(DataArray]): keyword args, as passed to either
+                ``__init__`` or ``add``. kwargs may contain non-data items in
+                keys other than x, y, and z.
 
         Raises:
            ValueError: if the shape of the data does not match that of args

--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -29,8 +29,8 @@ class QtPlot(BasePlot):
     Plot x/y lines or x/y/z heatmap data. The first trace may be included
     in the constructor, other traces can be added with QtPlot.add().
 
-    For information on how x/y/z \*args are handled see add() in the base
-    plotting class.
+    For information on how ``x/y/z *args`` are handled see ``add()`` in the
+     base plotting class.
 
     Args:
         *args: shortcut to provide the x/y/z data. See BasePlot.add

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -17,28 +17,30 @@ class Station(Metadatable, DelegateAttributes):
     """
     A representation of the entire physical setup.
 
-    Lists all the connected `Component`\s and the current default
+    Lists all the connected Components and the current default
     measurement (a list of actions). Contains a convenience method
     `.measure()` to measure these defaults right now, but this is separate
     from the code used by `Loop`.
 
     Args:
-        *components (list[Any]): components to add immediately to the Station.
-            can be added later via self.add_component
+        *components (list[Any]): components to add immediately to the
+             Station. Can be added later via self.add_component
 
-        monitor (None): Not implemented, the object that monitors the system continuously
+        monitor (None): Not implemented, the object that monitors the system
+            continuously
 
         default (bool): is this station the default, which gets
-            used in Loops and elsewhere that a Station can be specified, default  true
+            used in Loops and elsewhere that a Station can be specified,
+            default true
 
         update_snapshot (bool): immediately update the snapshot
             of each component as it is added to the Station, default true
 
     Attributes:
         default (Station): class attribute to store the default station
-        delegate_attr_dicts (list): a list of names (strings) of dictionaries which are
-            (or will be) attributes of self, whose keys should be treated as
-            attributes of self
+        delegate_attr_dicts (list): a list of names (strings) of dictionaries
+            which are (or will be) attributes of self, whose keys should be
+            treated as attributes of self
     """
 
     default = None # type: 'Station'
@@ -128,7 +130,7 @@ class Station(Metadatable, DelegateAttributes):
 
     def set_measurement(self, *actions):
         """
-        Save a set \*actions as the default measurement for this Station.
+        Save a set ``*actions``` as the default measurement for this Station.
 
         These actions will be executed by default by a Loop if this is the
         default Station, and any measurements among them can be done once

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -190,7 +190,7 @@ class TestChannels(TestCase):
             chan.temperature(setpoints[i])
 
         expected = tuple(setpoints[0:2] + [0, 0] + setpoints[2:])
-        self.assertEquals(self.instrument.channels.temperature(), expected)
+        self.assertEqual(self.instrument.channels.temperature(), expected)
 
     @given(start=hst.integers(-8,7), stop=hst.integers(-8,7), step=hst.integers(1,7))
     def test_access_channels_by_slice(self, start, stop, step):

--- a/qcodes/tests/test_deprecate.py
+++ b/qcodes/tests/test_deprecate.py
@@ -1,6 +1,8 @@
+import pytest
+
 from qcodes.utils.deprecate import deprecate
 
-
+@pytest.mark.filterwarnings('ignore:The function "add_one" is deprecated,')
 def test_similar_output():
 
     def _add_one(x):


### PR DESCRIPTION
Pytest 3.8 has been released and this now shows deprecation warnings by default. Turns out we trigger a few of those. This should fix that. This is WIP until all of them have been fixed. Please don't merge just yet
