### PR TITLE
Azure pipeline: independent steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ tmp/
 docs/examples/data/*
 
 .idea/
+.vscode/
 
 # Mac files
 .DS_Store

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,12 @@ jobs:
         inputs:
           testResultsFiles: 'qcodes\test-*.xml'
           testRunTitle: 'Publish test results'
+      - task: PublishCodeCoverageResults@1
+        condition: always() # this step will always run, even if the pipeline is cancelled
+        inputs:
+          codeCoverageTool: Cobertura
+          summaryFileLocation: '$(System.DefaultWorkingDirectory)\qcodes\coverage.xml'
+          reportDirectory: '$(System.DefaultWorkingDirectory)\qcodes\htmlcov'
       - script: |
           CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
@@ -69,8 +75,3 @@ jobs:
           pathtoPublish: 'docs/_build/html'
           artifactName: 'qcodes_docs'
           publishLocation: 'Container'
-      - task: PublishCodeCoverageResults@1
-        inputs:
-          codeCoverageTool: Cobertura
-          summaryFileLocation: '$(System.DefaultWorkingDirectory)\qcodes\coverage.xml'
-          reportDirectory: '$(System.DefaultWorkingDirectory)\qcodes\htmlcov'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,12 +42,14 @@ jobs:
           python generate_version_2.py
           python generate_version_3.py
         displayName: "Generate db fixtures"
+        condition: successOrFailure()
       - script: |
           CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
           cd qcodes
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-report=html --cov-config=.coveragerc
         displayName: "Pytest"
+        condition: successOrFailure()
       - task: PublishTestResults@1
         condition: always() # this step will always run, even if the pipeline is cancelled
         inputs:
@@ -61,6 +63,7 @@ jobs:
           set SPHINXOPTS=-W -v
           make.bat htmlapi
         displayName: "docsbuild"
+        condition: successOrFailure()
       - task: PublishBuildArtifacts@1
         inputs:
           pathtoPublish: 'docs/_build/html'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,12 +51,12 @@ jobs:
         displayName: "Pytest"
         condition: succeededOrFailed()
       - task: PublishTestResults@1
-        condition: always() # this step will always run, even if the pipeline is cancelled
+        condition: succeededOrFailed()
         inputs:
           testResultsFiles: 'qcodes\test-*.xml'
           testRunTitle: 'Publish test results'
       - task: PublishCodeCoverageResults@1
-        condition: always() # this step will always run, even if the pipeline is cancelled
+        condition: succeededOrFailed()
         inputs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)\qcodes\coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
           pip install -r test_requirements.txt
           pip install -r docs_requirements.txt
           pip install -e .
-        displayName: "Installation"
+        displayName: "Install environment, qcodes"
       - script: |
           CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
@@ -48,7 +48,7 @@ jobs:
           CALL conda activate qcodes
           cd qcodes
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-report=html --cov-config=.coveragerc
-        displayName: "Pytest"
+        displayName: "Run pytest"
         condition: succeededOrFailed()
       - task: PublishTestResults@1
         condition: succeededOrFailed()
@@ -56,6 +56,7 @@ jobs:
           testResultsFiles: 'qcodes\test-*.xml'
           testRunTitle: 'Publish test results'
       - task: PublishCodeCoverageResults@1
+        displayName: "Publish code coverage results"
         condition: succeededOrFailed()
         inputs:
           codeCoverageTool: Cobertura
@@ -68,9 +69,10 @@ jobs:
           REM Turn warnings into errors
           set SPHINXOPTS=-W -v
           make.bat htmlapi
-        displayName: "docsbuild"
+        displayName: "Build docs"
         condition: succeededOrFailed()
       - task: PublishBuildArtifacts@1
+        displayName: "Publish build docs to Azure DevOps"
         inputs:
           pathtoPublish: 'docs/_build/html'
           artifactName: 'qcodes_docs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,14 +42,14 @@ jobs:
           python generate_version_2.py
           python generate_version_3.py
         displayName: "Generate db fixtures"
-        condition: successOrFailure()
+        condition: succeededOrFailed()
       - script: |
           CALL C:\Miniconda\condabin\conda_hook.bat
           CALL conda activate qcodes
           cd qcodes
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-report=html --cov-config=.coveragerc
         displayName: "Pytest"
-        condition: successOrFailure()
+        condition: succeededOrFailed()
       - task: PublishTestResults@1
         condition: always() # this step will always run, even if the pipeline is cancelled
         inputs:
@@ -63,7 +63,7 @@ jobs:
           set SPHINXOPTS=-W -v
           make.bat htmlapi
         displayName: "docsbuild"
-        condition: successOrFailure()
+        condition: succeededOrFailed()
       - task: PublishBuildArtifacts@1
         inputs:
           pathtoPublish: 'docs/_build/html'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,7 @@ jobs:
         displayName: "Run pytest"
         condition: succeededOrFailed()
       - task: PublishTestResults@1
+        displayName: "Publish test results"
         condition: succeededOrFailed()
         inputs:
           testResultsFiles: 'qcodes\test-*.xml'

--- a/qcodes/math/field_vector.py
+++ b/qcodes/math/field_vector.py
@@ -39,7 +39,7 @@ class FieldVector(object):
                 (x, y, z) values, (r, theta, phi) values or (phi, rho, z)
                 values for meaningful computation
         """
-        self._x: int = x
+        self._x = x
         self._y = y
         self._z = z
 

--- a/qcodes/math/field_vector.py
+++ b/qcodes/math/field_vector.py
@@ -17,7 +17,7 @@ class FieldVector(object):
     attributes = ["x", "y", "z", "r", "theta", "phi", "rho"]
     repr_format = "cartesian"
 
-    def __init__(self, x: float=None, y=None, z=None, r=None, theta=None, phi=None,
+    def __init__(self, x=None, y=None, z=None, r=None, theta=None, phi=None,
                  rho=None):
         """
         Parameters:

--- a/qcodes/math/field_vector.py
+++ b/qcodes/math/field_vector.py
@@ -17,7 +17,7 @@ class FieldVector(object):
     attributes = ["x", "y", "z", "r", "theta", "phi", "rho"]
     repr_format = "cartesian"
 
-    def __init__(self, x=None, y=None, z=None, r=None, theta=None, phi=None,
+    def __init__(self, x: float=None, y=None, z=None, r=None, theta=None, phi=None,
                  rho=None):
         """
         Parameters:

--- a/qcodes/math/field_vector.py
+++ b/qcodes/math/field_vector.py
@@ -39,7 +39,7 @@ class FieldVector(object):
                 (x, y, z) values, (r, theta, phi) values or (phi, rho, z)
                 values for meaningful computation
         """
-        self._x = x
+        self._x: int = x
         self._y = y
         self._z = z
 


### PR DESCRIPTION
* Run mypy, pytest, db generation, docs build independent of each others success or failure (say, still run pytest if mypy failed)
* publish coverage results after pytest results, not after docs build
* make more steps succeededOrFailed instead of always
* add more display names
* finally ignore .vscode files