### PR TITLE
qcodes.dataset.* fool-proofing and minor fixes

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -775,7 +775,7 @@ def load_by_id(run_id: int) -> DataSet:
     return d
 
 
-def load_by_counter(counter, exp_id) -> DataSet:
+def load_by_counter(counter: int, exp_id: int) -> DataSet:
     """
     Load a dataset given its counter in a given experiment
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1,10 +1,3 @@
-#! /usr/bin/env python
-# -*- coding: utf-8 -*-
-# vim:fenc=utf-8
-#
-# Copyright © 2017 unga <giulioungaretti@me.com>
-#
-# Distributed under terms of the MIT license.
 import functools
 import json
 from typing import Any, Dict, List, Optional, Union, Sized, Callable

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -215,8 +215,6 @@ class DataSet(Sized):
             metadata: metadata to insert into the dataset. Ignored if run_id
               is provided.
         """
-        # TODO: handle fail here by defaulting to
-        # a standard db
         self.path_to_db = path_to_db or get_DB_location()
         if conn is None:
             self.conn = connect(self.path_to_db)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -225,7 +225,7 @@ class DataSet(Sized):
         self.path_to_db = path_to_db or get_DB_location()
         self.conn = conn or connect(self.path_to_db)
 
-        self.run_id = run_id
+        self._run_id = run_id
         self._debug = False
         self.subscribers: Dict[str, _Subscriber] = {}
 
@@ -254,8 +254,12 @@ class DataSet(Sized):
                                        specs, values, metadata)
 
             # this is really the UUID (an ever increasing count in the db)
-            self.run_id = run_id
+            self._run_id = run_id
             self._completed = False
+
+    @property
+    def run_id(self):
+        return self._run_id
 
     @property
     def name(self):

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -54,8 +54,6 @@ from qcodes.dataset.guids import generate_guid
 # how do the user/us know which are metatadata?  I THINK the only sane solution
 # is to store JSON in a column called metadata
 
-# TODO: we cant have parameters with the same name in the same dataset/run
-
 # TODO: fixix  a subset of metadata that we define well known (and create them)
 # i.e. no dynamic creation of metadata columns, but add stuff to
 # a json inside a 'metadata' column

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -425,14 +425,9 @@ class DataSet(Sized):
         Args:
             tag: represents the key in the metadata dictionary
             metadata: actual metadata
-
         """
-        # TODO: this follows the spec but another option:
-        # json_meta_data = json.dumps(metadata)
-        # add_meta_data(self.conn, self.run_id, {"metadata": json_meta_data})
-
         add_meta_data(self.conn, self.run_id, {tag: metadata})
-        # adding meta-data does not commit
+        # `add_meta_data` does not commit, hence we commit here:
         self.conn.commit()
 
     @property

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -756,7 +756,7 @@ class DataSet(Sized):
 
 
 # public api
-def load_by_id(run_id) -> DataSet:
+def load_by_id(run_id: int) -> DataSet:
     """
     Load dataset by run id
 
@@ -768,7 +768,10 @@ def load_by_id(run_id) -> DataSet:
     Returns:
         dataset with the given run id
     """
-    d = DataSet(get_DB_location(), run_id=run_id)
+    if run_id is None:
+        raise ValueError('run_id has to be a positive integer, not None.')
+
+    d = DataSet(path_to_db=get_DB_location(), run_id=run_id)
     return d
 
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -281,9 +281,7 @@ class DataSet(Sized):
 
     @property
     def number_of_results(self):
-        tabnam = self.table_name
-        # TODO: is it better/faster to use the max index?
-        sql = f'SELECT COUNT(*) FROM "{tabnam}"'
+        sql = f'SELECT COUNT(*) FROM "{self.table_name}"'
         cursor = atomic_transaction(self.conn, sql)
         return one(cursor, 'COUNT(*)')
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -234,8 +234,10 @@ class DataSet(Sized):
                 raise ValueError(f"Run with run_id {run_id} does not exist in "
                                  f"the database")
             self._completed = completed(self.conn, self.run_id)
-        else:
 
+        else:
+            # Actually perform all the side effects needed for the creation
+            # of a new dataset
             if exp_id is None:
                 if len(get_experiments(self.conn)) > 0:
                     exp_id = get_last_experiment(self.conn)
@@ -243,16 +245,10 @@ class DataSet(Sized):
                     raise ValueError("No experiments found."
                                      "You can start a new one with:"
                                      " new_experiment(name, sample_name)")
-
-            # Actually perform all the side effects needed for
-            # the creation of a new dataset.
-
             name = name or "dataset"
-
             _, run_id, __ = create_run(self.conn, exp_id, name,
                                        generate_guid(),
                                        specs, values, metadata)
-
             # this is really the UUID (an ever increasing count in the db)
             self._run_id = run_id
             self._completed = False

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -4,10 +4,8 @@ from typing import Any, Dict, List, Optional, Union, Sized, Callable
 from threading import Thread
 import time
 import logging
-import hashlib
 import uuid
 from queue import Queue, Empty
-import warnings
 
 from qcodes.dataset.param_spec import ParamSpec
 from qcodes.instrument.parameter import _BaseParameter
@@ -814,18 +812,3 @@ def new_data_set(name, exp_id: Optional[int] = None,
                 metadata=metadata, exp_id=exp_id)
 
     return d
-
-
-# helpers
-def hash_from_parts(*parts: str) -> str:
-    """
-    Args:
-        *parts:  parts to use to create hash
-    Returns:
-        hash created with the given parts
-    """
-    warnings.warn("hash_from_parts has been deprecated and will be removed. "
-                  "Use stdlib uuid4 instead",
-                  stacklevel=2)
-    combined = "".join(parts)
-    return hashlib.sha1(combined.encode("utf-8")).hexdigest()

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -210,7 +210,8 @@ class DataSet(Sized):
             raise ValueError("Both `path_to_db` and `conn` arguments have "
                              "been passed together with non-None values. "
                              "This is not allowed.")
-        self.path_to_db = path_to_db or get_DB_location()
+        self._path_to_db = path_to_db or get_DB_location()
+
         self.conn = conn or connect(self.path_to_db)
 
         self._run_id = run_id
@@ -244,6 +245,10 @@ class DataSet(Sized):
     @property
     def run_id(self):
         return self._run_id
+
+    @property
+    def path_to_db(self):
+        return self._path_to_db
 
     @property
     def name(self):

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -817,9 +817,9 @@ def new_data_set(name, exp_id: Optional[int] = None,
         name: the name of the new dataset
         exp_id: the id of the experiments this dataset belongs to, defaults
             to the last experiment
-        specs: list of parameters to create this data_set with
+        specs: list of parameters to create this dataset with
         values: the values to associate with the parameters
-        metadata: the values to associate with the dataset
+        metadata: the metadata to associate with the dataset
 
     Return:
         the newly created dataset

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -32,6 +32,7 @@ from qcodes.dataset.sqlite_base import (atomic, atomic_transaction,
                                         run_exists)
 from qcodes.dataset.database import get_DB_location
 from qcodes.dataset.guids import generate_guid
+from qcodes.utils.deprecate import deprecate
 
 # TODO: as of now every time a result is inserted with add_result the db is
 # saved same for add_results. IS THIS THE BEHAVIOUR WE WANT?
@@ -48,9 +49,6 @@ from qcodes.dataset.guids import generate_guid
 # i.e. no dynamic creation of metadata columns, but add stuff to
 # a json inside a 'metadata' column
 
-
-# SPECS is a list of ParamSpec
-from qcodes.utils.deprecate import deprecate
 
 SPECS = List[ParamSpec]
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -824,6 +824,8 @@ def new_data_set(name, exp_id: Optional[int] = None,
     Return:
         the newly created dataset
     """
