### PR TITLE
Fix typechecking with mypy=0.670

### DIFF
--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -89,7 +89,7 @@ def get_level_code(level: Union[str, int]) -> int:
         # bug:
         # >>> import logging
         # >>> print(logging.getLevelName('DEBUG'))
-        return logging.getLevelName(level)  # type: ignore
+        return logging.getLevelName(level)
     else:
         raise RuntimeError('get_level_code: '
                            f'Cannot to convert level {level} of type '

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ pytest-cov
 pytest
 codacy-coverage
 hypothesis!=3.69.11 # due to bug in log capture
-mypy>=0.630
+mypy==0.670
 git+https://github.com/QCoDeS/pyvisa-sim.git
 lxml
 codecov


### PR DESCRIPTION
To avoid failures in the future this locks mypy to version 0.670. If we go down this route someone should remember to regularly update our dependency on mypy 
