### PR TITLE
Publish docs even if the whole job failed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,6 +74,7 @@ jobs:
         condition: succeededOrFailed()
       - task: PublishBuildArtifacts@1
         displayName: "Publish build docs to Azure DevOps"
+        condition: succeededOrFailed()
         inputs:
           pathtoPublish: 'docs/_build/html'
           artifactName: 'qcodes_docs'


### PR DESCRIPTION
.. useful when docs build is successful but, say, mypy failed.