### PR TITLE
Introduce ParamSpecTree

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -511,6 +511,12 @@ class DataSet(Sized):
         if not isinstance(interdeps, InterDependencies_):
             raise TypeError('Wrong input type. Expected InterDepencies_, '
                             f'got {type(interdeps)}')
+
+        if not self.pristine:
+            mssg = ('Can not set interdependencies on a DataSet that has '
+                    'been started.')
+            raise RuntimeError(mssg)
+
         self._interdeps = interdeps
 
     def get_parameters(self) -> SPECS:

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -497,27 +497,11 @@ class DataSet(Sized):
 
     def add_parameter(self, spec: ParamSpec):
         """
-        Add a parameter to the DataSet. To ensure sanity, parameters must be
-        added to the DataSet in a sequence matching their internal
-        dependencies, i.e. first independent parameters, next other
-        independent parameters inferred from the first ones, and finally
-        the dependent parameters. Note that adding parameters to the DataSet
-        does not reflect in the DB file until the DataSet is marked as started
+        Old method; don't use it.
         """
-
-        if not self.pristine:
-            raise RuntimeError('Can not add parameters to a DataSet that has '
-                               'been started.')
-
-        if self.parameters:
-            old_params = self.parameters.split(',')
-        else:
-            old_params = []
-
-        if spec.name in old_params:
-            raise ValueError(f'Duplicate parameter name: {spec.name}')
-
-        self._interdeps = self._interdeps._extend_with_paramspec(spec)
+        raise NotImplementedError('This method has been removed. '
+                                  'Please use DataSet.set_interdependencies '
+                                  'instead.')
 
     def set_interdependencies(self, interdeps: InterDependencies_) -> None:
         """

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -112,6 +112,12 @@ class ParamSpecGrove:
 
         self._trees_as_dict_inv = self._invert_grove()
 
+        self._names_to_paramspec = {
+            ps.name: ps for ps in self._roots.union(self._leafs)}
+
+        self._stubs: Tuple[ParamSpecTree, ...] = tuple(
+            t for t in self._trees if t.is_stub)
+
     def as_dict(self) -> Dict[ParamSpecBase, Tuple[ParamSpecBase, ...]]:
         return self._trees_as_dict
 
@@ -124,6 +130,9 @@ class ParamSpecGrove:
 
     @property
     def leafs(self) -> Set[ParamSpecBase]:
+    def as_dict_str(self) -> Dict[str, Set[str]]:
+        return self._trees_as_dict_str
+
         return self._leafs
 
     def extend(self, new: ParamSpecTree) -> 'ParamSpecGrove':

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -419,49 +419,6 @@ class InterDependencies_:
         """
         return tuple(self._id_to_paramspec.keys())
 
-    def _extend_with_paramspec(self, ps: ParamSpec) -> 'InterDependencies_':
-        """
-        Create a new InterDependencies_ object extended with the provided
-        ParamSpec. A helper function for DataSet's add_parameter function.
-        Note that this function will only work as expected if the ParamSpecs
-        are extended into the InterDependencies_ in the "logical order", i.e.
-        independent ParamSpecs before dependent ones.
-        """
-        base_ps = ps.base_version()
-
-        old_standalones = set(self.standalones.copy())
-        new_standalones: Tuple[ParamSpecBase, ...]
-
-        if len(ps.depends_on_) > 0:
-            deps_list = [self._id_to_paramspec[name] for name in ps.depends_on_]
-            new_deps = {base_ps: tuple(deps_list)}
-            old_standalones = old_standalones.difference(set(deps_list))
-        else:
-            new_deps = {}
-
-        if len(ps.inferred_from_) > 0:
-            inffs_list = [self._id_to_paramspec[name]
-                          for name in ps.inferred_from_]
-            new_inffs = {base_ps: tuple(inffs_list)}
-            old_standalones = old_standalones.difference(set(inffs_list))
-        else:
-            new_inffs = {}
-
-        if new_deps == new_inffs == {}:
-            new_standalones = (base_ps,)
-        else:
-            old_standalones = old_standalones.difference({base_ps})
-            new_standalones = ()
-
-        new_deps.update(self.dependencies.copy())
-        new_inffs.update(self.inferences.copy())
-        new_standalones = tuple(list(new_standalones) + list(old_standalones))
-
-        new_idps = InterDependencies_(dependencies=new_deps,
-                                      inferences=new_inffs,
-                                      standalones=new_standalones)
-
-        return new_idps
 
     def extend(
             self,

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -38,6 +38,7 @@ class ParamSpecTree:
         self._leaf_names = set(leaf.name for leaf in leafs)
         self._as_dict = {root: leafs}
         self._as_dict_str = {root.name: self.leaf_names}
+        self._is_stub = not(bool(self._leafs_set))
 
     @property
     def leaf_names(self) -> Set[str]:
@@ -47,11 +48,23 @@ class ParamSpecTree:
     def leafs(self) -> Set[ParamSpecBase]:
         return self._leafs_set
 
+    @property
+    def is_stub(self) -> bool:
+        return self._is_stub
+
     def as_dict(self) -> Dict[ParamSpecBase, Tuple[ParamSpecBase, ...]]:
         return self._as_dict
 
     def as_dict_str(self) -> Dict[str, Set[str]]:
         return self._as_dict_str
+
+    def __repr__(self) -> str:
+        rpr = f'ParamSpecTree({self.root}'
+        if self.is_stub:
+            rpr += ')'
+        else:
+            rpr += f', {", ".join([str(l) for l in self._leafs_tuple])})'
+        return rpr
 
 
 class ParamSpecGrove:

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -66,6 +66,18 @@ class ParamSpecTree:
             rpr += f', {", ".join([str(l) for l in self._leafs_tuple])})'
         return rpr
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, ParamSpecTree):
+            return False
+        if self.root != other.root:
+            return False
+        if self._leafs_tuple != other._leafs_tuple:
+            return False
+        return True
+
+    def __hash__(self) -> int:
+        return hash((self.root, self._leafs_tuple))
+
 
 class ParamSpecGrove:
 

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -50,7 +50,7 @@ class ParamSpecTree:
     def as_dict(self) -> Dict[ParamSpecBase, Tuple[ParamSpecBase, ...]]:
         return self._as_dict
 
-    def as_dict_str(self) -> Dict[str, str]:
+    def as_dict_str(self) -> Dict[str, Set[str]]:
         return self._as_dict_str
 
 

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -52,6 +52,9 @@ class ParamSpecTree:
     def is_stub(self) -> bool:
         return self._is_stub
 
+    def as_set_of_stubs(self) -> Set['ParamSpecTree']:
+        return set(ParamSpecTree(p) for p in (self.root,) + self._leafs_tuple)
+
     def as_dict(self) -> Dict[ParamSpecBase, Tuple[ParamSpecBase, ...]]:
         return self._as_dict
 
@@ -137,6 +140,14 @@ class ParamSpecGrove:
 
     def extend(self, new: ParamSpecTree) -> 'ParamSpecGrove':
         return ParamSpecGrove(*self._trees, new)
