### PR TITLE
Fix JSON-dumping of snapshots with numpy-typed values (and other)

### DIFF
--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -16,6 +16,7 @@ from qcodes.instrument.parameter import ArrayParameter, _BaseParameter, \
 from qcodes.dataset.experiment_container import Experiment
 from qcodes.dataset.param_spec import ParamSpec
 from qcodes.dataset.data_set import DataSet
+from qcodes.utils.helpers import NumpyJSONEncoder
 
 log = logging.getLogger(__name__)
 
@@ -464,7 +465,9 @@ class Runner:
 
         if station:
             self.ds.add_metadata('snapshot',
-                                 json.dumps({'station': station.snapshot()}))
+                                 json.dumps({'station': station.snapshot()},
+                                            cls=NumpyJSONEncoder)
+                                 )
 
         if self.parameters is not None:
             for paramspec in self.parameters.values():

--- a/qcodes/tests/dataset/test_snapshot.py
+++ b/qcodes/tests/dataset/test_snapshot.py
@@ -1,8 +1,9 @@
 import json
 
+import numpy
 import pytest
 
-import qcodes as qc
+from qcodes.instrument.parameter import ManualParameter
 from qcodes.tests.instrument_mocks import DummyInstrument
 from qcodes.dataset.measurements import Measurement
 from qcodes.station import Station
@@ -65,3 +66,42 @@ def test_station_snapshot_during_measurement(experiment, dac, dmm,
     # 3. Test `snapshot` property
 
     assert expected_snapshot == data_saver.dataset.snapshot
+
+
+@pytest.mark.usefixtures('set_default_station_to_none')
+def test_snapshot_creation_for_types_not_supported_by_builtin_json(experiment):
+    """
+    Test that `Measurement`/`Runner`/`DataSaver` infrastructure
+    successfully dumps station snapshots in JSON format in cases when the
+    snapshot contains data of types that are not supported by python builtin
+    `json` module, for example, numpy scalars.
+    """
+    p1 = ManualParameter('p_np_int32', initial_value=numpy.int32(5))
+    p2 = ManualParameter('p_np_float16', initial_value=numpy.float16(5.0))
+    p3 = ManualParameter('p_np_array',
+                         initial_value=numpy.meshgrid((1, 2), (3, 4)))
+    p4 = ManualParameter('p_np_bool', initial_value=numpy.bool_(False))
+
+    station = Station(p1, p2, p3, p4)
+
+    measurement = Measurement(experiment, station)
+
+    with measurement.run() as data_saver:
+        # we do this in order to create a snapshot of the station and add it
+        # to the database
+        pass
+
+    snapshot = data_saver.dataset.snapshot
+
+    assert 5 == snapshot['station']['parameters']['p_np_int32']['value']
+    assert 5 == snapshot['station']['parameters']['p_np_int32']['raw_value']
+
+    assert 5.0 == snapshot['station']['parameters']['p_np_float16']['value']
+    assert 5.0 == snapshot['station']['parameters']['p_np_float16']['raw_value']
+
+    lst = [[[1, 2], [1, 2]], [[3, 3], [4, 4]]]
+    assert lst == snapshot['station']['parameters']['p_np_array']['value']
+    assert lst == snapshot['station']['parameters']['p_np_array']['raw_value']
+
+    assert False is snapshot['station']['parameters']['p_np_bool']['value']
+    assert False is snapshot['station']['parameters']['p_np_bool']['raw_value']

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -632,6 +632,26 @@ class TestJSONencoder(TestCase):
             self.assertEqual(e.encode(np.complex(1, 2)),
                              '{"__dtype__": "complex", "re": 1.0, "im": 2.0}')
 
+        def test_numpy_int_types(self):
+            e = NumpyJSONEncoder()
+
+            numpy_ints = (np.int, np.int_, np.int8, np.int16, np.int32,
+                          np.int64, np.intc, np.intp,
+                          np.uint, np.uint8, np.uint16, np.uint32, np.uint64,
+                          np.uintc, np.uintp)
+
+            for int_type in numpy_ints:
+                self.assertEqual(e.encode(int_type(3)), '3')
+
+        def test_numpy_float_types(self):
+            e = NumpyJSONEncoder()
+
+            numpy_floats = (np.float, np.float_, np.float16, np.float32,
+                            np.float64)
+
+            for float_type in numpy_floats:
+                self.assertEqual(e.encode(float_type(2.5)), '2.5')
+
         def test_numpy_array(self):
             e = NumpyJSONEncoder()
 

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -664,16 +664,19 @@ class TestJSONencoder(TestCase):
             self.assertEqual(e.encode(np.meshgrid((1, 2), (3, 4))),
                              '[[[1, 2], [1, 2]], [[3, 3], [4, 4]]]')
 
-        def test_class(self):
+        def test_non_serializable(self):
+            """
+            Test that non-serializable objects are serialzed to their
+            string representation
+            """
             e = NumpyJSONEncoder()
 
-            # test class
-            class dummy(object):
-                pass
+            class Dummy(object):
+                def __str__(self):
+                    return 'i am a dummy with \\ slashes /'
 
-            # test that does not raise, do not care about
-            # return value
-            e.encode(dummy())
+            self.assertEqual(e.encode(Dummy()),
+                             '"i am a dummy with \\\\ slashes /"')
 
 
 class TestCompareDictionaries(TestCase):

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -615,9 +615,11 @@ class TestJSONencoder(TestCase):
             od = OrderedDict()
             od['a'] = 0
             od['b'] = 1
-            testinput = [10, float(10.), 'hello', od]
-            testoutput = ['10', '10.0', '"hello"',  '{"a": 0, "b": 1}']
-            # int
+            testinput = [None, True, False, 10, float(10.), 'hello',
+                         od]
+            testoutput = ['null', 'true', 'false', '10', '10.0', '"hello"',
+                          '{"a": 0, "b": 1}']
+
             for d, r in zip(testinput, testoutput):
                 v = e.encode(d)
                 if type(d) == dict:

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -633,6 +633,8 @@ class TestJSONencoder(TestCase):
                              '{"__dtype__": "complex", "re": 1.0, "im": 2.0}')
             self.assertEqual(e.encode(np.complex(1, 2)),
                              '{"__dtype__": "complex", "re": 1.0, "im": 2.0}')
