### PR TITLE
Fix warnings and test failures

### DIFF
--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -413,7 +413,7 @@ class MercuryiPS(VisaInstrument):
         """
 
         visalog.debug(f"Writing to instrument {self.name}: {cmd}")
-        resp = self.visa_handle.ask(cmd)
+        resp = self.visa_handle.query(cmd)
         visalog.debug(f"Got instrument response: {resp}")
 
         if 'INVALID' in resp:

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -54,7 +54,7 @@ def test_generate_guid(loc, stat, smpl):
         assert comps['time'] - gen_time < 2
 
 
-@settings(max_examples=50, deadline=500)
+@settings(max_examples=50, deadline=None)
 @given(loc=hst.integers(-10, 350))
 def test_set_guid_location_code(loc, monkeypatch):
     monkeypatch.setattr('builtins.input', lambda x: str(loc))

--- a/qcodes/tests/test_combined_loop.py
+++ b/qcodes/tests/test_combined_loop.py
@@ -64,7 +64,7 @@ class TestLoopCombined(TestCase):
                                   min_size=2, max_size=2, unique=True).map(sorted),
            z_start_stop=hst.lists(hst.integers(min_value=-800, max_value=400),
                                   min_size=2, max_size=2, unique=True).map(sorted))
-    @settings(max_examples=10, deadline=300)
+    @settings(max_examples=10, deadline=None)
     def testLoopCombinedParameterTwice(self, npoints, x_start_stop, y_start_stop, z_start_stop):
         x_set = np.linspace(x_start_stop[0], x_start_stop[1], npoints)
         y_set = np.linspace(y_start_stop[0], y_start_stop[1], npoints)


### PR DESCRIPTION
The 2 tests failed on travis due to a timeout so disable the timeout (https://travis-ci.org/QCoDeS/Qcodes/builds/429636945 and https://travis-ci.org/QCoDeS/Qcodes/builds/429937977)

The Mercury driver uses ask from pyvisa which is deprecated so change that to use query instead. This fix is already applied in the main driver 