### PR TITLE
Remove warning when taking snapshot of ZIHDAWG8

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -182,11 +182,11 @@ class InstrumentBase(Metadatable, DelegateAttributes):
 
         snap['parameters'] = {}
         for name, param in self.parameters.items():
-            update = update
+            iter_update = update
             if params_to_skip_update and name in params_to_skip_update:
-                update = False
+                iter_update = False
             try:
-                snap['parameters'][name] = param.snapshot(update=update)
+                snap['parameters'][name] = param.snapshot(update=iter_update)
             except:
                 # really log this twice. Once verbose for the UI and once
                 # at lower level with more info for file based loggers

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -182,11 +182,11 @@ class InstrumentBase(Metadatable, DelegateAttributes):
 
         snap['parameters'] = {}
         for name, param in self.parameters.items():
-            iter_update = update
+            update = update
             if params_to_skip_update and name in params_to_skip_update:
-                iter_update = False
+                update = False
             try:
-                snap['parameters'][name] = param.snapshot(update=iter_update)
+                snap['parameters'][name] = param.snapshot(update=update)
             except:
                 # really log this twice. Once verbose for the UI and once
                 # at lower level with more info for file based loggers

--- a/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
+++ b/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
@@ -64,7 +64,7 @@ class ZIHDAWG8(Instrument):
         self._compiler_sleep_time = 0.01
 
     def snapshot_base(self, update: bool = True,
-                      params_to_skip_update: Sequence[str] = 'features_code') -> Dict:
+                      params_to_skip_update: Sequence[str] = ('features_code',)) -> Dict:
         """ Override the base method to ignore 'feature_code' by default."""
         return super(ZIHDAWG8, self).snapshot_base(update=update,
                                                    params_to_skip_update=params_to_skip_update)

--- a/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
+++ b/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
@@ -64,11 +64,14 @@ class ZIHDAWG8(Instrument):
         self._compiler_sleep_time = 0.01
 
     def snapshot_base(self, update: bool = True,
-                      params_to_skip_update: Sequence[str] = None) -> Dict:
-        """ Override the base method to ensure all values are up-to-date"""
-        params_to_skip = 'features_code'
+                      params_to_skip_update: Sequence[str] = 'features_code') -> Dict:
+        """ Override the base method to ignore 'feature_code' by default."""
         return super(ZIHDAWG8, self).snapshot_base(update=update,
-                                                   params_to_skip_update=params_to_skip)
+                                                   params_to_skip_update=params_to_skip_update)
+
+    def snapshot(self, update=True):
+        """ Override base method to make update default True."""
+        return super(ZIHDAWG8, self).snapshot(update)
 
     def enable_channel(self, channel_number: int) -> None:
         """

--- a/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
+++ b/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
@@ -64,10 +64,13 @@ class ZIHDAWG8(Instrument):
         self._compiler_sleep_time = 0.01
 
     def snapshot_base(self, update: bool = True,
-                      params_to_skip_update: Sequence[str] = ('features_code',)) -> Dict:
+                      params_to_skip_update: Sequence[str] = None) -> Dict:
         """ Override the base method to ignore 'feature_code' by default."""
+        params_to_skip = ['features_code']
+        if params_to_skip_update is not None:
+            params_to_skip += list(params_to_skip_update)
         return super(ZIHDAWG8, self).snapshot_base(update=update,
-                                                   params_to_skip_update=params_to_skip_update)
+                                                   params_to_skip_update=params_to_skip)
 
     def snapshot(self, update=True):
         """ Override base method to make update default True."""

--- a/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
+++ b/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
@@ -63,11 +63,12 @@ class ZIHDAWG8(Instrument):
         self.warnings_as_errors: List[str] = []
         self._compiler_sleep_time = 0.01
 
-    def snapshot_base(self, update: bool = False,
+    def snapshot_base(self, update: bool = True,
                       params_to_skip_update: Sequence[str] = None) -> Dict:
         """ Override the base method to ensure all values are up-to-date"""
-        return super(ZIHDAWG8, self).snapshot_base(update=True,
-                                                   params_to_skip_update=None)
+        params_to_skip = 'features_code'
+        return super(ZIHDAWG8, self).snapshot_base(update=update,
+                                                   params_to_skip_update=params_to_skip)
 
     def enable_channel(self, channel_number: int) -> None:
         """


### PR DESCRIPTION
Changes proposed in this pull request:
- update parameter in ZIHDAWG.snapshot_base should work as advertised.
- feature_code should be ignored when getting an update snapshot.


@WilliamHPNielsen 
