### PR TITLE
Lakeshore Model 336: make runnable, add minimal test, and fixes along the way

### DIFF
--- a/qcodes/instrument_drivers/Lakeshore/Model_336.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_336.py
@@ -148,6 +148,9 @@ class Model_336(LakeshoreBase):
 
     CHANNEL_CLASS = Model_336_Channel
 
+    input_channel_parameter_values_to_channel_name_on_instrument = \
+        _channel_name_to_command_map
+
     def __init__(self, name: str, address: str, **kwargs) -> None:
         super().__init__(name, address, **kwargs)
 

--- a/qcodes/instrument_drivers/Lakeshore/Model_336.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_336.py
@@ -1,5 +1,5 @@
 import os
-from typing import ClassVar, Dict
+from typing import ClassVar, Dict, Any
 
 from qcodes.instrument.group_parameter import GroupParameter, Group
 from .lakeshore_base import LakeshoreBase, BaseOutput, BaseSensorChannel
@@ -41,17 +41,11 @@ class Output_336_CurrentSource(BaseOutput):
         'medium': 2,
         'high': 3}
 
+    _input_channel_parameter_kwargs = {
+        'val_mapping': _channel_name_to_outmode_command_map}
+
     def __init__(self, parent, output_name, output_index):
         super().__init__(parent, output_name, output_index, has_pid=True)
-
-        # Redefine input_channel to use string names instead of numbers
-        self.add_parameter('input_channel',
-                           label='Input channel',
-                           docstring='Specifies which measurement input to '
-                                     'control from (note that only '
-                                     'measurement inputs are available)',
-                           val_mapping=_channel_name_to_outmode_command_map,
-                           parameter_class=GroupParameter)
 
         self.P.vals = vals.Numbers(0.1, 1000)
         self.I.vals = vals.Numbers(0.1, 1000)

--- a/qcodes/instrument_drivers/Lakeshore/Model_336.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_336.py
@@ -57,9 +57,6 @@ class Output_336_CurrentSource(BaseOutput):
         self.I.vals = vals.Numbers(0.1, 1000)
         self.D.vals = vals.Numbers(0, 200)
 
-        self.range_limits.vals = vals.Sequence(
-            vals.Numbers(0, 400), length=2, require_sorted=True)
-
 
 class Output_336_VoltageSource(BaseOutput):
     """
@@ -83,10 +80,6 @@ class Output_336_VoltageSource(BaseOutput):
 
     def __init__(self, parent, output_name, output_index):
         super().__init__(parent, output_name, output_index, has_pid=False)
-
-        self.range_limits.vals = vals.Sequence(
-            vals.Numbers(0, 400), length=2, require_sorted=True)
-
 
 
 class Model_336_Channel(BaseSensorChannel):

--- a/qcodes/instrument_drivers/Lakeshore/Model_336.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_336.py
@@ -1,4 +1,3 @@
-import os
 from typing import ClassVar, Dict, Any
 
 from qcodes.instrument.group_parameter import GroupParameter, Group

--- a/qcodes/instrument_drivers/Lakeshore/Model_372.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_372.py
@@ -234,11 +234,15 @@ class Model_372(LakeshoreBase):
     """
     channel_name_command: Dict[str, str] = {'ch{:02}'.format(i): str(i)
                                             for i in range(1, 1 + _n_channels)}
+    input_channel_parameter_values_to_channel_name_on_instrument = {
+        i: f'ch{i:02}' for i in range(1, 1 + _n_channels)
+    }
 
     CHANNEL_CLASS = Model_372_Channel
 
     def __init__(self, name: str, address: str, **kwargs) -> None:
         super().__init__(name, address, **kwargs)
+
         self.sample_heater = Output_372(self, 'sample_heater', 0)
         self.warmup_heater = Output_372(self, 'warmup_heater', 1)
         self.analog_heater = Output_372(self, 'analog_heater', 2)

--- a/qcodes/instrument_drivers/Lakeshore/Model_372.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_372.py
@@ -1,4 +1,4 @@
-from typing import Dict, ClassVar
+from typing import Dict, ClassVar, Any
 
 from qcodes.instrument_drivers.Lakeshore.lakeshore_base import (
     LakeshoreBase, BaseOutput, BaseSensorChannel)
