### PR TITLE
Dont upgrade conda

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,6 @@ jobs:
       - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
         displayName: "Add conda to PATH"
       - script: |
-          conda update -n base conda
-          conda init cmd.exe
-        displayName: "Conda setup"
-      - script: |
           conda --version
           conda env create --file environment.yml
           CALL activate qcodes


### PR DESCRIPTION
At the moment it seems like conda 4.6 is very unstable

Hopefully fixes ci builds on Azure

On the other hand there has definitely been issues where an old version of conda has not mixed well with new packages