### PR TITLE
Ensure that post actions are performed in some context managers 

### DIFF
--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -65,10 +65,11 @@ def location_and_station_set_to(location: int, work_station: int):
     cfg['GUID_components']['work_station'] = work_station
     cfg.save_to_home()
 
-    yield
-
-    cfg.current_config = old_cfg
-    cfg.save_to_home()
+    try:
+        yield
+    finally:
+        cfg.current_config = old_cfg
+        cfg.save_to_home()
 
 
 def test_tables_exist(empty_temp_db):

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -21,11 +21,12 @@ def protected_config():
     ocfg: DotDict = Config().current_config
     original_config = deepcopy(ocfg)
 
-    yield
-
-    cfg = Config()
-    cfg.current_config = original_config
-    cfg.save_to_home()
+    try:
+        yield
+    finally:
+        cfg = Config()
+        cfg.current_config = original_config
+        cfg.save_to_home()
 
 
 @settings(max_examples=50)

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -164,16 +164,18 @@ def default_config():
     default_config_obj = qcodes.config
     qcodes.config = qcodes.Config()
 
-    yield
+    try:
+        yield
+    finally:
+        qcodes.Config.home_file_name = home_file_name
+        qcodes.Config.schema_home_file_name = schema_home_file_name
+        qcodes.Config.env_file_name = env_file_name
+        qcodes.Config.schema_env_file_name = schema_env_file_name
+        qcodes.Config.cwd_file_name = cwd_file_name
+        qcodes.Config.schema_cwd_file_name = schema_cwd_file_name
 
-    qcodes.Config.home_file_name = home_file_name
-    qcodes.Config.schema_home_file_name = schema_home_file_name
-    qcodes.Config.env_file_name = env_file_name
-    qcodes.Config.schema_env_file_name = schema_env_file_name
-    qcodes.Config.cwd_file_name = cwd_file_name
-    qcodes.Config.schema_cwd_file_name = schema_cwd_file_name
+        qcodes.config = default_config_obj
 
-    qcodes.config = default_config_obj
 
 def side_effect(map, name):
     return map[name]

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -580,8 +580,10 @@ def attribute_set_to(object_: Any, attribute_name: str, new_value: Any):
 
     old_value = getattr(object_, attribute_name)
     setattr(object_, attribute_name, new_value)
-    yield
-    setattr(object_, attribute_name, old_value)
+    try:
+        yield
+    finally:
+        setattr(object_, attribute_name, old_value)
 
 
 def partial_with_docstring(func, docstring, **kwargs):


### PR DESCRIPTION
even if an exception is thrown. 

The code after a yield statement in a context manager (the ``__exit__`` code) is not run if an exception is thrown unless wrapped in a try finally construct. In these cases I think it makes sense to always run the `__exit__` code @WilliamHPNielsen 