@@ -35,10 +35,12 @@ class Output_372(BaseOutput):
         '31.6mA': 7,
         '100mA': 8}
 
+    _input_channel_parameter_kwargs: ClassVar[Dict[str, Any]] = {
+        'get_parser': int,
+        'vals': vals.Numbers(1, _n_channels)}
+
     def __init__(self, parent, output_name, output_index) -> None:
         super().__init__(parent, output_name, output_index, has_pid=True)
-
-        self.input_channel.vals = vals.Numbers(1, _n_channels)
 
         # Add more parameters for OUTMODE command 
         # and redefine the corresponding group

--- a/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -268,9 +268,12 @@ class BaseOutput(InstrumentChannel):
                                    self.wait_equilibration_time.get_latest())
 
         active_channel_id = self.input_channel()
-        active_channel_number_in_list = active_channel_id - 1
-        active_channel = \
-            self.root_instrument.channels[active_channel_number_in_list]
+        active_channel = getattr(
+            self.root_instrument,
+            (self.root_instrument
+                .input_channel_parameter_values_to_channel_name_on_instrument[active_channel_id]
+            )
+        )
 
         if active_channel.units() != 'kelvin':
             raise ValueError(f"Waiting until the setpoint is reached requires "
@@ -445,6 +448,8 @@ class LakeshoreBase(VisaInstrument):
     # "B" is referred to in instrument commands as '2', then this dictionary
     # will contain {'B': '2'} entry.
     channel_name_command: Dict[str, str] = {}
+
+    input_channel_parameter_values_to_channel_name_on_instrument: Dict[Any, str]
 
     def __init__(self,
                  name: str,

--- a/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -207,7 +207,12 @@ class BaseOutput(InstrumentChannel):
                                'before automatically setting the range '
                                '(e.g. inst.range_limits([0.021, 0.1, 0.2, '
                                '1.1, 2, 4, 8]))')
-        i = bisect(self.range_limits.get_latest(), temperature)
+        range_limits = self.range_limits.get_latest()
+        i = bisect(range_limits, temperature)
+        # if temperature is larger than the highest range, then bisect returns
+        # an index that is +1 from the needed index, hence we need to take
+        # care of this corner case here:
+        i = min(i, len(range_limits) - 1)
         # there is a `+1` because `self.RANGES` includes `'off'` as the first
         # value.
         orange = self.INVERSE_RANGES[i+1] # this is `output range` not the fruit
@@ -279,7 +284,7 @@ class BaseOutput(InstrumentChannel):
             raise ValueError(f"Waiting until the setpoint is reached requires "
                              f"channel's {active_channel._channel!r} units to "
                              f"be set to 'kelvin'.")
-        
+
         t_setpoint = self.setpoint()
 
         time_now = time.perf_counter()

--- a/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -273,12 +273,9 @@ class BaseOutput(InstrumentChannel):
                                    self.wait_equilibration_time.get_latest())
 
         active_channel_id = self.input_channel()
