### PR TITLE
Use getattr to get ask/write from instruments

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -520,9 +520,8 @@ class _BaseParameter(Metadatable):
                 # isn't, even though it's valid.
                 # probably MultiType with a mix of numeric and non-numeric types
                 # just set the endpoint and move on
-                logging.warning(
-                    'cannot sweep {} from {} to {} - jumping.'.format(
-                        self.name, start_value, value))
+                logging.warning('cannot sweep %s from %r to %r - jumping.',
+                                self.name, start_value, value)
                 return []
 
             # drop the initial value, we're already there
@@ -851,7 +850,7 @@ class Parameter(_BaseParameter):
                                       'when max_val_age is set')
                 self.get_raw = lambda: self._latest['raw_value']
             else:
-                exec_str_ask = instrument.ask if instrument else None
+                exec_str_ask = getattr(instrument, "ask", None) if instrument else None
                 self.get_raw = Command(arg_count=0, cmd=get_cmd, exec_str=exec_str_ask)
             self.get = self._wrap_get(self.get_raw)
 
@@ -859,7 +858,7 @@ class Parameter(_BaseParameter):
             if set_cmd is None:
                 self.set_raw = partial(self._save_val, validate=False)# type: Callable
             else:
-                exec_str_write = instrument.write if instrument else None
+                exec_str_write = getattr(instrument, "write", None) if instrument else None
                 self.set_raw = Command(arg_count=1, cmd=set_cmd, exec_str=exec_str_write)# type: Callable
             self.set = self._wrap_set(self.set_raw)
 
@@ -1593,10 +1592,10 @@ class StandardParameter(Parameter):
                  delay=0, max_delay=None, step=None, max_val_age=3600,
                  vals=None, val_mapping=None, **kwargs):
         super().__init__(name, instrument=instrument,
-                 get_cmd=get_cmd, get_parser=get_parser,
-                 set_cmd=set_cmd, set_parser=set_parser,
-                 post_delay=delay, step=step, max_val_age=max_val_age,
-                 vals=vals, val_mapping=val_mapping, **kwargs)
+                         get_cmd=get_cmd, get_parser=get_parser,
+                         set_cmd=set_cmd, set_parser=set_parser,
+                         post_delay=delay, step=step, max_val_age=max_val_age,
+                         vals=vals, val_mapping=val_mapping, **kwargs)
         warnings.warn('`StandardParameter` is deprecated, '
                         'use `Parameter` instead. {}'.format(self))
 

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -4,7 +4,7 @@ import logging
 
 import numpy as np
 
-from qcodes.instrument.base import Instrument
+from qcodes.instrument.base import Instrument, InstrumentBase
 from qcodes.utils.validators import Numbers
 from qcodes.instrument.parameter import MultiParameter, Parameter, ArrayParameter
 from qcodes.instrument.channel import InstrumentChannel, ChannelList
@@ -56,25 +56,31 @@ class MockParabola(Instrument):
         Adds an -x term to add a corelation between the parameters.
         '''
         return ((self.x.get()**2 + self.y.get()**2 +
-                self.z.get()**2)*(1 + abs(self.y.get()-self.x.get())) +
-                self.noise.get()*np.random.rand(1))
+                 self.z.get()**2)*(1 + abs(self.y.get()-self.x.get())) +
+                 self.noise.get()*np.random.rand(1))
 
 
-class MockMetaParabola(Instrument):
+class MockMetaParabola(InstrumentBase):
     '''
     Test for a meta instrument, has a tunable gain knob
+
+    Unlike a MockParabola, a MockMetaParabola does not have a connection, or
+    access to ask_raw/write_raw, i.e. it would not be connected to a real instrument.
+
+    It is also not tracked in the global _all_instruments list, but is still
+    snapshottable in a station.
     '''
 
     def __init__(self, name, mock_parabola_inst, **kw):
+        """
+        Create a new MockMetaParabola, connected to an existing MockParabola instance.
+        """
         super().__init__(name, **kw)
         self.mock_parabola_inst = mock_parabola_inst
 
         # Instrument parameters
         for parname in ['x', 'y', 'z']:
-            self.add_parameter(parname, unit='a.u.',
-                               parameter_class=Parameter,
-                               vals=Numbers(), initial_value=0,
-                               get_cmd=None, set_cmd=None)
+            self.parameters[parname] = getattr(mock_parabola_inst, parname)
         self.add_parameter('gain', parameter_class=Parameter,
                            initial_value=1,
                            get_cmd=None, set_cmd=None)
@@ -95,7 +101,7 @@ class MockMetaParabola(Instrument):
 
 class DummyInstrument(Instrument):
 
-    def __init__(self, name='dummy', gates=['dac1', 'dac2', 'dac3'], **kwargs):
+    def __init__(self, name='dummy', gates=('dac1', 'dac2', 'dac3'), **kwargs):
 
         """
         Create a dummy instrument that can be used for testing

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -259,6 +259,12 @@ class TestParameter(TestCase):
         p(44.5)
         self.assertListEqual(p.set_values, [42, 43, 44, 44.5])
 
+        # Test error conditions
+        with self.assertLogs(level='WARN'):
+            self.assertEqual(p.get_ramp_values("A", 1), [])
+        with self.assertRaises(RuntimeError):
+            p.get_ramp_values((1, 2, 3), 1)
+
     def test_scale_raw_value(self):
         p = Parameter(name='test_scale_raw_value', set_cmd=None)
         p(42)


### PR DESCRIPTION
This allows us to use InstrumentBase as the base class for virtual instruments

Fixes #1450.

Changes proposed in this pull request:
- Use getattr to get ask/write from instruments

@jenshnielsen @astafan8 
