### PR TITLE
Ignore mypy_cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ target/
 *.py~
 tmp/
 .#*
+.mypy_cache/*
 
 docs/examples/data/*
 


### PR DESCRIPTION
When using mypy in VSCode, a lot of files are generated in `.mypy_cache`. Better to ignore them.

@Dominik-Vogel 
