### PR TITLE
Use modern way of activating conda env on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,9 +18,9 @@ jobs:
           conda init cmd.exe powershell
         displayName: "Conda setup"
       - script: |
-          CALL C:\Miniconda\condabin\conda_hook.bat
           conda --version
           conda env create --file environment.yml
+          CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
           pip install -r test_requirements.txt
           pip install -r docs_requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,18 +15,18 @@ jobs:
         displayName: "Add conda to PATH"
       - script: |
           conda update -n base conda
-          conda init cmd.exe
+          conda init cmd.exe powershell
         displayName: "Conda setup"
       - script: |
           conda --version
           conda env create --file environment.yml
-          CALL activate qcodes
+          CALL conda activate qcodes
           pip install -r test_requirements.txt
           pip install -r docs_requirements.txt
           pip install -e .
         displayName: "Installation"
       - script: |
-          CALL activate qcodes
+          CALL conda activate qcodes
           mypy qcodes
         displayName: "mypy"
       - script: |
@@ -40,7 +40,7 @@ jobs:
           python generate_version_3.py
         displayName: "Generate db fixtures"
       - script: |
-          CALL activate qcodes
+          CALL conda activate qcodes
           cd qcodes
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-report=html --cov-config=.coveragerc
         displayName: "Pytest"
@@ -50,7 +50,7 @@ jobs:
           testResultsFiles: 'qcodes\test-*.xml'
           testRunTitle: 'Publish test results'
       - script: |
-          CALL activate qcodes
+          CALL conda activate qcodes
           cd docs
           REM Turn warnings into errors
           set SPHINXOPTS=-W -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,7 @@ jobs:
           python generate_version_3.py
         displayName: "Generate db fixtures"
       - script: |
+          CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
           cd qcodes
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-report=html --cov-config=.coveragerc
@@ -53,6 +54,7 @@ jobs:
           testResultsFiles: 'qcodes\test-*.xml'
           testRunTitle: 'Publish test results'
       - script: |
+          CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
           cd docs
           REM Turn warnings into errors

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ jobs:
         displayName: "Conda setup"
       - script: |
           CALL C:\Miniconda\condabin\conda_hook.bat
-          conda --version
+          CALL conda --version
           conda env create --file environment.yml
           CALL conda activate qcodes
           pip install -r test_requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ jobs:
           conda init cmd.exe powershell
         displayName: "Conda setup"
       - script: |
+          CALL C:\Miniconda\condabin\conda_hook.bat
           conda --version
           conda env create --file environment.yml
           CALL conda activate qcodes
@@ -26,11 +27,13 @@ jobs:
           pip install -e .
         displayName: "Installation"
       - script: |
+          CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
           mypy qcodes
         displayName: "mypy"
       - script: |
-          CALL activate qcodes
+          CALL C:\Miniconda\condabin\conda_hook.bat
+          CALL conda activate qcodes
           cd ..
           git clone https://github.com/QCoDeS/qcodes_generate_test_db.git
           cd qcodes_generate_test_db

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       - script: |
           CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda --version
-          conda env create --file environment.yml
+          CALL conda env create --file environment.yml
           CALL conda activate qcodes
           pip install -r test_requirements.txt
           pip install -r docs_requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,9 +18,9 @@ jobs:
           conda init cmd.exe powershell
         displayName: "Conda setup"
       - script: |
+          CALL C:\Miniconda\condabin\conda_hook.bat
           conda --version
           conda env create --file environment.yml
-          CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
           pip install -r test_requirements.txt
           pip install -r docs_requirements.txt


### PR DESCRIPTION
It seems like the `conda_hook` script is not being run correctly so we need to run it at each iteration before we are able to run `conda activate qcodes` this is arguably uglier than the original deprecated activation.

Furthermore it seems that conda then is a batch script so we need to add CALL in front of every invocation of conda to prevent it terminating the script early (at exit of conda)