### PR TITLE
AMI430 driver: fix using numeric field_limit

### DIFF
--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -672,8 +672,7 @@ class AMI430_3D(Instrument):
         )
 
     def _verify_safe_setpoint(self, setpoint_values):
-
-        if repr(self._field_limit).isnumeric():
+        if isinstance(self._field_limit, numbers.Real):
             return np.linalg.norm(setpoint_values) < self._field_limit
 
         answer = any([limit_function(*setpoint_values) for

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -14,6 +14,9 @@ from qcodes.utils.validators import Bool, Numbers, Ints, Anything
 
 log = logging.getLogger(__name__)
 
+CartesianFieldLimitFunction = \
+    Callable[[numbers.Real, numbers.Real, numbers.Real], bool]
+
 
 class AMI430Exception(Exception):
     pass
@@ -476,7 +479,8 @@ class AMI430(IPInstrument):
 class AMI430_3D(Instrument):
     def __init__(self, name,
                  instrument_x, instrument_y, instrument_z,
-                 field_limit: Union[numbers.Real, Iterable[Callable]],
+                 field_limit: Union[numbers.Real,
+                                    Iterable[CartesianFieldLimitFunction]],
                  **kwargs):
         super().__init__(name, **kwargs)
 
@@ -494,7 +498,7 @@ class AMI430_3D(Instrument):
         self._instrument_y = instrument_y
         self._instrument_z = instrument_z
 
-        self._field_limit: Union[float, Iterable[Callable]]
+        self._field_limit: Union[float, Iterable[CartesianFieldLimitFunction]]
         if isinstance(field_limit, collections.abc.Iterable):
             self._field_limit = field_limit
         elif isinstance(field_limit, numbers.Real):

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -494,11 +494,12 @@ class AMI430_3D(Instrument):
         self._instrument_y = instrument_y
         self._instrument_z = instrument_z
 
-        self._field_limit: Union[numbers.Real, Iterable[Callable]]
+        self._field_limit: Union[float, Iterable[Callable]]
         if isinstance(field_limit, collections.abc.Iterable):
             self._field_limit = field_limit
         elif isinstance(field_limit, numbers.Real):
-            self._field_limit = field_limit
+            # Convertion to float makes related driver logic simpler
+            self._field_limit = float(field_limit)
         else:
             raise ValueError("field limit should either be a number or "
                              "an iterable of callable field limit functions.")
@@ -674,7 +675,7 @@ class AMI430_3D(Instrument):
         )
 
     def _verify_safe_setpoint(self, setpoint_values):
-        if isinstance(self._field_limit, numbers.Real):
+        if isinstance(self._field_limit, float):
             return np.linalg.norm(setpoint_values) < self._field_limit
 
         answer = any([limit_function(*setpoint_values) for

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -498,8 +498,8 @@ class AMI430_3D(Instrument):
         elif isinstance(field_limit, numbers.Real):
             self._field_limit = field_limit
         else:
-            raise ValueError("field limit should either be"
-                             " a number or an iterable")
+            raise ValueError("field limit should either be a number or "
+                             "an iterable of callable field limit functions.")
 
         self._set_point = FieldVector(
             x=self._instrument_x.field(),

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -3,6 +3,8 @@ import logging
 import time
 from functools import partial
 from warnings import warn
+from typing import Union, Iterable, Callable
+import numbers
 
 import numpy as np
 
@@ -490,7 +492,10 @@ class AMI430_3D(Instrument):
         self._instrument_y = instrument_y
         self._instrument_z = instrument_z
 
-        if repr(field_limit).isnumeric() or isinstance(field_limit, collections.abc.Iterable):
+        self._field_limit: Union[numbers.Real, Iterable[Callable]]
+        if isinstance(field_limit, collections.abc.Iterable):
+            self._field_limit = field_limit
+        elif isinstance(field_limit, numbers.Real):
             self._field_limit = field_limit
         else:
             raise ValueError("field limit should either be"

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -474,8 +474,10 @@ class AMI430(IPInstrument):
 
 
 class AMI430_3D(Instrument):
-    def __init__(self, name, instrument_x, instrument_y,
-                 instrument_z, field_limit, **kwargs):
+    def __init__(self, name,
+                 instrument_x, instrument_y, instrument_z,
+                 field_limit: Union[numbers.Real, Iterable[Callable]],
+                 **kwargs):
         super().__init__(name, **kwargs)
 
         if not isinstance(name, str):

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -26,6 +26,10 @@ visalib = sims.__file__.replace('__init__.py', 'AMI430.yaml@sim')
 
 @pytest.fixture(scope='function')
 def magnet_axes_instances():
+    """
+    Start three mock instruments representing current drivers for the x, y,
+    and z directions.
+    """
     mag_x = AMI430_VISA('x', address='GPIB::1::INSTR', visalib=visalib,
                         terminator='\n', port=1)
     mag_y = AMI430_VISA('y', address='GPIB::2::INSTR', visalib=visalib,
@@ -43,8 +47,8 @@ def magnet_axes_instances():
 @pytest.fixture(scope='function')
 def current_driver(magnet_axes_instances):
     """
-    Start three mock instruments representing current drivers for the x, y,
-    and z directions.
+    Instantiate AMI430_3D instrument with the three mock instruments
+    representing current drivers for the x, y, and z directions.
     """
     mag_x, mag_y, mag_z = magnet_axes_instances
 

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -431,3 +431,17 @@ def test_blocking_ramp_parameter(current_driver, caplog):
 
         assert len([mssg for mssg in messages if 'blocking' in mssg]) == 0
 
+
+@pytest.mark.parametrize('field_limit', [2, 2.2], ids=['integer', 'float'])
+def test_numeric_field_limit(magnet_axes_instances, field_limit, request):
+    mag_x, mag_y, mag_z = magnet_axes_instances
+    ami = AMI430_3D("AMI430-3D", mag_x, mag_y, mag_z, field_limit)
+    request.addfinalizer(ami.close)
+
+    target_within_limit = (field_limit * 0.95, 0, 0)
+    ami.cartesian(target_within_limit)
+
+    target_outside_limit = (field_limit * 1.05, 0, 0)
+    with pytest.raises(ValueError,
+                       match='_set_fields aborted; field would exceed limit'):
+        ami.cartesian(target_outside_limit)

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -25,12 +25,7 @@ visalib = sims.__file__.replace('__init__.py', 'AMI430.yaml@sim')
 
 
 @pytest.fixture(scope='function')
-def current_driver():
-    """
-    Start three mock instruments representing current drivers for the x, y,
-    and z directions.
-    """
-
+def magnet_axes_instances():
     mag_x = AMI430_VISA('x', address='GPIB::1::INSTR', visalib=visalib,
                         terminator='\n', port=1)
     mag_y = AMI430_VISA('y', address='GPIB::2::INSTR', visalib=visalib,
@@ -38,13 +33,25 @@ def current_driver():
     mag_z = AMI430_VISA('z', address='GPIB::3::INSTR', visalib=visalib,
                         terminator='\n', port=1)
 
-    driver = AMI430_3D("AMI430-3D", mag_x, mag_y, mag_z, field_limit)
-
-    yield driver
+    yield mag_x, mag_y, mag_z
 
     mag_x.close()
     mag_y.close()
     mag_z.close()
+
+
+@pytest.fixture(scope='function')
+def current_driver(magnet_axes_instances):
+    """
+    Start three mock instruments representing current drivers for the x, y,
+    and z directions.
+    """
+    mag_x, mag_y, mag_z = magnet_axes_instances
+
+    driver = AMI430_3D("AMI430-3D", mag_x, mag_y, mag_z, field_limit)
+
+    yield driver
+
     driver.close()
 
 

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -438,6 +438,8 @@ def test_numeric_field_limit(magnet_axes_instances, field_limit, request):
     ami = AMI430_3D("AMI430-3D", mag_x, mag_y, mag_z, field_limit)
     request.addfinalizer(ami.close)
 
+    assert isinstance(ami._field_limit, float)
+
     target_within_limit = (field_limit * 0.95, 0, 0)
     ami.cartesian(target_within_limit)
 

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -8,11 +8,14 @@ from typing import Union
 
 numpy_concrete_ints = (np.int8, np.int16, np.int32, np.int64,
                        np.uint8, np.uint16, np.uint32, np.uint64)
-numpy_non_concrete_ints = (np.int, np.int_, np.uint, np.integer)
+numpy_non_concrete_ints_instantiable = (np.int, np.int_, np.uint)
+numpy_non_concrete_ints = \
+    numpy_non_concrete_ints_instantiable + (np.integer,)
 
 numpy_concrete_floats = (np.float16, np.float32, np.float64)
-numpy_non_concrete_floats = (np.float, np.float_,
-                             np.floating)
+numpy_non_concrete_floats_instantiable = (np.float, np.float_)
+numpy_non_concrete_floats = \
+    numpy_non_concrete_floats_instantiable + (np.floating,)
 
 numpy_concrete_complex = (np.complex64, np.complex128)
 numpy_non_concrete_complex = (np.complex, np.complex_, np.complexfloating)


### PR DESCRIPTION
The original user problem was that the driver would raise `ValueError` when initialized with a floating point value. This prevented the user to set the field limit to smth like 2.1T, and the workaround was to use an unsafe limit of 3T. 

This is the code:
https://github.com/QCoDeS/Qcodes/blob/1923c8d5c60580c902c93ec5e22b2cfd2bede401/qcodes/instrument_drivers/american_magnetics/AMI430.py#L493-L497

The problem is that `repr(field_limit).isnumeric()` is used to check whether the `field_limit` is "numeric" - which returns `True` for integer values but returns `False` for floating point values. Also, it's pretty bizarre that a string method is used to check for "numeric-ness", and is used wrongly.

This PR implements a fix for it, see the list below.

List of changes:
* Use `isinstance` for type checking instead of `repr(field_limit).isnumeric()`
* Make sure numeric field_limit is converted to `float` internally
* Annotate field_limit argument type in AMI430 driver
* Clarify error message for the field limit type upon AMI430 initialization
* Test using int and float field_limit in AMI430 driver
* Make separate fixture for magnet axes instances in AMI430 magnet driver tests

Thanks to @vhartong for informing about this issue.