### PR TITLE
Feature: access snapshot of a DataSet, and docs

### DIFF
--- a/docs/examples/DataSet/Working with snapshots.ipynb
+++ b/docs/examples/DataSet/Working with snapshots.ipynb
@@ -88,7 +88,7 @@
       " 'name': 'p',\n",
       " 'post_delay': 0,\n",
       " 'raw_value': 123,\n",
-      " 'ts': '2018-10-16 11:44:28',\n",
+      " 'ts': '2018-10-16 12:54:04',\n",
       " 'unit': 'kg',\n",
       " 'value': 123}\n"
      ]
@@ -223,7 +223,7 @@
       "                                   'name': 'input',\n",
       "                                   'post_delay': 0,\n",
       "                                   'raw_value': 0,\n",
-      "                                   'ts': '2018-10-16 11:44:28',\n",
+      "                                   'ts': '2018-10-16 12:54:04',\n",
       "                                   'unit': 'V',\n",
       "                                   'vals': '<Numbers -800<=v<=400>',\n",
       "                                   'value': 0},\n",
@@ -236,7 +236,7 @@
       "                                    'name': 'output',\n",
       "                                    'post_delay': 0,\n",
       "                                    'raw_value': 0,\n",
-      "                                    'ts': '2018-10-16 11:44:28',\n",
+      "                                    'ts': '2018-10-16 12:54:04',\n",
       "                                    'unit': 'V',\n",
       "                                    'vals': '<Numbers -800<=v<=400>',\n",
       "                                    'value': 0}},\n",
@@ -322,7 +322,7 @@
       "                                                                'model': 'instr',\n",
       "                                                                'serial': None,\n",
       "                                                                'vendor': None},\n",
-      "                                                  'ts': '2018-10-16 11:44:28',\n",
+      "                                                  'ts': '2018-10-16 12:54:04',\n",
       "                                                  'unit': '',\n",
       "                                                  'vals': '<Anything>',\n",
       "                                                  'value': {'firmware': None,\n",
@@ -338,7 +338,7 @@
       "                                                    'name': 'input',\n",
       "                                                    'post_delay': 0,\n",
       "                                                    'raw_value': 0,\n",
-      "                                                    'ts': '2018-10-16 11:44:28',\n",
+      "                                                    'ts': '2018-10-16 12:54:04',\n",
       "                                                    'unit': 'V',\n",
       "                                                    'vals': '<Numbers '\n",
       "                                                            '-800<=v<=400>',\n",
@@ -353,7 +353,7 @@
       "                                                     'post_delay': 0,\n",
       "                                                     'raw_value': 0,\n",
       "                                                     'ts': '2018-10-16 '\n",
-      "                                                           '11:44:28',\n",
+      "                                                           '12:54:04',\n",
       "                                                     'unit': 'V',\n",
       "                                                     'vals': '<Numbers '\n",
       "                                                             '-800<=v<=400>',\n",
@@ -366,7 +366,7 @@
       "                      'name': 'p',\n",
       "                      'post_delay': 0,\n",
       "                      'raw_value': 456,\n",
-      "                      'ts': '2018-10-16 11:44:28',\n",
+      "                      'ts': '2018-10-16 12:54:04',\n",
       "                      'unit': 'kg',\n",
       "                      'value': 456}}}\n"
      ]
@@ -463,7 +463,7 @@
    "source": [
     "Now we have a dataset that contains data from the measurement run. It also contains the snapshot.\n",
     "\n",
-    "Snapshot is considered to be a part of metadata for a run, hence we need to use `get_metadata` method of the dataset to retrieve the snapshot. Snapshots are saved under the `snapshot` tag in the dataset, hence the argument to the `get_metadata` method."
+    "In order to access the snapshot, use the `DataSet`'s properties called `snapshot` and `snapshot_raw`. As their docstrings declare, the former returns the snapshot of the run as a python dictionary, while the latter returns it as JSON string (in other words, in exactly the same format as it is stored in the experiments database)."
    ]
   },
   {
@@ -472,14 +472,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "snapshot_of_run_in_json_format = dataset.get_metadata('snapshot')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "As mentioned above, the snapshot in the dataset is stored in JSON format. In order to work with the snapshot data in python, we need to convert JSON to a python dictionary."
+    "snapshot_of_run = dataset.snapshot"
    ]
   },
   {
@@ -488,7 +481,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "snapshot_of_run = json.loads(snapshot_of_run_in_json_format)"
+    "snapshot_of_run_in_json_format = dataset.snapshot_raw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To prove that these snapshots are the same, use `json.loads` or `json.dumps` to assert the values of the variables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert json.loads(snapshot_of_run_in_json_format) == snapshot_of_run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert json.dumps(snapshot_of_run) == snapshot_of_run_in_json_format"
    ]
   },
   {
@@ -500,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -525,7 +543,7 @@
       "                                                                            'serial': None,\n",
       "                                                                            'vendor': None},\n",
       "                                                              'ts': '2018-10-16 '\n",
-      "                                                                    '11:44:28',\n",
+      "                                                                    '12:54:04',\n",
       "                                                              'unit': '',\n",
       "                                                              'vals': '<Anything>',\n",
       "                                                              'value': {'firmware': None,\n",
@@ -543,7 +561,7 @@
       "                                                                'post_delay': 0,\n",
       "                                                                'raw_value': 0,\n",
       "                                                                'ts': '2018-10-16 '\n",
-      "                                                                      '11:44:28',\n",
+      "                                                                      '12:54:04',\n",
       "                                                                'unit': 'V',\n",
       "                                                                'vals': '<Numbers '\n",
       "                                                                        '-800<=v<=400>',\n",
@@ -559,7 +577,7 @@
       "                                                                 'post_delay': 0,\n",
       "                                                                 'raw_value': 0,\n",
       "                                                                 'ts': '2018-10-16 '\n",
-      "                                                                       '11:44:28',\n",
+      "                                                                       '12:54:04',\n",
       "                                                                 'unit': 'V',\n",
       "                                                                 'vals': '<Numbers '\n",
       "                                                                         '-800<=v<=400>',\n",
@@ -572,7 +590,7 @@
       "                                  'name': 'p',\n",
       "                                  'post_delay': 0,\n",
       "                                  'raw_value': 456,\n",
-      "                                  'ts': '2018-10-16 11:44:28',\n",
+      "                                  'ts': '2018-10-16 12:54:04',\n",
       "                                  'unit': 'kg',\n",
       "                                  'value': 456}}}}\n"
      ]