+
+    def remove_stubs(self, *stubs: ParamSpecTree) -> 'ParamSpecGrove':
+        for stub in stubs:
+            if stub not in self._stubs:
+                raise ValueError(f'Cannot remove stub {stub}, not a stub '
+                                 'of this grove.')
+        new_trees = self._trees.difference(set(stubs))
+        return ParamSpecGrove(*new_trees)
 
     def _invert_grove(self) -> Dict[ParamSpecBase, Tuple[ParamSpecBase, ...]]:
         """

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -169,6 +169,12 @@ class ParamSpecGrove:
     def __contains__(self, ps: ParamSpecBase) -> bool:
         return ps in self._trees_as_dict or ps in self._trees_as_dict_inv
 
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, ParamSpecGrove):
+            return False
+        if self._trees != other._trees:
+            return False
+        return True
 
 class DependencyError(Exception):
     def __init__(self,

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -176,6 +176,11 @@ class ParamSpecGrove:
             return False
         return True
 
+    def __repr__(self) -> str:
+        str_trees = [str(t) for t in self._trees]
+        return 'ParamSpecGrove(' + ', '.join(str_trees) + ')'
+
+
 class DependencyError(Exception):
     def __init__(self,
                  param_name: str,

--- a/qcodes/dataset/dependencies.py
+++ b/qcodes/dataset/dependencies.py
@@ -124,15 +124,15 @@ class ParamSpecGrove:
     def as_dict_inv(self) -> Dict[ParamSpecBase, Tuple[ParamSpecBase, ...]]:
         return self._trees_as_dict_inv
 
+    def as_dict_str(self) -> Dict[str, Set[str]]:
+        return self._trees_as_dict_str
+
     @property
     def roots(self) -> Set[ParamSpecBase]:
         return self._roots
 
     @property
     def leafs(self) -> Set[ParamSpecBase]:
-    def as_dict_str(self) -> Dict[str, Set[str]]:
-        return self._trees_as_dict_str
-
         return self._leafs
 
     def extend(self, new: ParamSpecTree) -> 'ParamSpecGrove':

--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -113,8 +113,10 @@ def error_caused_by(excinfo: 'ExceptionInfo', cause: str) -> bool:
     # however there are cases where this is empty
     # in such cases fall back to the traceback
     if error_location is not None:
-        return cause in str(error_location)
+        where_to_look = str(error_location)
     else:
-        return cause in str(root_traceback)
+        where_to_look = str(root_traceback)
+
+    return cause in where_to_look
 
 

--- a/qcodes/tests/dataset/dataset_fixtures.py
+++ b/qcodes/tests/dataset/dataset_fixtures.py
@@ -1,7 +1,8 @@
 import pytest
 import numpy as np
-from qcodes.dataset.param_spec import ParamSpec
+from qcodes.dataset.param_spec import ParamSpecBase
 
+from qcodes.dataset.dependencies import InterDependencies_
 from qcodes.dataset.measurements import Measurement
 from qcodes.tests.instrument_mocks import ArraySetPointParam, Multi2DSetPointParam
 from qcodes.instrument.parameter import Parameter
@@ -15,21 +16,24 @@ from qcodes.tests.dataset.temporary_databases import dataset, experiment
 def scalar_dataset(dataset):
     n_params = 3
     n_rows = 10**3
-    params_indep = [ParamSpec(f'param_{i}',
-                              'numeric',
-                              label=f'param_{i}',
-                              unit='V')
+    params_indep = [ParamSpecBase(f'param_{i}',
+                                  'numeric',
+                                  label=f'param_{i}',
+                                  unit='V')
                     for i in range(n_params)]
-    params = params_indep + [ParamSpec(f'param_{n_params}',
-                                       'numeric',
-                                       label=f'param_{n_params}',
-                                       unit='Ohm',
-                                       depends_on=params_indep)]
-    for p in params:
-        dataset.add_parameter(p)
+    param_dep = ParamSpecBase(f'param_{n_params}',
+                              'numeric',
+                              label=f'param_{n_params}',
+                              unit='Ohm')
+
+    all_params = params_indep + [param_dep]
+
+    idps = InterDependencies_(dependencies={param_dep: tuple(params_indep)})
+
+    dataset.set_interdependencies(idps)
     dataset.mark_started()
     dataset.add_results([{p.name: np.int(n_rows*10*pn+i)
-                          for pn, p in enumerate(params)}
+                          for pn, p in enumerate(all_params)}
                          for i in range(n_rows)])
     dataset.mark_completed()
     yield dataset
@@ -41,12 +45,12 @@ def scalar_dataset_with_nulls(dataset):
     A very simple dataset. A scalar is varied, and two parameters are measured
     one by one
     """
-    sp = ParamSpec('setpoint', 'numeric')
-    val1 = ParamSpec('first_value', 'numeric', depends_on=(sp,))
-    val2 = ParamSpec('second_value', 'numeric', depends_on=(sp,))
+    sp = ParamSpecBase('setpoint', 'numeric')
+    val1 = ParamSpecBase('first_value', 'numeric')
+    val2 = ParamSpecBase('second_value', 'numeric')
 
-    for p in [sp, val1, val2]:
-        dataset.add_parameter(p)
+    idps = InterDependencies_(dependencies={val1: (sp,), val2: (sp,)})
+    dataset.set_interdependencies(idps)
 
     dataset.mark_started()
 
@@ -210,22 +214,28 @@ def array_in_str_dataset(experiment, request):
 def standalone_parameters_dataset(dataset):
     n_params = 3
     n_rows = 10**3
-    params_indep = [ParamSpec(f'param_{i}',
-                              'numeric',
-                              label=f'param_{i}',
-                              unit='V')
+    params_indep = [ParamSpecBase(f'param_{i}',
+                                  'numeric',
+                                  label=f'param_{i}',
+                                  unit='V')
                     for i in range(n_params)]
 
-    params = params_indep + [ParamSpec(f'param_{n_params}',
-                                       'numeric',
-                                       label=f'param_{n_params}',
-                                       unit='Ohm',
-                                       depends_on=params_indep[0:1])]
-    for p in params:
-        dataset.add_parameter(p)
+    param_dep = ParamSpecBase(f'param_{n_params}',
+                              'numeric',
+                              label=f'param_{n_params}',
+                              unit='Ohm')
+
+    params_all = params_indep + [param_dep]
+
+    idps = InterDependencies_(
+        dependencies={param_dep: tuple(params_indep[0:1])},
+        standalones=tuple(params_indep[1:]))
+
+    dataset.set_interdependencies(idps)
+
     dataset.mark_started()
     dataset.add_results([{p.name: np.int(n_rows*10*pn+i)
-                          for pn, p in enumerate(params)}
+                          for pn, p in enumerate(params_all)}
                          for i in range(n_rows)])
     dataset.mark_completed()
     yield dataset

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -9,7 +9,7 @@ import pytest
 
 import qcodes as qc
 from qcodes import new_experiment, new_data_set