+            self.assertEqual(e.encode(np.complex64(complex(1, 2))),
+                             '{"__dtype__": "complex", "re": 1.0, "im": 2.0}')
 
         def test_numpy_int_types(self):
             e = NumpyJSONEncoder()

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -608,7 +608,7 @@ class TestIsSequenceOf(TestCase):
 # tests related to JSON encoding
 class TestJSONencoder(TestCase):
 
-        def testNumpyJSONEncoder(self):
+        def test_python_types(self):
             e = NumpyJSONEncoder()
 
             # test basic python types
@@ -625,14 +625,21 @@ class TestJSONencoder(TestCase):
                 else:
                     self.assertEqual(v, r)
 
+        def test_numpy_types(self):
+            e = NumpyJSONEncoder()
+
             # test numpy array
             x = np.array([1, 0, 0])
             v = e.encode(x)
             self.assertEqual(v, '[1, 0, 0]')
 
+        def test_class(self):
+            e = NumpyJSONEncoder()
+
             # test class
             class dummy(object):
                 pass
+
             # test that does not raise, do not care about
             # return value
             e.encode(dummy())

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -655,9 +655,14 @@ class TestJSONencoder(TestCase):
         def test_numpy_array(self):
             e = NumpyJSONEncoder()
 
-            x = np.array([1, 0, 0])
-            v = e.encode(x)
-            self.assertEqual(v, '[1, 0, 0]')
+            self.assertEqual(e.encode(np.array([1, 0, 0])),
+                             '[1, 0, 0]')
+
+            self.assertEqual(e.encode(np.arange(1.0, 3.0, 1.0)),
+                             '[1.0, 2.0]')
+
+            self.assertEqual(e.encode(np.meshgrid((1, 2), (3, 4))),
+                             '[[[1, 2], [1, 2]], [[3, 3], [4, 4]]]')
 
         def test_class(self):
             e = NumpyJSONEncoder()

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -625,6 +625,13 @@ class TestJSONencoder(TestCase):
                 else:
                     self.assertEqual(v, r)
 
