### PR TITLE
Refactor / experiment init

### DIFF
--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -203,6 +203,8 @@ def load_experiment(exp_id: int) -> Experiment:
     Returns:
         experiment with the specified id
     """
+    if not isinstance(exp_id, int):
+        raise ValueError('Experiment ID must be an integer')
     return Experiment(exp_id=exp_id)
 
 

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -27,7 +27,6 @@ class Experiment(Sized):
                  sample_name: Optional[str]=None,
                  format_string: Optional[str]="{}-{}-{}") -> None:
 
-        self._debug = False
         self.path_to_db = path_to_db or get_DB_location()
         self.conn = connect(self.path_to_db, get_DB_debug())
 

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -45,7 +45,7 @@ class Experiment(Sized):
                 raise ValueError('No such experiment in the database')
             self._exp_id = exp_id
         else:
-            log.info("creating new experiment in {}".format(get_DB_location()))
+            log.info("creating new experiment in {}".format(self.path_to_db))
 
             name = name or f"experiment_{max_id+1}"
             sample_name = sample_name or "some_sample"

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -21,23 +21,41 @@ log = logging.getLogger(__name__)
 
 
 class Experiment(Sized):
-    def __init__(self, path_to_db: str) -> None:
-        self.path_to_db = path_to_db
-        self.conn = connect(self.path_to_db, get_DB_debug())
-        self._debug = False
+    def __init__(self, path_to_db: Optional[str]=None,
+                 exp_id: Optional[int]=None,
+                 name: Optional[str]=None,
+                 sample_name: Optional[str]=None,
+                 format_string: Optional[str]="{}-{}-{}") -> None:
 
-    def _new(self,
-             name: str,
-             sample_name: str,
-             format_string: Optional[str] = "{}-{}-{}"
-             ) -> None:
-        """
-        Actually perform all the side effects needed for
-        the creation of a new dataset.
-        """
-        exp_id = ne(self.conn, name, sample_name, format_string)
-        self.exp_id = exp_id
-        self.format_string = format_string
+        self._debug = False
+        self.path_to_db = path_to_db or get_DB_location()
+        self.conn = connect(self.path_to_db, get_DB_debug())
+
+        # it is better to catch an invalid format string earlier than later
+        try:
+            # the sqlite_base will try to format (name, exp_id, run_counter)
+            format_string.format("name", 1, 1)
+        except Exception as e:
+            raise ValueError("Invalid format string. Can not format "
+                             "(name, exp_id, run_counter)") from e
+
+        max_id = len(get_experiments(self.conn))
+
+        if exp_id:
+            if exp_id not in range(1, max_id+1):
+                raise ValueError('No such experiment in the database')
+            self._exp_id = exp_id
+        else:
+            log.info("creating new experiment in {}".format(get_DB_location()))
+
+            name = name or f"experiment_{max_id+1}"
+            sample_name = sample_name or "some_sample"
+            self._exp_id = ne(self.conn, name, sample_name, format_string)
+            self.format_string = format_string
+
+    @property
+    def exp_id(self) -> int:
+        return self._exp_id
 
     @property
     def name(self) -> str:
@@ -53,13 +71,13 @@ class Experiment(Sized):
 
     @property
     def started_at(self) -> int:
-        return select_one_where(self.conn, "experiments",
-                                "exp_id", "start_time", self.exp_id)
+        return select_one_where(self.conn, "experiments", "start_time",
+                                "exp_id", self.exp_id)
 
     @property
     def finished_at(self) -> int:
-        return select_one_where(self.conn, "experiments",
-                                "exp_id", "end_time", self.exp_id)
+        return select_one_where(self.conn, "experiments", "end_time",
+                                "exp_id", self.exp_id)
 
     def new_data_set(self, name, specs: SPECS = None, values=None,
                      metadata=None) -> DataSet:
@@ -156,10 +174,9 @@ def new_experiment(name: str,
     Returns:
         the new experiment
     """
-    log.info("creating new experiment in {}".format(get_DB_location()))
-    e = Experiment(get_DB_location())
-    e._new(name, sample_name, format_string)
-    return e
+
+    return Experiment(name=name, sample_name=sample_name,
+                      format_string=format_string)
 
 
 def load_experiment(exp_id: int) -> Experiment:
@@ -171,9 +188,7 @@ def load_experiment(exp_id: int) -> Experiment:
     Returns:
         experiment with the specified id
     """
-    e = Experiment(get_DB_location())
-    e.exp_id = exp_id
-    return e
+    return Experiment(exp_id=exp_id)
 
 
 def load_last_experiment() -> Experiment:
@@ -183,9 +198,8 @@ def load_last_experiment() -> Experiment:
     Returns:
         last experiment
     """