@@ -591,7 +609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/examples/DataSet/Working with snapshots.ipynb
+++ b/docs/examples/DataSet/Working with snapshots.ipynb
@@ -1,0 +1,633 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Working with snapshots\n",
+    "\n",
+    "Here, the following topics are going to be covered:\n",
+    "* What is a snapshot\n",
+    "* How to create it\n",
+    "* How it is saved next to the measurement data\n",
+    "* How to extract snapshot from the dataset\n",
+    "* How to conveniently inspect the extracted snapshot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Useful imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pprint import pprint  # for pretty-printing python variables like 'dict'\n",
+    "import json  # for converting JSON data into python 'dict'\n",
+    "\n",
+    "import qcodes\n",
+    "from qcodes import Parameter, Station, \\\n",
+    "                   new_experiment, Measurement\n",
+    "from qcodes.tests.instrument_mocks import DummyInstrument\n",
+    "from qcodes.dataset.database import initialise_database"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What is a snapshot\n",
+    "\n",
+    "Often times experiments comprise a complex network of interconnected devices, numerous setting of each of them define the overall behavior of the experimental setup. Obviously, the experimental setup has a direct impact on the measured data which is of prime interest of researchers. In order to capture this link, the measured data should have metadata associated with it. An important part of that metadata is a captured state of the experimental setup. In QCoDeS terms, this is called snapshot."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to create a snapshot\n",
+    "\n",
+    "All QCoDeS instruments and parameters (and some other objects too, like `InstrumentChannel`s) support snapshotting, which means that they provide a method to retrieve their state."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Snapshot example for Parameter object"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a `Parameter`, call its `snapshot` method, and then inspect the output of that method. The returned snapshot is a python dictionary that reflects all the important properties of that parameter (check the name, label, unit, and even value)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      " 'full_name': 'p',\n",
+      " 'inter_delay': 0,\n",
+      " 'label': 'Parameter P',\n",
+      " 'name': 'p',\n",
+      " 'post_delay': 0,\n",
+      " 'raw_value': 123,\n",
+      " 'ts': '2018-08-02 12:01:19',\n",
+      " 'unit': 'kg',\n",
+      " 'value': 123}\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = Parameter('p', label='Parameter P', unit='kg', set_cmd=None, get_cmd=None)\n",
+    "p.set(123)\n",
+    "\n",
+    "snapshot_of_p = p.snapshot()\n",
+    "\n",
+    "pprint(snapshot_of_p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case you want to use the snapshot object in your code, you can refer to its contents in the same way as you work with python dictionaries, for example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Value of Parameter P was 123 (when it was snapshotted).\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Value of {snapshot_of_p['label']} was {snapshot_of_p['value']} (when it was snapshotted).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the implementation of a particular QCoDeS object defines which attributes are snapshotted and how. For example, `Parameter` implements a keyword argument `snapshot_value` which allows to choose if the value of the parameter is snapshotted (the reasons for this are out of scope of this article)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below is a demonstration of the `snapshot_value` keyword argument, notice that the value of the parameter is not part of the snapshot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      " 'full_name': 'q',\n",
+      " 'inter_delay': 0,\n",
+      " 'label': 'Parameter Q',\n",
+      " 'name': 'q',\n",
+      " 'post_delay': 0,\n",
+      " 'ts': None,\n",
+      " 'unit': 'A'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "q = Parameter('q', label='Parameter Q', unit='A', snapshot_value=False, set_cmd=None, get_cmd=None)\n",
+    "p.set(456)\n",
+    "\n",
+    "snapshot_of_q = q.snapshot()\n",
+    "\n",
+    "pprint(snapshot_of_q)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Snapshot of an Instrument\n",
+    "\n",
+    "Now let's have a brief look at snapshots of instruments. For the sake of exercise, we are going to use a \"dummy\" instrument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A dummy instrument with two parameters, \"input\" and \"output\"\n",
+    "instr = DummyInstrument('instr', gates=['input', 'output'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   '__class__': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "    'functions': {},\n",
+      "    'name': 'instr',\n",
+      "    'parameters': {   'IDN': {   '__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                 'full_name': 'instr_IDN',\n",
+      "                                 'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                 'instrument_name': 'instr',\n",
+      "                                 'inter_delay': 0,\n",
+      "                                 'label': 'IDN',\n",
+      "                                 'name': 'IDN',\n",
+      "                                 'post_delay': 0,\n",
+      "                                 'raw_value': None,\n",
+      "                                 'ts': None,\n",
+      "                                 'unit': '',\n",
+      "                                 'vals': '<Anything>',\n",
+      "                                 'value': None},\n",
+      "                      'input': {   '__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                   'full_name': 'instr_input',\n",
+      "                                   'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                   'instrument_name': 'instr',\n",
+      "                                   'inter_delay': 0,\n",
+      "                                   'label': 'Gate input',\n",
+      "                                   'name': 'input',\n",
+      "                                   'post_delay': 0,\n",
+      "                                   'raw_value': 0,\n",
+      "                                   'ts': '2018-08-02 12:01:19',\n",
+      "                                   'unit': 'V',\n",
+      "                                   'vals': '<Numbers -800<=v<=400>',\n",
+      "                                   'value': 0},\n",
+      "                      'output': {   '__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                    'full_name': 'instr_output',\n",
+      "                                    'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                    'instrument_name': 'instr',\n",
+      "                                    'inter_delay': 0,\n",
+      "                                    'label': 'Gate output',\n",
+      "                                    'name': 'output',\n",
+      "                                    'post_delay': 0,\n",
+      "                                    'raw_value': 0,\n",
+      "                                    'ts': '2018-08-02 12:01:19',\n",
+      "                                    'unit': 'V',\n",
+      "                                    'vals': '<Numbers -800<=v<=400>',\n",
+      "                                    'value': 0}},\n",
+      "    'submodules': {}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "snapshot_of_instr = instr.snapshot()\n",
+    "\n",
+    "pprint(snapshot_of_instr, indent=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Station and its snapshot\n",
+    "\n",
+    "Experimental setups are large, and instruments tend to be quite complex in that they comprise many parameters and other stateful parts. It would be very time-consuming for the user to manually go through every instrument and parameter, and collect the snapshot data.\n",
+    "\n",
+    "Here is where the concept of station comes into play. Instruments, parameters, and other submodules can be added to a station. In turn, the station has a method that allows to create a collective, single snapshot of all the instruments, parameters, and submodules in it.\n",
+    "\n",
+    "Note that in this article the focus is on the snapshot feature of the QCoDeS `Station` while it has some other (mostly legacy) features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a station, and add a parameter, instrument, and submodule to it. Then we will print the snapshot. Notice that station is aware of insturments and stand-alone parameters, and classifies them into dedicated lists within the snapshot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'instr'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "station = Station()\n",
+    "\n",
+    "station.add_component(p)\n",
+    "station.add_component(instr)\n",
+    "# Note that it is also possible to add components to the station's constructor like this:\n",
+    "#     station = Station(p, instr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'components': {},\n",
+      " 'default_measurement': [],\n",
+      " 'instruments': {'instr': {'__class__': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                           'functions': {},\n",
+      "                           'name': 'instr',\n",
+      "                           'parameters': {'IDN': {'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                                  'full_name': 'instr_IDN',\n",
+      "                                                  'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                                  'instrument_name': 'instr',\n",
+      "                                                  'inter_delay': 0,\n",
+      "                                                  'label': 'IDN',\n",
+      "                                                  'name': 'IDN',\n",
+      "                                                  'post_delay': 0,\n",
+      "                                                  'raw_value': {'firmware': None,\n",
+      "                                                                'model': 'instr',\n",
+      "                                                                'serial': None,\n",
+      "                                                                'vendor': None},\n",
+      "                                                  'ts': '2018-08-02 12:01:19',\n",
+      "                                                  'unit': '',\n",
+      "                                                  'vals': '<Anything>',\n",
+      "                                                  'value': {'firmware': None,\n",
+      "                                                            'model': 'instr',\n",
+      "                                                            'serial': None,\n",
+      "                                                            'vendor': None}},\n",
+      "                                          'input': {'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                                    'full_name': 'instr_input',\n",
+      "                                                    'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                                    'instrument_name': 'instr',\n",
+      "                                                    'inter_delay': 0,\n",
+      "                                                    'label': 'Gate input',\n",
+      "                                                    'name': 'input',\n",
+      "                                                    'post_delay': 0,\n",
+      "                                                    'raw_value': 0,\n",
+      "                                                    'ts': '2018-08-02 12:01:19',\n",
+      "                                                    'unit': 'V',\n",
+      "                                                    'vals': '<Numbers '\n",
+      "                                                            '-800<=v<=400>',\n",
+      "                                                    'value': 0},\n",
+      "                                          'output': {'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                                     'full_name': 'instr_output',\n",
+      "                                                     'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                                     'instrument_name': 'instr',\n",
+      "                                                     'inter_delay': 0,\n",
+      "                                                     'label': 'Gate output',\n",
+      "                                                     'name': 'output',\n",
+      "                                                     'post_delay': 0,\n",
+      "                                                     'raw_value': 0,\n",
+      "                                                     'ts': '2018-08-02 '\n",
+      "                                                           '12:01:19',\n",
+      "                                                     'unit': 'V',\n",
+      "                                                     'vals': '<Numbers '\n",
+      "                                                             '-800<=v<=400>',\n",
+      "                                                     'value': 0}},\n",
+      "                           'submodules': {}}},\n",
+      " 'parameters': {'p': {'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                      'full_name': 'p',\n",
+      "                      'inter_delay': 0,\n",
+      "                      'label': 'Parameter P',\n",
+      "                      'name': 'p',\n",
+      "                      'post_delay': 0,\n",
+      "                      'raw_value': 456,\n",
+      "                      'ts': '2018-08-02 12:01:19',\n",
+      "                      'unit': 'kg',\n",
+      "                      'value': 456}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "snapshot_of_station = station.snapshot()\n",
+    "\n",
+    "pprint(snapshot_of_station)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Saving snapshot next to the measurement data\n",
+    "\n",
+    "With the power of the station object, it is now possible to conveniently associate the snapshot information with the measured data.\n",
+    "\n",
+    "In order to do so, a station needs to be created, and then that station needs to be provided to the `Measurement` object. That's it. At the moment the new measurement run is started, a snapshot of the whole station will be taken, and added next to the measured data.\n",
+    "\n",
+    "Note that the snapshot is stored in JSON format, in other words, an automatically convertion from python dictionary to JSON takes place. This is done in order to make sure that the snapshot can be read without the need for python. JSON is an extemely popular data format, and all platforms/environments/languages/frameworks have means to read JSON-formatted data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is how it looks in the code. We will create a new experiment. Then we are going to reuse the station object created above, and create a new measurement object. Then we will perform a dummy measurement. After that we are going to extract the snapshot from the resulting dataset, and print it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's initialize a database to be sure that it exists\n",
+    "initialise_database()\n",
+    "\n",
+    "# Let's create a new experiment\n",
+    "experiment = new_experiment('snapshot_experiment', 'no_sample_yet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "measurement = Measurement(experiment, station)\n",
+    "\n",
+    "measurement.register_parameter(instr.input)\n",
+    "measurement.register_parameter(instr.output, setpoints=[instr.input])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting experimental run with id: 68\n"
+     ]
+    }
+   ],
+   "source": [
+    "with measurement.run() as data_saver:\n",
+    "    input_value = 111\n",
+    "    instr.input.set(input_value)\n",
+    "    instr.output.set(222)  # assuming that the instrument measured this value on the output\n",
+    "    \n",
+    "    data_saver.add_result((instr.input, input_value), (instr.output, instr.output()))\n",
+    "\n",
+    "# For convenience, let's work with the dataset object directly\n",
+    "dataset = data_saver.dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Extracting snapshot from dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have a dataset that contains data from the measurement run. It also contains the snapshot.\n",
+    "\n",
+    "Snapshot is considered to be a part of metadata for a run, hence we need to use `get_metadata` method of the dataset to retrieve the snapshot. Snapshots are saved under the `snapshot` tag in the dataset, hence the argument to the `get_metadata` method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snapshot_of_run_in_json_format = dataset.get_metadata('snapshot')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As mentioned above, the snapshot in the dataset is stored in JSON format. In order to work with the snapshot data in python, we need to convert JSON to a python dictionary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snapshot_of_run = json.loads(snapshot_of_run_in_json_format)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's pretty-print the snapshot. Notice that the values of the `input` and `output` parameters of the `instr` instrument have `0`s as values, and not `111` and `222` that were set during the measurement run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'station': {'components': {},\n",
+      "             'default_measurement': [],\n",
+      "             'instruments': {'instr': {'__class__': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                       'functions': {},\n",
+      "                                       'name': 'instr',\n",
+      "                                       'parameters': {'IDN': {'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                                              'full_name': 'instr_IDN',\n",
+      "                                                              'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                                              'instrument_name': 'instr',\n",
+      "                                                              'inter_delay': 0,\n",
+      "                                                              'label': 'IDN',\n",
+      "                                                              'name': 'IDN',\n",
+      "                                                              'post_delay': 0,\n",
+      "                                                              'raw_value': {'firmware': None,\n",
+      "                                                                            'model': 'instr',\n",
+      "                                                                            'serial': None,\n",
+      "                                                                            'vendor': None},\n",
+      "                                                              'ts': '2018-08-02 '\n",
+      "                                                                    '12:01:19',\n",
+      "                                                              'unit': '',\n",
+      "                                                              'vals': '<Anything>',\n",
+      "                                                              'value': {'firmware': None,\n",
+      "                                                                        'model': 'instr',\n",
+      "                                                                        'serial': None,\n",
+      "                                                                        'vendor': None}},\n",
+      "                                                      'input': {'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                                                'full_name': 'instr_input',\n",
+      "                                                                'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                                                'instrument_name': 'instr',\n",
+      "                                                                'inter_delay': 0,\n",
+      "                                                                'label': 'Gate '\n",
+      "                                                                         'input',\n",
+      "                                                                'name': 'input',\n",
+      "                                                                'post_delay': 0,\n",
+      "                                                                'raw_value': 0,\n",
+      "                                                                'ts': '2018-08-02 '\n",
+      "                                                                      '12:01:19',\n",
+      "                                                                'unit': 'V',\n",
+      "                                                                'vals': '<Numbers '\n",
+      "                                                                        '-800<=v<=400>',\n",
+      "                                                                'value': 0},\n",
+      "                                                      'output': {'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                                                 'full_name': 'instr_output',\n",
+      "                                                                 'instrument': 'qcodes.tests.instrument_mocks.DummyInstrument',\n",
+      "                                                                 'instrument_name': 'instr',\n",
+      "                                                                 'inter_delay': 0,\n",
+      "                                                                 'label': 'Gate '\n",
+      "                                                                          'output',\n",
+      "                                                                 'name': 'output',\n",
+      "                                                                 'post_delay': 0,\n",
+      "                                                                 'raw_value': 0,\n",
+      "                                                                 'ts': '2018-08-02 '\n",
+      "                                                                       '12:01:19',\n",
+      "                                                                 'unit': 'V',\n",
+      "                                                                 'vals': '<Numbers '\n",
+      "                                                                         '-800<=v<=400>',\n",
+      "                                                                 'value': 0}},\n",
+      "                                       'submodules': {}}},\n",
+      "             'parameters': {'p': {'__class__': 'qcodes.instrument.parameter.Parameter',\n",
+      "                                  'full_name': 'p',\n",
+      "                                  'inter_delay': 0,\n",
+      "                                  'label': 'Parameter P',\n",
+      "                                  'name': 'p',\n",
+      "                                  'post_delay': 0,\n",
+      "                                  'raw_value': 456,\n",
+      "                                  'ts': '2018-08-02 12:01:19',\n",
+      "                                  'unit': 'kg',\n",
+      "                                  'value': 456}}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "pprint(snapshot_of_run)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the snapshot that we have just loaded from the dataset is almost the same as the snapshot that we directly obtained from the station above. The only difference is that the snapshot loaded from the dataset has a top-level `station` field. If you do not trust what I am saying, have a look at the following `assert` statement for the proof."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert {'station': snapshot_of_station} == snapshot_of_run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## How to conveniently inspect the snapshot\n",
+    "\n",
+    "This functionality is not yet available in QCoDeS. Nevertheless, soon a simple and convenient function will be implemented to streamline the work with huge snapshots."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:qcodes]",
+   "language": "python",
+   "name": "conda-env-qcodes-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/examples/DataSet/Working with snapshots.ipynb
+++ b/docs/examples/DataSet/Working with snapshots.ipynb
@@ -10,8 +10,7 @@
     "* What is a snapshot\n",
     "* How to create it\n",
     "* How it is saved next to the measurement data\n",
