### PR TITLE
Bugfix: removing a channel instance that was added with `extend`

### DIFF
--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -327,6 +327,9 @@ class ChannelList(Metadatable):
                             "type.")
         channels = cast(List[InstrumentChannel], self._channels)
         channels.extend(objects_tuple)
+        self._channel_mapping.update({
+            obj.short_name: obj for obj in objects
+        })
         self._channels = channels
 
     def index(self, obj: InstrumentChannel):

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -122,6 +122,8 @@ class TestChannels(TestCase):
         self.assertEqual(len(self.instrument.channels), n_channels + len(names))
         last_channel = self.instrument.channels[-1]
         self.instrument.channels.remove(last_channel)
+        assert last_channel not in self.instrument.channels
+        self.assertEqual(len(self.instrument.channels), n_channels + len(names) - 1)
 
     def test_insert_channel(self):
         n_channels = len(self.instrument.channels)

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -114,7 +114,6 @@ class TestChannels(TestCase):
         self.assertEqual(len(self.instrument.channels), n_channels + len(names))
 
     def test_extend_then_remove(self):
-
         n_channels = len(self.instrument.channels)
         names = ('foo', 'bar', 'foobar')
         channels = [DummyChannel(self.instrument, 'Chan' + name, name) for name in names]
@@ -123,7 +122,6 @@ class TestChannels(TestCase):
         self.assertEqual(len(self.instrument.channels), n_channels + len(names))
         last_channel = self.instrument.channels[-1]
         self.instrument.channels.remove(last_channel)
-
 
     def test_insert_channel(self):
         n_channels = len(self.instrument.channels)

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -113,6 +113,18 @@ class TestChannels(TestCase):
 
         self.assertEqual(len(self.instrument.channels), n_channels + len(names))
 
+    def test_extend_then_remove(self):
+
+        n_channels = len(self.instrument.channels)
+        names = ('foo', 'bar', 'foobar')
+        channels = [DummyChannel(self.instrument, 'Chan' + name, name) for name in names]
+        self.instrument.channels.extend(channels)
+
+        self.assertEqual(len(self.instrument.channels), n_channels + len(names))
+        last_channel = self.instrument.channels[-1]
+        self.instrument.channels.remove(last_channel)
+
+
     def test_insert_channel(self):
         n_channels = len(self.instrument.channels)
         name = 'foo'


### PR DESCRIPTION
In the `extend` method of channel list, we did not update the channel mapping. As a result a `KeyError` was generated when removing the channel. This is fixed in this PR. A test is added to verify the effectiveness.


@jenshnielsen or @WilliamHPNielsen Can you perhaps look at this?  