### PR TITLE
Remove pined version of ipykernel and upgrade matplotlib dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
  - python=3.6
  - numpy=1.15
- - matplotlib=2.2.3
+ - matplotlib=3.0.0
  - pyqtgraph=0.10.0
  - pyvisa=1.9.1
  - h5py=2.8.0

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
  - QtPy
  - jsonschema
  - jupyter=1.0.0
- - ipykernel=4.8.2 # https://github.com/spyder-ide/spyder/issues/7842
  - hypothesis
  - pytest
  - pytest-runner

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.15.*
-matplotlib==2.2.3
+matplotlib==3.0.0
 pyqtgraph==0.10.0
 PyVISA==1.9.1
 h5py==2.8.0


### PR DESCRIPTION
Ipykernel 4.10/5.0 has been released with a bugfix for the issue in 4.9 that broke the kernel in spyder

I also took the chance to upgrade matplotlib to 3.0. I have checked the changelog and there does not seem to be any changes likely to break any functionality for us