-    "* How to extract snapshot from the dataset\n",
-    "* How to conveniently inspect the extracted snapshot"
+    "* How to extract snapshot from the dataset"
    ]
   },
   {
@@ -32,9 +31,9 @@
     "\n",
     "import qcodes\n",
     "from qcodes import Parameter, Station, \\\n",
+    "                   initialise_database, \\\n",
     "                   new_experiment, Measurement\n",
-    "from qcodes.tests.instrument_mocks import DummyInstrument\n",
-    "from qcodes.dataset.database import initialise_database"
+    "from qcodes.tests.instrument_mocks import DummyInstrument"
    ]
   },
   {
@@ -43,7 +42,7 @@
    "source": [
     "## What is a snapshot\n",
     "\n",
-    "Often times experiments comprise a complex network of interconnected devices, numerous setting of each of them define the overall behavior of the experimental setup. Obviously, the experimental setup has a direct impact on the measured data which is of prime interest of researchers. In order to capture this link, the measured data should have metadata associated with it. An important part of that metadata is a captured state of the experimental setup. In QCoDeS terms, this is called snapshot."
+    "Often times experiments comprise a complex network of interconnected instruments. Their numerous settings define the overall behavior of the experimental setup. Obviously, the experimental setup has a direct impact on the measured data which is of prime interest for researchers. In order to capture this link, the measured data should have metadata associated with it. An important part of that metadata is a captured state of the experimental setup. In QCoDeS terms, this is called snapshot."
    ]
   },
   {
@@ -52,7 +51,9 @@
    "source": [
     "## How to create a snapshot\n",
     "\n",
-    "All QCoDeS instruments and parameters (and some other objects too, like `InstrumentChannel`s) support snapshotting, which means that they provide a method to retrieve their state."
+    "All QCoDeS instruments and parameters (and some other objects too, like `InstrumentChannel`s) support snapshotting, which means that they provide a method to retrieve their state.\n",
+    "\n",
+    "Let's look at snapshots of various objects."
    ]
   },
   {
@@ -66,7 +67,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's create a `Parameter`, call its `snapshot` method, and then inspect the output of that method. The returned snapshot is a python dictionary that reflects all the important properties of that parameter (check the name, label, unit, and even value)."
+    "Let's create a `Parameter`, call its `snapshot` method, and then inspect the output of that method.\n",
+    "\n",
+    "The returned snapshot is a python dictionary that reflects all the important properties of that parameter (check the name, label, unit, and even value)."
    ]
   },
   {
@@ -85,7 +88,7 @@
       " 'name': 'p',\n",
       " 'post_delay': 0,\n",
       " 'raw_value': 123,\n",
-      " 'ts': '2018-08-02 12:01:19',\n",
+      " 'ts': '2018-10-16 11:44:28',\n",
       " 'unit': 'kg',\n",
       " 'value': 123}\n"
      ]