+        def test_complex_types(self):
+            e = NumpyJSONEncoder()
+            self.assertEqual(e.encode(complex(1, 2)),
+                             '{"__dtype__": "complex", "re": 1.0, "im": 2.0}')
+            self.assertEqual(e.encode(np.complex(1, 2)),
+                             '{"__dtype__": "complex", "re": 1.0, "im": 2.0}')
+
         def test_numpy_types(self):
             e = NumpyJSONEncoder()
 

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -689,6 +689,26 @@ class TestJSONencoder(TestCase):
             self.assertEqual(e.encode(Dummy()),
                              '"i am a dummy with \\\\ slashes /"')
 
+        def test_object_with_serialization_method(self):
+            """
+            Test that objects with `_JSONEncoder` method are serialized via
+            calling that method
+            """
+            e = NumpyJSONEncoder()
+
+            class Dummy(object):
+                def __init__(self):
+                    self.confession = 'a_dict_addict'
+
+                def __str__(self):
+                    return 'me as a string'
+
+                def _JSONEncoder(self):
+                    return {'i_am_actually': self.confession}
+
+            self.assertEqual(e.encode(Dummy()),
+                             '{"i_am_actually": "a_dict_addict"}')
+
 
 class TestCompareDictionaries(TestCase):
     def test_same(self):

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -632,10 +632,9 @@ class TestJSONencoder(TestCase):
             self.assertEqual(e.encode(np.complex(1, 2)),
                              '{"__dtype__": "complex", "re": 1.0, "im": 2.0}')
 
-        def test_numpy_types(self):
+        def test_numpy_array(self):
             e = NumpyJSONEncoder()
 
-            # test numpy array
             x = np.array([1, 0, 0])
             v = e.encode(x)
             self.assertEqual(v, '[1, 0, 0]')

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -656,6 +656,13 @@ class TestJSONencoder(TestCase):
             for float_type in numpy_floats:
                 self.assertEqual(e.encode(float_type(2.5)), '2.5')
 
+        def test_numpy_bool_type(self):
+            e = NumpyJSONEncoder()
+
+            self.assertEqual(e.encode(np.bool_(True)), 'true')
+            self.assertEqual(e.encode(np.int8(5) == 5), 'true')
+            self.assertEqual(e.encode(np.array([8, 5]) == 5), '[false, true]')
+
         def test_numpy_array(self):
             e = NumpyJSONEncoder()
 

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -5,7 +5,6 @@ import math
 import numbers
 import time
 import os
-
 from collections.abc import Iterator, Sequence, Mapping
 from copy import deepcopy
 from typing import Dict, List, Any
@@ -19,14 +18,33 @@ import numpy as np
 
 _tprint_times= {} # type: Dict[str, float]
 
+
 log = logging.getLogger(__name__)
 
+
 class NumpyJSONEncoder(json.JSONEncoder):
-    """Return numpy types as standard types."""
-    # http://stackoverflow.com/questions/27050108/convert-numpy-type-to-python
-    # http://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types/11389998#11389998
+    """
+    This JSON encoder adds support for serializing types that the built-in
+    `json` module does not support out-of-the-box. See the docstring of the
+    `default` method for the description of all conversions.
+    """
 
     def default(self, obj):
