### PR TITLE
Hotfix/JSON dump description as old

### DIFF
--- a/qcodes/dataset/database_extract_runs.py
+++ b/qcodes/dataset/database_extract_runs.py
@@ -192,7 +192,13 @@ def _extract_single_dataset_into_db(dataset: DataSet,
     if run_id != -1:
         return
 
-    parspecs = new_to_old(dataset._interdeps).paramspecs
+    if dataset.parameters is not None:
+        param_names = dataset.parameters.split(',')
+    else:
+        param_names = []
+    parspecs_dict = {p.name: p for p in new_to_old(dataset._interdeps).paramspecs}
+    parspecs = [parspecs_dict[p] for p in param_names]
+
     metadata = dataset.metadata
     snapshot_raw = dataset.snapshot_raw
 
@@ -200,7 +206,7 @@ def _extract_single_dataset_into_db(dataset: DataSet,
                                                      target_exp_id,
                                                      name=dataset.name,
                                                      guid=dataset.guid,
-                                                     parameters=list(parspecs),
+                                                     parameters=parspecs,
                                                      metadata=metadata)
     _populate_results_table(source_conn,
                             target_conn,

--- a/qcodes/dataset/descriptions.py
+++ b/qcodes/dataset/descriptions.py
@@ -1,5 +1,5 @@
 import io
-from typing import Dict, Any, Union
+from typing import Dict, Any, Union, cast
 import json
 
 from qcodes.dataset.dependencies import (InterDependencies,

--- a/qcodes/dataset/descriptions.py
+++ b/qcodes/dataset/descriptions.py
@@ -3,7 +3,8 @@ from typing import Dict, Any, Union
 import json
 
 from qcodes.dataset.dependencies import (InterDependencies,
-                                         InterDependencies_)
+                                         InterDependencies_,
+                                         new_to_old)
 SomeDeps = Union[InterDependencies, InterDependencies_]
 
 
@@ -91,7 +92,11 @@ class RunDescriber:
         """
         Output the run describtion as a JSON string
         """
-        return json.dumps(self.serialize())
+        if not self._old_style_deps:
+            obj_to_dump = RunDescriber(new_to_old(self.interdeps))
+        else:
+            obj_to_dump = self
+        return json.dumps(obj_to_dump.serialize())
 
     @classmethod
     def from_yaml(cls, yaml_str: str) -> 'RunDescriber':

--- a/qcodes/dataset/descriptions.py
+++ b/qcodes/dataset/descriptions.py
@@ -93,7 +93,8 @@ class RunDescriber:
         Output the run describtion as a JSON string
         """
         if not self._old_style_deps:
-            obj_to_dump = RunDescriber(new_to_old(self.interdeps))
+            new_interdeps = cast(InterDependencies_, self.interdeps)
+            obj_to_dump = RunDescriber(new_to_old(new_interdeps))
         else:
             obj_to_dump = self
         return json.dumps(obj_to_dump.serialize())

--- a/qcodes/dataset/descriptions.py
+++ b/qcodes/dataset/descriptions.py
@@ -41,7 +41,13 @@ class RunDescriber:
         Serialize this object into a dictionary
         """
         ser = {}
-        ser['interdependencies'] = self.interdeps.serialize()
+        old_interdeps: InterDependencies
+        if not self._old_style_deps:
+            new_interdeps = cast(InterDependencies_, self.interdeps)
+            old_interdeps = new_to_old(new_interdeps)
+        else:
+            old_interdeps = cast(InterDependencies, self.interdeps)
+        ser['interdependencies'] = old_interdeps.serialize()
         return ser
 
     @classmethod
@@ -92,12 +98,7 @@ class RunDescriber:
         """
         Output the run describtion as a JSON string
         """
-        if not self._old_style_deps:
-            new_interdeps = cast(InterDependencies_, self.interdeps)
-            obj_to_dump = RunDescriber(new_to_old(new_interdeps))
-        else:
-            obj_to_dump = self
-        return json.dumps(obj_to_dump.serialize())
+        return json.dumps(self.serialize())
 
     @classmethod
     def from_yaml(cls, yaml_str: str) -> 'RunDescriber':

--- a/qcodes/tests/dataset/test_dependencies.py
+++ b/qcodes/tests/dataset/test_dependencies.py
@@ -131,6 +131,14 @@ def test_serialize(some_paramspecbases):
     tester(idps)
 
 
+def test_old_to_new_and_back(some_paramspecs):
+
+    idps_old = InterDependencies(*some_paramspecs[1].values())
+    idps_new = old_to_new(idps_old)
+
+    assert new_to_old(idps_new) == idps_old
+
+
 def test_old_to_new(some_paramspecs):
 
     ps1 = some_paramspecs[1]['ps1']
@@ -220,6 +228,7 @@ def test_new_to_old(some_paramspecbases):
                                           paramspec1, paramspec4)
 
     assert new_to_old(idps_new) == idps_old_expected
+
 
 
 def test_extend_with_paramspec(some_paramspecs):

--- a/qcodes/tests/dataset/test_descriptions.py
+++ b/qcodes/tests/dataset/test_descriptions.py
@@ -2,8 +2,7 @@ import pytest
 
 from qcodes.dataset.param_spec import ParamSpec
 from qcodes.dataset.descriptions import RunDescriber
-from qcodes.dataset.dependencies import InterDependencies
-
+from qcodes.dataset.dependencies import InterDependencies, old_to_new
 
 @pytest.fixture
 def some_paramspecs():
@@ -106,3 +105,18 @@ def test_yaml_creation_and_loading(some_paramspecs):
 
         new_desc = RunDescriber.from_yaml(yaml_str)
         assert new_desc == desc
+
+
+def test_serialization_as_old(some_paramspecs):
+    """
+    Test that a RunDescriber always serializes itself as an old style
+    RunDescriber, even when given new style interdeps
+    """
+
+    idps_old = InterDependencies(*some_paramspecs[2].values())
+    idps_new = old_to_new(idps_old)
+
+    new_desc = RunDescriber(idps_new)
+    old_desc = RunDescriber(idps_old)
+
+    assert new_desc.to_json() == old_desc.to_json()


### PR DESCRIPTION
Fix something broken by #1477 

Until a formal schema upgrade is in place, we should JSON dump the run description old-style.

Changes proposed in this pull request:
- Always JSON dump `RunDescriber` using the old style.



@Dominik-Vogel 
