### PR TITLE
Improvement / dataset metadata

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -24,7 +24,9 @@ from qcodes.dataset.sqlite_base import (atomic, atomic_transaction,
                                         VALUE, VALUES, get_data,
                                         get_values,
                                         get_setpoints,
-                                        get_metadata, one,
+                                        get_metadata,
+                                        get_metadata_from_run_id,
+                                        one,
                                         get_experiment_name_from_experiment_id,
                                         get_sample_name_from_experiment_id,
                                         get_guid_from_run_id,
@@ -231,6 +233,7 @@ class DataSet(Sized):
             self._completed = completed(self.conn, self.run_id)
             self._started = self.number_of_results > 0
             self._description = self._get_run_description_from_db()
+            self._metadata = get_metadata_from_run_id(self.conn, run_id)
 
         else:
             # Actually perform all the side effects needed for the creation
@@ -252,6 +255,7 @@ class DataSet(Sized):
             self._started = False
             specs = specs or []
             self._description = RunDescriber(InterDependencies(*specs))
+            self._metadata = get_metadata_from_run_id(self.conn, self.run_id)
 
     @property
     def run_id(self):
@@ -341,6 +345,10 @@ class DataSet(Sized):
     @property
     def description(self) -> RunDescriber:
         return self._description
+
+    @property
+    def metadata(self) -> Dict:
+        return self._metadata
 
     def run_timestamp(self, fmt: str="%Y-%m-%d %H:%M:%S") -> str:
         """
@@ -464,6 +472,7 @@ class DataSet(Sized):
             tag: represents the key in the metadata dictionary
             metadata: actual metadata
         """
+        self._metadata[tag] = metadata
         add_meta_data(self.conn, self.run_id, {tag: metadata})
         # `add_meta_data` does not commit, hence we commit here:
         self.conn.commit()

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -466,12 +466,13 @@ class DataSet(Sized):
     def add_metadata(self, tag: str, metadata: Any):
         """
         Adds metadata to the DataSet. The metadata is stored under the
-        provided tag.
+        provided tag. Note that None is not allowed as a metadata value.
 
         Args:
             tag: represents the key in the metadata dictionary
             metadata: actual metadata
         """
+
         self._metadata[tag] = metadata
         add_meta_data(self.conn, self.run_id, {tag: metadata})
         # `add_meta_data` does not commit, hence we commit here:

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -100,6 +100,13 @@ CREATE TABLE IF NOT EXISTS dependencies (
 
 _unicode_categories = ('Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nd', 'Pc', 'Pd', 'Zs')
 
+# in the current version, these are the standard columns of the "runs" table
+# Everything else is metadata
+RUNS_TABLE_COLUMNS = ["run_id", "exp_id", "name", "result_table_name",
+                      "result_counter", "run_timestamp", "completed_timestamp",
+                      "is_completed", "parameters", "guid",
+                      "run_description"]
+
 
 class ConnectionPlus(wrapt.ObjectProxy):
     """
@@ -1902,6 +1909,13 @@ def get_metadata(conn: SomeConnection, tag: str, table_name: str):
     """
     return select_one_where(conn, "runs", tag,
                             "result_table_name", table_name)
+
+
+def get_metadata_from_run_id(conn: SomeConnection, run_id: int) -> Dict:
+    """
+    Get all metadata associated with the specified run
+    """
+    # first fetch all columns of the runs table
 
 
 def insert_meta_data(conn: SomeConnection, row_id: int, table_name: str,

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1947,7 +1947,8 @@ def get_metadata_from_run_id(conn: SomeConnection, run_id: int) -> Dict:
 def insert_meta_data(conn: SomeConnection, row_id: int, table_name: str,
                      metadata: Dict[str, Any]) -> None:
     """
-    Insert new metadata column and add values
+    Insert new metadata column and add values. Note that None is not a valid
+    metadata value
 
     Args:
         - conn: the connection to the sqlite database
@@ -1955,6 +1956,10 @@ def insert_meta_data(conn: SomeConnection, row_id: int, table_name: str,
         - table_name: the table to add to, defaults to runs
         - metadata: the metadata to add
     """
+    for tag, val in metadata.items():
+        if val is None:
+            raise ValueError(f'Tag {tag} has value None. '
+                             ' That is not a valid metadata value!')
     for key in metadata.keys():
         insert_column(conn, table_name, key)
     update_meta_data(conn, row_id, table_name, metadata)
@@ -1980,6 +1985,7 @@ def add_meta_data(conn: SomeConnection,
                   table_name: str = "runs") -> None:
     """
     Add metadata data (updates if exists, create otherwise).
+    Note that None is not a valid metadata value.
 
     Args:
         - conn: the connection to the sqlite database

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -526,3 +526,23 @@ def test_get_description(some_paramspecs):
     loaded_ds = DataSet(run_id=1)
 
     assert loaded_ds.description == desc
+
+
+@pytest.mark.usefixtures('experiment')
+def test_metadata():
+
+    metadata1 = {'number': 1, "string": "Once upon a time..."}
+    metadata2 = {'more': 'meta'}
+
+    ds1 = DataSet(metadata=metadata1)
+    ds2 = DataSet(metadata=metadata2)
+
+    assert ds1.run_id == 1
+    assert ds1.metadata == metadata1
+    assert ds2.run_id == 2
+    assert ds2.metadata == metadata2
+
+    loaded_ds1 = DataSet(run_id=1)
+    assert loaded_ds1.metadata == metadata1
+    loaded_ds2 = DataSet(run_id=2)
+    assert loaded_ds2.metadata == metadata2

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -546,3 +546,13 @@ def test_metadata():
     assert loaded_ds1.metadata == metadata1
     loaded_ds2 = DataSet(run_id=2)
     assert loaded_ds2.metadata == metadata2
+
+    badtag = 'lex luthor'
+    sorry_metadata = {'superman': 1, badtag: None, 'spiderman': 'two'}
+
+    match = (f'Tag {badtag} has value None. '
+             ' That is not a valid metadata value!')
+
+    with pytest.raises(ValueError, match=match):
+        for tag, value in sorry_metadata.items():
+            ds1.add_metadata(tag, value)

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -171,3 +171,17 @@ def test_update_runs_description(dataset):
 
     desc = RunDescriber(InterDependencies()).to_json()
     mut.update_run_description(dataset.conn, dataset.run_id, desc)
+
+
+def test_runs_table_columns(empty_temp_db):
+    """
+    Ensure that the column names of a pristine runs table are what we expect
+    """
+    colnames = mut.RUNS_TABLE_COLUMNS.copy()
+    conn = mut.connect(get_DB_location())
+    query = "PRAGMA table_info(runs)"
+    cursor = conn.cursor()
+    for row in cursor.execute(query):
+        colnames.remove(row['name'])
+
+    assert colnames == []


### PR DESCRIPTION
There is currently no way to query for the metadata associated with a particular dataset. One can only look up metadata by tag, which requires some auxiliary knowledge about the metadata.

Changes proposed in this pull request:
- Add a `metadata` property to a `DataSet` object to see all associated metadata.

This little improvement is needed for #1352 in order to ensure correct copying of metadata.

@astafan8 
