### PR TITLE
changes imports of abstract base class collections

### DIFF
--- a/qcodes/config/config.py
+++ b/qcodes/config/config.py
@@ -444,7 +444,7 @@ class DotDict(dict):
 
 def update(d, u):
     for k, v in u.items():
-        if isinstance(v, collections.Mapping):
+        if isinstance(v, collections.abc.Mapping):
             r = update(d.get(k, {}), v)
             d[k] = r
         else:

--- a/qcodes/data/data_array.py
+++ b/qcodes/data/data_array.py
@@ -268,7 +268,7 @@ class DataArray(DelegateAttributes):
         """
         if data is not None:
             if not isinstance(data, np.ndarray):
-                if isinstance(data, collections.Iterator):
+                if isinstance(data, collections.abc.Iterator):
                     # faster than np.array(tuple(data)) (or via list)
                     # but requires us to assume float
                     data = np.fromiter(data, float)
@@ -320,7 +320,7 @@ class DataArray(DelegateAttributes):
         Also update the record of modifications to the array. If you don't
         want this overhead, you can access ``self.ndarray`` directly.
         """
-        if isinstance(loop_indices, collections.Iterable):
+        if isinstance(loop_indices, collections.abc.Iterable):
             min_indices = list(loop_indices)
             max_indices = list(loop_indices)
         else:

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -1,4 +1,4 @@
-from collections import Sized
+from collections.abc import Sized
 from typing import Optional, List
 import logging
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -367,11 +367,11 @@ class _BaseParameter(Metadatable):
                 # apply offset first (native scale)
                 if self.offset is not None:
                     # offset values
-                    if isinstance(self.offset, collections.Iterable):
+                    if isinstance(self.offset, collections.abc.Iterable):
                         # offset contains multiple elements, one for each value
                         value = tuple(value - offset for value, offset
                                       in zip(value, self.offset))
-                    elif isinstance(value, collections.Iterable):
+                    elif isinstance(value, collections.abc.Iterable):
                         # Use single offset for all values
                         value = tuple(value - self.offset for value in value)
                     else:
@@ -380,11 +380,11 @@ class _BaseParameter(Metadatable):
                 # scale second
                 if self.scale is not None:
                     # Scale values
-                    if isinstance(self.scale, collections.Iterable):
+                    if isinstance(self.scale, collections.abc.Iterable):
                         # Scale contains multiple elements, one for each value
                         value = tuple(value / scale for value, scale
                                       in zip(value, self.scale))
-                    elif isinstance(value, collections.Iterable):
+                    elif isinstance(value, collections.abc.Iterable):
                         # Use single scale for all values
                         value = tuple(value / self.scale for value in value)
                     else:
@@ -431,7 +431,7 @@ class _BaseParameter(Metadatable):
                     # getter:
                     # apply scale first
                     if self.scale is not None:
-                        if isinstance(self.scale, collections.Iterable):
+                        if isinstance(self.scale, collections.abc.Iterable):
                             # Scale contains multiple elements, one for each value
                             raw_value = tuple(val * scale for val, scale
                                               in zip(raw_value, self.scale))
@@ -441,7 +441,7 @@ class _BaseParameter(Metadatable):
 
                     # apply offset next
                     if self.offset is not None:
-                        if isinstance(self.offset, collections.Iterable):
+                        if isinstance(self.offset, collections.abc.Iterable):
                             # offset contains multiple elements, one for each value
                             raw_value = tuple(val + offset for val, offset
                                               in zip(raw_value, self.offset))
@@ -501,7 +501,7 @@ class _BaseParameter(Metadatable):
         if step is None:
             return [value]
         else:
-            if isinstance(value, collections.Sized) and len(value) > 1:
+            if isinstance(value, collections.abc.Sized) and len(value) > 1:
                 raise RuntimeError("Don't know how to step a parameter with more than one value")
             if self.get_latest() is None:
                 self.get()
@@ -1052,8 +1052,8 @@ class ArrayParameter(_BaseParameter):
         # require one setpoint per dimension of shape
         sp_shape = (len(shape),)
 
-        sp_types = (nt, DataArray, collections.Sequence,
-                    collections.Iterator, numpy.ndarray)
+        sp_types = (nt, DataArray, collections.abc.Sequence,
+                    collections.abc.Iterator, numpy.ndarray)
         if (setpoints is not None and
                 not is_sequence_of(setpoints, sp_types, shape=sp_shape)):
             raise ValueError('setpoints must be a tuple of arrays')
@@ -1251,8 +1251,8 @@ class MultiParameter(_BaseParameter):
                              'of ints, not ' + repr(shapes))
         self.shapes = shapes
 
-        sp_types = (nt, DataArray, collections.Sequence,
-                    collections.Iterator, numpy.ndarray)
+        sp_types = (nt, DataArray, collections.abc.Sequence,
+                    collections.abc.Iterator, numpy.ndarray)
         if not _is_nested_sequence_or_none(setpoints, sp_types, shapes):
             raise ValueError('setpoints must be a tuple of tuples of arrays')
 

--- a/qcodes/instrument_drivers/Advantech/PCIE_1751.py
+++ b/qcodes/instrument_drivers/Advantech/PCIE_1751.py
@@ -116,7 +116,7 @@ class Advantech_PCIE_1751(Instrument):
         integers, writes the binary representations of their values to the pins
         of ports i, ..., i+len(value)-1 respectively.
         """
-        if isinstance(value, collections.Iterable):
+        if isinstance(value, collections.abc.Iterable):
             vallist = list(value)
         else:
             vallist = [value]

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -490,7 +490,7 @@ class AMI430_3D(Instrument):
         self._instrument_y = instrument_y
         self._instrument_z = instrument_z
 
-        if repr(field_limit).isnumeric() or isinstance(field_limit, collections.Iterable):
+        if repr(field_limit).isnumeric() or isinstance(field_limit, collections.abc.Iterable):
             self._field_limit = field_limit
         else:
             raise ValueError("field limit should either be"

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -6,7 +6,7 @@ import numbers
 import time
 import os
 
-from collections import Iterator, Sequence, Mapping
+from collections.abc import Iterator, Sequence, Mapping
 from copy import deepcopy
 from typing import Dict, List, Any
 from contextlib import contextmanager

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -626,8 +626,8 @@ class Sequence(Validator):
         msg += self._elt_validator.__repr__() + '>'
         return msg
 
-    def validate(self, value: collections.Sequence, context: str='') -> None:
-        if not isinstance(value, collections.Sequence):
+    def validate(self, value: collections.abc.Sequence, context: str='') -> None:
+        if not isinstance(value, collections.abc.Sequence):
             raise TypeError(
                 '{} is not a sequence; {}'.format(repr(value), context))
         if self._length and not len(value) == self._length:


### PR DESCRIPTION
Fixes #1319 .

Changes proposed in this pull request:
- importing the abstract collections (like Sequences, Iterable, ..) directly from the `collections` module is deprecated. This patch changes the imports to`import from `collections.abc`.
- note that the fix as it is might break things for users who use python <3.3. 


@astafan8 