-        active_channel = getattr(
-            self.root_instrument,
-            (self.root_instrument
-                .input_channel_parameter_values_to_channel_name_on_instrument[active_channel_id]
-            )
-        )
+        active_channel_name_on_instrument = (self.root_instrument
+            .input_channel_parameter_values_to_channel_name_on_instrument[active_channel_id])
+        active_channel = getattr(self.root_instrument, active_channel_name_on_instrument)
 
         if active_channel.units() != 'kelvin':
             raise ValueError(f"Waiting until the setpoint is reached requires "

--- a/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -1,4 +1,4 @@
-from typing import Dict, ClassVar, List
+from typing import Dict, ClassVar, List, Any
 import time
 from bisect import bisect
 
@@ -29,6 +29,8 @@ class BaseOutput(InstrumentChannel):
     MODES: ClassVar[Dict[str, int]] = {}
     RANGES: ClassVar[Dict[str, int]] = {}
 
+    _input_channel_parameter_kwargs: ClassVar[Dict[str, Any]] = {}
+
     def __init__(self, parent, output_name, output_index, has_pid: bool=True) \
             -> None:
         super().__init__(parent, output_name)
@@ -49,8 +51,8 @@ class BaseOutput(InstrumentChannel):
                            docstring='Specifies which measurement input to '
                                      'control from (note that only '
                                      'measurement inputs are available)',
-                           get_parser=int,
-                           parameter_class=GroupParameter)
+                           parameter_class=GroupParameter,
+                           **self._input_channel_parameter_kwargs)
         self.add_parameter('powerup_enable',
                            label='Power-up enable on/off',
                            docstring='Specifies whether the output remains on '

--- a/qcodes/tests/drivers/test_lakeshore.py
+++ b/qcodes/tests/drivers/test_lakeshore.py
@@ -352,9 +352,13 @@ def test_select_range_limits(lakeshore_372):
     h = lakeshore_372.sample_heater
     ranges = list(range(1, 9))
     h.range_limits(ranges)
+
     for i in ranges:
-        h.set_range_from_temperature(i-0.5)
+        h.set_range_from_temperature(i - 0.5)
         assert h.output_range() == h.INVERSE_RANGES[i]
+
+    h.set_range_from_temperature(i + 0.5)
+    assert h.output_range() == h.INVERSE_RANGES[len(ranges)]
 
 
 def test_set_and_wait_unit_setpoint_reached(lakeshore_372):

--- a/qcodes/tests/drivers/test_lakeshore_336.py
+++ b/qcodes/tests/drivers/test_lakeshore_336.py
@@ -230,7 +230,7 @@ def test_select_range_limits(lakeshore_336):
     for i in ranges:
         h.set_range_from_temperature(i - 0.5)
         assert h.output_range() == h.INVERSE_RANGES[i]
-    # currently fails!!!
+
     h.set_range_from_temperature(i + 0.5)
     assert h.output_range() == h.INVERSE_RANGES[len(ranges)]
 

--- a/qcodes/tests/drivers/test_lakeshore_336.py
+++ b/qcodes/tests/drivers/test_lakeshore_336.py
@@ -1,0 +1,251 @@
+import logging
+import time
+from typing import Dict
+
+from qcodes.instrument.base import InstrumentBase
+from qcodes.instrument_drivers.Lakeshore.Model_336 import Model_336
+import qcodes.instrument.sims as sims
+
+from .test_lakeshore import MockVisaInstrument, split_args, DictClass, \
+    query, command, instrument_fixture
+
+
+log = logging.getLogger(__name__)
+
+VISA_LOGGER = '.'.join((InstrumentBase.__module__, 'com', 'visa'))
+
+
+class Model_336_Mock(MockVisaInstrument, Model_336):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # initial values
+        self.heaters: Dict[str, DictClass] = {}
+        self.heaters['1'] = DictClass(P=1, I=2, D=3,
+                                      mode=1,  # 'off'
+                                      input_channel=1,  # 'A'
+                                      powerup_enable=0, polarity=0,
+                                      use_filter=0, delay=1,
+                                      output_range=0,
+                                      setpoint=4)
+        self.heaters['2'] = DictClass(P=1, I=2, D=3,
+                                      mode=2,  # 'closed_loop'
+                                      input_channel=2,  # 'B'
+                                      powerup_enable=0, polarity=0,
+                                      use_filter=0, delay=1,
+                                      output_range=0,
+                                      setpoint=4)
+        self.heaters['3'] = DictClass(mode=4,  # 'monitor_out'
+                                      input_channel=2,  # 'B'
+                                      powerup_enable=0, polarity=0,
+                                      use_filter=0, delay=1,
+                                      output_range=0,
+                                      setpoint=4)
+        self.heaters['4'] = DictClass(mode=5,  # 'warm_up'
+                                      input_channel=1,  # 'A'
+                                      powerup_enable=0, polarity=0,
+                                      use_filter=0, delay=1,
+                                      output_range=0,
+                                      setpoint=4)
+
+        self.channel_mock = \
+            {str(i): DictClass(t_limit=i, T=4,
+                               sensor_name=f'sensor_{i}',
+                               sensor_type=1,  # 'diode',
+                               auto_range_enabled=0,  # 'off',
+                               range=0,
+                               compensation_enabled=0,  # False,
+                               units=1)  # 'kelvin')
+             for i in self.channel_name_command.keys()}
+
+        # simulate delayed heating
+        self.simulate_heating = False
+        self.start_heating_time = time.perf_counter()
+
+    def start_heating(self):
+        self.start_heating_time = time.perf_counter()
+        self.simulate_heating = True
+
+    def get_t_when_heating(self):
+        """
+        Simply define a fixed setpoint of 4 k for now
+        """
+        delta = abs(time.perf_counter() - self.start_heating_time)
+        # make it simple to start with: linear ramp 1K per second
+        # start at 7K.
+        return max(4, 7 - delta)
+
+    @query('PID?')
+    def pidq(self, arg):
+        heater = self.heaters[arg]
+        return f'{heater.P},{heater.I},{heater.D}'
+
+    @command('PID')
+    @split_args()
+    def pid(self, output, P, I, D):
+        for a, v in zip(['P', 'I', 'D'], [P, I, D]):
+            setattr(self.heaters[output], a, v)
+
+    @query('OUTMODE?')
+    def outmodeq(self, arg):
+        heater = self.heaters[arg]
+        return (f'{heater.mode},{heater.input_channel},'
+                f'{heater.powerup_enable}')
+
+    @command('OUTMODE')
+    @split_args()
+    def outputmode(self, output, mode, input_channel, powerup_enable):
+        h = self.heaters[output]
+        h.output = output
+        h.mode = mode
+        h.input_channel = input_channel
+        h.powerup_enable = powerup_enable
+
+    @query('INTYPE?')
+    def intypeq(self, channel):
+        ch = self.channel_mock[channel]
+        return (f'{ch.sensor_type},'
+                f'{ch.auto_range_enabled},{ch.range},'
+                f'{ch.compensation_enabled},{ch.units}')
+
+    @command('INTYPE')
+    @split_args()
+    def intype(self, channel, sensor_type, auto_range_enabled,
+               range_, compensation_enabled, units):
+        ch = self.channel_mock[channel]
+        ch.sensor_type = sensor_type
+        ch.auto_range_enabled = auto_range_enabled
+        ch.range = range_
+        ch.compensation_enabled = compensation_enabled
+        ch.units = units
+
+    @query('RANGE?')
+    def rangeq(self, heater):
+        h = self.heaters[heater]
+        return f'{h.output_range}'
+
+    @command('RANGE')
+    @split_args()
+    def range_cmd(self, heater, output_range):
+        h = self.heaters[heater]
+        h.output_range = output_range
+
+    @query('SETP?')
+    def setpointq(self, heater):
+        h = self.heaters[heater]
+        return f'{h.setpoint}'
+
+    @command('SETP')
+    @split_args()
+    def setpoint(self, heater, setpoint):
+        h = self.heaters[heater]
+        h.setpoint = setpoint
+
+    @query('TLIMIT?')
+    def tlimitq(self, channel):
+        chan = self.channel_mock[channel]
+        return f'{chan.tlimit}'
+
+    @command('TLIMIT')
+    @split_args()
+    def tlimitcmd(self, channel, tlimit):
+        chan = self.channel_mock[channel]
+        chan.tlimit = tlimit
+
+    @query('KRDG?')
+    def temperature(self, output):
+        chan = self.channel_mock[output]
+        if self.simulate_heating:
+            return self.get_t_when_heating()
+        return f'{chan.T}'
+
+
+@instrument_fixture(scope='function')
+def lakeshore_336():
+    visalib = sims.__file__.replace('__init__.py',
+                                    'lakeshore_model336.yaml@sim')
+    return Model_336_Mock('lakeshore_336_fixture', 'GPIB::2::INSTR',
+                          visalib=visalib, device_clear=False)
+
+
+def test_pid_set(lakeshore_336):
+    ls = lakeshore_336
+    P, I, D = 1, 2, 3
+    # Only current source outputs/heaters have PID parameters,
+    # voltages source outputs/heaters do not.
+    outputs = [ls.output_1, ls.output_2]
+    for h in outputs:  # a.k.a. heaters
+        h.P(P)
+        h.I(I)
+        h.D(D)
+        assert (h.P(), h.I(), h.D()) == (P, I, D)
+
+
+def test_output_mode(lakeshore_336):
+    ls = lakeshore_336
+    mode = 'off'
+    input_channel = 'A'
+    powerup_enable = True
+    outputs = [getattr(ls, f'output_{n}') for n in range(1, 5)]
+    for h in outputs:  # a.k.a. heaters
+        h.mode(mode)
+        h.input_channel(input_channel)
+        h.powerup_enable(powerup_enable)
+        assert h.mode() == mode
+        assert h.input_channel() == input_channel
+        assert h.powerup_enable() == powerup_enable
+
+
+def test_range(lakeshore_336):
+    ls = lakeshore_336
+    output_range = 'medium'
+    outputs = [getattr(ls, f'output_{n}') for n in range(1, 5)]
+    for h in outputs:  # a.k.a. heaters
+        h.output_range(output_range)
+        assert h.output_range() == output_range
+
+
+def test_tlimit(lakeshore_336):
+    ls = lakeshore_336
+    tlimit = 5.1
+    for ch in ls.channels:
+        ch.t_limit(tlimit)
+        assert ch.t_limit() == tlimit
+
+
+def test_setpoint(lakeshore_336):
+    ls = lakeshore_336
+    setpoint = 5.1
+    outputs = [getattr(ls, f'output_{n}') for n in range(1, 5)]
+    for h in outputs:  # a.k.a. heaters
+        h.setpoint(setpoint)
+        assert h.setpoint() == setpoint
+
+
+def test_select_range_limits(lakeshore_336):
+    h = lakeshore_336.output_1
+    ranges = [1, 2, 3]
+    h.range_limits(ranges)
+
+    for i in ranges:
+        h.set_range_from_temperature(i - 0.5)
+        assert h.output_range() == h.INVERSE_RANGES[i]
+    # currently fails!!!
+    h.set_range_from_temperature(i + 0.5)
+    assert h.output_range() == h.INVERSE_RANGES[len(ranges)]
+
+
+def test_set_and_wait_unit_setpoint_reached(lakeshore_336):
+    ls = lakeshore_336
+    ls.output_1.setpoint(4)
+    ls.start_heating()
+    ls.output_1.wait_until_set_point_reached()
+
+
+def test_blocking_t(lakeshore_336):
+    ls = lakeshore_336
+    h = ls.output_1
+    ranges = [1.2, 2.4, 3.1]
+    h.range_limits(ranges)
+    ls.start_heating()
+    h.blocking_t(4)


### PR DESCRIPTION
This PR is a result of a wish of using Lakeshore Model 336 driver in Delft, which turned into fixing some bugs in the drivers.

Most notable:
* Add test for Model 336 that is very similar to test for Model 372 (quick copy-paste mostly)
* Fix BaseOutput's input_channel parameter creation. It has to be a group parameter, but other kwargs like val_mapping and/or vals and others can be now specified in the subclasses to allow aproprivate variations between models. in Lakeshore Model 336, Model 372, and their base class.
* Map input_channel values and sensor channel names. Add map between BaseOutput's input_channel values and sensor channel object names. Model 336 uses letters for sensor channel names, hence the values of the BaseOutput's input_channel parameter naturally become strings. Model 372 uses numbers (it has 16 channels, while 366 has 4) for sensor channels, hence the values of the BaseOutput's input_channel parameter naturally become integers. To bridge this difference, and make wait_until_set_point_reached work for any Lakeshore model driver, a new mapping with a long ugly name input_channel_parameter_values_to_channel_name_on_instrument is introduced.
* Fix set_range_from_temperature bug for upper range - If the given temperature is from the highest range, the logic in the function would throw an exception because the index that bisect returns
is +1 relative to what it should be. Now it's fixed, and a test is added. For Lakeshore drivers, all models

@QCoDeS/core This PR "as is" does not act on the fact that the driver and test infrastructure for it is quite a bit convoluted and difficult to wrap ones head around. Hence, this PR only makes fixes, so that Model 336 driver works. Would you insist on reworking the structure of the driver and the test infrastructure in this PR or shall we leave it for "later"?