### PR TITLE
Make error_caused_by more robust

### DIFF
--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -105,7 +105,16 @@ def error_caused_by(excinfo: 'ExceptionInfo', cause: str) -> bool:
         cause: the error message or a substring of it
     """
     chain = excinfo.getrepr().chain
-    cause_found = False
-    for link in chain:
-        cause_found = cause_found or cause in str(link[1])
-    return cause_found
+    # first element of the chain is info about the root exception
+    error_location = chain[0][1]
+    root_traceback = chain[0][0]
+    # the error location is the most reliable data since
+    # it only contains the location and the error raised.
+    # however there are cases where this is empty
+    # in such cases fall back to the traceback
+    if error_location is not None:
+        return cause in str(error_location)
+    else:
+        return cause in str(root_traceback)
+
+

--- a/qcodes/tests/test_testutils.py
+++ b/qcodes/tests/test_testutils.py
@@ -1,0 +1,50 @@
+import pytest
+from .common import error_caused_by
+
+
+def test_error_caused_by_simple():
+    """
+    Test that `error_caused_by` will only match the root error and not
+    the error raised. For errors raised directly from other errors
+    """
+
+    with pytest.raises(Exception) as execinfo:
+        raise KeyError('foo') from ValueError('bar')
+
+    assert error_caused_by(execinfo, "ValueError: bar")
+    assert not error_caused_by(execinfo, "KeyError: foo")
+
+
+def test_error_caused_by_try_catch():
+    """
+    Test that `error_caused_by` will only match the root error and not
+    the error raised for errors. For errors reraised in a try except chain.
+    """
+    with pytest.raises(KeyError) as execinfo:
+        try:
+            raise ValueError('bar')
+        except ValueError as e:
+            raise KeyError('foo') from e
+
+    assert error_caused_by(execinfo, "ValueError: bar")
+    assert not error_caused_by(execinfo, "KeyError: foo")
+
+
+def test_error_caused_by_3_level():
+    """
+    Test that error caused by does not match the middle element in a chain
+    of 3 exceptions
+    """
+
+    with pytest.raises(RuntimeError) as execinfo:
+        try:
+            raise ValueError('bar')
+        except ValueError as e:
+            try:
+                raise KeyError('foo') from e
+            except KeyError as ee:
+                raise RuntimeError('goo') from ee
+
+    assert not error_caused_by(execinfo, "RuntimeError: goo")
+    assert not error_caused_by(execinfo, "KeyError: foo")
+    assert error_caused_by(execinfo, "ValueError: bar")

--- a/qcodes/tests/test_wrong_address.py
+++ b/qcodes/tests/test_wrong_address.py
@@ -23,8 +23,6 @@ def test_wrong_address():
                             address=wrong_address,
                             visalib=visalib)
 
-    assert error_caused_by(exc_info, wrong_address)
-
     right_address = 'GPIB::1::INSTR'  # from the simulation yaml file
 
     _ = Keysight_34465A('keysight_34465A_sim',


### PR DESCRIPTION
* Handles cases where line information is missing (such as worked around in #1477 
* Only match against the root cause of the exception. This seems like what was always intended
* Add tests of the above
* Remove one incorrect use of error_caused_by


