### PR TITLE
Remove redundant reshape

### DIFF
--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -259,13 +259,9 @@ class DataSaver:
                     if hasattr(value, '__len__') and not isinstance(value, str):
                         value = cast(Union[Sequence, np.ndarray], value)
                         if isinstance(value, np.ndarray):
-                            # this is significantly faster than atleast_1d
-                            # espcially for non 0D arrays
-                            # because we already know that this is a numpy
-                            # array and just one numpy array. atleast_1d
-                            # performs additional checks.
-                            if value.ndim == 0:
-                                value = value.reshape(1)
+                            # we always want to iterate over a 1d array
+                            # ravel unconditionally returns a 1d representation
+                            # both for >1D arrays and for 0D arrays
                             value = value.ravel()
                         res_dict[param] = value[index]
                     else:


### PR DESCRIPTION
This reshape is redundant since ravel below does the same

The 0D numpy array insertion that needed this is tested by `test_datasaver_unsized_arrays`

