### PR TITLE
Catch generic exceptions in import of dependencies. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,13 @@ valueerror_template = '''
 *****
 '''
 
+othererror_template = '''
+*****
+***** could not import package {0}. Please try importing it from 
+***** the commandline to diagnose the issue.
+*****
+'''
+
 # now test the versions of extras
 for extra, (module_name, min_version) in extras.items():
     try:
@@ -114,3 +121,5 @@ for extra, (module_name, min_version) in extras.items():
     except ValueError:
         print(valueerror_template.format(
             module_name, module.__version__, min_version, extra))
+    except:
+        print(othererror_template.format(module_name))


### PR DESCRIPTION
We don't want these to block the install of qcodes fixes #1314

I am not sure if the code to check extra dependencies actually adds much value. Regardless of the output it will not be shown when you pip install qcodes unless you pass the `-v` flag. We could also just remove it
