### PR TITLE
docs fix restructured text syntax.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -386,7 +386,7 @@ if any([re.match("\s*api\s*", l) for l in index_rst_lines]):
 # there when generating the docs
 autodoc_mock_imports = ['pyspcm', 'zhinst', 'zhinst.utils',
                         'keysightSD1', 'cffi', 'spirack', 'clr', 'win32com',
-                        'win32com.client', 'pythoncom']
+                        'win32com.client', 'pythoncom', 'slacker']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx==1.8.3
+sphinx==1.8.4
 sphinx_rtd_theme
 sphinx-jsonschema
 nbsphinx

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -20,6 +20,7 @@ def flatten_1D_data_for_plot(rawdata: Sequence[Sequence[Any]]) -> np.ndarray:
 
     Returns:
         A one-dimensional numpy array
+
     """
     dataarray = np.array(rawdata)
     shape = np.shape(dataarray)
@@ -38,6 +39,8 @@ def get_data_by_id(run_id: int) -> List:
 
     Returns:
         a list of lists of dictionaries like this:
+
+    ::
 
         [
           # each element in this list refers
@@ -59,6 +62,7 @@ def get_data_by_id(run_id: int) -> List:
             ],
             ...
         ]
+
     """
 
     data = load_by_id(run_id)

--- a/qcodes/instrument/group_parameter.py
+++ b/qcodes/instrument/group_parameter.py
@@ -7,19 +7,19 @@ from qcodes import Instrument
 
 class GroupParameter(Parameter):
     """
-    Group parameter is a `Parameter` which value can be set or gotten only
-    together with other group parameters. This happens when an instrument
+    Group parameter is a :class:`.Parameter` which value can be set or gotten
+    only together with other group parameters. This happens when an instrument
     has commands which set and get more than one parameter per call.
 
-    The `set_raw` method of a group parameter forwards the call to the
+    The ``set_raw`` method of a group parameter forwards the call to the
     group, and the group then makes sure that the values of other parameters
-    within the group are left unchanged. The `get_raw` method of a group
+    within the group are left unchanged. The ``get_raw`` method of a group
     parameter also forwards the call to the group, and the group makes sure
     that the command output is parsed correctly, and the value of the
     parameter of interest is returned.
 
     After initialization, the group parameters need to be added to a group.
-    See `Group` for more information.
+    See :class:`.Group` for more information.
 
     Args:
         name
@@ -68,7 +68,7 @@ class GroupParameter(Parameter):
 
 class Group:
     """
-    The group combines `GroupParameter`s that are to be gotten or set via the
+    The group combines :class:`.GroupParameter` s that are to be gotten or set via the
     same command. The command has to be a string, for example, a VISA command.
 
     The `Group`'s methods are used within `GroupParameter` in order to
@@ -77,17 +77,18 @@ class Group:
 
     The command used for setting values of parameters has to be a format
     string which contains the names of the parameters the group has been
-    initialized with. For example, if a command has syntax `"CMD a_value,
-    b_value"`, where `'a_value'` and `'b_value'` are values of two parameters
-    with names `"a"` and `"b"`, then the command string has to be "CMD {a},
-    {b}", and the group has to be initialized with two `GroupParameter`s
-    `a_param` and `b_param`, where `a_param.name=="a"` and `b_param.name=="b"`.
+    initialized with. For example, if a command has syntax ``CMD a_value,
+    b_value``, where ``a_value`` and ``b_value`` are values of two parameters
+    with names ``a`` and ``b``, then the command string has to be ``CMD {a},
+    {b}``, and the group has to be initialized with two ``GroupParameter`` s
+    ``a_param`` and ``b_param``, where ``a_param.name=="a"`` and
+    ``b_param.name=="b"``.
 
     Note that by default, it is assumed that the command used for getting
     values returns a comma-separated list of values of parameters, and their
-    order corresponds to the order of `GroupParameter`s in the list that is
-    passed to the `Group`'s constructor. Through keyword arguments of the
-    `Group`'s constructor, it is possible to change the separator, and even
+    order corresponds to the order of ``GroupParameter`` s in the list that is
+    passed to the ``Group``'s constructor. Through keyword arguments of the
+    ``Group``'s constructor, it is possible to change the separator, and even
     the parser of the output of the get command.
 
     The get and set commands are called via the instrument that the first
@@ -95,52 +96,53 @@ class Group:
     group belong to the same instrument.
 
     Example:
