### PR TITLE
Fix unclarity about post_delay/inter_delay of Parameter, remove deprecated get/set delay and get/set step

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -462,7 +462,7 @@ class _BaseParameter(Metadatable):
                     t_elapsed = time.perf_counter() - self._t_last_set
                     if t_elapsed < self.inter_delay:
                         # Sleep until time since last set is larger than
-                        # self.post_delay
+                        # self.inter_delay
                         time.sleep(self.inter_delay - t_elapsed)
 
                     # Start timer to measure execution time of set_function
@@ -606,22 +606,26 @@ class _BaseParameter(Metadatable):
 
     @property
     def post_delay(self):
-        """Property that returns the delay time of this parameter"""
+        """Delay time after *start* of set operation, for each set"""
         return self._post_delay
 
     @post_delay.setter
     def post_delay(self, post_delay):
         """
-        Configure this parameter with a delay between set operations.
+        Configure this parameter with a delay after the *start* of every set
+        operation.
 
-        Typically used in conjunction with set_step to create an effective
-        ramp rate, but can also be used without a step to enforce a delay
-        after every set.
+        Typically used in conjunction with `step` to create an effective
+        ramp rate, but can also be used without a `step` to enforce a delay
+        *after* every set. One might think of post_delay as how long a set
+        operation is supposed to take. For example, there might be an
+        instrument that needs extra time after setting a parameter although
+        the command for setting the parameter returns quickly.
 
         Args:
-            post_delay(Union[int, float]): the target time between set calls.
-                The actual time will not be shorter than this, but may be longer
-                if the underlying set call takes longer.
+            post_delay(Union[int, float]): the target time after the *start*
+                of a set operation. The actual time will not be shorter than
+                this, but may be longer if the underlying set call takes longer.
 
         Raises:
             TypeError: If delay is not int nor float
@@ -637,7 +641,7 @@ class _BaseParameter(Metadatable):
 
     @property
     def inter_delay(self):
-        """Property that returns the delay time of this parameter"""
+        """Delay time between consecutive set operations"""
         return self._inter_delay
 
     @inter_delay.setter
@@ -645,12 +649,12 @@ class _BaseParameter(Metadatable):
         """
         Configure this parameter with a delay between set operations.
 
-        Typically used in conjunction with set_step to create an effective
-        ramp rate, but can also be used without a step to enforce a delay
-        between sets.
+        Typically used in conjunction with `step` to create an effective
+        ramp rate, but can also be used without a `step` to enforce a delay
+        *between* sets.
 
         Args:
-            inter_delay(Union[int, float]): the target time between set calls.
+            inter_delay(Union[int, float]): the minimum time between set calls.
                 The actual time will not be shorter than this, but may be longer
                 if the underlying set call takes longer.
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -580,18 +580,6 @@ class _BaseParameter(Metadatable):
         else:
             self._step = step
 
-    def set_step(self, value):
-        warnings.warn(
-            "set_step is deprecated use step property as in `inst.step = "
-            "stepvalue` instead")
-        self.step = value
-
-    def get_step(self):
-        warnings.warn(
-            "set_step is deprecated use step property as in `a = inst.step` "
-            "instead")
-        return self._step
-
     @property
     def post_delay(self):
         """Delay time after *start* of set operation, for each set"""

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -592,18 +592,6 @@ class _BaseParameter(Metadatable):
             "instead")
         return self._step
 
-    def set_delay(self, value):
-        warnings.warn(
-            "set_delay is deprecated use inter_delay or post_delay property "
-            "as in `inst.inter_delay = delayvalue` instead")
-        self.post_delay = value
-
-    def get_delay(self):
-        warnings.warn(
-            "get_delay is deprecated use inter_delay or post_delay property "
-            "as in `a = inst.inter_delay` instead")
-        return self._post_delay
-
     @property
     def post_delay(self):
         """Delay time after *start* of set operation, for each set"""

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -200,7 +200,7 @@ class _BaseParameter(Metadatable):
                  snapshot_value: bool=True,
                  max_val_age: Optional[float]=None,
                  vals: Optional[Validator]=None,
-                 delay: Optional[Union[int, float]]=None) -> None:
+                 **kwargs) -> None:
         super().__init__(metadata)
         if not str(name).isidentifier():
             raise ValueError(f"Parameter name must be a valid identifier "
@@ -223,11 +223,7 @@ class _BaseParameter(Metadatable):
         self.scale = scale
         self.offset = offset
         self.raw_value = None
-        if delay is not None:
-            warnings.warn("Delay kwarg is deprecated. Replace with "
-                          "inter_delay or post_delay as needed")
-            if post_delay == 0:
-                post_delay = delay
+
         self.inter_delay = inter_delay
         self.post_delay = post_delay
 


### PR DESCRIPTION
`Parameter`'s `post_delay` and `inter_delay` properties have confusing descriptions. This PR addresses this.

Also remove deprecated `get_delay`, `set_delay`, `get_step`, `set_step`. Make `delay` kwarg a noop.

Discovered by @damazter 