+        """
+        List of conversions that this encoder performs:
+        * `numpy.integer` gets converted to python `int`
+        * `numpy.floating` gets converted to python `float`
+        * `numpy.ndarray` gets converted to python list using its `tolist`
+        method
+        * complex number (a number that conforms to `numbers.Complex` ABC) gets
+        converted to a dictionary with fields "re" and "im" containing floating
+        numbers for the real and imaginary parts respectively, and a field
+        "__dtype__" containing value "complex"
+        * object with a `_JSONEncoder` method get converted the return value of
+        that method
+        * other objects which cannot be serialized get converted to their
+        string representation (suing the `str` function)
+        """
         if isinstance(obj, np.integer):
             return int(obj)
         elif isinstance(obj, np.floating):

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -32,8 +32,10 @@ class NumpyJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         """
         List of conversions that this encoder performs:
-        * `numpy.integer` gets converted to python `int`
-        * `numpy.floating` gets converted to python `float`
+        * `numpy.generic` (all integer, floating, and other types) gets
+        converted to its python equivalent using its `item` method (see
+        `numpy` docs for more information,
+        https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html)
         * `numpy.ndarray` gets converted to python list using its `tolist`
         method
         * complex number (a number that conforms to `numbers.Complex` ABC) gets
@@ -45,11 +47,12 @@ class NumpyJSONEncoder(json.JSONEncoder):
         * other objects which cannot be serialized get converted to their
         string representation (suing the `str` function)
         """
-        if isinstance(obj, np.integer):
-            return int(obj)
-        elif isinstance(obj, np.floating):
-            return float(obj)
+        if isinstance(obj, np.generic) \
+                and not isinstance(obj, np.complexfloating):
+            # for numpy scalars
+            return obj.item()
         elif isinstance(obj, np.ndarray):
+            # for numpy arrays
             return obj.tolist()
         elif (isinstance(obj, numbers.Complex) and
               not isinstance(obj, numbers.Real)):


### PR DESCRIPTION
### Example situation
If an instrument parameter is set to a value of `numpy.int32` type, JSON dumping of the snapshot will fail with an exception that "int32 type cannot be serialized to JSON". It's easy to get into such a situation, for example, start an experiment after code like this has been executed: `... for x in np.arange(10, 20, 2): my_instrument.power(x) ...` (explanation: the code leaves the `power` parameter with the value of type `numpy.int32`, so if you start a new measurement afterwards, JSON-ifying the snapshot fails). Note however that using floats in that `arange` call removes the problem: `... np.arange(10.0, 20.0, 2)....`. This is has to do with the interesting fact that `json.dumps(numpy.float64(1))` works while `json.dumps(numpy.float32(1))` or `json.dumps(numpy.float16(1))` (or other) raises `"Object of type <type> is not JSON serializable"`. It seems to be a [python 3 bug/problem, read more here (especially last comments)](https://bugs.python.org/issue24313).

### Reason
`Runner` uses bare `json.dumps` call to serialize the station snapshot. The python built-in `json` does not support `numpy` types (and other stuff as well).

### Solution
`qcodes.utils.helpers` contains `NumpyJSONEncoder` class that allows serialize many things, including `numpy` types. Moreover, it is used for the old qcodes dataset for writing metadata, including station snapshots. Hence, let's re-use it. 

The name of the encoder class is bad, but it is kept for the reasons of not having to spend time on refactoring.

Note that this solution does have a small performance impact (dumping is ~40% faster without the custom encoder class), but it's negligible with respect to the benefits the solution brings. Moreover, snapshot is taken only once before the measurement, and generally takes less than a ms (modulo interaction with actual instruments), so it's really unnoticeable.

### Contents of this PR
* Improve `NumpyJSONEncoder` docstring
* Make `NumpyJSONEncoder` support all `numpy` scalar types via using `numpy.generic` in its `isinstance` call
* Add more tests for `NumpyJSONEncoder` class to capture all of its behavior
* Use `NumpyJSONEncoder` class in `Runner` for converting station snapshot into JSON
* Add a test for `Runner`/`Measurement` for the case where snapshot contains `numpy`-typed values
