### PR TITLE
Fix potential divide_by_zero warning in scale selection

### DIFF
--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -365,7 +365,10 @@ def _make_rescaled_ticks_and_units(data_dict: Dict[str, Any]) \
             selected_scale = largest_scale
             prefix = _ENGINEERING_PREFIXES[largest_scale]
     else:
-        selected_scale = 3*(np.floor(np.floor(np.log10(maxval))/3))
+        if maxval > 0:
+            selected_scale = 3*(np.floor(np.floor(np.log10(maxval))/3))
+        else:
+            selected_scale = 0
         if selected_scale != 0:
             prefix = f'$10^{{{selected_scale:.0f}}}$ '
         else:


### PR DESCRIPTION
maxval may be zero if all data is zero so protect against that. @Dominik-Vogel 

We have an example of this in one of the notebooks