+    # note that passing `conn` is a secret feature that is unfortunately used
+    # in `Runner` to pass a connection from an existing `Experiment`.
     d = DataSet(path_to_db=None, run_id=None, conn=conn,
                 name=name, specs=specs, values=values,
                 metadata=metadata, exp_id=exp_id)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -50,6 +50,8 @@ from qcodes.dataset.guids import generate_guid
 
 
 # SPECS is a list of ParamSpec
+from qcodes.utils.deprecate import deprecate
+
 SPECS = List[ParamSpec]
 
 
@@ -415,7 +417,7 @@ class DataSet(Sized):
     def get_parameters(self) -> SPECS:
         return get_parameters(self.conn, self.run_id)
 
-    # TODO: deprecate
+    @deprecate(reason=None, alternative="DataSet.add_parameter")
     def add_parameters(self, specs: SPECS):
         add_parameter(self.conn, self.table_name, *specs)
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -5,7 +5,6 @@
 # Copyright © 2017 unga <giulioungaretti@me.com>
 #
 # Distributed under terms of the MIT license.
-# import json
 import functools
 import json
 from typing import Any, Dict, List, Optional, Union, Sized, Callable

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -222,13 +222,8 @@ class DataSet(Sized):
             raise ValueError("Both `path_to_db` and `conn` arguments have "
                              "been passed together with non-None values. "
                              "This is not allowed.")
-
         self.path_to_db = path_to_db or get_DB_location()
-
-        if conn is None:
-            self.conn = connect(self.path_to_db)
-        else:
-            self.conn = conn
+        self.conn = conn or connect(self.path_to_db)
 
         self.run_id = run_id
         self._debug = False

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -387,8 +387,6 @@ class DataSet(Sized):
         else:
             old_params = []
 
-        # better to catch this one early
-        # alternatively make this a warning and a NOOP
         if spec.name in old_params:
             raise ValueError(f'Duplicate parameter name: {spec.name}')
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -218,7 +218,7 @@ class DataSet(Sized):
         self._debug = False
         self.subscribers: Dict[str, _Subscriber] = {}
 
-        if run_id:
+        if run_id is not None:
             if not run_exists(self.conn, run_id):
                 raise ValueError(f"Run with run_id {run_id} does not exist in "
                                  f"the database")

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -416,8 +416,8 @@ class DataSet(Sized):
     def get_parameters(self) -> SPECS:
         return get_parameters(self.conn, self.run_id)
 
-    @deprecate(reason=None, alternative="DataSet.add_parameter")
-    def add_parameters(self, specs: SPECS):
+    @deprecate(reason=None, alternative="DataSet.add_parameter")  # type: ignore
+    def add_parameters(self, specs: SPECS) -> None:
         add_parameter(self.conn, self.table_name, *specs)
 
     def add_metadata(self, tag: str, metadata: Any):

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -204,7 +204,10 @@ class DataSet(Sized):
               path will be read from the config.
             run_id: provide this when loading an existing run, leave it
               as None when creating a new run
-            conn: connection to the DB
+            conn: connection to the DB; if provided and `path_to_db` is
+              provided as well, then a ValueError is raised (this is to
+              prevent the possibility of providing a connection to a DB
+              file that is different from `path_to_db`)
             exp_id: the id of the experiment in which to create a new run.
               Ignored if run_id is provided.
             name: the name of the dataset. Ignored if run_id is provided.