-    e = Experiment(get_DB_location())
-    e.exp_id = get_last_experiment(e.conn)
-    return e
+    conn = connect(get_DB_location())
+    return Experiment(exp_id=get_last_experiment(conn))
 
 
 def load_experiment_by_name(name: str,
@@ -205,7 +219,7 @@ def load_experiment_by_name(name: str,
     Raises:
         ValueError if the name is not unique and sample name is None.
     """
-    e = Experiment(get_DB_location())
+    conn = connect(get_DB_location())
     if sample:
         sql = """
         SELECT
@@ -216,7 +230,7 @@ def load_experiment_by_name(name: str,
             sample_name = ? AND
             name = ?
         """
-        c = transaction(e.conn, sql, sample, name)
+        c = transaction(conn, sql, sample, name)
     else:
         sql = """
         SELECT
@@ -226,19 +240,21 @@ def load_experiment_by_name(name: str,
         WHERE
             name = ?
         """
-        c = transaction(e.conn, sql, name)
+        c = transaction(conn, sql, name)
     rows = c.fetchall()
     if len(rows) == 0:
         raise ValueError("Experiment not found \n")
     elif len(rows) > 1:
         _repr = []
         for row in rows:
-            s = f"exp_id:{row['exp_id']} ({row['name']}-{row['sample_name']}) started at({row['start_time']})"
+            s = (f"exp_id:{row['exp_id']} ({row['name']}-{row['sample_name']})"
+                 f" started at({row['start_time']})")
             _repr.append(s)
         _repr_str = "\n".join(_repr)
-        raise ValueError(f"Many experiments matching your request found {_repr_str}")
+        raise ValueError(f"Many experiments matching your request"
+                         f" found {_repr_str}")
     else:
-        e.exp_id = rows[0]['exp_id']
+        e = Experiment(exp_id=rows[0]['exp_id'])
     return e
 
 

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -41,17 +41,8 @@ class Experiment(Sized):
               Ignored if exp_id is not None.
         """
 
-
         self.path_to_db = path_to_db or get_DB_location()
         self.conn = connect(self.path_to_db, get_DB_debug())
-
-        # it is better to catch an invalid format string earlier than later
-        try:
-            # the sqlite_base will try to format (name, exp_id, run_counter)
-            format_string.format("name", 1, 1)
-        except Exception as e:
-            raise ValueError("Invalid format string. Can not format "
-                             "(name, exp_id, run_counter)") from e
 
         max_id = len(get_experiments(self.conn))
 
@@ -60,6 +51,16 @@ class Experiment(Sized):
                 raise ValueError('No such experiment in the database')
             self._exp_id = exp_id
         else:
+
+            # it is better to catch an invalid format string earlier than later
+            try:
+                # the sqlite_base will try to format
+                # (name, exp_id, run_counter)
+                format_string.format("name", 1, 1)
+            except Exception as e:
+                raise ValueError("Invalid format string. Can not format "
+                                "(name, exp_id, run_counter)") from e
+
             log.info("creating new experiment in {}".format(self.path_to_db))
 
             name = name or f"experiment_{max_id+1}"

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -26,6 +26,21 @@ class Experiment(Sized):
                  name: Optional[str]=None,
                  sample_name: Optional[str]=None,
                  format_string: Optional[str]="{}-{}-{}") -> None:
+        """
+        Create or load an experiment. If exp_id is None, a new experiment is
+        created. If exp_id is not None, an experiment is loaded.
+
+        Args:
+            path_to_db: The path of the database file to create in/load from
+            exp_id: The id of the experiment to load
+            name: The name of the experiment to create. Ignored if exp_id is
+              not None
+            sample_name: The sample name for this experiment. Ignored if exp_id
+              is not None
+            format_string: The format string used to name result-tables.
+              Ignored if exp_id is not None.
+        """
+
 
         self.path_to_db = path_to_db or get_DB_location()
         self.conn = connect(self.path_to_db, get_DB_debug())

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -88,10 +88,10 @@ def test_has_attributes_after_init():
     attrs = ['name', 'sample_name', 'last_counter', 'path_to_db',
              'conn', 'started_at', 'finished_at']
 
-    # This creates a run in the db
+    # This creates an experiment in the db
     exp1 = Experiment(exp_id=None)
 
-    # This loads the run that we just created
+    # This loads the experiment that we just created
     exp2 = Experiment(exp_id=1)
 
     # This tries to load an experiment that we don't have

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -1,7 +1,10 @@
 import pytest
 
-from qcodes.dataset.experiment_container import load_experiment_by_name, \
-    new_experiment, load_or_create_experiment, experiments
+from qcodes.dataset.experiment_container import (load_experiment_by_name,
+                                                 new_experiment,
+                                                 load_or_create_experiment,
+                                                 experiments,
+                                                 Experiment)
 from qcodes.dataset.measurements import Measurement
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import empty_temp_db
@@ -73,3 +76,29 @@ def test_load_or_create_experiment_creating_not_empty():
 
     assert_experiments_equal(actual_experiments[0], exp)
     assert_experiments_equal(actual_experiments[1], exp_2)
+
+
+@pytest.mark.usefixtures("empty_temp_db")
+def test_has_attributes_after_init():
+    """
+    Ensure that all attributes are populated after __init__ in BOTH cases
+    (exp_id is None / exp_id is not None)
+    """
+
+    attrs = ['name', 'sample_name', 'last_counter', 'path_to_db',
+             'conn', 'started_at', 'finished_at']
+
+    # This creates a run in the db
+    exp1 = Experiment(exp_id=None)
+
+    # This loads the run that we just created
+    exp2 = Experiment(exp_id=1)
+
+    # This tries to load an experiment that we don't have
+    with pytest.raises(ValueError, match='No such experiment in the database'):
+        Experiment(exp_id=2)
+
+    for exp in (exp1, exp2):
+        for attr in attrs:
+            assert hasattr(exp, attr)
+            getattr(exp, attr)


### PR DESCRIPTION
In the spirit of #1323, this PR proposed to do the same for the `Experiment` class

Changes proposed in this pull request:
- Refactor the `__init__` of Experiment so that no `_new` method exists
- Add a test for the new behaviour
- Fix two broken properties of the `Experiment` (`started_at` and `finished_at`)

@astafan8 @QCoDeS/core 