### PR TITLE
Meaningful exception when loading/creating dataset for non-existing run id

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -38,7 +38,8 @@ from qcodes.dataset.sqlite_base import (atomic, atomic_transaction,
                                         get_sample_name_from_experiment_id,
                                         get_guid_from_run_id,
                                         get_run_timestamp_from_run_id,
-                                        get_completed_timestamp_from_run_id)
+                                        get_completed_timestamp_from_run_id,
+                                        run_exists)
 from qcodes.dataset.database import get_DB_location
 from qcodes.dataset.guids import generate_guid
 
@@ -226,6 +227,9 @@ class DataSet(Sized):
         self._debug = False
         self.subscribers: Dict[str, _Subscriber] = {}
         if run_id:
+            if not run_exists(self.conn, run_id):
+                raise ValueError(f"Run with run_id {run_id} does not exist in "
+                                 f"the database")
             self._completed = completed(self.conn, self.run_id)
         else:
 

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1174,6 +1174,21 @@ def get_last_run(conn: SomeConnection, exp_id: int) -> str:
     return one(c, 'run_id')
 
 
+def run_exists(conn: SomeConnection, run_id: int) -> bool:
+    # the following query always returns a single sqlite3.Row with an integer
+    # value of `1` or `0` for existing and non-existing run_id in the database
+    query = """
+    SELECT EXISTS(
+        SELECT 1
+        FROM runs
+        WHERE run_id = ?
+        LIMIT 1
+    );
+    """
+    res: sqlite3.Row = atomic_transaction(conn, query, run_id).fetchone()
+    return bool(res[0])
+
+
 def data_sets(conn: SomeConnection) -> List[sqlite3.Row]:
     """ Get a list of datasets
     Args:

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -48,7 +48,7 @@ def test_has_attributes_after_init():
 
 
 @pytest.mark.usefixtures("experiment")
-@pytest.mark.parametrize("non_existing_run_id", (999999, 'number#42'))
+@pytest.mark.parametrize("non_existing_run_id", (1, 'number#42'))
 def test_create_dataset_from_non_existing_run_id(non_existing_run_id):
     with pytest.raises(ValueError, match=f"Run with run_id "
                                          f"{non_existing_run_id} does not "

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -47,6 +47,15 @@ def test_has_attributes_after_init():
         getattr(ds, attr)
 
 
+@pytest.mark.usefixtures("experiment")
+@pytest.mark.parametrize("non_existing_run_id", (999999, 'number#42'))
+def test_create_dataset_from_non_existing_run_id(non_existing_run_id):
+    with pytest.raises(ValueError, match=f"Run with run_id "
+                                         f"{non_existing_run_id} does not "
+                                         f"exist in the database"):
+        _ = DataSet(run_id=non_existing_run_id)
+
+
 @settings(deadline=None)
 @given(experiment_name=hst.text(min_size=1),
        sample_name=hst.text(min_size=1),

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -29,9 +29,8 @@ def test_load_by_id():
     assert loaded_ds.completed is False
     assert loaded_ds.exp_id == 1
 
-    # let's take a reasonably arbitrary run number that is quite definitely not
-    # in the temporary test database file
-    non_existing_run_id = run_id + 9999
+    # let's take a run number that is not in the temporary test database file
+    non_existing_run_id = run_id + 1
     with pytest.raises(ValueError, match=f"Run with run_id "
                                          f"{non_existing_run_id} does not "
                                          f"exist in the database"):

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -31,8 +31,11 @@ def test_load_by_id():
 
     # let's take a reasonably arbitrary run number that is quite definitely not
     # in the temporary test database file
-    with pytest.raises(RuntimeError, match='Expected one row'):
-        _ = load_by_id(run_id + 9999)
+    non_existing_run_id = run_id + 9999
+    with pytest.raises(ValueError, match=f"Run with run_id "
+                                         f"{non_existing_run_id} does not "
+                                         f"exist in the database"):
+        _ = load_by_id(non_existing_run_id)
 
 
 @pytest.mark.usefixtures("empty_temp_db")

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -29,6 +29,11 @@ def test_load_by_id():
     assert loaded_ds.completed is False
     assert loaded_ds.exp_id == 1
 
+    # let's take a reasonably arbitrary run number that is quite definitely not
+    # in the temporary test database file
+    with pytest.raises(RuntimeError, match='Expected one row'):
+        _ = load_by_id(run_id + 9999)
+
 
 @pytest.mark.usefixtures("empty_temp_db")
 def test_load_by_counter():

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -125,4 +125,4 @@ def test_column_in_table(dataset):
 
 def test_run_exist(dataset):
     assert mut.run_exists(dataset.conn, dataset.run_id)
-    assert not mut.run_exists(dataset.conn, dataset.run_id + 9999)
+    assert not mut.run_exists(dataset.conn, dataset.run_id + 1)

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -121,3 +121,8 @@ def test_get_dependents(experiment):
 def test_column_in_table(dataset):
     assert mut.is_column_in_table(dataset.conn, "runs", "run_id")
     assert not mut.is_column_in_table(dataset.conn, "runs", "non-existing-column")
+
+
+def test_run_exist(dataset):
+    assert mut.run_exists(dataset.conn, dataset.run_id)
+    assert not mut.run_exists(dataset.conn, dataset.run_id + 9999)


### PR DESCRIPTION
Currently when one uses `load_by_id` for non-existing `run_id`, the exception looks like `"Expected one row"`. This PR fixes it with:
* add `run_exists` method to `sqlite_base`
* call `run_exists` in `DataSet` constructor and raise exception with clear message if the `run_id` does not exist
* tests

Note that the used query seems to be quite fast according to [this stackoverflow discussion](https://stackoverflow.com/questions/1676551/best-way-to-test-if-a-row-exists-in-a-mysql-table).