### PR TITLE
Cryocon / Allow setting termination character

### DIFF
--- a/qcodes/instrument_drivers/cryocon/cryocon_26.py
+++ b/qcodes/instrument_drivers/cryocon/cryocon_26.py
@@ -6,7 +6,7 @@ class Cryocon_26(VisaInstrument):
     """
     Driver for the Cryo-con Model 26 temperature controller.
     """
-    def __init__(self, name, address, reset=False, terminator='\n', **kwargs):
+    def __init__(self, name, address, terminator='\n', **kwargs):
         super().__init__(name, address, terminator=terminator, **kwargs)
 
         on_off_map = {True: 'ON', False: 'OFF'}

--- a/qcodes/instrument_drivers/cryocon/cryocon_26.py
+++ b/qcodes/instrument_drivers/cryocon/cryocon_26.py
@@ -6,8 +6,8 @@ class Cryocon_26(VisaInstrument):
     """
     Driver for the Cryo-con Model 26 temperature controller.
     """
-    def __init__(self, name, address, reset=False, **kwargs):
-        super().__init__(name, address, terminator='\n', **kwargs)
+    def __init__(self, name, address, reset=False, terminator='\n', **kwargs):
+        super().__init__(name, address, terminator=terminator, **kwargs)
 
         on_off_map = {True: 'ON', False: 'OFF'}
 


### PR DESCRIPTION
* Make termination a kwarg of init, and pass it to super's init call.
* remove `reset` argument

Delft users discovered that the terminator is actually `\r\n` although `\n` also works. The hint to this was discovered when the queue of the visa responses got out of sync. But i've decided not to change the default terminator and just let the users set it, and if they confirm with usage that `\r\n` is the right one, then we'll change it.