### PR TITLE
DataSet.get_data bugs with start/end arguments

### DIFF
--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1060,8 +1060,8 @@ def length(conn: SomeConnection,
 def get_data(conn: SomeConnection,
              table_name: str,
              columns: List[str],
-             start: int = None,
-             end: int = None,
+             start: Optional[int] = None,
+             end: Optional[int] = None,
              ) -> List[List[Any]]:
     """
     Get data from the columns of a table.
@@ -1078,7 +1078,7 @@ def get_data(conn: SomeConnection,
         the data requested
     """
     _columns = ",".join(columns)
-    if start and end:
+    if start is not None and end is not None:
         query = f"""
         SELECT {_columns}
         FROM "{table_name}"
@@ -1087,14 +1087,14 @@ def get_data(conn: SomeConnection,
               rowid
             <= {end}
         """
-    elif start:
+    elif start is not None:
         query = f"""
         SELECT {_columns}
         FROM "{table_name}"
         WHERE rowid
             >= {start}
         """
-    elif end:
+    elif end is not None:
         query = f"""
         SELECT {_columns}
         FROM "{table_name}"

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1065,7 +1065,8 @@ def get_data(conn: SomeConnection,
              ) -> List[List[Any]]:
     """
     Get data from the columns of a table.
-    Allows to specfiy a range.
+    Allows to specify a range of rows (1-based indexing, both ends are
+    included).
 
     Args:
         conn: database connection
@@ -1083,7 +1084,7 @@ def get_data(conn: SomeConnection,
         SELECT {_columns}
         FROM "{table_name}"
         WHERE rowid
-            > {start} and
+            >= {start} and
               rowid
             <= {end}
         """

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1079,34 +1079,22 @@ def get_data(conn: SomeConnection,
         the data requested in the format of list of rows of values
     """
     _columns = ",".join(columns)
-    if start is not None and end is not None:
-        query = f"""
-        SELECT {_columns}
-        FROM "{table_name}"
-        WHERE rowid
-            >= {start} and
-              rowid
-            <= {end}
-        """
-    elif start is not None:
-        query = f"""
-        SELECT {_columns}
-        FROM "{table_name}"
-        WHERE rowid
-            >= {start}
-        """
-    elif end is not None:
-        query = f"""
-        SELECT {_columns}
-        FROM "{table_name}"
-        WHERE rowid
-            <= {end}
-        """
-    else:
-        query = f"""
-        SELECT {_columns}
-        FROM "{table_name}"
-        """
+
+    query = f"""
+            SELECT {_columns}
+            FROM "{table_name}"
+            """
+
+    start_specified = start is not None
+    end_specified = end is not None
+
+    where = ' WHERE' if start_specified or end_specified else ''
+    start_condition = f' rowid >= {start}' if start_specified else ''
+    end_condition = f' rowid <= {end}' if end_specified else ''
+    and_ = ' AND' if start_specified and end_specified else ''
+
+    query += where + start_condition + and_ + end_condition
+
     c = atomic_transaction(conn, query)
     res = many_many(c, *columns)
 

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -1072,11 +1072,11 @@ def get_data(conn: SomeConnection,
         conn: database connection
         table_name: name of the table
         columns: list of columns
-        start: start of range (1 indedex)
-        end: start of range (1 indedex)
+        start: start of range; if None, then starts from the top of the table
+        end: end of range; if None, then ends at the bottom of the table
 
     Returns:
-        the data requested
+        the data requested in the format of list of rows of values
     """
     _columns = ",".join(columns)
     if start is not None and end is not None:

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -614,8 +614,7 @@ class TestGetData:
             (n_vals + 2, None, []),
 
             # test for end only
-            pytest.param(None, 0, [], marks=xfail(
-                reason="Now returns `xdata`, treats 0 as None")),
+            (None, 0, []),
             (None, 2, xdata[:2]),
             (None, -2, []),
             (None, n_vals, xdata),
@@ -623,15 +622,12 @@ class TestGetData:
             (None, n_vals + 2, xdata),
 
             # test for start and end
-            pytest.param(0, 0, [], marks=xfail(
-                reason="Now returns `xdata`, treats 0 as None")),
+            (0, 0, []),
             pytest.param(1, 1, xdata[1-1], marks=xfail(
                 reason="Now returns `[]`")),
             (2, 1, []),
-            pytest.param(2, 0, [], marks=xfail(
-                reason="Now returns `xdata[(2-1):], treats 0 as None`")),
-            pytest.param(1, 0, [], marks=xfail(
-                reason="Now returns `xdata[(1-1):], treats 0 as None`")),
+            (2, 0, []),
+            (1, 0, []),
             pytest.param(n_vals, n_vals, xdata[n_vals-1], marks=xfail(
                 reason="Should not exclude start, now returns `[]`")),
             (n_vals, n_vals - 1, []),

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1,9 +1,6 @@
 import itertools
 
 import pytest
-from pytest import mark
-
-xfail = mark.xfail
 import numpy as np
 from hypothesis import given, settings
 import hypothesis.strategies as hst

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -17,9 +17,10 @@ from qcodes.dataset.guids import parse_guid
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import (empty_temp_db,
                                                       experiment, dataset)
+# pylint: disable=unused-import
+from qcodes.tests.dataset.test_descriptions import some_paramspecs
 
 n_experiments = 0
-
 
 @pytest.mark.usefixtures("experiment")
 def test_has_attributes_after_init():

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -623,17 +623,13 @@ class TestGetData:
 
             # test for start and end
             (0, 0, []),
-            pytest.param(1, 1, [xdata[1-1]], marks=xfail(
-                reason="Now returns `[]`")),
+            (1, 1, [xdata[1-1]]),
             (2, 1, []),
             (2, 0, []),
             (1, 0, []),
-            pytest.param(n_vals, n_vals, [xdata[n_vals-1]], marks=xfail(
-                reason="Should not exclude start, now returns `[]`")),
+            (n_vals, n_vals, [xdata[n_vals-1]]),
             (n_vals, n_vals - 1, []),
-            pytest.param(2, 4, xdata[(2-1):4], marks=xfail(
-                reason="Should not exclude start, "
-                       "now returns `xdata[2:4]`")),  # wolfgang
+            (2, 4, xdata[(2-1):4]),
         ],
     )
     def test_get_data_with_start_and_end_args(self, ds_with_vals,

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -576,7 +576,7 @@ class TestGetData:
     @pytest.fixture(scope='class', autouse=True)
     def ds_with_vals(self):
         """
-        This fixture creates a DataSet with value that is to be used by all
+        This fixture creates a DataSet with values that is to be used by all
         the tests in this class
         """
         with tempfile.TemporaryDirectory() as tmpdirname:
@@ -602,7 +602,7 @@ class TestGetData:
     @pytest.mark.parametrize(
         ("start", "end", "expected"),
         [
-            # sanity check
+            # test without start and end
             (None, None, xdata),
 
             # test for start only

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -623,12 +623,12 @@ class TestGetData:
 
             # test for start and end
             (0, 0, []),
-            pytest.param(1, 1, xdata[1-1], marks=xfail(
+            pytest.param(1, 1, [xdata[1-1]], marks=xfail(
                 reason="Now returns `[]`")),
             (2, 1, []),
             (2, 0, []),
             (1, 0, []),
-            pytest.param(n_vals, n_vals, xdata[n_vals-1], marks=xfail(
+            pytest.param(n_vals, n_vals, [xdata[n_vals-1]], marks=xfail(
                 reason="Should not exclude start, now returns `[]`")),
             (n_vals, n_vals - 1, []),
             pytest.param(2, 4, xdata[(2-1):4], marks=xfail(


### PR DESCRIPTION
Fixes #1384.

There are two bugs in the underlying `get_data` function of `sqlite_base.py`:
* `0` are treated as `None`
* sql query has a typo in the `where` clause for `start` for the case where both `start` and `end` are not `None`

This PR fixes both. 

Note that the current behavior suggests a `1`-based indexing (unlike python `0`-based), with both `start` and `end` indexes being _included_ into retuned data. This behavior is captured by the test suite.

Ideally, the very same test should be done for `get_data` from `sqlite_base.py` but did not make it to this PR in order to avoid code duplication.

Note that `get_data` from `sqlite_base.py` was also refactored to reduce the possibility for bugs like the ones mentioned above. In case it made the function less readable, the refactoring can be reverted.