### PR TITLE
[wip] [discussion] Dev/move deps to interdependencies

### DIFF
--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -1,8 +1,8 @@
 from typing import Dict, Any, Tuple, Sequence
 
-from qcodes.dataset.param_spec import ParamSpec
+from qcodes.dataset.param_spec import ParamSpecBase, ParamSpec
 
-ParamSpecTree = Dict[ParamSpec, Tuple[ParamSpec, ...]]
+ParamSpecTree = Dict[ParamSpecBase, Tuple[ParamSpecBase, ...]]
 
 
 class InterDependencies_:
@@ -21,7 +21,7 @@ class InterDependencies_:
     def __init__(self,
                  dependencies: ParamSpecTree = {},
                  inferences: ParamSpecTree = {},
-                 standalones: Tuple[ParamSpec, ...] = ()):
+                 standalones: Tuple[ParamSpecBase, ...] = ()):
 
         deps_code = self.validate_paramspectree(dependencies)
         if not deps_code == 0:
@@ -34,7 +34,7 @@ class InterDependencies_:
             raise ValueError('Invalid inferences') from e
 
         for ps in standalones:
-            if not isinstance(ps, ParamSpec):
+            if not isinstance(ps, ParamSpecBase):
                 e = TypeError('Standalones must be a sequence of ParamSpecs')
                 raise ValueError('Invalid standalones') from e
 
@@ -66,12 +66,12 @@ class InterDependencies_:
             return 1
 
         for key, values in paramspectree.items():
-            if not isinstance(key, ParamSpec):
+            if not isinstance(key, ParamSpecBase):
                 return 2
             if not isinstance(values, tuple):
                 return 3
             for value in values:
-                if not isinstance(value, ParamSpec):
+                if not isinstance(value, ParamSpecBase):
                     return 4
 
         # check for cycles

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -1,6 +1,88 @@
-from typing import Dict, Any
+from typing import Dict, Any, Tuple, Sequence
 
 from qcodes.dataset.param_spec import ParamSpec
+
+ParamSpecTree = Dict[ParamSpec, Tuple[ParamSpec, ...]]
+
+
+class InterDependencies_:
+    """
+    Object containing a group of ParamSpecs and the information about their
+    internal relations to each other
+    """
+
+    error_codes = {1: TypeError('ParamSpecTree must be a dict'),
+                   2: TypeError('ParamSpecTree must have ParamSpecs as keys'),
+                   3: TypeError('ParamSpecTree must have tuple values'),
+                   4: TypeError('ParamSpecTree can only have tuples of '
+                                'ParamSpecs as values'),
+                   5: ValueError('ParamSpecTree can not have cycles')}
+
+    def __init__(self,
+                 dependencies: ParamSpecTree = {},
+                 inferences: ParamSpecTree = {},
+                 standalones: Tuple[ParamSpec, ...] = ()):
+
+        deps_code = self.validate_paramspectree(dependencies)
+        if not deps_code == 0:
+            e = self.error_codes[deps_code]
+            raise ValueError('Invalid dependencies') from e
+
+        inffs_code = self.validate_paramspectree(inferences)
+        if not inffs_code == 0:
+            e = self.error_codes[inffs_code]
+            raise ValueError('Invalid inferences') from e
+
+        for ps in standalones:
+            if not isinstance(ps, ParamSpec):
+                e = TypeError('Standalones must be a sequence of ParamSpecs')
+                raise ValueError('Invalid standalones') from e
+
+        self.dependencies = dependencies
+        self.inferences = inferences
+        self.standalones = standalones
+
+    @staticmethod
+    def validate_paramspectree(paramspectree: ParamSpecTree) -> int:
+        """
+        Validate a ParamSpecTree. Apart from adhering to the type, a
+        ParamSpecTree must not have any cycles.
+
+        Returns:
+            An error code describing what is wrong with the tree (or 0, if the
+            tree is valid).
+            1: The passed tree is not a dict
+            2: The dict's keys are not all ParamSpecs
+            3: The dict's values are not all tuples
+            4: The dict's values are tuples containing something that
+            is not a ParamSpec
+            5: There is at least one ParamSpec that is present as a key and
+            inside a value (i.e there is a cycle in the tree)
+        """
+
+        # Validate the type
+
+        if not isinstance(paramspectree, dict):
+            return 1
+
+        for key, values in paramspectree.items():
+            if not isinstance(key, ParamSpec):
+                return 2
+            if not isinstance(values, tuple):
+                return 3
+            for value in values:
+                if not isinstance(value, ParamSpec):
+                    return 4
+
+        # check for cycles
+
+        roots = set(paramspectree.keys())
+        leafs = set(ps for tup in paramspectree.items() for ps in tup)
+
+        if roots.intersection(leafs) != set():
+            return 5
+
+        return 0
 
 
 class InterDependencies:

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Tuple, Sequence
+from typing import Dict, Any, Tuple, Sequence, Optional
 
 from qcodes.dataset.param_spec import ParamSpecBase, ParamSpec
 
@@ -19,9 +19,12 @@ class InterDependencies_:
                    5: ValueError('ParamSpecTree can not have cycles')}
 
     def __init__(self,
-                 dependencies: ParamSpecTree = {},
-                 inferences: ParamSpecTree = {},
+                 dependencies: Optional[ParamSpecTree] = None,
+                 inferences: Optional[ParamSpecTree] = None,
                  standalones: Tuple[ParamSpecBase, ...] = ()):