-        ```
-        class InstrumentWithGroupParameters(VisaInstrument):
-            def __init__(self, name, address, **kwargs):
-                super().__init__(name, address, **kwargs)
 
-                ...
+        ::
 
-                # Here is how group of group parameters is defined for
-                # a simple case of an example "SGP" command that sets and gets
-                # values of "enabled" and "gain" parameters (it is assumed that
-                # "SGP?" returns the parameter values as comma-separated list
-                # "enabled_value,gain_value")
-                self.add_parameter('enabled',
-                                   label='Enabled',
-                                   val_mapping={True: 1, False: 0},
-                                   parameter_class=GroupParameter)
-                self.add_parameter('gain',
-                                   label='Some gain value',
-                                   get_parser=float,
-                                   parameter_class=GroupParameter)
-                self.output_group = Group([self.enabled, self.gain],
-                                          set_cmd='SGP {enabled}, {gain}',
-                                          get_cmd='SGP?')
+            class InstrumentWithGroupParameters(VisaInstrument):
+                def __init__(self, name, address, **kwargs):
+                    super().__init__(name, address, **kwargs)
 
-                ...
-        ```
+                    ...
+
+                    # Here is how group of group parameters is defined for
+                    # a simple case of an example "SGP" command that sets and gets
+                    # values of "enabled" and "gain" parameters (it is assumed that
+                    # "SGP?" returns the parameter values as comma-separated list
+                    # "enabled_value,gain_value")
+                    self.add_parameter('enabled',
+                                       label='Enabled',
+                                       val_mapping={True: 1, False: 0},
+                                       parameter_class=GroupParameter)
+                    self.add_parameter('gain',
+                                       label='Some gain value',
+                                       get_parser=float,
+                                       parameter_class=GroupParameter)
+                    self.output_group = Group([self.enabled, self.gain],
+                                              set_cmd='SGP {enabled}, {gain}',
+                                              get_cmd='SGP?')
+
+                    ...
 
     Args:
         parameters
             a list of `GroupParameter` instances which have to be gotten and
             set via the same command; the order of parameters in the list
             should correspond to the order of the values returned by the
-            `get_cmd`
+            ``get_cmd``
         set_cmd
             format string of the command that is used for setting the values
-            of the parameters; for example, "CMD {a}, {b}"
+            of the parameters; for example, ``CMD {a}, {b}``
         get_cmd
             string of the command that is used for getting the values of the
-            parameters; for example, "CMD?"
+            parameters; for example, ``CMD?``
         separator
-            a separator that is used when parsing the output of the `get_cmd`
+            a separator that is used when parsing the output of the ``get_cmd``
             in order to obtain the values of the parameters; it is ignored in
-            case a custom `get_parser` is used
+            case a custom ``get_parser`` is used
         get_parser
             a callable with a single string argument that is used to parse
