### PR TITLE
Metadatable should accept extra kwargs

### DIFF
--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -22,7 +22,7 @@ ParameterDict = Dict[ParameterKey, T]
 RunId = NewType('RunId', int)
 
 class Metadatable:
-    def __init__(self, metadata=None):
+    def __init__(self, metadata=None, **kwargs):
         self.metadata = {}
         self.load_metadata(metadata or {})
 


### PR DESCRIPTION
Several subclasses of Metadatable accept extra (keyword)arguments.
Through this it can happen that extra arguments are handed up the
hierarchy to Metadatable. This is why Metadatable should accept extra
kwargs.


Changes proposed in this pull request:
- Adds `**kwargs` argument to `Metadatable.__init__`



@jenshnielsen @astafan8 