@@ -215,7 +218,13 @@ class DataSet(Sized):
             metadata: metadata to insert into the dataset. Ignored if run_id
               is provided.
         """
+        if path_to_db is not None and conn is not None:
+            raise ValueError("Both `path_to_db` and `conn` arguments have "
+                             "been passed together with non-None values. "
+                             "This is not allowed.")
+
         self.path_to_db = path_to_db or get_DB_location()
+
         if conn is None:
             self.conn = connect(self.path_to_db)
         else:
@@ -224,6 +233,7 @@ class DataSet(Sized):
         self.run_id = run_id
         self._debug = False
         self.subscribers: Dict[str, _Subscriber] = {}
+
         if run_id:
             if not run_exists(self.conn, run_id):
                 raise ValueError(f"Run with run_id {run_id} does not exist in "

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -224,8 +224,10 @@ def load_last_experiment() -> Experiment:
     Returns:
         last experiment
     """
-    conn = connect(get_DB_location())
-    return Experiment(exp_id=get_last_experiment(conn))
+    last_exp_id = get_last_experiment(connect(get_DB_location()))
+    if last_exp_id is None:
+        raise ValueError('There are no experiments in the database file')
+    return Experiment(exp_id=last_exp_id)
 
 
 def load_experiment_by_name(name: str,

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -99,35 +99,32 @@ class Experiment(Sized):
 
     def new_data_set(self, name, specs: SPECS = None, values=None,
                      metadata=None) -> DataSet:
-        """ Create a new dataset in this experimetn
+        """
+        Create a new dataset in this experiment
 
         Args:
             name: the name of the new dataset
-            specs: list of parameters to create this data_set with
+            specs: list of parameters (as ParamSpecs) to create this data_set
+                with
             values: the values to associate with the parameters
-            metadata:  the values to associate with the dataset
+            metadata: the metadata to associate with the dataset
         """
         return new_data_set(name, self.exp_id, specs, values, metadata)
 
     def data_set(self, counter: int) -> DataSet:
-        """ Get dataset with the secified counter from this experiment
+        """
+        Get dataset with the specified counter from this experiment
 
         Args:
-            counter: the counter we want to load
+            counter: the counter of the run we want to load
 
         Returns:
             the dataset
-
         """
         return load_by_counter(counter, self.exp_id)
 
     def data_sets(self) -> List[DataSet]:
-        """ Get all the datasets
-
-        Returns:
-            All the datasets of this experiment
-
-        """
+        """Get all the datasets of this experiment"""
         runs = get_runs(self.conn, self.exp_id)
         data_sets = []
         for run in runs:
@@ -135,6 +132,7 @@ class Experiment(Sized):
         return data_sets
 
     def last_data_set(self) -> DataSet:
+        """Get the last dataset of this experiment"""
         run_id = get_last_run(self.conn, self.exp_id)
         if run_id is None:
             raise ValueError('There are no runs in this experiment')
@@ -142,7 +140,8 @@ class Experiment(Sized):
 
     def finish(self) -> None:
         """
-        Marks this experiment as finished
+        Marks this experiment as finished by saving the moment in time
+        when this method is called
         """
         finish_experiment(self.conn, self.exp_id)
 
@@ -168,11 +167,10 @@ class Experiment(Sized):
 
 def experiments()->List[Experiment]:
     """
-    List all the experiments in the container
+    List all the experiments in the container (database file from config)
 
     Returns:
         All the experiments in the container
-
     """
     log.info("loading experiments from {}".format(get_DB_location()))
     rows = get_experiments(connect(get_DB_location(), get_DB_debug()))
@@ -185,7 +183,8 @@ def experiments()->List[Experiment]:
 def new_experiment(name: str,
                    sample_name: str,
                    format_string: Optional[str] = "{}-{}-{}") -> Experiment:
-    """ Create a new experiment
+    """
+    Create a new experiment (in the database file from config)
 
     Args:
         name: the name of the experiment
@@ -195,14 +194,14 @@ def new_experiment(name: str,
     Returns:
         the new experiment
     """
-
     return Experiment(name=name, sample_name=sample_name,
                       format_string=format_string)
 
 
 def load_experiment(exp_id: int) -> Experiment:
     """
-    Load experiment with the specified id
+    Load experiment with the specified id (from database file from config)
+
     Args:
         exp_id: experiment id
 
@@ -216,7 +215,7 @@ def load_experiment(exp_id: int) -> Experiment:
 
 def load_last_experiment() -> Experiment:
     """
-    Load last experiment
+    Load last experiment (from database file from config)
 
     Returns:
         last experiment
@@ -229,9 +228,10 @@ def load_experiment_by_name(name: str,
                             sample: Optional[str] = None) -> Experiment:
     """
     Try to load experiment with the specified name.
-    Nothing stops you from having many experiments with
-    the same name and sample_name.
-    In that case this won't work. And warn you.
+
+    Nothing stops you from having many experiments with the same name and
+    sample_name. In that case this won't work. And warn you.
+
     Args:
         name: the name of the experiment
         sample: the name of the sample

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -40,8 +40,7 @@ class Experiment(Sized):
             format_string: The format string used to name result-tables.
               Ignored if exp_id is not None.
         """
-
-        self.path_to_db = path_to_db or get_DB_location()
+        self._path_to_db = path_to_db or get_DB_location()
         self.conn = connect(self.path_to_db, get_DB_debug())
 
         max_id = len(get_experiments(self.conn))
@@ -71,6 +70,10 @@ class Experiment(Sized):
     @property
     def exp_id(self) -> int:
         return self._exp_id
+
+    @property
+    def path_to_db(self) -> str:
+        return self._path_to_db
 
     @property
     def name(self) -> str:

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -272,16 +272,16 @@ def load_experiment_by_name(name: str,
         c = transaction(conn, sql, name)
     rows = c.fetchall()
     if len(rows) == 0:
-        raise ValueError("Experiment not found \n")
+        raise ValueError("Experiment not found")
     elif len(rows) > 1:
         _repr = []
         for row in rows:
             s = (f"exp_id:{row['exp_id']} ({row['name']}-{row['sample_name']})"
-                 f" started at({row['start_time']})")
+                 f" started at ({row['start_time']})")
             _repr.append(s)
         _repr_str = "\n".join(_repr)
         raise ValueError(f"Many experiments matching your request"
-                         f" found {_repr_str}")
+                         f" found:\n{_repr_str}")
     else:
         e = Experiment(exp_id=rows[0]['exp_id'])
     return e

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -99,7 +99,10 @@ class Experiment(Sized):
         return data_sets
 
     def last_data_set(self) -> DataSet:
-        return load_by_id(get_last_run(self.conn, self.exp_id))
+        run_id = get_last_run(self.conn, self.exp_id)
+        if run_id is None:
+            raise ValueError('There are no runs in this experiment')
+        return load_by_id(run_id)
 
     def finish(self) -> None:
         """

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -243,7 +243,7 @@ def load_experiment_by_name(name: str,
 
 
 def load_or_create_experiment(experiment_name: str,
-                              sample_name: str
+                              sample_name: Optional[str] = None
                               ) -> Experiment:
     """
     Find and return an experiment with the given name and sample name,

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -45,7 +45,7 @@ class Experiment(Sized):
 
         max_id = len(get_experiments(self.conn))
 
-        if exp_id:
+        if exp_id is not None:
             if exp_id not in range(1, max_id+1):
                 raise ValueError('No such experiment in the database')
             self._exp_id = exp_id

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -25,7 +25,7 @@ class Experiment(Sized):
                  exp_id: Optional[int]=None,
                  name: Optional[str]=None,
                  sample_name: Optional[str]=None,
-                 format_string: Optional[str]="{}-{}-{}") -> None:
+                 format_string: str="{}-{}-{}") -> None:
         """
         Create or load an experiment. If exp_id is None, a new experiment is
         created. If exp_id is not None, an experiment is loaded.
@@ -58,14 +58,13 @@ class Experiment(Sized):
                 format_string.format("name", 1, 1)
             except Exception as e:
                 raise ValueError("Invalid format string. Can not format "
-                                "(name, exp_id, run_counter)") from e
+                                 "(name, exp_id, run_counter)") from e
 
             log.info("creating new experiment in {}".format(self.path_to_db))
 
             name = name or f"experiment_{max_id+1}"
             sample_name = sample_name or "some_sample"
             self._exp_id = ne(self.conn, name, sample_name, format_string)
-            self.format_string = format_string
 
     @property
     def exp_id(self) -> int:
@@ -95,6 +94,11 @@ class Experiment(Sized):
     @property
     def finished_at(self) -> int:
         return select_one_where(self.conn, "experiments", "end_time",
+                                "exp_id", self.exp_id)
+
+    @property
+    def format_string(self) -> str:
+        return select_one_where(self.conn, "experiments", "format_string",
                                 "exp_id", self.exp_id)
 
     def new_data_set(self, name, specs: SPECS = None, values=None,

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -46,8 +46,8 @@ def is_number(thing: Any) -> bool:
 
 class DataSaver:
     """
-    The class used byt the Runner context manager to handle the
-    datasaving to the database
+    The class used by the Runner context manager to handle the datasaving to
+    the database.
     """
 
     default_callback: Optional[dict] = None
@@ -55,7 +55,9 @@ class DataSaver:
     def __init__(self, dataset: DataSet, write_period: numeric_types,
                  parameters: Dict[str, ParamSpec]) -> None:
         self._dataset = dataset
-        if DataSaver.default_callback is not None and 'run_tables_subscription_callback' in DataSaver.default_callback:
+        if DataSaver.default_callback is not None \
+                and 'run_tables_subscription_callback' \
+                    in DataSaver.default_callback:
             callback = DataSaver.default_callback[
                 'run_tables_subscription_callback']
             min_wait = DataSaver.default_callback[
@@ -63,7 +65,8 @@ class DataSaver:
             min_count = DataSaver.default_callback[
                 'run_tables_subscription_min_count']
             snapshot = dataset.get_metadata('snapshot')
-            self._dataset.subscribe(callback, min_wait=min_wait,
+            self._dataset.subscribe(callback,
+                                    min_wait=min_wait,
                                     min_count=min_count,
                                     state={},
                                     callback_kwargs={'run_id':
@@ -81,8 +84,7 @@ class DataSaver:
                 self._known_dependencies.update(
                     {str(param): parspec.depends_on.split(', ')})
 
-    def add_result(self,
-                   *res_tuple: res_type) -> None:
+    def add_result(self, *res_tuple: res_type) -> None:
         """
         Add a result to the measurement results. Represents a measurement
         point in the space of measurement parameters, e.g. in an experiment
@@ -231,7 +233,7 @@ class DataSaver:
         Args:
             res: A sequence of the data to be added
             input_size: The length of the data to be added. 1 if its
-             to be inserted as arrays.
+                to be inserted as arrays.
         """
         for index in range(input_size):
             res_dict = {}
@@ -275,18 +277,12 @@ class DataSaver:
             found_parameters: The list of all parameters that we know of by now
               Note that this is modified in place.
         """
-        # TODO (WilliamHPNielsen): The following code block is ugly and
-        # brittle and should be enough to convince us to abandon the
-        # design of ArrayParameters (possibly) containing (some of) their
-        # setpoints
-
         sp_names = parameter.setpoint_full_names
         fallback_sp_name = f"{parameter.full_name}_setpoint"
         self._unbundle_setpoints_from_param(parameter, sp_names,
                                             fallback_sp_name,
                                             parameter.setpoints,
                                             res, found_parameters)
-
 
     def _unbundle_setpoints_from_param(self, parameter: _BaseParameter,
                                        sp_names: Sequence[str],
@@ -296,12 +292,12 @@ class DataSaver:
                                        found_parameters: List[str]):
         """
         Private function to unbundle setpoints from an ArrayParameter or
-         a subset of a MultiParameter.
+        a subset of a MultiParameter.
 
         Args:
             parameter:
             sp_names: Names of the setpoint axes
-            fallback_sp_name:  Fallback name for setpoints in case sp_names
+            fallback_sp_name: Fallback name for setpoints in case sp_names
               is None. The axis num is appended to this name to ensure all
               setpoint axes names are unique.
             setpoints: The actual setpoints i.e. `parameter.setpoints` for an
@@ -311,12 +307,12 @@ class DataSaver:
             found_parameters: The list of all parameters that we know of by now
               This is modified in place with new parameters found here.
         """
-
         setpoint_axes = []
         setpoint_meta = []
         if setpoints is None:
             raise RuntimeError(f"{parameter.full_name} is an {type(parameter)} "
                                f"without setpoints. Cannot handle this.")
+
         for i, sps in enumerate(setpoints):
             if sp_names is not None:
                 spname = sp_names[i]
@@ -336,6 +332,7 @@ class DataSaver:
             setpoint_meta.append(spname)
             found_parameters.append(spname)
             setpoint_axes.append(sps)
+
         output_grids = np.meshgrid(*setpoint_axes, indexing='ij')
         for grid, meta in zip(output_grids, setpoint_meta):
             res.append((meta, grid))
@@ -345,10 +342,9 @@ class DataSaver:
                                  data: Union[tuple, list, np.ndarray],
                                  res: List[res_type],
                                  found_parameters: List[str]) -> None:
-
         """
         Extract the subarrays and setpoints from an MultiParameter and
-         add them to res as a regular parameter tuple.
+        add them to res as a regular parameter tuple.
 
         Args:
             parameter: The MultiParameter to extract from
@@ -407,6 +403,7 @@ class DataSaver:
 class Runner:
     """
     Context manager for the measurement.
+
     Lives inside a Measurement and should never be instantiated
     outside a Measurement.
 
@@ -510,22 +507,15 @@ class Measurement:
     """
     Measurement procedure container
 
-    Attributes:
-        name (str): The name of this measurement/run. Is used by the dataset
-            to give a name to the results_table.
+    Args:
+        exp: Specify the experiment to use. If not given
+            the default one is used.
+        station: The QCoDeS station to snapshot. If not given, the
+            default one is used.
     """
 
     def __init__(self, exp: Optional[Experiment] = None,
                  station: Optional[qc.Station] = None) -> None:
-        """
-        Init
-
-        Args:
-            exp: Specify the experiment to use. If not given
-                the default one is used.
-            station: The QCoDeS station to snapshot. If not given, the
-                default one is used.
-        """
         self.exitactions: List[Tuple[Callable, Sequence]] = []
         self.enteractions: List[Tuple[Callable, Sequence]] = []
         self.subscribers: List[Tuple[Callable, Union[MutableSequence,
@@ -605,8 +595,6 @@ class Measurement:
         """
         Add QCoDeS Parameter to the dataset produced by running this
         measurement.
-
-        TODO: Does not handle metadata yet
 
         Args:
             parameter: The parameter to add

--- a/qcodes/dataset/param_spec.py
+++ b/qcodes/dataset/param_spec.py
@@ -1,9 +1,6 @@
 from typing import Union, Sequence, List
 
-# TODO: we should validate type somehow
-# we can't accept everything (or we can but crash at runtime?)
-# we only support the types in VALUES type, that is:
-# str, Number, List, ndarray, bool
+
 class ParamSpec:
 
     allowed_types = ['array', 'numeric', 'text']

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1379,15 +1379,17 @@ def get_paramspec(conn: SomeConnection,
 def add_parameter(conn: SomeConnection,
                   formatted_name: str,
                   *parameter: ParamSpec):
-    """ Add parameters to the dataset
+    """
+    Add parameters to the dataset
 
     This will update the layouts and dependencies tables
 
     NOTE: two parameters with the same name are not allowed
+
     Args:
-        - conn: the connection to the sqlite database
-        - formatted_name: name of the table
-        - parameter: the paraemters to add
+        conn: the connection to the sqlite database
+        formatted_name: name of the table
+        parameter: the list of ParamSpecs for parameters to add
     """
     with atomic(conn) as conn:
         p_names = []

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1164,7 +1164,18 @@ def get_runs(conn: SomeConnection,
     return c.fetchall()
 
 
-def get_last_run(conn: SomeConnection, exp_id: int) -> str:
+def get_last_run(conn: SomeConnection, exp_id: int) -> Optional[int]:
+    """
+    Get run_id of the last run in experiment with exp_id
+
+    Args:
+        conn: connection to use for the query
+        exp_id: id of the experiment to look inside
+
+    Returns:
+        the integer id of the last run or None if there are not runs in the
+        experiment
+    """
     query = """
     SELECT run_id, max(run_timestamp), exp_id
     FROM runs

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1129,9 +1129,11 @@ def get_experiments(conn: SomeConnection) -> List[sqlite3.Row]:
     return c.fetchall()
 
 
-def get_last_experiment(conn: SomeConnection) -> int:
+def get_last_experiment(conn: SomeConnection) -> Optional[int]:
     """
     Return last started experiment id
+
+    Returns None if there are no experiments in the database
     """
     query = "SELECT MAX(exp_id) FROM experiments"
     c = atomic_transaction(conn, query)

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -359,14 +359,33 @@ def test_add_parameter_values(N, M):
 
 @pytest.mark.usefixtures("dataset")
 def test_load_by_counter():
-    dataset = load_by_counter(1, 1)
     exps = experiments()
     assert len(exps) == 1
     exp = exps[0]
-    assert dataset.name == "test-dataset"
     assert exp.name == "test-experiment"
     assert exp.sample_name == "test-sample"
     assert exp.last_counter == 1
+
+    dataset = load_by_counter(1, 1)
+
+    assert "test-dataset" == dataset.name
+    assert exp.sample_name == dataset.sample_name
+    assert exp.name == dataset.exp_name
+
+
+@pytest.mark.usefixtures("experiment")
+@pytest.mark.parametrize('nonexisting_counter', (-1, 0, 1, None))
+def test_load_by_counter_for_nonexisting_counter(nonexisting_counter):
+    exp_id = 1
+    with pytest.raises(RuntimeError, match='Expected one row'):
+        _ = load_by_counter(exp_id, nonexisting_counter)
+
+
+@pytest.mark.usefixtures("empty_temp_db")
+@pytest.mark.parametrize('nonexisting_exp_id', (-1, 0, 1, None))
+def test_load_by_counter_for_nonexisting_experiment(nonexisting_exp_id):
+    with pytest.raises(RuntimeError, match='Expected one row'):
+        _ = load_by_counter(nonexisting_exp_id, 1)
 
 
 @pytest.mark.usefixtures("empty_temp_db")

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -80,6 +80,28 @@ def test_create_dataset_pass_both_connection_and_path_to_db(experiment):
         _ = DataSet(path_to_db="some valid path", conn=some_valid_connection)
 
 
+def test_load_by_id(dataset):
+    ds = load_by_id(dataset.run_id)
+    assert dataset.run_id == ds.run_id
+    assert dataset.path_to_db == ds.path_to_db
+
+
+@pytest.mark.usefixtures('experiment')
+@pytest.mark.parametrize('non_existing_run_id', (1, 0, -1))
+def test_load_by_id_for_nonexisting_run_id(non_existing_run_id):
+    with pytest.raises(ValueError, match=f'Run with run_id '
+                                         f'{non_existing_run_id} does not '
+                                         f'exist in the database'):
+        _ = load_by_id(non_existing_run_id)
+
+
+@pytest.mark.usefixtures('experiment')
+def test_load_by_id_for_none():
+    with pytest.raises(ValueError, match='run_id has to be a positive integer, '
+                                         'not None.'):
+        _ = load_by_id(None)
+
+
 @settings(deadline=None)
 @given(experiment_name=hst.text(min_size=1),
        sample_name=hst.text(min_size=1),

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -63,7 +63,7 @@ def test_dataset_read_only_properties(dataset):
 
 
 @pytest.mark.usefixtures("experiment")
-@pytest.mark.parametrize("non_existing_run_id", (1, 'number#42'))
+@pytest.mark.parametrize("non_existing_run_id", (1, 0, -1, 'number#42'))
 def test_create_dataset_from_non_existing_run_id(non_existing_run_id):
     with pytest.raises(ValueError, match=f"Run with run_id "
                                          f"{non_existing_run_id} does not "

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -27,11 +27,12 @@ def test_has_attributes_after_init():
     (run_id is None / run_id is not None)
     """
 
-    attrs = ['path_to_db', 'conn', '_run_id', 'run_id', '_debug', 'subscribers',
-             '_completed', 'name', 'table_name', 'guid', 'number_of_results',
-             'counter', 'parameters', 'paramspecs', 'exp_id', 'exp_name',
-             'sample_name', 'run_timestamp_raw', 'completed_timestamp_raw',
-             'completed', 'snapshot', 'snapshot_raw']
+    attrs = ['path_to_db', '_path_to_db', 'conn', '_run_id', 'run_id',
+             '_debug', 'subscribers', '_completed', 'name', 'table_name',
+             'guid', 'number_of_results', 'counter', 'parameters',
+             'paramspecs', 'exp_id', 'exp_name', 'sample_name',
+             'run_timestamp_raw', 'completed_timestamp_raw', 'completed',
+             'snapshot', 'snapshot_raw']
 
     path_to_db = get_DB_location()
     ds = DataSet(path_to_db, run_id=None)
@@ -48,7 +49,7 @@ def test_has_attributes_after_init():
 
 
 def test_dataset_read_only_properties(dataset):
-    read_only_props = ['run_id', 'name', 'table_name', 'guid',
+    read_only_props = ['run_id', 'path_to_db', 'name', 'table_name', 'guid',
                        'number_of_results', 'counter', 'parameters',
                        'paramspecs', 'exp_id', 'exp_name', 'sample_name',
                        'run_timestamp_raw', 'completed_timestamp_raw',

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -56,6 +56,15 @@ def test_create_dataset_from_non_existing_run_id(non_existing_run_id):
         _ = DataSet(run_id=non_existing_run_id)
 
 
+def test_create_dataset_pass_both_connection_and_path_to_db(experiment):
+    with pytest.raises(ValueError, match="Both `path_to_db` and `conn` "
+                                         "arguments have been passed together "
+                                         "with non-None values. This is not "
+                                         "allowed."):
+        some_valid_connection = experiment.conn
+        _ = DataSet(path_to_db="some valid path", conn=some_valid_connection)
+
+
 @settings(deadline=None)
 @given(experiment_name=hst.text(min_size=1),
        sample_name=hst.text(min_size=1),

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -166,8 +166,11 @@ def test_add_paramspec_one_by_one(dataset):
         ps = paramspecs[expected_param_name]
         assert ps.name == expected_param_name
 
-    with pytest.raises(ValueError):
+    # Test that is not possible to add the same parameter again to the dataset
+    with pytest.raises(ValueError, match=f'Duplicate parameter name: '
+                                         f'{parameters[0].name}'):
         dataset.add_parameter(parameters[0])
+
     assert len(dataset.paramspecs.keys()) == 3
 
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -27,7 +27,7 @@ def test_has_attributes_after_init():
     (run_id is None / run_id is not None)
     """
 
-    attrs = ['path_to_db', 'conn', 'run_id', '_debug', 'subscribers',
+    attrs = ['path_to_db', 'conn', '_run_id', 'run_id', '_debug', 'subscribers',
              '_completed', 'name', 'table_name', 'guid', 'number_of_results',
              'counter', 'parameters', 'paramspecs', 'exp_id', 'exp_name',
              'sample_name', 'run_timestamp_raw', 'completed_timestamp_raw',
@@ -45,6 +45,20 @@ def test_has_attributes_after_init():
     for attr in attrs:
         assert hasattr(ds, attr)
         getattr(ds, attr)
+
+
+def test_dataset_read_only_properties(dataset):
+    read_only_props = ['run_id', 'name', 'table_name', 'guid',
+                       'number_of_results', 'counter', 'parameters',
+                       'paramspecs', 'exp_id', 'exp_name', 'sample_name',
+                       'run_timestamp_raw', 'completed_timestamp_raw',
+                       'snapshot', 'snapshot_raw']
+
+    for prop in read_only_props:
+        with pytest.raises(AttributeError, match="can't set attribute",
+                           message=f"It is not expected to be possible to set "
+                                   f"property {prop!r}"):
+            setattr(dataset, prop, True)
 
 
 @pytest.mark.usefixtures("experiment")

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -1,11 +1,13 @@
 import pytest
 
+from qcodes.dataset.database import get_DB_location
 from qcodes.dataset.experiment_container import (load_experiment_by_name,
                                                  new_experiment,
                                                  load_or_create_experiment,
                                                  experiments,
                                                  load_experiment,
-                                                 Experiment)
+                                                 Experiment,
+                                                 load_last_experiment)
 from qcodes.dataset.measurements import Measurement
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import empty_temp_db, dataset, \
@@ -157,3 +159,22 @@ def test_format_string(empty_temp_db):
                                          r"format \(name, exp_id, "
                                          r"run_counter\)"):
         _ = Experiment(exp_id=None, format_string=fmt_str)
+
+
+def test_load_last_experiment(empty_temp_db):
+    # test in case of no experiments
+    with pytest.raises(ValueError, match='There are no experiments in the '
+                                         'database file'):
+        _ = load_last_experiment()
+
+    # create 2 experiments
+    exp1 = Experiment(exp_id=None)
+    exp2 = Experiment(exp_id=None)
+    assert get_DB_location() == exp1.path_to_db
+    assert get_DB_location() == exp2.path_to_db
+
+    # load last and assert that its the 2nd one that was created
+    last_exp = load_last_experiment()
+    assert last_exp.exp_id == exp2.exp_id
+    assert last_exp.exp_id != exp1.exp_id
+    assert last_exp.path_to_db == exp2.path_to_db

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -1,10 +1,11 @@
 import pytest
 
 from qcodes.dataset.experiment_container import load_experiment_by_name, \
-    new_experiment, load_or_create_experiment, experiments
+    new_experiment, load_or_create_experiment, experiments, load_experiment
 from qcodes.dataset.measurements import Measurement
 # pylint: disable=unused-import
-from qcodes.tests.dataset.temporary_databases import empty_temp_db
+from qcodes.tests.dataset.temporary_databases import empty_temp_db, dataset, \
+    experiment
 
 
 def assert_experiments_equal(exp, exp_2):
@@ -28,6 +29,25 @@ def test_run_loaded_experiment():
 
     with meas.run():
         pass
+
+def test_last_data_set_from_experiment(dataset):
+    experiment = load_experiment(dataset.exp_id)
+    ds = experiment.last_data_set()
+
+    assert dataset.run_id == ds.run_id
+    assert dataset.name == ds.name
+    assert dataset.exp_id == ds.exp_id
+    assert dataset.exp_name == ds.exp_name
+    assert dataset.sample_name == ds.sample_name
+    assert dataset.path_to_db == ds.path_to_db
+
+    assert experiment.path_to_db == ds.path_to_db
+
+
+def test_last_data_set_from_experiment_with_no_datasets(experiment):
+    with pytest.raises(ValueError, match='There are no runs in this '
+                                         'experiment'):
+        _ = experiment.last_data_set()
 
 
 @pytest.mark.usefixtures("empty_temp_db")

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -126,6 +126,18 @@ def test_has_attributes_after_init():
             getattr(exp, attr)
 
 
+def test_experiment_read_only_properties(experiment):
+    read_only_props = ['name', 'exp_id', 'sample_name', 'last_counter',
+                       'path_to_db', 'started_at', 'finished_at',
+                       'format_string']
+
+    for prop in read_only_props:
+        with pytest.raises(AttributeError, match="can't set attribute",
+                           message=f"It is not expected to be possible to set "
+                                   f"property {prop!r}"):
+            setattr(experiment, prop, True)
+
+
 def test_format_string(empty_temp_db):
     # default format string
     exp1 = Experiment(exp_id=None)

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -124,3 +124,21 @@ def test_has_attributes_after_init():
         for attr in attrs:
             assert hasattr(exp, attr)
             getattr(exp, attr)
+
+
+def test_format_string(empty_temp_db):
+    # default format string
+    exp1 = Experiment(exp_id=None)
+    assert "{}-{}-{}" == exp1.format_string
+
+    # custom format string
+    fmt_str = "name_{}__id_{}__run_cnt_{}"
+    exp2 = Experiment(exp_id=None, format_string=fmt_str)
+    assert fmt_str == exp2.format_string
+
+    # invalid format string
+    fmt_str = "name_{}__id_{}__{}__{}"
+    with pytest.raises(ValueError, match=r"Invalid format string. Can not "
+                                         r"format \(name, exp_id, "
+                                         r"run_counter\)"):
+        _ = Experiment(exp_id=None, format_string=fmt_str)

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -143,6 +143,20 @@ def test_create_experiment_from_non_existing_id(non_existing_id):
         _ = Experiment(exp_id=non_existing_id)
 
 
+@pytest.mark.usefixtures("empty_temp_db")
+@pytest.mark.parametrize("non_existing_id", (1, 0, -1))
+def test_load_experiment_from_non_existing_id(non_existing_id):
+    with pytest.raises(ValueError, match="No such experiment in the database"):
+        _ = load_experiment(non_existing_id)
+
+
+@pytest.mark.usefixtures("empty_temp_db")
+@pytest.mark.parametrize("bad_id", (None, 'number#42'))
+def test_load_experiment_from_bad_id(bad_id):
+    with pytest.raises(ValueError, match="Experiment ID must be an integer"):
+        _ = load_experiment(bad_id)
+
+
 def test_format_string(empty_temp_db):
     # default format string
     exp1 = Experiment(exp_id=None)

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -106,8 +106,9 @@ def test_has_attributes_after_init():
     (exp_id is None / exp_id is not None)
     """
 
-    attrs = ['name', 'sample_name', 'last_counter', 'path_to_db',
-             'conn', 'started_at', 'finished_at']
+    attrs = ['name', 'exp_id', '_exp_id', 'sample_name', 'last_counter',
+             'path_to_db', '_path_to_db', 'conn', 'started_at',
+             'finished_at', 'format_string']
 
     # This creates an experiment in the db
     exp1 = Experiment(exp_id=None)

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -116,10 +116,6 @@ def test_has_attributes_after_init():
     # This loads the experiment that we just created
     exp2 = Experiment(exp_id=1)
 
-    # This tries to load an experiment that we don't have
-    with pytest.raises(ValueError, match='No such experiment in the database'):
-        Experiment(exp_id=2)
-
     for exp in (exp1, exp2):
         for attr in attrs:
             assert hasattr(exp, attr)
@@ -136,6 +132,13 @@ def test_experiment_read_only_properties(experiment):
                            message=f"It is not expected to be possible to set "
                                    f"property {prop!r}"):
             setattr(experiment, prop, True)
+
+
+@pytest.mark.usefixtures("empty_temp_db")
+@pytest.mark.parametrize("non_existing_id", (1, 0, -1, 'number#42'))
+def test_create_experiment_from_non_existing_id(non_existing_id):
+    with pytest.raises(ValueError, match="No such experiment in the database"):
+        _ = Experiment(exp_id=non_existing_id)
 
 
 def test_format_string(empty_temp_db):

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -8,6 +8,7 @@ from hypothesis import given
 import unicodedata
 
 import qcodes.dataset.sqlite_base as mut  # mut: module under test
+from qcodes.dataset.database import get_DB_location
 from qcodes.dataset.guids import generate_guid
 from qcodes.dataset.param_spec import ParamSpec
 # pylint: disable=unused-import
@@ -134,3 +135,12 @@ def test_get_last_run(dataset):
 
 def test_get_last_run_no_runs(experiment):
     assert None is mut.get_last_run(experiment.conn, experiment.exp_id)
+
+
+def test_get_last_experiment(experiment):
+    assert experiment.exp_id == mut.get_last_experiment(experiment.conn)
+
+
+def test_get_last_experiment_no_experiments(empty_temp_db):
+    conn = mut.connect(get_DB_location())
+    assert None is mut.get_last_experiment(conn)

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -126,3 +126,11 @@ def test_column_in_table(dataset):
 def test_run_exist(dataset):
     assert mut.run_exists(dataset.conn, dataset.run_id)
     assert not mut.run_exists(dataset.conn, dataset.run_id + 1)
+
+
+def test_get_last_run(dataset):
+    assert dataset.run_id == mut.get_last_run(dataset.conn, dataset.exp_id)
+
+
+def test_get_last_run_no_runs(experiment):
+    assert None is mut.get_last_run(experiment.conn, experiment.exp_id)


### PR DESCRIPTION
Major changes proposed in this pull request:
* Raise when creating DataSet with path_to_db and connection both not-None
* Make run_id read-only attribute of DataSet + tests
* Make path_to_db read-only attribute of DataSet + tests
* Type annotation of load_or_create_experiment same as load_experiment
* Adding duplicate parameters: remove confusing todo and improve the test
* load_by_id does not allow None as argument (which would result in creating a new dataset)
* Only create new experiment if exp_id is not None
* load_last_experiment does not create new experiments if there a none in database

Minor changes proposed in this pull request:
* Remove comments that are outdated or useless
* Deprecate DataSet.add_parameters in favor of DataSet.add_parameter
* Experiment.last_data_set raises if there are no runs in the experiment
* Experiment.format_string is made a proper read-only property
* Test load_by_counter properly
* Test get_last_run properly
* Test load_experiment_by_name properly
* Test get_last_experiment properly
* Remove reference to Giulio as author of data_set.py
* Remove deprecated and unused hash_from_parts function
* Some pep8, reformatting, type annotation fixes here and there

@QCoDeS/core Feel free to say what to do else, or what to undo.