@@ -128,7 +131,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the implementation of a particular QCoDeS object defines which attributes are snapshotted and how. For example, `Parameter` implements a keyword argument `snapshot_value` which allows to choose if the value of the parameter is snapshotted (the reasons for this are out of scope of this article)."
+    "Note that the implementation of a particular QCoDeS object defines which attributes are snapshotted and how. For example, `Parameter` implements a keyword argument `snapshot_value` which allows to choose if the value of the parameter is snapshotted (the reasons for this are out of scope of this article). (Another interesting keyword argument of `Parameter` that is realated to snapshotting is `snapshot_get` - refer to `Parameters`'s docstring for more information.)"
    ]
   },
   {
@@ -220,7 +223,7 @@
       "                                   'name': 'input',\n",
       "                                   'post_delay': 0,\n",
       "                                   'raw_value': 0,\n",
-      "                                   'ts': '2018-08-02 12:01:19',\n",
+      "                                   'ts': '2018-10-16 11:44:28',\n",
       "                                   'unit': 'V',\n",
       "                                   'vals': '<Numbers -800<=v<=400>',\n",
       "                                   'value': 0},\n",
@@ -233,7 +236,7 @@
       "                                    'name': 'output',\n",
       "                                    'post_delay': 0,\n",
       "                                    'raw_value': 0,\n",
-      "                                    'ts': '2018-08-02 12:01:19',\n",
+      "                                    'ts': '2018-10-16 11:44:28',\n",
       "                                    'unit': 'V',\n",
       "                                    'vals': '<Numbers -800<=v<=400>',\n",
       "                                    'value': 0}},\n",
@@ -255,16 +258,16 @@
     "\n",
     "Experimental setups are large, and instruments tend to be quite complex in that they comprise many parameters and other stateful parts. It would be very time-consuming for the user to manually go through every instrument and parameter, and collect the snapshot data.\n",
     "\n",
-    "Here is where the concept of station comes into play. Instruments, parameters, and other submodules can be added to a station. In turn, the station has a method that allows to create a collective, single snapshot of all the instruments, parameters, and submodules in it.\n",
+    "Here is where the concept of station comes into play. Instruments, parameters, and other submodules can be added to a station. In turn, the station has its `snapshot` method that allows to create a collective, single snapshot of all the instruments, parameters, and submodules.\n",
     "\n",
-    "Note that in this article the focus is on the snapshot feature of the QCoDeS `Station` while it has some other (mostly legacy) features."
+    "Note that in this article the focus is on the snapshot feature of the QCoDeS `Station`, while it has some other (mostly legacy) features."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's create a station, and add a parameter, instrument, and submodule to it. Then we will print the snapshot. Notice that station is aware of insturments and stand-alone parameters, and classifies them into dedicated lists within the snapshot."
+    "Let's create a station, and add a parameter, instrument, and submodule to it. Then we will print the snapshot. Notice that the station is aware of insturments and stand-alone parameters, and classifies them into dedicated lists within the snapshot."
    ]
   },
   {
@@ -288,7 +291,8 @@
     "\n",
     "station.add_component(p)\n",
     "station.add_component(instr)\n",
-    "# Note that it is also possible to add components to the station's constructor like this:\n",
+    "# Note that it is also possible to add components \n",
+    "# to a station via arguments of its constructor, like this:\n",
     "#     station = Station(p, instr)"
    ]
   },
