### PR TITLE
Minicircuits USB_SPDT catch the correct error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -385,7 +385,7 @@ if any([re.match("\s*api\s*", l) for l in index_rst_lines]):
 # there when generating the docs
 autodoc_mock_imports = ['pyspcm', 'zhinst', 'zhinst.utils',
                         'keysightSD1', 'cffi', 'spirack', 'clr',
-                        'System.IO']
+                        'System.IO', 'System.IO.FileNotFoundException']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -384,8 +384,7 @@ if any([re.match("\s*api\s*", l) for l in index_rst_lines]):
 # we mock modules that for one reason or another is not
 # there when generating the docs
 autodoc_mock_imports = ['pyspcm', 'zhinst', 'zhinst.utils',
-                        'keysightSD1', 'cffi', 'spirack', 'clr',
-                        'System.IO', 'System.IO.FileNotFoundException']
+                        'keysightSD1', 'cffi', 'spirack', 'clr']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -384,7 +384,8 @@ if any([re.match("\s*api\s*", l) for l in index_rst_lines]):
 # we mock modules that for one reason or another is not
 # there when generating the docs
 autodoc_mock_imports = ['pyspcm', 'zhinst', 'zhinst.utils',
-                        'keysightSD1', 'cffi', 'spirack', 'clr']
+                        'keysightSD1', 'cffi', 'spirack', 'clr',
+                        'System.IO']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
@@ -6,6 +6,8 @@ from qcodes.instrument_drivers.Minicircuits.Base_SPDT import (
 
 try:
     import clr
+    clr.AddReference('System.IO')
+    from System.IO import FileNotFoundException
 except ImportError:
     raise ImportError("""Module clr not found. Please obtain it by
                          running 'pip install pythonnet'
@@ -45,11 +47,11 @@ class USB_SPDT(SPDT_Base):
             else:
                 clr.AddReference(driver_path)
 
-        except ImportError:
+        except (ImportError, FileNotFoundException):
             raise ImportError(
                 """Load of mcl_RF_Switch_Controller64.dll not possible. Make sure
                 the dll file is not blocked by Windows. To unblock right-click
-                the dll to open proporties and check the 'unblock' checkmark
+                the dll to open properties and check the 'unblock' checkmark
                 in the bottom. Check that your python installation is 64bit."""
             )
         import mcl_RF_Switch_Controller64

--- a/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
@@ -7,8 +7,6 @@ from qcodes.instrument_drivers.Minicircuits.Base_SPDT import (
 
 try:
     import clr
-    clr.AddReference('System.IO')
-    from System.IO import FileNotFoundException
 except ImportError:
     raise ImportError("""Module clr not found. Please obtain it by
                          running 'pip install pythonnet'
@@ -45,6 +43,11 @@ class USB_SPDT(SPDT_Base):
         # in __getattr__ of `SPDT_Base` it's important that it's
         # always set to something to avoid infinite recursion
         self._deprecated_attributes = None
+        # import .net exception so we can catch it below
+        # we keep this import local so that the module can be imported
+        # without a working .net install
+        clr.AddReference('System.IO')
+        from System.IO import FileNotFoundException
         super().__init__(name, **kwargs)
         if os.name != 'nt':
             raise ImportError("""This driver only works in Windows.""")

--- a/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 # QCoDeS imports
 from qcodes.instrument_drivers.Minicircuits.Base_SPDT import (
@@ -28,8 +29,9 @@ class USB_SPDT(SPDT_Base):
     Mini-Circuits SPDT RF switch
 
     Args:
-            name (str): the name of the instrument
-            serial_number (str, optional): the serial number of the device
+            name: the name of the instrument
+            driver_path: path to the dll
+            serial_number: the serial number of the device
                (printed on the sticker on the back side, without s/n)
             kwargs (dict): kwargs to be passed to Instrument class.
     """
@@ -37,7 +39,12 @@ class USB_SPDT(SPDT_Base):
     CHANNEL_CLASS = SwitchChannelUSB
     PATH_TO_DRIVER = r'mcl_RF_Switch_Controller64'
 
-    def __init__(self, name, driver_path=None, serial_number=None, **kwargs):
+    def __init__(self, name: str, driver_path: Optional[str]=None,
+                 serial_number: Optional[str]=None, **kwargs):
+        # we are eventually overwriting this but since it's called
+        # in __getattr__ of `SPDT_Base` it's important that it's
+        # always set to something to avoid infinite recursion
+        self._deprecated_attributes = None
         super().__init__(name, **kwargs)
         if os.name != 'nt':
             raise ImportError("""This driver only works in Windows.""")

--- a/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
@@ -33,7 +33,7 @@ class USB_SPDT(SPDT_Base):
             driver_path: path to the dll
             serial_number: the serial number of the device
                (printed on the sticker on the back side, without s/n)
-            kwargs (dict): kwargs to be passed to Instrument class.
+            kwargs: kwargs to be passed to Instrument class.
     """
 
     CHANNEL_CLASS = SwitchChannelUSB


### PR DESCRIPTION
So that we actually print the error message when this fails. 

In addition fix an infinite (well up to  maximum recursion depth) error that will happen when closing the instrument and some docstring fixes