### PR TITLE
feat: add specs for model '33512B' in KeysightAgilent_33XXX

### DIFF
--- a/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -298,12 +298,14 @@ class WaveformGenerator_33XXX(VisaInstrument):
         no_of_channels = {'33210A': 1,
                           '33250A': 1,
                           '33511B': 1,
+                          '33512B': 2,
                           '33522B': 2,
                           '33622A': 2
                           }
 
         self._max_freqs = {'33210A': 10e6,
                            '33511B': 20e6,
+                           '33512B': 20e6,
                            '33250A': 80e6,
                            '33522B': 30e6,
                            '33622A': 120e6}


### PR DESCRIPTION
Extends Qcodes/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py

Changes proposed in this pull request:
- Add support for model 33512B by adding its specs to `no_of_channels `and `self._max_freqs` dictionaries

@jenshnielsen @WilliamHPNielsen 
