### PR TITLE
Bug: Return core.loglevel and file_loglevel to config

### DIFF
--- a/qcodes/config/qcodesrc.json
+++ b/qcodes/config/qcodesrc.json
@@ -3,7 +3,9 @@
         "default_fmt": "data/{date}/#{counter}_{name}_{time}",
         "register_magic": true,
         "db_location": "~/experiments.db",
-        "db_debug": false
+        "db_debug": false,
+        "loglevel": "WARNING",	
+        "file_loglevel": "INFO"
     },
     "logger":{
         "console_level": "WARNING",


### PR DESCRIPTION
These are deprecated but still need to be there for backwards compatibility. The were accidentally removed in https://github.com/QCoDeS/Qcodes/pull/1309 that introduced new logging.

Without this, people who use other logging, like logging from qdev-wrappers, will experience exception when they update to the latest qcodes.