### PR TITLE
[wip] Dataset serializer

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,11 +1,11 @@
 name: qcodes
-channels: 
+channels:
  - defaults
  - conda-forge
 dependencies:
  - h5py
  - matplotlib=2.2.3
- - pyqtgraph 
+ - pyqtgraph
  - python=3.6
  - jsonschema
  - pyvisa=1.8.0
@@ -19,3 +19,4 @@ dependencies:
  - pytest-runner
  - spyder
  - pyzmq
+ - jsonpickle

--- a/qcodes/dataset/__init__.py
+++ b/qcodes/dataset/__init__.py
@@ -1,0 +1,6 @@
+from jsonpickle import handlers
+
+from .jsonpickle_handler import DataSetHandler
+from .data_set import DataSet
+
+handlers.register(DataSet, DataSetHandler)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -22,6 +22,7 @@ from qcodes.instrument.parameter import _BaseParameter
 from qcodes.dataset.sqlite_base import (atomic, atomic_transaction,
                                         transaction, add_parameter,
                                         connect, create_run, completed,
+                                        column_in_table,
                                         get_parameters,
                                         get_experiments,
                                         get_last_experiment, select_one_where,
@@ -229,6 +230,14 @@ class DataSet(Sized):
     def table_name(self):
         return select_one_where(self.conn, "runs",
                                 "result_table_name", "run_id", self.run_id)
+
+    @property
+    def snapshot(self):
+        if column_in_table(self.conn, "runs", "snapshot"):
+            return select_one_where(self.conn, "runs", "snapshot",
+                                    "run_id", self.run_id)
+        else:
+            return None
 
     @property
     def number_of_results(self):

--- a/qcodes/dataset/jsonpickle_handler.py
+++ b/qcodes/dataset/jsonpickle_handler.py
@@ -19,9 +19,11 @@ class DataSetHandler(handlers.BaseHandler):
         jdict['snapshot'] = dataset.snapshot
         #
         data = {}
-        for parameter in dataset.parameters.split(','):
-            pdata = flatten_1D_data_for_plot(dataset.get_data(parameter))
-            data[parameter] = jsonpickle.encode(pdata)
+
+        if dataset.parameters is not None:
+            for parameter in dataset.parameters.split(','):
+                pdata = flatten_1D_data_for_plot(dataset.get_data(parameter))
+                data[parameter] = jsonpickle.encode(pdata)
 
         jdict['DATA'] = data
 

--- a/qcodes/dataset/jsonpickle_handler.py
+++ b/qcodes/dataset/jsonpickle_handler.py
@@ -1,0 +1,41 @@
+from jsonpickle import handlers
+import jsonpickle
+
+from qcodes.dataset.data_set import DataSet, load_by_id
+from qcodes.dataset.plotting import flatten_1D_data_for_plot
+
+
+class DataSetHandler(handlers.BaseHandler):
+
+    def flatten(self, dataset: DataSet, jdict: dict) -> dict:
+        jdict['run_id'] = dataset.run_id
+        jdict['exp_id'] = dataset.exp_id
+        jdict['result_table_name'] = dataset.table_name
+        jdict['result_counter'] = dataset.number_of_results
+        jdict['run_timestamp'] = dataset.run_timestamp_raw
+        jdict['completed_timestamp'] = dataset.completed_timestamp_raw
+        jdict['is_completed'] = dataset.completed
+        jdict['parameters'] = dataset.parameters
+        jdict['snapshot'] = dataset.snapshot
+        #
+        data = {}
+        for parameter in dataset.parameters.split(','):
+            pdata = flatten_1D_data_for_plot(dataset.get_data(parameter))
+            data[parameter] = jsonpickle.encode(pdata)
+
+        jdict['DATA'] = data
+
+        return jdict
+
+    # Note: the restoration is actually tricky, since we're either looking up
+    # an existing run in the database or creating a new one; two very distinct
+    # situations. Without a GUID, it's hard to determine which of the two
+    # situations we are in. Here we just try to look up the run for a
+    # proof-of-principle
+    def restore(self, jdict: dict) -> DataSet:
+        try:
+            return load_by_id(jdict['run_id'])
+        except RuntimeError:
+            raise RuntimeError('No such run in database. Run insertion not '
+                               'implemented yet. Can not proceed.')
+

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -290,6 +290,23 @@ def init_db(conn: sqlite3.Connection)->None:
         transaction(conn, _dependencies_table_schema)
 
 
+def column_in_table(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    """
+    A look-before-you-leap function to look up if a table has a certain column.
+    Intented for the runs table where columns are dynamically added.
+
+    Args:
+        conn: The connection
+        table: the table name
+        column: the column name
+    """
+    cur = atomic_transaction(conn, f"PRAGMA table_info({table})")
+    for row in cur.fetchall():
+        if row['name'] == column:
+            return True
+    return False
+
+
 def insert_column(conn: sqlite3.Connection, table: str, name: str,
                   paramtype: Optional[str] = None) -> None:
     """Insert new column to a table

--- a/qcodes/tests/dataset/test_jsonpickle.py
+++ b/qcodes/tests/dataset/test_jsonpickle.py
@@ -1,0 +1,41 @@
+import jsonpickle
+
+from qcodes.dataset.data_set import new_data_set, DataSet
+from qcodes.dataset.param_spec import ParamSpec
+
+from .test_dataset_basic import empty_temp_db, experiment  # noqa: F401
+
+
+def test_basic_dump_and_load(experiment):  # noqa: F811
+
+    # empty dataset
+
+    ds = new_data_set('jsonpickletest')
+
+    ds_string = jsonpickle.dumps(ds)
+    ds_new = jsonpickle.loads(ds_string)
+    assert isinstance(ds_new, DataSet)
+    assert ds_new.name == ds.name
+    assert ds_new.run_id == ds.run_id
+
+    # Fill in some data and correctly read it out
+
+    psx = ParamSpec("x", "numeric")
+    psy = ParamSpec("y", "numeric", depends_on=['x'])
+
+    ds = new_data_set("test-dataset", specs=[psx, psy])
+
+    expected_x = []
+    expected_y = []
+    for x in range(100):
+        expected_x.append([x])
+        y = 3 * x + 10
+        expected_y.append([y])
+        ds.add_result({"x": x, "y": y})
+
+    ds_string = jsonpickle.dumps(ds)
+    ds_new = jsonpickle.loads(ds_string)
+
+    assert ds_new.get_data('x') == expected_x
+    assert ds_new.get_data('y') == expected_y
+

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,3 +9,4 @@ git+https://github.com/QCoDeS/broadbean
 lxml
 codecov
 asv
+jsonpickle


### PR DESCRIPTION
Changes proposed in this pull request:
- Make it possible to serialize a DataSet object and dump it to a string
- Make it possible (under some circumstances) to re-create a DataSet object from said string

This PR uses the `jsonpickle` module for the serialization. A custom handler for the `DataSet` is added (and registered when the `dataset` module is imported).

The usage is straightforward:

```python
import jsonpickle

ds = load_from_id(1)
json_string = jsonpickle.dumps(ds)
new_ds = jsonpickle.loads(json_string)
```

There's still quite a lot to discuss about what exactly should be jsonpickled down (like, does `results_table_name` make _any_ sense?) and how datasets not already in the database should be treated.

@johnazariah 