@@ -318,7 +322,7 @@
       "                                                                'model': 'instr',\n",
       "                                                                'serial': None,\n",
       "                                                                'vendor': None},\n",
-      "                                                  'ts': '2018-08-02 12:01:19',\n",
+      "                                                  'ts': '2018-10-16 11:44:28',\n",
       "                                                  'unit': '',\n",
       "                                                  'vals': '<Anything>',\n",
       "                                                  'value': {'firmware': None,\n",
@@ -334,7 +338,7 @@
       "                                                    'name': 'input',\n",
       "                                                    'post_delay': 0,\n",
       "                                                    'raw_value': 0,\n",
-      "                                                    'ts': '2018-08-02 12:01:19',\n",
+      "                                                    'ts': '2018-10-16 11:44:28',\n",
       "                                                    'unit': 'V',\n",
       "                                                    'vals': '<Numbers '\n",
       "                                                            '-800<=v<=400>',\n",
@@ -348,8 +352,8 @@
       "                                                     'name': 'output',\n",
       "                                                     'post_delay': 0,\n",
       "                                                     'raw_value': 0,\n",
-      "                                                     'ts': '2018-08-02 '\n",
-      "                                                           '12:01:19',\n",
+      "                                                     'ts': '2018-10-16 '\n",
+      "                                                           '11:44:28',\n",
       "                                                     'unit': 'V',\n",
       "                                                     'vals': '<Numbers '\n",
       "                                                             '-800<=v<=400>',\n",
@@ -362,7 +366,7 @@
       "                      'name': 'p',\n",
       "                      'post_delay': 0,\n",
       "                      'raw_value': 456,\n",
-      "                      'ts': '2018-08-02 12:01:19',\n",
+      "                      'ts': '2018-10-16 11:44:28',\n",
       "                      'unit': 'kg',\n",
       "                      'value': 456}}}\n"
      ]
@@ -384,7 +388,7 @@
     "\n",
     "In order to do so, a station needs to be created, and then that station needs to be provided to the `Measurement` object. That's it. At the moment the new measurement run is started, a snapshot of the whole station will be taken, and added next to the measured data.\n",
     "\n",
-    "Note that the snapshot is stored in JSON format, in other words, an automatically convertion from python dictionary to JSON takes place. This is done in order to make sure that the snapshot can be read without the need for python. JSON is an extemely popular data format, and all platforms/environments/languages/frameworks have means to read JSON-formatted data."
+    "Note that the snapshot gets stored in a JSON format (an automatic convertion from python dictionary to JSON takes place). This is done in order to ensure that the snapshot can be read in environments other than python. JSON is an extemely popular data format, and all platforms/environments/languages/frameworks have means to read JSON-formatted data."
    ]
   },
   {
@@ -400,7 +404,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's initialize a database to be sure that it exists\n",
+    "# Let's initialize a database to ensure that it exists\n",
     "initialise_database()\n",
     "\n",
     "# Let's create a new experiment\n",
@@ -428,7 +432,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Starting experimental run with id: 68\n"
+      "Starting experimental run with id: 2\n"
      ]
     }
    ],
@@ -436,9 +440,11 @@
     "with measurement.run() as data_saver:\n",
     "    input_value = 111\n",
     "    instr.input.set(input_value)\n",
+    "    \n",
     "    instr.output.set(222)  # assuming that the instrument measured this value on the output\n",
     "    \n",
-    "    data_saver.add_result((instr.input, input_value), (instr.output, instr.output()))\n",
+    "    data_saver.add_result((instr.input, input_value),\n",
+    "                          (instr.output, instr.output()))\n",
     "\n",
     "# For convenience, let's work with the dataset object directly\n",
     "dataset = data_saver.dataset"
@@ -518,8 +524,8 @@
       "                                                                            'model': 'instr',\n",
       "                                                                            'serial': None,\n",
       "                                                                            'vendor': None},\n",
-      "                                                              'ts': '2018-08-02 '\n",
-      "                                                                    '12:01:19',\n",
+      "                                                              'ts': '2018-10-16 '\n",
+      "                                                                    '11:44:28',\n",
       "                                                              'unit': '',\n",
       "                                                              'vals': '<Anything>',\n",
       "                                                              'value': {'firmware': None,\n",
@@ -536,8 +542,8 @@
       "                                                                'name': 'input',\n",
       "                                                                'post_delay': 0,\n",
       "                                                                'raw_value': 0,\n",
