### PR TITLE
Remove mypy workarounds

### DIFF
--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -196,14 +196,11 @@ class ChannelList(Metadatable):
         else:
             self._locked = True
             self._channels = tuple(chan_list)
-            # At this stage mypy (0.610) is convinced that self._channels is
-            # None. Creating a local variable seems to resolve this
-            channels = cast(Tuple[InstrumentChannel, ...], self._channels)
-            if channels is None:
+            if self._channels is None:
                 raise RuntimeError("Empty channel list")
             self._channel_mapping = {channel.short_name: channel
-                                     for channel in channels}
-            if not all(isinstance(chan, chan_type) for chan in channels):
+                                     for channel in self._channels}
+            if not all(isinstance(chan, chan_type) for chan in self._channels):
                 raise TypeError("All items in this channel list must be of "
                                 "type {}.".format(chan_type.__name__))
 

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -189,7 +189,7 @@ class Numbers(Validator):
         else:
             raise TypeError('min_value must be a number')
 
-        valuesok = max_value > min_value  # type: ignore
+        valuesok = max_value > min_value
 
         if isinstance(max_value, self.validtypes) and valuesok:
             self._max_value = max_value
@@ -490,7 +490,7 @@ class Arrays(Validator):
         else:
             raise TypeError('min_value must be a number')
 
-        valuesok = max_value > min_value  # type: ignore
+        valuesok = max_value > min_value
 
         if isinstance(max_value, self.validtypes) and valuesok:
             self._max_value = max_value
@@ -614,7 +614,6 @@ class Dict(Validator):
                 raise SyntaxError('Dictionary keys {} are not in allowed keys '
                                   '{}'.format(forbidden_keys,
                                               self.allowed_keys))
-
 
     def __repr__(self):
         if self.allowed_keys is None:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ pytest-cov
 pytest
 codacy-coverage
 hypothesis!=3.69.11 # due to bug in log capture
-mypy!=0.570 # due to https://github.com/python/mypy/issues/4674
+mypy>=0.630
 git+https://github.com/QCoDeS/pyvisa-sim.git
 git+https://github.com/QCoDeS/broadbean
 lxml


### PR DESCRIPTION
Now that `mypy` version `0.630` is out, we can remove a few workarounds from our code.

@QCoDeS/core 