-from qcodes.dataset.param_spec import ParamSpec, ParamSpecBase
+from qcodes.dataset.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions import RunDescriber
 from qcodes.dataset.dependencies import InterDependencies, InterDependencies_
 from qcodes.dataset.database import (initialise_database,

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -8,9 +8,10 @@ import json
 import pytest
 
 import qcodes as qc
-from qcodes import new_experiment, new_data_set, ParamSpec
+from qcodes import new_experiment, new_data_set
+from qcodes.dataset.param_spec import ParamSpec, ParamSpecBase
 from qcodes.dataset.descriptions import RunDescriber
-from qcodes.dataset.dependencies import InterDependencies
+from qcodes.dataset.dependencies import InterDependencies, InterDependencies_
 from qcodes.dataset.database import (initialise_database,
                                      initialise_or_create_database_at)
 # pylint: disable=unused-import
@@ -551,13 +552,14 @@ def test_update_existing_guids(caplog):
         new_experiment('test', sample_name='test_sample')
 
         ds1 = new_data_set('ds_one')
-        xparam = ParamSpec('x', 'numeric')
-        ds1.add_parameter(xparam)
+        xparam = ParamSpecBase('x', 'numeric')
+        idps = InterDependencies_(standalones=(xparam,))
+        ds1.set_interdependencies(idps)
         ds1.mark_started()
         ds1.add_result({'x': 1})
 
         ds2 = new_data_set('ds_two')
-        ds2.add_parameter(xparam)
+        ds2.set_interdependencies(idps)
         ds2.mark_started()
         ds2.add_result({'x': 2})
 
@@ -571,22 +573,19 @@ def test_update_existing_guids(caplog):
 
     with location_and_station_set_to(0, old_ws):
         ds3 = new_data_set('ds_three')
-        xparam = ParamSpec('x', 'numeric')
-        ds3.add_parameter(xparam)
+        ds3.set_interdependencies(idps)
         ds3.mark_started()
         ds3.add_result({'x': 3})
 
     with location_and_station_set_to(old_loc, 0):
         ds4 = new_data_set('ds_four')
-        xparam = ParamSpec('x', 'numeric')
-        ds4.add_parameter(xparam)
+        ds4.set_interdependencies(idps)
         ds4.mark_started()
         ds4.add_result({'x': 4})
 
     with location_and_station_set_to(old_loc, old_ws):
         ds5 = new_data_set('ds_five')
-        xparam = ParamSpec('x', 'numeric')
-        ds5.add_parameter(xparam)
+        ds5.set_interdependencies(idps)
         ds5.mark_started()
         ds5.add_result({'x': 5})
 

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -15,7 +15,7 @@ from qcodes.dataset.data_set import (DataSet, load_by_guid, load_by_counter,
 from qcodes.dataset.database import path_to_dbfile
 from qcodes.dataset.database_extract_runs import extract_runs_into_db
 from qcodes.tests.dataset.temporary_databases import two_empty_temp_db_connections
-from qcodes.tests.dataset.test_descriptions import some_paramspecs
+from qcodes.tests.dataset.test_dependencies import some_interdeps
 from qcodes.tests.common import error_caused_by
 from qcodes.dataset.measurements import Measurement
 from qcodes import Station
@@ -165,7 +165,7 @@ def test_basic_extraction(two_empty_temp_db_connections, some_paramspecs):
 
 
 def test_correct_experiment_routing(two_empty_temp_db_connections,
-                                    some_paramspecs):
+                                    some_interdeps):
     """
     Test that existing experiments are correctly identified AND that multiple
     insertions of the same runs don't matter (run insertion is idempotent)
@@ -182,14 +182,13 @@ def test_correct_experiment_routing(two_empty_temp_db_connections,
         source_dataset = DataSet(conn=source_conn, exp_id=source_exp_1.exp_id)
         exp_1_run_ids.append(source_dataset.run_id)
 
-        for ps in some_paramspecs[2].values():
-            source_dataset.add_parameter(ps)
+        source_dataset.set_interdependencies(some_interdeps[1])
 
         source_dataset.mark_started()
 
         for val in range(10):
-            source_dataset.add_result({ps.name: val
-                                       for ps in some_paramspecs[2].values()})
+            source_dataset.add_result({name: val
+                                       for name in some_interdeps[1].names})
         source_dataset.mark_completed()
 
     # make a new experiment with 1 run
@@ -198,13 +197,12 @@ def test_correct_experiment_routing(two_empty_temp_db_connections,
     ds = DataSet(conn=source_conn, exp_id=source_exp_2.exp_id, name="lala")
     exp_2_run_ids = [ds.run_id]
 
-    for ps in some_paramspecs[2].values():
-        ds.add_parameter(ps)
+    ds.set_interdependencies(some_interdeps[1])
 
     ds.mark_started()
 
     for val in range(10):
-        ds.add_result({ps.name: val for ps in some_paramspecs[2].values()})
+        ds.add_result({name: val for name in some_interdeps[1].names})
 
     ds.mark_completed()
 
@@ -261,7 +259,7 @@ def test_correct_experiment_routing(two_empty_temp_db_connections,
 
 
 def test_runs_from_different_experiments_raises(two_empty_temp_db_connections,
-                                                some_paramspecs):
+                                                some_interdeps):
     """
     Test that inserting runs from multiple experiments raises
     """
@@ -281,14 +279,13 @@ def test_runs_from_different_experiments_raises(two_empty_temp_db_connections,
         source_dataset = DataSet(conn=source_conn, exp_id=source_exp_1.exp_id)
         exp_1_run_ids.append(source_dataset.run_id)
 
-        for ps in some_paramspecs[2].values():
-            source_dataset.add_parameter(ps)
+        source_dataset.set_interdependencies(some_interdeps[1])
 
         source_dataset.mark_started()
 
         for val in range(10):
-            source_dataset.add_result({ps.name: val
-                                       for ps in some_paramspecs[2].values()})
+            source_dataset.add_result({name: val
+                                       for name in some_interdeps[1].names})
         source_dataset.mark_completed()
 
     # make 5 runs in second experiment
@@ -299,14 +296,14 @@ def test_runs_from_different_experiments_raises(two_empty_temp_db_connections,
         source_dataset = DataSet(conn=source_conn, exp_id=source_exp_2.exp_id)
         exp_2_run_ids.append(source_dataset.run_id)
 
-        for ps in some_paramspecs[2].values():
-            source_dataset.add_parameter(ps)
+        source_dataset.set_interdependencies(some_interdeps[1])
+
 
         source_dataset.mark_started()
 
         for val in range(10):
-            source_dataset.add_result({ps.name: val
-                                       for ps in some_paramspecs[2].values()})
+            source_dataset.add_result({name: val
+                                       for name in some_interdeps[1].names})
         source_dataset.mark_completed()
 
     run_ids = exp_1_run_ids + exp_2_run_ids
@@ -319,8 +316,7 @@ def test_runs_from_different_experiments_raises(two_empty_temp_db_connections,
         extract_runs_into_db(source_path, target_path, *run_ids)
 
 
-def test_extracting_dataless_run(two_empty_temp_db_connections,
-                                 some_paramspecs):
+def test_extracting_dataless_run(two_empty_temp_db_connections):
     """
     Although contrived, it could happen that a run with no data is extracted
     """
@@ -343,7 +339,7 @@ def test_extracting_dataless_run(two_empty_temp_db_connections,
 
 
 def test_result_table_naming_and_run_id(two_empty_temp_db_connections,
-                                        some_paramspecs):
+                                        some_interdeps):
     """
     Check that a correct result table name is given and that a correct run_id
     is assigned
@@ -355,29 +351,28 @@ def test_result_table_naming_and_run_id(two_empty_temp_db_connections,
 
     source_exp1 = Experiment(conn=source_conn)
     source_ds_1_1 = DataSet(conn=source_conn, exp_id=source_exp1.exp_id)
-    for ps in some_paramspecs[2].values():
-        source_ds_1_1.add_parameter(ps)
+    source_ds_1_1.set_interdependencies(some_interdeps[1])
+
     source_ds_1_1.mark_started()
-    source_ds_1_1.add_result({ps.name: 0.0
-                              for ps in some_paramspecs[2].values()})
+    source_ds_1_1.add_result({name: 0.0
+                              for name in some_interdeps[1].names})
     source_ds_1_1.mark_completed()
 
     source_exp2 = Experiment(conn=source_conn)
     source_ds_2_1 = DataSet(conn=source_conn, exp_id=source_exp2.exp_id)
-    for ps in some_paramspecs[2].values():
-        source_ds_2_1.add_parameter(ps)
+    source_ds_2_1.set_interdependencies(some_interdeps[1])
     source_ds_2_1.mark_started()
-    source_ds_2_1.add_result({ps.name: 0.0
-                              for ps in some_paramspecs[2].values()})
+    source_ds_2_1.add_result({name: 0.0
+                              for name in some_interdeps[1].names})
     source_ds_2_1.mark_completed()
     source_ds_2_2 = DataSet(conn=source_conn,
                             exp_id=source_exp2.exp_id,
                             name="customname")
-    for ps in some_paramspecs[2].values():
-        source_ds_2_2.add_parameter(ps)
+
+    source_ds_2_2.set_interdependencies(some_interdeps[1])
     source_ds_2_2.mark_started()
-    source_ds_2_2.add_result({ps.name: 0.0
-                              for ps in some_paramspecs[2].values()})
+    source_ds_2_2.add_result({name: 0.0
+                              for name in some_interdeps[1].names})
     source_ds_2_2.mark_completed()
 
     extract_runs_into_db(source_path, target_path, source_ds_2_2.run_id)
@@ -391,7 +386,7 @@ def test_result_table_naming_and_run_id(two_empty_temp_db_connections,
 
 
 def test_load_by_X_functions(two_empty_temp_db_connections,
-                             some_paramspecs):
+                             some_interdeps):
     """
     Test some different loading functions
     """
@@ -402,30 +397,19 @@ def test_load_by_X_functions(two_empty_temp_db_connections,
 
     source_exp1 = Experiment(conn=source_conn)
     source_ds_1_1 = DataSet(conn=source_conn, exp_id=source_exp1.exp_id)
-    for ps in some_paramspecs[2].values():
-        source_ds_1_1.add_parameter(ps)
-    source_ds_1_1.mark_started()
-    source_ds_1_1.add_result({ps.name: 0.0
-                              for ps in some_paramspecs[2].values()})
-    source_ds_1_1.mark_completed()
 
     source_exp2 = Experiment(conn=source_conn)
     source_ds_2_1 = DataSet(conn=source_conn, exp_id=source_exp2.exp_id)
-    for ps in some_paramspecs[2].values():
-        source_ds_2_1.add_parameter(ps)
-    source_ds_2_1.mark_started()
-    source_ds_2_1.add_result({ps.name: 0.0
-                              for ps in some_paramspecs[2].values()})
-    source_ds_2_1.mark_completed()
+
     source_ds_2_2 = DataSet(conn=source_conn,
                             exp_id=source_exp2.exp_id,
                             name="customname")
-    for ps in some_paramspecs[2].values():
-        source_ds_2_2.add_parameter(ps)
-    source_ds_2_2.mark_started()
-    source_ds_2_2.add_result({ps.name: 0.0
-                              for ps in some_paramspecs[2].values()})
-    source_ds_2_2.mark_completed()
+
+    for ds in (source_ds_1_1, source_ds_2_1, source_ds_2_2):
+        ds.set_interdependencies(some_interdeps[1])
+        ds.mark_started()
+        ds.add_result({name: 0.0 for name in some_interdeps[1].names})
+        ds.mark_completed()
 
     extract_runs_into_db(source_path, target_path, source_ds_2_2.run_id)
 
@@ -440,7 +424,7 @@ def test_load_by_X_functions(two_empty_temp_db_connections,
 
 
 def test_old_versions_not_touched(two_empty_temp_db_connections,
-                                  some_paramspecs):
+                                  some_interdeps):
 
     source_conn, target_conn = two_empty_temp_db_connections
 
@@ -473,11 +457,11 @@ def test_old_versions_not_touched(two_empty_temp_db_connections,
     source_exp = Experiment(conn=source_conn)
     source_ds = DataSet(conn=source_conn, exp_id=source_exp.exp_id)
 
-    for ps in some_paramspecs[2].values():
-        source_ds.add_parameter(ps)
+    source_ds.set_interdependencies(some_interdeps[1])
+
     source_ds.mark_started()
-    source_ds.add_result({ps.name: 0.0
-                              for ps in some_paramspecs[2].values()})
+    source_ds.add_result({name: 0.0
+                          for name in some_interdeps[1].names})
     source_ds.mark_completed()
 
     with raise_if_file_changed(fixturepath):
@@ -492,7 +476,7 @@ def test_old_versions_not_touched(two_empty_temp_db_connections,
 
 
 def test_experiments_with_NULL_sample_name(two_empty_temp_db_connections,
-                                           some_paramspecs):
+                                           some_interdeps):
     """
     In older API versions (corresponding to DB version 3),
     users could get away with setting the sample name to None
@@ -514,13 +498,12 @@ def test_experiments_with_NULL_sample_name(two_empty_temp_db_connections,
         source_dataset = DataSet(conn=source_conn, exp_id=source_exp_1.exp_id)
         exp_1_run_ids.append(source_dataset.run_id)
 
-        for ps in some_paramspecs[2].values():
-            source_dataset.add_parameter(ps)
+        source_dataset.set_interdependencies(some_interdeps[1])
         source_dataset.mark_started()
 
         for val in range(10):
-            source_dataset.add_result({ps.name: val
-                                       for ps in some_paramspecs[2].values()})
+            source_dataset.add_result({name: val
+                                       for name in some_interdeps[1].names})
         source_dataset.mark_completed()
 
     sql = """
@@ -578,7 +561,7 @@ def test_integration_station_and_measurement(two_empty_temp_db_connections,
     assert datasaver.dataset.the_same_dataset_as(target_ds)
 
 
-def test_atomicity(two_empty_temp_db_connections, some_paramspecs):
+def test_atomicity(two_empty_temp_db_connections, some_interdeps):
     """
     Test the atomicity of the transaction by extracting and inserting two
     runs where the second one is not completed. The not completed error must
@@ -595,20 +578,16 @@ def test_atomicity(two_empty_temp_db_connections, some_paramspecs):
 
     source_exp = Experiment(conn=source_conn)
     source_ds_1 = DataSet(conn=source_conn, exp_id=source_exp.exp_id)
-    for ps in some_paramspecs[2].values():
-        source_ds_1.add_parameter(ps)
-    source_ds_1.mark_started()
-    source_ds_1.add_result({ps.name: 2.1
-                            for ps in some_paramspecs[2].values()})
-    source_ds_1.mark_completed()
-
     source_ds_2 = DataSet(conn=source_conn, exp_id=source_exp.exp_id)
-    for ps in some_paramspecs[2].values():
-        source_ds_2.add_parameter(ps)
-    source_ds_2.mark_started()
-    source_ds_2.add_result({ps.name: 2.1
-                            for ps in some_paramspecs[2].values()})
-    # This dataset is NOT marked as completed
+
+    for ds in (source_ds_1, source_ds_2):
+        ds.set_interdependencies(some_interdeps[1])
+        ds.mark_started()
+        ds.add_result({name: 2.1
+                       for name in some_interdeps[1].names})
+
+    # importantly, source_ds_2 is NOT marked as completed
+    source_ds_1.mark_completed()
 
     # now check that the target file is untouched
     with raise_if_file_changed(target_path):
@@ -618,7 +597,7 @@ def test_atomicity(two_empty_temp_db_connections, some_paramspecs):
             extract_runs_into_db(source_path, target_path, 1, 2)
 
 
-def test_column_mismatch(two_empty_temp_db_connections, some_paramspecs, inst):
+def test_column_mismatch(two_empty_temp_db_connections, some_interdeps, inst):
     """
     Test insertion of runs with no metadata and no snapshot into a DB already
     containing a run that has both
@@ -648,11 +627,11 @@ def test_column_mismatch(two_empty_temp_db_connections, some_paramspecs, inst):
 
     Experiment(conn=source_conn)
     source_ds = DataSet(conn=source_conn)
-    for ps in some_paramspecs[2].values():
-        source_ds.add_parameter(ps)
+    source_ds.set_interdependencies(some_interdeps[1])
+
     source_ds.mark_started()
-    source_ds.add_result({ps.name: 2.1
-                          for ps in some_paramspecs[2].values()})
+    source_ds.add_result({name: 2.1
+                          for name in some_interdeps[1].names})
     source_ds.mark_completed()
 
     extract_runs_into_db(source_path, target_path, 1)

--- a/qcodes/tests/dataset/test_datasaver.py
+++ b/qcodes/tests/dataset/test_datasaver.py
@@ -6,7 +6,7 @@ from hypothesis import given, strategies as hst
 
 import qcodes as qc
 from qcodes.dataset.measurements import DataSaver
-from qcodes.dataset.param_spec import ParamSpec
+from qcodes.dataset.param_spec import ParamSpecBase
 from qcodes.dataset.dependencies import InterDependencies_
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import empty_temp_db, experiment
@@ -70,12 +70,12 @@ def test_numpy_types():
     Test that we can save numpy types in the data set
     """
 
-    p = ParamSpec(name="p", paramtype="numeric")
+    p = ParamSpecBase(name="p", paramtype="numeric")
     test_set = qc.new_data_set("test-dataset")
-    test_set.add_parameter(p)
+    test_set.set_interdependencies(InterDependencies_(standalones=(p,)))
     test_set.mark_started()
 
-    idps = InterDependencies_(standalones=(p.base_version(),))
+    idps = InterDependencies_(standalones=(p,))
 
     data_saver = DataSaver(
         dataset=test_set, write_period=0, interdeps=idps)
@@ -99,13 +99,13 @@ def test_saving_numeric_values_as_text(numeric_type):
     """
     Test the saving numeric values into 'text' parameter raises an exception
     """
-    p = ParamSpec("p", "text")
+    p = ParamSpecBase("p", "text")
 
     test_set = qc.new_data_set("test-dataset")
-    test_set.add_parameter(p)
+    test_set.set_interdependencies(InterDependencies_(standalones=(p,)))
     test_set.mark_started()
 
-    idps = InterDependencies_(standalones=(p.base_version(),))
+    idps = InterDependencies_(standalones=(p,))
 
     data_saver = DataSaver(
         dataset=test_set, write_period=0, interdeps=idps)

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -11,10 +11,11 @@ from hypothesis import given, settings
 import hypothesis.strategies as hst
 
 import qcodes as qc
-from qcodes import ParamSpec, new_data_set, new_experiment, experiments
+from qcodes import new_data_set, new_experiment, experiments
 from qcodes import load_by_id, load_by_counter
 from qcodes.dataset.descriptions import RunDescriber
 from qcodes.dataset.dependencies import InterDependencies_
+from qcodes.dataset.param_spec import ParamSpecBase
 from qcodes.tests.common import error_caused_by
 from qcodes.dataset.sqlite_base import _unicode_categories, get_non_dependencies
 from qcodes.dataset.database import get_DB_location
@@ -29,7 +30,7 @@ from qcodes.tests.dataset.dataset_fixtures import scalar_dataset, \
     standalone_parameters_dataset, array_in_scalar_dataset_unrolled, \
     varlen_array_in_scalar_dataset
 # pylint: disable=unused-import
-from qcodes.tests.dataset.test_descriptions import some_paramspecs
+from qcodes.tests.dataset.test_dependencies import some_interdeps
 
 pytest.register_assert_rewrite('qcodes.tests.dataset.helper_functions')
 from qcodes.tests.dataset.helper_functions import verify_data_dict
@@ -106,9 +107,10 @@ def test_dataset_states():
     with pytest.raises(RuntimeError, match=match):
         ds.add_results([{'x': 1}])
 
-    parameter = ParamSpec(name='single', paramtype='numeric',
-                          label='', unit='N/A')
-    ds.add_parameter(parameter)
+    parameter = ParamSpecBase(name='single', paramtype='numeric',
+                              label='', unit='N/A')
+    idps = InterDependencies_(standalones=(parameter,))
+    ds.set_interdependencies(idps)
 
     ds.mark_started()
 
@@ -117,11 +119,11 @@ def test_dataset_states():
     assert ds.started is True
     assert ds.completed is False
 
-    match = ('Can not add parameters to a DataSet that has '
+    match = ('Can not set interdependencies on a DataSet that has '
              'been started.')
 
     with pytest.raises(RuntimeError, match=match):
-        ds.add_parameter(parameter)
+        ds.set_interdependencies(idps)
 
     ds.add_result({parameter.name: 1})
     ds.add_results([{parameter.name: 1}])
@@ -133,11 +135,11 @@ def test_dataset_states():
     assert ds.started is True
     assert ds.completed is True
 
-    match = ('Can not add parameters to a DataSet that has '
+    match = ('Can not set interdependencies on a DataSet that has '
              'been started.')
 
     with pytest.raises(RuntimeError, match=match):
-        ds.add_parameter(parameter)
+        ds.set_interdependencies(idps)
 
     match = ('This DataSet is complete, no further '
              'results can be added to it.')
@@ -251,8 +253,7 @@ def test_add_experiments(experiment_name,
                                                           exp.exp_id,
                                                           loaded_dataset.counter)
 
-
-def test_add_paramspec(dataset):
+def test_set_interdependencies(dataset):
     exps = experiments()
     assert len(exps) == 1
     exp = exps[0]
@@ -260,13 +261,14 @@ def test_add_paramspec(dataset):
     assert exp.sample_name == "test-sample"
     assert exp.last_counter == 1
 
-    parameter_a = ParamSpec("a_param", "NUMERIC")
-    parameter_b = ParamSpec("b_param", "NUMERIC", key="value", number=1)
-    parameter_c = ParamSpec("c_param", "array", inferred_from=[parameter_a,
-                                                               parameter_b])
-    dataset.add_parameter(parameter_a)
-    dataset.add_parameter(parameter_b)
-    dataset.add_parameter(parameter_c)
+    parameter_a = ParamSpecBase("a_param", "NUMERIC")
+    parameter_b = ParamSpecBase("b_param", "NUMERIC")
+    parameter_c = ParamSpecBase("c_param", "array")
+
+    idps = InterDependencies_(
+        inferences={parameter_c: (parameter_a, parameter_b)})
+
+    dataset.set_interdependencies(idps)
 
     # write the parameters to disk
     dataset.mark_started()
@@ -284,52 +286,7 @@ def test_add_paramspec(dataset):
         ps = paramspecs[expected_param_name]
         assert ps.name == expected_param_name
 
-    assert set(paramspecs['c_param'].inferred_from_) == {'a_param', 'b_param'}
-
     assert paramspecs == dataset.paramspecs
-
-
-def test_add_paramspec_one_by_one(dataset):
-    exps = experiments()
-    assert len(exps) == 1
-    exp = exps[0]
-    assert exp.name == "test-experiment"
-    assert exp.sample_name == "test-sample"
-    assert exp.last_counter == 1
-
-    parameters = [ParamSpec("a", "NUMERIC"),
-                  ParamSpec("b", "NUMERIC", key="value", number=1),
-                  ParamSpec("c", "array")]
-    for parameter in parameters:
-        dataset.add_parameter(parameter)
-
-    # test that we can not re-add any parameter already added once
-    for param in parameters:
-        with pytest.raises(ValueError, match=f'Duplicate parameter name: '
-                                             f'{param.name}'):
-            dataset.add_parameter(param)
-
-    dataset.mark_started()
-    shadow_ds = make_shadow_dataset(dataset)
-
-    paramspecs = shadow_ds.paramspecs
-
-    expected_keys = ['a', 'b', 'c']
-    keys = sorted(list(paramspecs.keys()))
-    assert keys == expected_keys
-    for expected_param_name in expected_keys:
-        ps = paramspecs[expected_param_name]
-        assert ps.name == expected_param_name
-
-    assert paramspecs == dataset.paramspecs
-
-    # Test that is not possible to add any parameter to the dataset
-    with pytest.raises(RuntimeError, match='Can not add parameters to a '
-                                           'DataSet that has been started.'):
-        dataset.add_parameter(parameters[0])
-
-    assert len(dataset.paramspecs.keys()) == 3
-    assert len(shadow_ds.paramspecs.keys()) == 3
 
 
 @pytest.mark.usefixtures("experiment")
@@ -341,10 +298,13 @@ def test_add_data_1d():
     assert exp.sample_name == "test-sample"
     assert exp.last_counter == 0
 
-    psx = ParamSpec("x", "numeric")
-    psy = ParamSpec("y", "numeric", depends_on=['x'])
+    psx = ParamSpecBase("x", "numeric")
+    psy = ParamSpecBase("y", "numeric")
 
-    mydataset = new_data_set("test-dataset", specs=[psx, psy])
+    idps = InterDependencies_(dependencies={psy: (psx,)})
+
+    mydataset = new_data_set("test-dataset")
+    mydataset.set_interdependencies(idps)
     mydataset.mark_started()
 
     expected_x = []
@@ -385,8 +345,11 @@ def test_add_data_array():
     assert exp.sample_name == "test-sample"
     assert exp.last_counter == 0
 
-    mydataset = new_data_set("test", specs=[ParamSpec("x", "numeric"),
-                                            ParamSpec("y", "array")])
+    idps = InterDependencies_(
+        standalones=(ParamSpecBase("x", "numeric"),
+                     ParamSpecBase("y", "array")))
+    mydataset = new_data_set("test")
+    mydataset.set_interdependencies(idps)
     mydataset.mark_started()
 
     expected_x = []
@@ -415,12 +378,12 @@ def test_adding_too_many_results():
     insert_many_values function of the sqlite_base module
     """
     dataset = new_data_set("test_adding_too_many_results")
-    xparam = ParamSpec("x", "numeric", label="x parameter",
-                       unit='V')
-    yparam = ParamSpec("y", 'numeric', label='y parameter',
-                       unit='Hz', depends_on=[xparam])
-    dataset.add_parameter(xparam)
-    dataset.add_parameter(yparam)
+    xparam = ParamSpecBase("x", "numeric", label="x parameter",
+                           unit='V')
+    yparam = ParamSpecBase("y", 'numeric', label='y parameter',
+                           unit='Hz')
+    idps = InterDependencies_(dependencies={yparam: (xparam,)})
+    dataset.set_interdependencies(idps)
     dataset.mark_started()
     n_max = qc.SQLiteSettings.limits['MAX_VARIABLE_NUMBER']
 
@@ -471,9 +434,7 @@ def test_load_by_counter_for_nonexisting_experiment(nonexisting_exp_id):
 @pytest.mark.usefixtures("empty_temp_db")
 def test_dataset_with_no_experiment_raises():
     with pytest.raises(ValueError):
-        new_data_set("test-dataset",
-                     specs=[ParamSpec("x", "numeric"),
-                            ParamSpec("y", "numeric")])
+        new_data_set("test-dataset")
 
 
 def test_guid(dataset):
@@ -486,8 +447,9 @@ def test_numpy_ints(dataset):
     """
      Test that we can insert numpy integers in the data set
     """
-    xparam = ParamSpec('x', 'numeric')
-    dataset.add_parameter(xparam)
+    xparam = ParamSpecBase('x', 'numeric')
+    idps = InterDependencies_(standalones=(xparam,))
+    dataset.set_interdependencies(idps)
     dataset.mark_started()
 
     numpy_ints = [
@@ -505,8 +467,9 @@ def test_numpy_floats(dataset):
     """
     Test that we can insert numpy floats in the data set
     """
-    float_param = ParamSpec('y', 'numeric')
-    dataset.add_parameter(float_param)
+    float_param = ParamSpecBase('y', 'numeric')
+    idps = InterDependencies_(standalones=(float_param,))
+    dataset.set_interdependencies(idps)
     dataset.mark_started()
 
     numpy_floats = [np.float, np.float16, np.float32, np.float64]
@@ -517,8 +480,9 @@ def test_numpy_floats(dataset):
 
 
 def test_numpy_nan(dataset):
-    parameter_m = ParamSpec("m", "numeric")
-    dataset.add_parameter(parameter_m)
+    parameter_m = ParamSpecBase("m", "numeric")
+    idps = InterDependencies_(standalones=(parameter_m,))
+    dataset.set_interdependencies(idps)
     dataset.mark_started()
 
     data_dict = [{"m": value} for value in [0.0, np.nan, 1.0]]
@@ -531,8 +495,9 @@ def test_numpy_inf(dataset):
     """
     Test that we can insert and retrieve numpy inf in the data set
     """
-    parameter_m = ParamSpec("m", "numeric")
-    dataset.add_parameter(parameter_m)
+    parameter_m = ParamSpecBase("m", "numeric")
+    idps = InterDependencies_(standalones=(parameter_m,))
+    dataset.set_interdependencies(idps)
     dataset.mark_started()
 
     data_dict = [{"m": value} for value in [-np.inf, np.inf]]
@@ -547,15 +512,13 @@ def test_missing_keys(dataset):
     example handy when having an interleaved 1D and 2D sweep.
     """
 
-    x = ParamSpec("x", paramtype='numeric')
-    y = ParamSpec("y", paramtype='numeric')
-    a = ParamSpec("a", paramtype='numeric', depends_on=[x])
-    b = ParamSpec("b", paramtype='numeric', depends_on=[x, y])
+    x = ParamSpecBase("x", paramtype='numeric')
+    y = ParamSpecBase("y", paramtype='numeric')
+    a = ParamSpecBase("a", paramtype='numeric')
+    b = ParamSpecBase("b", paramtype='numeric')
 
-    dataset.add_parameter(x)
-    dataset.add_parameter(y)
-    dataset.add_parameter(a)
-    dataset.add_parameter(b)
+    idps = InterDependencies_(dependencies={a: (x,), b: (x, y)})
+    dataset.set_interdependencies(idps)
     dataset.mark_started()
 
     def fa(xv):
@@ -589,9 +552,8 @@ def test_missing_keys(dataset):
     assert dataset.get_setpoints("b")['y'] == expected_setpoints[1]
 
 
-def test_get_description(experiment, some_paramspecs):
+def test_get_description(experiment, some_interdeps):
 
-    paramspecs = some_paramspecs[2]
 
     ds = DataSet()
 
@@ -600,22 +562,9 @@ def test_get_description(experiment, some_paramspecs):
     desc = ds.description
     assert desc == RunDescriber(InterDependencies_())
 
-    ds.add_parameter(paramspecs['ps1'])
-    desc = ds.description
-    expected_desc = RunDescriber(
-                        InterDependencies_(
-                            standalones=(
-                                paramspecs['ps1'].base_version(),)))
-    assert desc == expected_desc
+    ds.set_interdependencies(some_interdeps[1])
 
-    ds.add_parameter(paramspecs['ps2'])
-    desc = ds.description
-    expected_desc = RunDescriber(
-                        InterDependencies_(
-                            dependencies=(
-                                {paramspecs['ps2'].base_version():
-                                 (paramspecs['ps1'].base_version(),)})))
-    assert desc == expected_desc
+    assert ds._interdeps == some_interdeps[1]
 
     # the run description gets written as the dataset is marked as started,
     # so now no description should be stored in the database
@@ -666,11 +615,10 @@ def test_metadata(experiment, request):
     assert error_caused_by(e, bad_tag_msg)
 
 
-def test_the_same_dataset_as(some_paramspecs, experiment):
-    paramspecs = some_paramspecs[2]
+def test_the_same_dataset_as(some_interdeps, experiment):
+
     ds = DataSet()
-    ds.add_parameter(paramspecs['ps1'])
-    ds.add_parameter(paramspecs['ps2'])
+    ds.set_interdependencies(some_interdeps[1])
     ds.mark_started()
     ds.add_result({'ps1': 1, 'ps2': 2})
 
@@ -682,7 +630,7 @@ def test_the_same_dataset_as(some_paramspecs, experiment):
 
 
 class TestGetData:
-    x = ParamSpec("x", paramtype='numeric')
+    x = ParamSpecBase("x", paramtype='numeric')
     n_vals = 5
     xvals = list(range(n_vals))
     # this is the format of how data is returned by DataSet.get_data
@@ -695,7 +643,8 @@ class TestGetData:
         This fixture creates a DataSet with values that is to be used by all
         the tests in this class
         """
-        dataset.add_parameter(self.x)
+        idps = InterDependencies_(standalones=(self.x,))
+        dataset.set_interdependencies(idps)
         dataset.mark_started()
         for xv in self.xvals:
             dataset.add_result({self.x.name: xv})

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -576,7 +576,9 @@ def test_get_description(experiment, some_interdeps):
 
     loaded_ds = DataSet(run_id=1)
 
-    assert loaded_ds.description == desc
+    expected_desc = RunDescriber(some_interdeps[1])
+
+    assert loaded_ds.description == expected_desc
 
 
 def test_metadata(experiment, request):
@@ -698,7 +700,7 @@ def test_mark_complete_is_deprecated_and_marks_as_completed(experiment):
         mark_completed.assert_called_once()
 
 
-@settings(deadline=400)
+@settings(deadline=600)
 @given(start=hst.one_of(hst.integers(1, 10**3), hst.none()),
        end=hst.one_of(hst.integers(1, 10**3), hst.none()))
 def test_get_parameter_data(scalar_dataset, start, end):

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -7,15 +7,16 @@ from qcodes.dataset.data_set import (DataSet,
                                      new_data_set,
                                      load_by_guid,
                                      load_by_id,
-                                     load_by_counter,
-                                     ParamSpec)
+                                     load_by_counter)
+from qcodes.dataset.param_spec import ParamSpecBase
+from qcodes.dataset.dependencies import InterDependencies_
 from qcodes.dataset.data_export import get_data_by_id
 from qcodes.dataset.experiment_container import new_experiment
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import (empty_temp_db,
                                                       experiment, dataset)
 # pylint: disable=unused-import
-from qcodes.tests.dataset.test_descriptions import some_paramspecs
+from qcodes.tests.dataset.test_dependencies import some_interdeps
 
 
 @pytest.mark.usefixtures("experiment")
@@ -176,18 +177,19 @@ def test_completed_timestamp_with_default_format():
 
 def test_get_data_by_id_order(dataset):
     """
-    Test if the values of the setpoints/dependent parameters is dependent on
-    the order of the `depends_on` value. This sounds far fetch but was
-    actually the case before #1250.
+    Test that the added values of setpoints end up associated with the correct
+    setpoint parameter, irrespective of the ordering of those setpoint
+    parameters
     """
-    indepA = ParamSpec('indep1', "numeric")
-    indepB = ParamSpec('indep2', "numeric")
-    depAB = ParamSpec('depAB', "numeric", depends_on=[indepA, indepB])
-    depBA = ParamSpec('depBA', "numeric", depends_on=[indepB, indepA])
-    dataset.add_parameter(indepA)
-    dataset.add_parameter(indepB)
-    dataset.add_parameter(depAB)
-    dataset.add_parameter(depBA)
+    indepA = ParamSpecBase('indep1', "numeric")
+    indepB = ParamSpecBase('indep2', "numeric")
+    depAB = ParamSpecBase('depAB', "numeric")
+    depBA = ParamSpecBase('depBA', "numeric")
+
+    idps = InterDependencies_(
+        dependencies={depAB: (indepA, indepB), depBA: (indepB, indepA)})
+
+    dataset.set_interdependencies(idps)
 
     dataset.mark_started()
 
@@ -211,11 +213,9 @@ def test_get_data_by_id_order(dataset):
 
 
 @pytest.mark.usefixtures('experiment')
-def test_load_by_guid(some_paramspecs):
-    paramspecs = some_paramspecs[2]
+def test_load_by_guid(some_interdeps):
     ds = DataSet()
-    ds.add_parameter(paramspecs['ps1'])
-    ds.add_parameter(paramspecs['ps2'])
+    ds.set_interdependencies(some_interdeps[1])
     ds.mark_started()
     ds.add_result({'ps1': 1, 'ps2': 2})
 

--- a/qcodes/tests/dataset/test_dependencies.py
+++ b/qcodes/tests/dataset/test_dependencies.py
@@ -25,6 +25,40 @@ def some_paramspecbases():
 
     return (psb1, psb2, psb3, psb4)
 
+@pytest.fixture
+def some_interdeps():
+    """
+    Some different InterDependencies_ objects for testing
+    """
+    idps_list = []
+    ps1 = ParamSpecBase('ps1', paramtype='numeric', label='Raw Data 1',
+                        unit='V')
+    ps2 = ParamSpecBase('ps2', paramtype='array', label='Raw Data 2',
+                        unit='V')
+    ps3 = ParamSpecBase('ps3', paramtype='text', label='Axis 1',
+                        unit='')
+    ps4 = ParamSpecBase('ps4', paramtype='numeric', label='Axis 2',
+                        unit='V')
+    ps5 = ParamSpecBase('ps5', paramtype='numeric', label='Signal',
+                        unit='Conductance')
+    ps6 = ParamSpecBase('ps6', paramtype='text', label='Goodness',
+                    unit='')
+
+    idps = InterDependencies_(dependencies={ps5: (ps3, ps4), ps6: (ps3, ps4)},
+                              inferences={ps4: (ps2,), ps3: (ps1,)})
+
+    idps_list.append(idps)
+
+    ps1 = ParamSpecBase('ps1', paramtype='numeric',
+                        label='setpoint', unit='Hz')
+    ps2 = ParamSpecBase('ps2', paramtype='numeric', label='signal',
+                        unit='V')
+    idps = InterDependencies_(dependencies={ps2: (ps1,)})
+
+    idps_list.append(idps)
+
+    return idps_list
+
 
 def test_wrong_input_raises():
 

--- a/qcodes/tests/dataset/test_dependencies.py
+++ b/qcodes/tests/dataset/test_dependencies.py
@@ -108,12 +108,11 @@ def test_init_validation_raises(some_paramspecbases):
                      {ps1: ('ps2',)},
                      {ps1: (ps2,), ps2: (ps1,)}
                      )
-    causes = ("ParamSpecTree must be a dict",
-              "ParamSpecTree must have ParamSpecs as keys",
-              "ParamSpecTree must have tuple values",
-              "ParamSpecTree can only have tuples "
-              "of ParamSpecs as values",
-              "ParamSpecTree can not have cycles")
+    causes = ("'list' object has no attribute 'items'",
+              "Root of ParamSpecTree must be of type ParamSpecBase",
+              "Leafs of ParamSpecTree must be of type ParamSpecBase",
+              "Leafs of ParamSpecTree must be of type ParamSpecBase",
+              "Cycles detected!")
 
     for tree, cause in zip(invalid_trees, causes):
         with pytest.raises(ValueError, match='Invalid dependencies') as ei:

--- a/qcodes/tests/dataset/test_string_data.py
+++ b/qcodes/tests/dataset/test_string_data.py
@@ -6,7 +6,7 @@ import numpy as np
 import qcodes as qc
 from qcodes.dataset.measurements import DataSaver, Measurement
 from qcodes.dataset.dependencies import InterDependencies_
-from qcodes.dataset.param_spec import ParamSpec
+from qcodes.dataset.param_spec import ParamSpecBase
 from qcodes.dataset.data_export import load_by_id
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import empty_temp_db, experiment
@@ -16,10 +16,11 @@ def test_string_via_dataset(experiment):
     """
     Test that we can save text into database via DataSet API
     """
-    p = ParamSpec("p", "text")
+    p = ParamSpecBase("p", "text")
 
     test_set = qc.new_data_set("test-dataset")
-    test_set.add_parameter(p)
+    idps = InterDependencies_(standalones=(p,))
+    test_set.set_interdependencies(idps)
     test_set.mark_started()
 
     test_set.add_result({"p": "some text"})
@@ -33,13 +34,14 @@ def test_string_via_datasaver(experiment):
     """
     Test that we can save text into database via DataSaver API
     """
-    p = ParamSpec(name="p", paramtype="text")
+    p = ParamSpecBase(name="p", paramtype="text")
 
     test_set = qc.new_data_set("test-dataset")
-    test_set.add_parameter(p)
+    idps = InterDependencies_(standalones=(p,))
+    test_set.set_interdependencies(idps)
     test_set.mark_started()
 
-    idps = InterDependencies_(standalones=(p.base_version(),))
+    idps = InterDependencies_(standalones=(p,))
 
     data_saver = DataSaver(
         dataset=test_set, write_period=0, interdeps=idps)
@@ -93,13 +95,14 @@ def test_string_with_wrong_paramtype_via_datasaver(experiment):
     Test that it is not possible to add a string value for a non-text
     parameter via DataSaver object
     """
-    p = ParamSpec("p", "numeric")
+    p = ParamSpecBase("p", "numeric")
 
     test_set = qc.new_data_set("test-dataset")
-    test_set.add_parameter(p)
+    idps = InterDependencies_(standalones=(p,))
+    test_set.set_interdependencies(idps)
     test_set.mark_started()
 
-    idps = InterDependencies_(standalones=(p.base_version(),))
+    idps = InterDependencies_(standalones=(p,))
 
     data_saver = DataSaver(
         dataset=test_set, write_period=0, interdeps=idps)
@@ -119,10 +122,11 @@ def test_string_saved_and_loaded_as_numeric_via_dataset(experiment):
     via DataSet API, and, importantly, to retrieve it thanks to the
     flexibility of `_convert_numeric` converter function.
     """
-    p = ParamSpec("p", "numeric")
+    p = ParamSpecBase("p", "numeric")
 
     test_set = qc.new_data_set("test-dataset")
-    test_set.add_parameter(p)
+    idps = InterDependencies_(standalones=(p,))
+    test_set.set_interdependencies(idps)
     test_set.mark_started()
 
     test_set.add_result({"p": 'some text'})

--- a/qcodes/tests/dataset/test_subscribing.py
+++ b/qcodes/tests/dataset/test_subscribing.py
@@ -7,7 +7,8 @@ from numpy import ndarray
 import logging
 
 import qcodes
-from qcodes.dataset.param_spec import ParamSpec
+from qcodes.dataset.param_spec import ParamSpecBase
+from qcodes.dataset.dependencies import InterDependencies_
 # pylint: disable=unused-import
 from qcodes.dataset.sqlite_base import atomic_transaction
 from qcodes.tests.dataset.temporary_databases import (
@@ -26,12 +27,12 @@ VALUE = Union[str, Number, List, ndarray, bool]
 
 class MockSubscriber():
     """
-    A basic subscriber factory that create a subscriber, that
+    A basic subscriber factory that creates a subscriber, that
     just puts results and length into state.
     *Important*
     This class is extremely dangerous! Within the callback,
     you cannot read or write to the database/dataset because it
-    is called from another thread as the connection of the
+    is called from another thread than the one holding the connection of the
     dataset!
     """
     def __init__(self, ds, lg):
@@ -66,12 +67,16 @@ def basic_subscriber():
 
 
 def test_basic_subscription(dataset, basic_subscriber):
-    xparam = ParamSpec(name='x', paramtype='numeric', label='x parameter',
-                       unit='V')
-    yparam = ParamSpec(name='y', paramtype='numeric', label='y parameter',
-                       unit='Hz', depends_on=[xparam])
-    dataset.add_parameter(xparam)
-    dataset.add_parameter(yparam)
+    xparam = ParamSpecBase(name='x',
+                           paramtype='numeric',
+                           label='x parameter',
+                           unit='V')
+    yparam = ParamSpecBase(name='y',
+                           paramtype='numeric',
+                           label='y parameter',
+                           unit='Hz')
+    idps = InterDependencies_(dependencies={yparam: (xparam,)})
+    dataset.set_interdependencies(idps)
     dataset.mark_started()
 
     sub_id = dataset.subscribe(basic_subscriber, min_wait=0, min_count=1,
@@ -99,7 +104,7 @@ def test_basic_subscription(dataset, basic_subscriber):
     assert len(dataset.subscribers) == 0
     assert list(dataset.subscribers.keys()) == []
 
-    # Ensure the trigger for the subscriber have been removed from the database
+    # Ensure the trigger for the subscriber has been removed from the database
     get_triggers_sql = "SELECT * FROM sqlite_master WHERE TYPE = 'trigger';"
     triggers = atomic_transaction(
         dataset.conn, get_triggers_sql).fetchall()
@@ -141,12 +146,17 @@ def test_subscription_from_config(dataset, basic_subscriber):
 
         assert 'test_subscriber' in qcodes.config.subscription.subscribers
 
-        xparam = ParamSpec(name='x', paramtype='numeric', label='x parameter',
+        xparam = ParamSpecBase(name='x',
+                           paramtype='numeric',
+                           label='x parameter',
                            unit='V')
-        yparam = ParamSpec(name='y', paramtype='numeric', label='y parameter',
-                           unit='Hz', depends_on=[xparam])
-        dataset.add_parameter(xparam)
-        dataset.add_parameter(yparam)
+        yparam = ParamSpecBase(name='y',
+                              paramtype='numeric',
+                              label='y parameter',
+                              unit='Hz')
+        idps = InterDependencies_(dependencies={yparam: (xparam,)})
+        dataset.set_interdependencies(idps)
+
         dataset.mark_started()
 
         sub_id = dataset.subscribe(basic_subscriber, min_wait=0, min_count=1,

--- a/qcodes/tests/dataset_generators.py
+++ b/qcodes/tests/dataset_generators.py
@@ -1,15 +1,16 @@
 import numpy as np
-from qcodes.dataset.param_spec import ParamSpec
+from qcodes.dataset.param_spec import ParamSpecBase
+from qcodes.dataset.dependencies import InterDependencies_
+
 
 def dataset_with_outliers_generator(ds, data_offset=5, low_outlier=-3,
                  high_outlier=1, background_noise=True):
-    x = ParamSpec('x', 'numeric', label='Flux', unit='e^2/hbar')
-    t = ParamSpec('t', 'numeric', label='Time', unit='s')
-    z = ParamSpec('z', 'numeric', label='Majorana number', unit='Anyon',
-                depends_on=[x, t])
-    ds.add_parameter(x)
-    ds.add_parameter(t)
-    ds.add_parameter(z)
+    x = ParamSpecBase('x', 'numeric', label='Flux', unit='e^2/hbar')
+    t = ParamSpecBase('t', 'numeric', label='Time', unit='s')
+    z = ParamSpecBase('z', 'numeric', label='Majorana number', unit='Anyon')
+
+    idps = InterDependencies_(dependencies={z: (x, t)})
+    ds.set_interdependencies(idps)
     ds.mark_started()
 
     npoints = 50


### PR DESCRIPTION
This PR introduces the `ParamSpecTree` object for describing the parameter tree that we have so great hopes for.

The PR is very much work in progress, but I'm opening it now just so we can look at the code together.

EDIT 2019-05-08:
The `dependencies.py` is now self-consistent and passes its own test. I'll start working on updating the rest of code base right away. You can get an idea of `ParamSpecTree`s from the code already.

A small outline here:
One or more `ParamSpecBase` objects can be combined into a `ParamSpecTree`:
```python
ps1 = ParamSpecBase('conductance', 'numeric', 'conductance', 'e^2/hbar')
ps2 = ParamSpecBase('vg', 'numeric', 'gate voltage', 'V')
ps3 = ParamSpecBase('vp', 'numeric', 'plunger voltage', 'V')
tree1 = ParamSpecTree(ps1, ps2, ps3)
```
the `InterDependencies_` object is instantiated with one or two tuple of trees:
```python
idps = InterDependencies_(dependencies=(tree1, tree2), inferences=(tree3,))
```
under the hood, the `InterDependencies_` object puts those trees into two `ParamSpecGrove` objects. Once we kill the inferences, a single `ParamSpecGrove` will take the place of the `InterDependencies_` object.

Note that this PR contains the changes of #1547 .

EDIT 2019-05-16:
Further development is hinging on/blocked by #1566 