### PR TITLE
Make Array validators shape optionally callable

### DIFF
--- a/qcodes/tests/test_validators.py
+++ b/qcodes/tests/test_validators.py
@@ -576,15 +576,26 @@ class TestArrays(TestCase):
 
     def test_shape(self):
         m = Arrays(min_value=-5, max_value=50, shape=(2, 2))
-        v = np.array([[2, 0], [1, 2], [2, 3]])
-        with self.assertRaises(ValueError):
-            m.validate(v)
 
-        # should pass if no shape specified
+        v1 = np.array([[2, 0], [1, 2]])
+        v2 = np.array([[2, 0], [1, 2], [2, 3]])
+
+        # v1 is the correct shape but v2 is not
+        m.validate(v1)
+        with self.assertRaises(ValueError):
+            m.validate(v2)
+        # both should pass if no shape specified
         m = Arrays(min_value=-5, max_value=50)
-        m.validate(v)
-        v = np.array([[2, 0], [1, 2]])
-        m.validate(v)
+        m.validate(v1)
+        m.validate(v2)
+
+    def test_shape_defered(self):
+        m = Arrays(min_value=-5, max_value=50, shape=(lambda: 2, lambda: 2))
+        v1 = np.array([[2, 5], [3, 7]])
+        m.validate(v1)
+        v2 = np.array([[2, 0], [1, 2], [2, 3]])
+        with self.assertRaises(ValueError):
+            m.validate(v2)
 
     def test_valid_values(self):
         val = Arrays(min_value=-5, max_value=50, shape=(2, 2))

--- a/qcodes/tests/test_validators.py
+++ b/qcodes/tests/test_validators.py
@@ -20,11 +20,6 @@ def a_func():
 
 class TestBaseClass(TestCase):
 
-    def test_instantiate(self):
-        # you cannot instantiate the base class
-        with self.assertRaises(NotImplementedError):
-            Validator()
-
     class BrokenValidator(Validator):
 
         def __init__(self):

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -88,10 +88,7 @@ class Validator:
 
     @property
     def valid_values(self) -> TList[Any]:
-        if hasattr(self, '_valid_values'):
-            return self._valid_values
-        else:
-            raise NotImplementedError
+        return self._valid_values
 
 
 class Anything(Validator):


### PR DESCRIPTION
This means that you can use another parameter to define the shape of a parameter with an array validator. This is part of doing #1263 with some more checks for consistency. 

I also did a bit of cleanup on the validators

* Did away with the super init method that cannot be called which is unusual and really doesn't add anything useful. 
* Added typehints to all validators 
* Improved a few docstrings
