### PR TITLE
Refactor / dataset __init__ method

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -183,7 +183,7 @@ class _Subscriber(Thread):
 
 
 class DataSet(Sized):
-    def __init__(self, path_to_db: str,
+    def __init__(self, path_to_db: str=None,
                  run_id: Optional[int]=None,
                  conn=None,
                  exp_id=None,
@@ -197,7 +197,8 @@ class DataSet(Sized):
         looked up, else a new run is created.
 
         Args:
-            path_to_db: path to the sqlite file on disk
+            path_to_db: path to the sqlite file on disk. If not provided, the
+              path will be read from the config.
             run_id: provide this when loading an existing run, leave it
               as None when creating a new run
             conn: connection to the DB
@@ -213,7 +214,7 @@ class DataSet(Sized):
         """
         # TODO: handle fail here by defaulting to
         # a standard db
-        self.path_to_db = path_to_db
+        self.path_to_db = path_to_db or get_DB_location()
         if conn is None:
             self.conn = connect(self.path_to_db)
         else:
@@ -791,9 +792,7 @@ def new_data_set(name, exp_id: Optional[int] = None,
         values: the values to associate with the parameters
         metadata:  the values to associate with the dataset
     """
-    path_to_db = get_DB_location()
-
-    d = DataSet(path_to_db, run_id=None, conn=conn,
+    d = DataSet(path_to_db=None, run_id=None, conn=conn,
                 name=name, specs=specs, values=values,
                 metadata=metadata, exp_id=exp_id)
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -795,7 +795,7 @@ def new_data_set(name, exp_id: Optional[int] = None,
 
     d = DataSet(path_to_db, run_id=None, conn=conn,
                 name=name, specs=specs, values=values,
-                metadata=metadata)
+                metadata=metadata, exp_id=exp_id)
 
     return d
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -778,7 +778,9 @@ def load_by_counter(counter, exp_id):
 def new_data_set(name, exp_id: Optional[int] = None,
                  specs: SPECS = None, values=None,
                  metadata=None, conn=None) -> DataSet:
-    """ Create a new dataset.
+    """
+    Create a new dataset in the currently active/selected database.
+
     If exp_id is not specified the last experiment will be loaded by default.
 
     Args:
@@ -790,22 +792,7 @@ def new_data_set(name, exp_id: Optional[int] = None,
         metadata:  the values to associate with the dataset
     """
     path_to_db = get_DB_location()
-    if conn is None:
-        tempcon = True
-        conn = connect(get_DB_location())
-    else:
-        tempcon = False
 
-    if exp_id is None:
-        if len(get_experiments(conn)) > 0:
-            exp_id = get_last_experiment(conn)
-        else:
-            raise ValueError("No experiments found."
-                             "You can start a new one with:"
-                             " new_experiment(name, sample_name)")
-    if tempcon:
-        conn.close()
-        conn = None
     d = DataSet(path_to_db, run_id=None, conn=conn,
                 name=name, specs=specs, values=values,
                 metadata=metadata)

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -10,8 +10,8 @@ from qcodes import ParamSpec, new_data_set, new_experiment, experiments
 from qcodes import load_by_id, load_by_counter
 
 from qcodes.dataset.sqlite_base import _unicode_categories
-
-from qcodes.dataset.data_set import CompletedError
+from qcodes.dataset.database import get_DB_location
+from qcodes.dataset.data_set import CompletedError, DataSet
 from qcodes.dataset.database import (initialise_database,
                                      initialise_or_create_database_at)
 from qcodes.dataset.guids import parse_guid
@@ -20,6 +20,28 @@ from qcodes.tests.dataset.temporary_databases import (empty_temp_db,
                                                       experiment, dataset)
 
 n_experiments = 0
+
+
+@pytest.mark.usefixtures("experiment")
+def test_has_attributes_after_init():
+    """
+    Ensure that all attributes are populated after __init__ in BOTH cases
+    (run_id is None / run_id is not None)
+    """
+
+    attrs = ['path_to_db', 'conn', 'run_id', '_debug', 'subscribers',
+             '_completed']
+
+    path_to_db = get_DB_location()
+    ds = DataSet(path_to_db, run_id=None)
+
+    for attr in attrs:
+        assert hasattr(ds, attr)
+
+    ds = DataSet(path_to_db, run_id=1)
+
+    for attr in attrs:
+        assert hasattr(ds, attr)
 
 
 @settings(deadline=None)

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -28,18 +28,23 @@ def test_has_attributes_after_init():
     """
 
     attrs = ['path_to_db', 'conn', 'run_id', '_debug', 'subscribers',
-             '_completed']
+             '_completed', 'name', 'table_name', 'guid', 'number_of_results',
+             'counter', 'parameters', 'paramspecs', 'exp_id', 'exp_name',
+             'sample_name', 'run_timestamp_raw', 'completed_timestamp_raw',
+             'completed']
 
     path_to_db = get_DB_location()
     ds = DataSet(path_to_db, run_id=None)
 
     for attr in attrs:
         assert hasattr(ds, attr)
+        getattr(ds, attr)
 
     ds = DataSet(path_to_db, run_id=1)
 
     for attr in attrs:
         assert hasattr(ds, attr)
+        getattr(ds, attr)
 
 
 @settings(deadline=None)

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -12,8 +12,6 @@ from qcodes import load_by_id, load_by_counter
 from qcodes.dataset.sqlite_base import _unicode_categories
 from qcodes.dataset.database import get_DB_location
 from qcodes.dataset.data_set import CompletedError, DataSet
-from qcodes.dataset.database import (initialise_database,
-                                     initialise_or_create_database_at)
 from qcodes.dataset.guids import parse_guid
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import (empty_temp_db,


### PR DESCRIPTION
Needed in #1227 

Changes proposed in this pull request:
- Refactor the `__init__` method of the `DataSet` class to kill the `_new` method

This is to ensure a more uniform behaviour of the `DataSet` no matter how it is initialized, which in turn will make it easier to implement the DSL-objects in the `DataSet`.

@QCoDeS/core 
