### PR TITLE
Hopefully unbreak on windows/azure by pinning python to 3.6.6

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
  - defaults
  - conda-forge
 dependencies:
- - python=3.6
+ - python=3.6.6 # Currently there is a problem with 3.6.7 and matplotlib 3.0.0 on conda
  - numpy=1.15
  - matplotlib=3.0.0
  - pyqtgraph=0.10.0


### PR DESCRIPTION
E.g fix failures such as https://quarcsw.visualstudio.com/QubitWorkbench/_build/results?buildId=7672&view=logs