### PR TITLE
Build docs with sphinx 1.8.3

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx==1.7.9
+sphinx==1.8.3
 sphinx_rtd_theme
 sphinx-jsonschema
 nbsphinx


### PR DESCRIPTION
The bug causing #1268 has been resolved so lets try building the docs with Sphinx 1.8.3