+
+        dependencies = dependencies or {}
+        inferences = inferences or {}
 
         deps_code = self.validate_paramspectree(dependencies)
         if not deps_code == 0:

--- a/qcodes/dataset/param_spec.py
+++ b/qcodes/dataset/param_spec.py
@@ -1,4 +1,4 @@
-from typing import Union, Sequence, List, Dict, Any
+from typing import Union, Sequence, List, Dict, Any, Optional
 from copy import deepcopy
 
 
@@ -6,7 +6,11 @@ class ParamSpecBase:
 
     allowed_types = ['array', 'numeric', 'text']
 
-    def __init__(self, name: str, paramtype: str, label: str='', unit: str=''):
+    def __init__(self,
+                 name: str,
+                 paramtype: str,
+                 label: Optional[str] = None,
+                 unit: Optional[str] = None):
         """
         Args:
             name: name of the parameter
@@ -28,8 +32,8 @@ class ParamSpecBase:
 
         self.name = name
         self.type = paramtype.lower()
-        self.label = label
-        self.unit = unit
+        self.label = label or ''
+        self.unit = unit or ''
 
     def sql_repr(self):
         return f"{self.name} {self.type}"
@@ -98,8 +102,8 @@ class ParamSpec(ParamSpecBase):
 
     def __init__(self, name: str,
                  paramtype: str,
-                 label: str='',
-                 unit: str='',
+                 label: Optional[str]=None,
+                 unit: Optional[str]=None,
                  inferred_from: Sequence[Union['ParamSpec', str]]=None,
                  depends_on: Sequence[Union['ParamSpec', str]]=None,
                  **metadata) -> None:

--- a/qcodes/tests/dataset/test_dependencies.py
+++ b/qcodes/tests/dataset/test_dependencies.py
@@ -1,7 +1,18 @@
 import pytest
 
-from qcodes.dataset.dependencies import InterDependencies
-from qcodes.dataset.param_spec import ParamSpec
+from qcodes.dataset.dependencies import (InterDependencies,
+                                         InterDependencies_)
+from qcodes.dataset.param_spec import ParamSpec, ParamSpecBase
+from qcodes.tests.common import error_caused_by
+
+
+@pytest.fixture
+def some_paramspecbases():
+
+    psb1 = ParamSpecBase('psb1', paramtype='text', label='blah', unit='')
+    psb2 = ParamSpecBase('psb2', paramtype='array', label='', unit='V')
+
+    return (psb1, psb2)
 
 
 def test_wrong_input_raises():
@@ -12,3 +23,39 @@ def test_wrong_input_raises():
 
         with pytest.raises(ValueError):
             InterDependencies(pspecs)
+
+
+def test_init_validation_raises(some_paramspecbases):
+
+    (ps1, ps2) = some_paramspecbases
+
+    invalid_trees = ([ps1, ps2],
+                     {'ps1': 'ps2'},
+                     {ps1: 'ps2'},
+                     {ps1: ('ps2',)},
+                     {ps1: (ps2,), ps2: (ps1,)}
+                     )
+    causes = ("ParamSpecTree must be a dict",
+              "ParamSpecTree must have ParamSpecs as keys",
+              "ParamSpecTree must have tuple values",
+              "ParamSpecTree can only have tuples "
+              "of ParamSpecs as values",
+              "ParamSpecTree can not have cycles")
+
+    for tree, cause in zip(invalid_trees, causes):
+        with pytest.raises(ValueError, match='Invalid dependencies') as ei:
+            InterDependencies_(dependencies=tree, inferences={})
+
+        assert error_caused_by(ei, cause=cause)
+
+    for tree, cause in zip(invalid_trees, causes):
+        with pytest.raises(ValueError, match='Invalid inferences') as ei:
+            InterDependencies_(dependencies={}, inferences=tree)
+
+        assert error_caused_by(ei, cause=cause)
+
+    with pytest.raises(ValueError, match='Invalid standalones') as ei:
+        InterDependencies_(standalones=('ps1', 'ps2'))
+
+    assert error_caused_by(ei, cause='Standalones must be a sequence of '
+                                     'ParamSpecs')


### PR DESCRIPTION
This PR may replace #1438 

The idea is to move all information about how parameters are related to each other into a new `InterDependencies` object and thus out of the the `ParamSpec`.

Changes proposed in this pull request:
- Make `ParamSpec` only have four attributes: name, datatype, label, unit
- Make `InterDependencies` take three input arguments: dependencies, inferences, and standalones
- Make the type of those arguments do most of the validation (nice, huh?)

All validation takes place upon instantiating an `InterDependencies` object, i.e. if it exists, it is valid.

You can get an impression of how this will work by looking at the `ParamSpecBase` and the `InterDependencies_` objects of this PR. If you like it, we can begin to discuss how to proceed with rolling this out, deprecating old things etc. I have a plan for that, but let's first decide whether we like this design.

Open questions:

- [ ] How should the new `InterDependencies` object serialize itself? Do we need a DB upgrade?
- [ ] Are the rules imposed by `InterDependencies_` for how parameters may relate to each other the correct rules. I _think_ they are, but I'd like your input on that.


@QCoDeS/core 

AB#2861
