### PR TITLE
Fix typo in log call with exc_info kwarg

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -186,7 +186,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
                 log.warning(f"Snapshot: Could not update parameter: "
                             f"{name} on {self.full_name}")
                 log.info(f"Details for Snapshot of {name}:",
-                         exec_info=True)
+                         exc_info=True)
 
                 snap['parameters'][name] = param.snapshot(update=False)
         for attr in set(self._meta_attrs):


### PR DESCRIPTION
`log.info(..., exc_info=smth)` is correct, where `exc_info` is the name of the kwarg. See [logging module docs](https://docs.python.org/3/library/logging.html#logging.Logger.debug)