-      "                                                                'ts': '2018-08-02 '\n",
-      "                                                                      '12:01:19',\n",
+      "                                                                'ts': '2018-10-16 '\n",
+      "                                                                      '11:44:28',\n",
       "                                                                'unit': 'V',\n",
       "                                                                'vals': '<Numbers '\n",
       "                                                                        '-800<=v<=400>',\n",
@@ -552,8 +558,8 @@
       "                                                                 'name': 'output',\n",
       "                                                                 'post_delay': 0,\n",
       "                                                                 'raw_value': 0,\n",
-      "                                                                 'ts': '2018-08-02 '\n",
-      "                                                                       '12:01:19',\n",
+      "                                                                 'ts': '2018-10-16 '\n",
+      "                                                                       '11:44:28',\n",
       "                                                                 'unit': 'V',\n",
       "                                                                 'vals': '<Numbers '\n",
       "                                                                         '-800<=v<=400>',\n",
@@ -566,7 +572,7 @@
       "                                  'name': 'p',\n",
       "                                  'post_delay': 0,\n",
       "                                  'raw_value': 456,\n",
-      "                                  'ts': '2018-08-02 12:01:19',\n",
+      "                                  'ts': '2018-10-16 11:44:28',\n",
       "                                  'unit': 'kg',\n",
       "                                  'value': 456}}}}\n"
      ]
