### PR TITLE
Add simultaneous blocking ramp parameters MercuryIPS

### DIFF
--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -284,7 +284,7 @@ class MercuryiPS(VisaInstrument):
             self.add_parameter(name=f'{coord}_ramp',
                                label=f'{coord.upper()} ramp field',
                                unit=unit,
-                               docstring='A safe ramp for each coordinate'
+                               docstring='A safe ramp for each coordinate',
                                get_cmd=partial(self._get_component, coord),
                                set_cmd=lambda x, y=coord:
                                             (self._set_target(y, x),
@@ -295,11 +295,11 @@ class MercuryiPS(VisaInstrument):
                                    label=f'{coord.upper()} ramp field',
                                    unit=unit,
                                    docstring='A simultaneous ramp for a combined'
-                                                'coordinate'
+                                                'coordinate',
                                    get_cmd=partial(self._get_component, coord),
                                    set_cmd=lambda x, y=coord: 
                                                 (self._set_target(y, x),
-                                                 self.ramp('simul')))
+                                                 self.ramp('simul_block')))
 
         # FieldVector-valued parameters #
 

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -280,19 +280,26 @@ class MercuryiPS(VisaInstrument):
                                unit=unit,
                                get_cmd=partial(self._get_measured, [coord]))
 
-            self.add_parameter(name=f'{coord}_saferamp',
-                               label=f'{coord.upper()} ramp field',
-                               unit=unit,
-                               get_cmd=partial(self._get_component, coord),
-                               set_cmd=lambda x, y=coord: (self._set_target(y, x),
-                                                           self.ramp('safe')))
 
-            self.add_parameter(name=f'{coord}_simulramp',
+            self.add_parameter(name=f'{coord}_ramp',
                                label=f'{coord.upper()} ramp field',
                                unit=unit,
+                               docstring='A safe ramp for each coordinate'
                                get_cmd=partial(self._get_component, coord),
-                               set_cmd=lambda x, y=coord: (self._set_target(y, x),
-                                                           self.ramp('simul')))
+                               set_cmd=lambda x, y=coord:
+                                            (self._set_target(y, x),
+                                             self.ramp('safe')))
+            
+            if coord in ['r', 'theta', 'phi', 'rho']:
+                self.add_parameter(name=f'{coord}_simulramp',
+                                   label=f'{coord.upper()} ramp field',
+                                   unit=unit,
+                                   docstring='A simultaneous ramp for a combined'
+                                                'coordinate'
+                                   get_cmd=partial(self._get_component, coord),
+                                   set_cmd=lambda x, y=coord: 
+                                                (self._set_target(y, x),
+                                                 self.ramp('simul')))
 
         # FieldVector-valued parameters #
 

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -280,26 +280,25 @@ class MercuryiPS(VisaInstrument):
                                unit=unit,
                                get_cmd=partial(self._get_measured, [coord]))
 
-
             self.add_parameter(name=f'{coord}_ramp',
                                label=f'{coord.upper()} ramp field',
                                unit=unit,
                                docstring='A safe ramp for each coordinate',
                                get_cmd=partial(self._get_component, coord),
-                               set_cmd=lambda x, y=coord:
-                                            (self._set_target(y, x),
-                                             self.ramp('safe')))
+                               set_cmd=partial(self._set_target_and_ramp, 
+                                               coordinate=coord, 
+                                               mode='safe'))
             
             if coord in ['r', 'theta', 'phi', 'rho']:
                 self.add_parameter(name=f'{coord}_simulramp',
                                    label=f'{coord.upper()} ramp field',
                                    unit=unit,
-                                   docstring='A simultaneous ramp for a combined'
-                                                'coordinate',
+                                   docstring='A simultaneous blocking ramp for a '
+                                             'combined coordinate',
                                    get_cmd=partial(self._get_component, coord),
-                                   set_cmd=lambda x, y=coord: 
-                                                (self._set_target(y, x),
-                                                 self.ramp('simul_block')))
+                                   set_cmd=partial(self._set_target_and_ramp, 
+                                                   coordinate=coord, 
+                                                   mode='simul_block'))
 
         # FieldVector-valued parameters #
 
@@ -522,6 +521,11 @@ class MercuryiPS(VisaInstrument):
         'safe': self._ramp_safely,
         'simul_block':self._ramp_simultaneously_blocking}[mode]()
 
+    def _set_target_and_ramp(self, coordinate: str, mode: str, target: float) -> None:
+        """Convenient method to combine setting target and ramping"""
+        self._set_target(coordinate, target)
+        self.ramp(mode)
+    
     def ask(self, cmd: str) -> str:
         """
         Since Oxford Instruments implement their own version of a SCPI-like

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -419,7 +419,7 @@ class MercuryiPS(VisaInstrument):
         self._ramp_simultaneously()
 
         for slave in self.submodules.values():
-            # wait for the ramp to finish, we don't car about the order
+            # wait for the ramp to finish, we don't care about the order
             while slave.ramp_status() == 'TO SET':
                 time.sleep(0.1)
 

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -286,8 +286,7 @@ class MercuryiPS(VisaInstrument):
                                docstring='A safe ramp for each coordinate',
                                get_cmd=partial(self._get_component, coord),
                                set_cmd=partial(self._set_target_and_ramp, 
-                                               coordinate=coord, 
-                                               mode='safe'))
+                                               coord, 'safe'))
             
             if coord in ['r', 'theta', 'phi', 'rho']:
                 self.add_parameter(name=f'{coord}_simulramp',
@@ -297,8 +296,7 @@ class MercuryiPS(VisaInstrument):
                                              'combined coordinate',
                                    get_cmd=partial(self._get_component, coord),
                                    set_cmd=partial(self._set_target_and_ramp, 
-                                                   coordinate=coord, 
-                                                   mode='simul_block'))
+                                                   coord, 'simul_block'))
 
         # FieldVector-valued parameters #
 


### PR DESCRIPTION
Added additional parameters to oxford\MercuryIPS_VISA.py allowing the magnet to be set and ramped with a single call. This is useful when running in a loop.

@WilliamHPNielsen 