-            the output of the `get_cmd`; the callable has to return a
+            the output of the ``get_cmd``; the callable has to return a
             dictionary where parameter names are keys, and the values are the
             values (as directly obtained from the output of the get command;
             note that parsers within the parameters will take care of
@@ -185,7 +187,7 @@ class Group:
     def set(self, set_parameter: GroupParameter, value: Any):
         """
         Sets the value of the given parameter within a group to the given
-        value by calling the `set_cmd`
+        value by calling the ``set_cmd``
 
         Args:
             set_parameter
@@ -209,7 +211,7 @@ class Group:
     def update(self):
         """
         Update the values of all the parameters within the group by calling
-        the `get_cmd`
+        the ``get_cmd``
         """
         ret = self.get_parser(self.instrument.ask(self.get_cmd))
         for name, p in list(self.parameters.items()):

--- a/qcodes/monitor/monitor.py
+++ b/qcodes/monitor/monitor.py
@@ -10,15 +10,13 @@ Monitor a set of parameters in a background thread
 stream output over websocket
 
 To start monitor, run this file, or if qcodes is installed as a module:
-```
-% python -m qcodes.monitor.monitor
-```
+
+``% python -m qcodes.monitor.monitor``
 
 Add parameters to monitor in your measurement by creating a new monitor with a list
 of parameters to monitor:
-```
-monitor = qcodes.Monitor(param1, param2, param3, ...)
-```
+
+``monitor = qcodes.Monitor(param1, param2, param3, ...)``
 """
 import sys
 import logging

--- a/qcodes/utils/magic.py
+++ b/qcodes/utils/magic.py
@@ -36,40 +36,38 @@ class QCoDeSMagic(Magics):
         Delays can be provided in a loop by adding `-d {delay}` after `for`
 
         The following options can be passed along with the measurement name
-        (e.g. %%measurement -px -d data_name {measurement_name}):
+        (e.g. ``%%measurement -px -d data_name {measurement_name})``::
+
             -p : print transformed code
             -x : Do not execute code
             -d <dataset_name> : Use custom name for dataset
             -l <loop_name> : Use custom name for Loop
 
-        An example for a loop cell is as follows:
+        An example for a loop cell is as follows::
 
-        %%measurement {-options} {measurement_name}
-        for {sweep_vals}:
-            {measure_parameter1}
-            {measure_parameter2}
-            for -d 1 {sweep_vals2}:
-                {measure_parameter3}
+            %%measurement {-options} {measurement_name}
+            for {sweep_vals}:
+                {measure_parameter1}
+                {measure_parameter2}
+                for -d 1 {sweep_vals2}:
+                    {measure_parameter3}
 
-        {Additional code}
-        ```
+            ...
 
-        which will be internally transformed to:
+        which will be internally transformed to::
 
-        ```
-        import qcodes
-        loop = qcodes.Loop({sweep_vals}).each(
-            {measure_parameter1},
-            {measure_parameter2},
-            qcodes.Loop({sweep_vals2}, delay=1).each(
-                {measure_parameter3}))
-        data = loop.get_data_set(name={measurement_name})
+            import qcodes
+            loop = qcodes.Loop({sweep_vals}).each(
+                {measure_parameter1},
+                {measure_parameter2},
+                qcodes.Loop({sweep_vals2}, delay=1).each(
+                    {measure_parameter3}))
+            data = loop.get_data_set(name={measurement_name})
 
-        {Additional code}
-        ```
+            ...
 
-        An explicit example of the line `for {sweep_vals}:` could be
-        `for sweep_parameter.sweep(0, 42, step=1):`
+        An explicit example of the line ``for {sweep_vals}:`` could be
+        ``for sweep_parameter.sweep(0, 42, step=1):``
 
         """
 
@@ -145,6 +143,7 @@ class QCoDeSMagic(Magics):
 def register_magic_class(cls=QCoDeSMagic, magic_commands=True):
     """
     Registers a iPython magic class
+
     Args:
         cls: magic class to register
         magic_commands (List): list of magic commands within the class to

--- a/qcodes/utils/slack.py
+++ b/qcodes/utils/slack.py
@@ -74,9 +74,10 @@ class Slack(threading.Thread):
     When an IM is sent to the Slack bot, it will be processed during the next
     `update()` call (provided the username is registered in the config).
     Standard commands provided to the Slack bot are:
-        plot: Upload latest qcodes plot
-        msmt/measurement: Print information about latest measurement
-        notify finished: Send message once measurement is finished
+
+    - plot: Upload latest qcodes plot
+    - msmt/measurement: Print information about latest measurement
+    - notify finished: Send message once measurement is finished
 
     Custom commands can be added as (cmd, func) key-value pairs to
     `self.commands`. When `cmd` is sent to the bot, `func` is evaluated.
@@ -86,23 +87,27 @@ class Slack(threading.Thread):
     indicates if the task should be removed from the list of tasks.
     A custom task can be added as a (cmd, func) key-value pair  to
     `self.task_commands`.
-    They can then be called through Slack IM via
-        notify/task {cmd} *args: register task with name `cmd` that is
-            performed every time `update()` is called.
+    They can then be called through Slack IM via:
+
+    ``notify/task {cmd} *args:`` register task with name `cmd` that is
+    performed every time `update()` is called.
     """
 
     def __init__(self, interval=3, config=None, auto_start=True, **commands):
         """
         Initializes Slack bot, including auto-updating widget if in notebook
         and using multiprocessing.
+
         Args:
             interval (int): Update interval for widget (must be over 1s).
             config (dict, optional): Config dict
                 If not given, uses qc.config['user']['slack']
                 The config dict must contain the following keys:
-                    'bot_name': Name of the bot
-                    'bot_token': Token from bot (obtained from slack website)
-                    'names': Usernames to periodically check for IM messages
+
+                - 'bot_name': Name of the bot
+                - 'bot_token': Token from bot (obtained from slack website)
+                - 'names': Usernames to periodically check for IM messages
+
             auto_start (Bool=True)
 
         """

--- a/qcodes/utils/zmq_helpers.py
+++ b/qcodes/utils/zmq_helpers.py
@@ -39,6 +39,7 @@ class Publisher(UnboundedPublisher):
     Allows for a publisher that will not use all the memory.
     Tune the timeout and hwm to fit the needs of the situation.
     We start with very permissive defaults:
+
         - 10 seconds linger
         - 2.5 GB cache
 


### PR DESCRIPTION
This fixes a bunch of invalid restructured text in the api documentation.
This is cherry-picked out of #1478 to make that pr smaller since this should be straightforward to review
but does carry the risk of more conflicts. I have made no attempts of improving the language or content. This is purely a rst syntax fix

Edit: I also updated the version of sphinx to the latest bug fix. 