@@ -580,7 +586,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the snapshot that we have just loaded from the dataset is almost the same as the snapshot that we directly obtained from the station above. The only difference is that the snapshot loaded from the dataset has a top-level `station` field. If you do not trust what I am saying, have a look at the following `assert` statement for the proof."
+    "Note that the snapshot that we have just loaded from the dataset is almost the same as the snapshot that we directly obtained from the station above. The only difference is that the snapshot loaded from the dataset has a top-level `station` field. If you do not trust me, have a look at the following `assert` statement for the proof."
    ]
   },
   {
@@ -591,22 +597,6 @@
    "source": [
     "assert {'station': snapshot_of_station} == snapshot_of_run"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## How to conveniently inspect the snapshot\n",
-    "\n",
-    "This functionality is not yet available in QCoDeS. Nevertheless, soon a simple and convenient function will be implemented to streamline the work with huge snapshots."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -625,7 +615,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.6.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/docs/examples/The Snapshot.ipynb
+++ b/docs/examples/The Snapshot.ipynb
@@ -6,7 +6,9 @@
    "source": [
     "# The Snapshot\n",
     "\n",
-    "This notebook sheds some light on the snapshot of instruments."
+    "This notebook sheds some light on the snapshot of instruments.\n",
+    "\n",
+    "__NOTE__: this notebook uses a depreated `Loop` construct for some of its examples. Please, instead, refer to [__Working with snapshots__ notebook from `docs/examples/DataSet`](DataSet/Working%20with%20snapshots.ipynb)."
    ]
   },
   {
@@ -51,9 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -91,9 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -166,9 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -208,9 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -268,7 +262,6 @@
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [
@@ -491,7 +484,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -505,7 +498,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.6.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -7,6 +7,7 @@
 # Distributed under terms of the MIT license.
 # import json
 import functools
+import json
 from typing import Any, Dict, List, Optional, Union, Sized, Callable
 from threading import Thread
 import time
@@ -240,7 +241,16 @@ class DataSet(Sized):
 
     @property
     def snapshot(self):
-        """Returns snapshot of the run in JSON format (or None)"""
+        """Snapshot of the run as dictionary (or None)"""
+        snapshot_json = self.snapshot_raw
+        if snapshot_json is not None:
+            return json.loads(snapshot_json)
+        else:
+            return None
+
+    @property
+    def snapshot_raw(self):
+        """Snapshot of the run in JSON format (or None)"""
         if column_in_table(self.conn, "runs", "snapshot"):
             return select_one_where(self.conn, "runs", "snapshot",
                                     "run_id", self.run_id)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -21,6 +21,7 @@ from qcodes.instrument.parameter import _BaseParameter
 from qcodes.dataset.sqlite_base import (atomic, atomic_transaction,
                                         transaction, add_parameter,
                                         connect, create_run, completed,
+                                        column_in_table,
                                         get_parameters,
                                         get_experiments,
                                         get_last_experiment, select_one_where,
@@ -236,6 +237,14 @@ class DataSet(Sized):
     @property
     def guid(self):
         return get_guid_from_run_id(self.conn, self.run_id)
+
+    @property
+    def snapshot(self):
+        if column_in_table(self.conn, "runs", "snapshot"):
+            return select_one_where(self.conn, "runs", "snapshot",
+                                    "run_id", self.run_id)
+        else:
+            return None
 
     @property
     def number_of_results(self):

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -240,6 +240,7 @@ class DataSet(Sized):
 
     @property
     def snapshot(self):
+        """Returns snapshot of the run in JSON format (or None)"""
         if column_in_table(self.conn, "runs", "snapshot"):
             return select_one_where(self.conn, "runs", "snapshot",
                                     "run_id", self.run_id)

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -485,6 +485,26 @@ def init_db(conn: SomeConnection)->None:
         transaction(conn, _layout_table_schema)
         transaction(conn, _dependencies_table_schema)
 
+
+def column_in_table(conn: SomeConnection, table: str, column: str) -> bool:
+    """
+    A look-before-you-leap function to look up if a table has a certain column.
+
+    Intended for the 'runs' table where columns might be dynamically added
+    via `add_meta_data`/`insert_meta_data` functions.
+
+    Args:
+        conn: The connection
+        table: the table name
+        column: the column name
+    """
+    cur = atomic_transaction(conn, f"PRAGMA table_info({table})")
+    for row in cur.fetchall():
+        if row['name'] == column:
+            return True
+    return False
+
+
 def insert_column(conn: SomeConnection, table: str, name: str,
                   paramtype: Optional[str] = None) -> None:
     """Insert new column to a table

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 import logging
 import tempfile
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -24,8 +25,27 @@ from qcodes.dataset.sqlite_base import (connect,
 from qcodes.dataset.guids import parse_guid
 import qcodes.tests.dataset
 
+if TYPE_CHECKING:
+    from _pytest._code.code import ExceptionInfo
+
 fixturepath = os.sep.join(qcodes.tests.dataset.__file__.split(os.sep)[:-1])
 fixturepath = os.path.join(fixturepath, 'fixtures')
+
+
+def error_caused_by(excinfo: 'ExceptionInfo', cause: str) -> bool:
+    """
+    Helper function to figure out whether an exception was caused by another
+    exception with the message provided.
+
+    Args:
+        excinfo: the output of with pytest.raises() as excinfo
+        cause: the error message or a substring of it
+    """
+    chain = excinfo.getrepr().chain
+    cause_found = False
+    for link in chain:
+        cause_found = cause_found or cause in str(link[1])
+    return cause_found
 
 
 @contextmanager

--- a/qcodes/tests/dataset/test_metadata.py
+++ b/qcodes/tests/dataset/test_metadata.py
@@ -1,45 +1,21 @@
-import os
-import sqlite3
-import tempfile
-
 import pytest
 
-import qcodes as qc
-from qcodes import new_data_set
-from qcodes.dataset.database import initialise_database
+# pylint: disable=unused-import
+from qcodes.tests.dataset.temporary_databases import dataset, experiment, \
+    empty_temp_db
+from qcodes.tests.dataset.test_database_creation_and_upgrading \
+    import error_caused_by
 
 
-@pytest.fixture(scope="function")
-def empty_temp_db():
-    # create a temp database for testing
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        qc.config["core"]["db_location"] = os.path.join(tmpdirname, 'temp.db')
-        qc.config["core"]["db_debug"] = True
-        initialise_database()
-        yield
-
-
-@pytest.fixture(scope='function')
-def experiment(empty_temp_db):
-    e = qc.new_experiment('experiment_name', 'sample_name')
-    yield e
-    e.conn.close()
-
-
-@pytest.fixture(scope='function')
-def dataset(experiment):
-    dataset = new_data_set("dataset_name")
-    yield dataset
-    dataset.conn.close()
-
-
+@pytest.mark.usefixtures("dataset")
 def test_get_metadata_from_dataset(dataset):
     dataset.add_metadata('something', 123)
     something = dataset.get_metadata('something')
     assert 123 == something
 
 
+@pytest.mark.usefixtures("dataset")
 def test_get_nonexisting_metadata(dataset):
-    with pytest.raises(sqlite3.OperationalError,
-                       match="no such column: something"):
+    with pytest.raises(RuntimeError) as excinfo:
         _ = dataset.get_metadata('something')
+    assert error_caused_by(excinfo, "no such column: something")

--- a/qcodes/tests/dataset/test_metadata.py
+++ b/qcodes/tests/dataset/test_metadata.py
@@ -1,0 +1,45 @@
+import os
+import sqlite3
+import tempfile
+
+import pytest
+
+import qcodes as qc
+from qcodes import new_data_set
+from qcodes.dataset.database import initialise_database
+
+
+@pytest.fixture(scope="function")
+def empty_temp_db():
+    # create a temp database for testing
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        qc.config["core"]["db_location"] = os.path.join(tmpdirname, 'temp.db')
+        qc.config["core"]["db_debug"] = True
+        initialise_database()
+        yield
+
+
+@pytest.fixture(scope='function')
+def experiment(empty_temp_db):
+    e = qc.new_experiment('experiment_name', 'sample_name')
+    yield e
+    e.conn.close()
+
+
+@pytest.fixture(scope='function')
+def dataset(experiment):
+    dataset = new_data_set("dataset_name")
+    yield dataset
+    dataset.conn.close()
+
+
+def test_get_metadata_from_dataset(dataset):
+    dataset.add_metadata('something', 123)
+    something = dataset.get_metadata('something')
+    assert 123 == something
+
+
+def test_get_nonexisting_metadata(dataset):
+    with pytest.raises(sqlite3.OperationalError,
+                       match="no such column: something"):
+        _ = dataset.get_metadata('something')

--- a/qcodes/tests/dataset/test_snapshot.py
+++ b/qcodes/tests/dataset/test_snapshot.py
@@ -1,0 +1,63 @@
+import json
+import os
+import tempfile
+
+import pytest
+
+import qcodes as qc
+from qcodes.dataset.database import initialise_database
+from qcodes.tests.instrument_mocks import DummyInstrument
+from qcodes.dataset.measurements import Measurement
+
+
+@pytest.fixture(scope="function")
+def empty_temp_db():
+    # create a temp database for testing
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        qc.config["core"]["db_location"] = os.path.join(tmpdirname, 'temp.db')
+        qc.config["core"]["db_debug"] = True
+        initialise_database()
+        yield
+
+
+@pytest.fixture(scope='function')
+def experiment(empty_temp_db):
+    e = qc.new_experiment('experiment_name', 'sample_name')
+    yield e
+    e.conn.close()
+
+
+@pytest.fixture  # scope is "function" per default
+def dac():
+    dac = DummyInstrument('dummy_dac', gates=['ch1', 'ch2'])
+    yield dac
+    dac.close()
+
+
+@pytest.fixture
+def dmm():
+    dmm = DummyInstrument('dummy_dmm', gates=['v1', 'v2'])
+    yield dmm
+    dmm.close()
+
+
+def test_station_snapshot_during_measurement(experiment, dac, dmm):
+    station = qc.Station()
+    station.add_component(dac)
+    station.add_component(dmm, 'renamed_dmm')
+
+    snapshot_of_station = station.snapshot()
+
+    measurement = Measurement(experiment, station)
+
+    measurement.register_parameter(dac.ch1)
+    measurement.register_parameter(dmm.v1, setpoints=[dac.ch1])
+
+    with measurement.run() as data_saver:
+        data_saver.add_result((dac.ch1, 7), (dmm.v1, 5))
+
+    json_snapshot_from_dataset = data_saver.dataset.get_metadata('snapshot')
+    snapshot_from_dataset = json.loads(json_snapshot_from_dataset)
+
+    expected_snapshot = {'station': snapshot_of_station}
+    assert expected_snapshot == snapshot_from_dataset

--- a/qcodes/tests/dataset/test_snapshot.py
+++ b/qcodes/tests/dataset/test_snapshot.py
@@ -24,7 +24,6 @@ def dmm():
     dmm.close()
 
 
-@pytest.mark.usefixtures("experiment")
 def test_station_snapshot_during_measurement(experiment, dac, dmm):
     station = qc.Station()
     station.add_component(dac)
@@ -40,8 +39,16 @@ def test_station_snapshot_during_measurement(experiment, dac, dmm):
     with measurement.run() as data_saver:
         data_saver.add_result((dac.ch1, 7), (dmm.v1, 5))
 
+    # 1. Test `get_metadata('snapshot')` method
+
     json_snapshot_from_dataset = data_saver.dataset.get_metadata('snapshot')
     snapshot_from_dataset = json.loads(json_snapshot_from_dataset)
 
     expected_snapshot = {'station': snapshot_of_station}
     assert expected_snapshot == snapshot_from_dataset
+
+    # 2. Test `snapshot` property
+
+    snapshot_from_dataset_via_property = data_saver.dataset.snapshot
+
+    assert json_snapshot_from_dataset == snapshot_from_dataset_via_property

--- a/qcodes/tests/dataset/test_snapshot.py
+++ b/qcodes/tests/dataset/test_snapshot.py
@@ -1,30 +1,13 @@
 import json
-import os
-import tempfile
 
 import pytest
 
 import qcodes as qc
-from qcodes.dataset.database import initialise_database
 from qcodes.tests.instrument_mocks import DummyInstrument
 from qcodes.dataset.measurements import Measurement
 
-
-@pytest.fixture(scope="function")
-def empty_temp_db():
-    # create a temp database for testing
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        qc.config["core"]["db_location"] = os.path.join(tmpdirname, 'temp.db')
-        qc.config["core"]["db_debug"] = True
-        initialise_database()
-        yield
-
-
-@pytest.fixture(scope='function')
-def experiment(empty_temp_db):
-    e = qc.new_experiment('experiment_name', 'sample_name')
-    yield e
-    e.conn.close()
+# pylint: disable=unused-import
+from qcodes.tests.dataset.temporary_databases import experiment, empty_temp_db
 
 
 @pytest.fixture  # scope is "function" per default
@@ -41,6 +24,7 @@ def dmm():
     dmm.close()
 
 
+@pytest.mark.usefixtures("experiment")
 def test_station_snapshot_during_measurement(experiment, dac, dmm):
     station = qc.Station()
     station.add_component(dac)

--- a/qcodes/tests/dataset/test_snapshot.py
+++ b/qcodes/tests/dataset/test_snapshot.py
@@ -47,8 +47,10 @@ def test_station_snapshot_during_measurement(experiment, dac, dmm):
     expected_snapshot = {'station': snapshot_of_station}
     assert expected_snapshot == snapshot_from_dataset
 
-    # 2. Test `snapshot` property
+    # 2. Test `snapshot_raw` property
 
-    snapshot_from_dataset_via_property = data_saver.dataset.snapshot
+    assert json_snapshot_from_dataset == data_saver.dataset.snapshot_raw
 
-    assert json_snapshot_from_dataset == snapshot_from_dataset_via_property
+    # 3. Test `snapshot` property
+
+    assert expected_snapshot == data_saver.dataset.snapshot

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -54,6 +54,11 @@ def test_insert_many_values_raises(experiment):
                                values=[[1], [1, 3]])
 
 
+def test_get_metadata_raises(experiment):
+    with pytest.raises(OperationalError, match="no such column: something"):
+        mut.get_metadata(experiment.conn, 'something', 'results')
+
+
 @given(table_name=hst.text(max_size=50))
 def test__validate_table_raises(table_name):
     should_raise = False

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -13,6 +13,8 @@ from qcodes.dataset.param_spec import ParamSpec
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import \
     empty_temp_db, experiment, dataset
+from qcodes.tests.dataset.test_database_creation_and_upgrading import \
+    error_caused_by
 
 _unicode_categories = ('Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nd', 'Pc', 'Pd', 'Zs')
 
@@ -56,8 +58,9 @@ def test_insert_many_values_raises(experiment):
 
 
 def test_get_metadata_raises(experiment):
-    with pytest.raises(OperationalError, match="no such column: something"):
+    with pytest.raises(RuntimeError) as excinfo:
         mut.get_metadata(experiment.conn, 'something', 'results')
+    assert error_caused_by(excinfo, "no such column: something")
 
 
 @given(table_name=hst.text(max_size=50))

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -11,7 +11,8 @@ import qcodes.dataset.sqlite_base as mut  # mut: module under test
 from qcodes.dataset.guids import generate_guid
 from qcodes.dataset.param_spec import ParamSpec
 # pylint: disable=unused-import
-from qcodes.tests.dataset.temporary_databases import empty_temp_db, experiment
+from qcodes.tests.dataset.temporary_databases import \
+    empty_temp_db, experiment, dataset
 
 _unicode_categories = ('Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nd', 'Pc', 'Pd', 'Zs')
 
@@ -112,3 +113,9 @@ def test_get_dependents(experiment):
                      mut.get_layout_id(experiment.conn, 'z', run_id)]
 
     assert deps == expected_deps
+
+
+@pytest.mark.usefixtures('dataset')
+def test_column_in_table(dataset):
+    assert mut.column_in_table(dataset.conn, "runs", "run_id")
+    assert not mut.column_in_table(dataset.conn, "runs", "non-existing-column")

--- a/qcodes/tests/dataset/test_string_data.py
+++ b/qcodes/tests/dataset/test_string_data.py
@@ -9,6 +9,7 @@ from qcodes.dataset.data_export import load_by_id
 from qcodes.tests.dataset.temporary_databases import empty_temp_db, experiment
 
 
+@pytest.mark.usefixtures('experiment')
 def test_string_via_dataset(experiment):
     """
     Test that we can save text into database via DataSet API
@@ -25,6 +26,7 @@ def test_string_via_dataset(experiment):
     assert test_set.get_data("p") == [["some text"]]
 
 
+@pytest.mark.usefixtures('experiment')
 def test_string_via_datasaver(experiment):
     """
     Test that we can save text into database via DataSaver API
@@ -43,6 +45,7 @@ def test_string_via_datasaver(experiment):
     assert test_set.get_data("p") == [["some text"]]
 
 
+@pytest.mark.usefixtures('experiment')
 def test_string(experiment):
     """
     Test that we can save text into database via Measurement API
@@ -61,6 +64,7 @@ def test_string(experiment):
     assert test_set.get_data("p") == [["some text"]]
 
 
+@pytest.mark.usefixtures('experiment')
 def test_string_with_wrong_paramtype(experiment):
     """
     Test that an exception occurs when saving string data if when registering a
@@ -81,6 +85,7 @@ def test_string_with_wrong_paramtype(experiment):
             datasaver.add_result((p, "some text"))
 
 
+@pytest.mark.usefixtures('experiment')
 def test_string_with_wrong_paramtype_via_datasaver(experiment):
     """
     Test that it is not possible to add a string value for a non-text
@@ -103,6 +108,7 @@ def test_string_with_wrong_paramtype_via_datasaver(experiment):
         data_saver.dataset.conn.close()
 
 
+@pytest.mark.usefixtures('experiment')
 def test_string_saved_and_loaded_as_numeric_via_dataset(experiment):
     """
     Test that it is possible to save a string value of a non-'text' parameter
@@ -124,6 +130,7 @@ def test_string_saved_and_loaded_as_numeric_via_dataset(experiment):
         test_set.conn.close()
 
 
+@pytest.mark.usefixtures('experiment')
 def test_list_of_strings(experiment):
     """
     Test saving list of strings via DataSaver


### PR DESCRIPTION
What's in:
* add `DataSet.snapshot` and `DataSet.snapshot_raw` (taken from #1262 PR) properties to retrieve snapshot dict and JSON
* add "Working with snapshots" notebook that explains what snapshot is and how to obtain it (original notebook about snapshots has a note that refers to the new notebook)
* tests

Some of the code from this PR was already in #1215 PR, but that one stalled for a bit in WIP mode, hence this new PR.