### PR TITLE
SR830: Add increment/decrement sensitivity functions.

### DIFF
--- a/docs/examples/driver_examples/Qcodes example with Stanford SR830.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Stanford SR830.ipynb
@@ -987,6 +987,37 @@
     "plot = qc.MatPlot()\n",
     "plot.add(data.lockin_ch1_databuffer)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Automatic sensitivity ranging\n",
+    "\n",
+    "Why push the sensitivity up and down buttons yourself when QCoDeS can do it for you? Run something like this in your measurement loop to automatically adjust the sensitivity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def autorange(srs, max_changes=1):\n",
+    "    def autorange_once():\n",
+    "        r = srs.R.get()\n",
+    "        sens = srs.sensitivity.get()\n",
+    "        if r > 0.9 * sens:\n",
+    "            return srs.increment_sensitivity()\n",
+    "        elif r < 0.1 * sens:\n",
+    "            return srs.decrement_sensitivity()\n",
+    "        return False\n",
+    "\n",
+    "    sets = 0\n",
+    "    while autorange_once() and sets < max_changes:\n",
+    "        sets += 1\n",
+    "        time.sleep(srs.time_constant.get())"
+   ]
   }
  ],
  "metadata": {

--- a/qcodes/instrument_drivers/stanford_research/SR830.py
+++ b/qcodes/instrument_drivers/stanford_research/SR830.py
@@ -496,7 +496,8 @@ class SR830(VisaInstrument):
         return self._change_sensitivity(-1)
 
     def _change_sensitivity(self, dn):
-        n = int(self.ask('SENS?'))
+        _ = self.sensitivity.get()
+        n = self.sensitivity.raw_value
         if self.input_config() in ['a', 'a-b']:
             n_to = self._N_TO_VOLT
         else:
@@ -505,7 +506,7 @@ class SR830(VisaInstrument):
         if n + dn > max(n_to.keys()) or n + dn < min(n_to.keys()):
             return False
 
-        self.write(f'SENS {n + dn:d}')
+        self.sensitivity.set(n_to[n + dn])
         return True
 
     def _set_buffer_SR(self, SR):

--- a/qcodes/instrument_drivers/stanford_research/SR830.py
+++ b/qcodes/instrument_drivers/stanford_research/SR830.py
@@ -473,6 +473,41 @@ class SR830(VisaInstrument):
 
         self.connect_message()
 
+    def increment_sensitivity(self):
+        """
+        Increment the sensitivity setting of the lock-in. This is equivalent
+        to pushing the sensitivity up button on the front panel. This has no
+        effect if the sensitivity is already at the maximum.
+
+        Returns:
+            Whether or not the sensitivity was actually changed.
+        """
+        return self._change_sensitivity(1)
+
+    def decrement_sensitivity(self):
+        """
+        Decrement the sensitivity setting of the lock-in. This is equivalent
+        to pushing the sensitivity down button on the front panel. This has no
+        effect if the sensitivity is already at the minimum.
+
+        Returns:
+            Whether or not the sensitivity was actually changed.
+        """
+        return self._change_sensitivity(-1)
+
+    def _change_sensitivity(self, dn):
+        n = int(self.ask('SENS?'))
+        if self.input_config() in ['a', 'a-b']:
+            n_to = self._N_TO_VOLT
+        else:
+            n_to = self._N_TO_CURR
+
+        if n + dn > max(n_to.keys()) or n + dn < min(n_to.keys()):
+            return False
+
+        self.write(f'SENS {n + dn:d}')
+        return True
+
     def _set_buffer_SR(self, SR):
         self.write('SRAT {}'.format(SR))
         self._buffer1_ready = False


### PR DESCRIPTION
I often need to auto range lock-ins mid-sweep. I think it's usually best for instrument drivers to only act as instrument drivers, so I went with as small a change as possible to let me implement autoranging outside of the driver. It would have also been possible to add autoranging behavior into the driver itself, and if y'all prefer that then I'd be happy to update this PR.

The two functions in this change make it possible to do things like the following in my measurement sweeps:

```python
def autorange(srs, max_changes=1):
    def autorange_once():
        r = srs.R.get()
        sens = srs.sensitivity.get()
        if r > 0.9 * sens:
            return srs.increment_sensitivity()
        elif r < 0.1 * sens:
            return srs.decrement_sensitivity()
        return False

    sets = 0
    while autorange_once() and sets < max_changes:
        sets += 1
        time.sleep(srs.time_constant.get())
```

@StefanD986 @astafan8 