### PR TITLE
DB upgrade: version 5 - snapshot column ALWAYS present in runs table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ script:
       cd ..
       git clone https://github.com/QCoDeS/qcodes_generate_test_db.git
       cd qcodes_generate_test_db
+      git checkout bumping-to-version-5
       python generate_version_0.py
       python generate_version_1.py
       python generate_version_2.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ script:
       cd ..
       git clone https://github.com/QCoDeS/qcodes_generate_test_db.git
       cd qcodes_generate_test_db
-      git checkout bumping-to-version-5
       python generate_version_0.py
       python generate_version_1.py
       python generate_version_2.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,7 @@ script:
       python generate_version_2.py
       python generate_version_3.py
       python generate_version_4a.py
+      python generate_version_4.py
       cd $TRAVIS_BUILD_DIR
       pip uninstall -y qcodes
       pip install .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,6 @@ jobs:
           cd ..
           git clone https://github.com/QCoDeS/qcodes_generate_test_db.git
           cd qcodes_generate_test_db
-          git checkout bumping-to-version-5
           python generate_version_0.py
           python generate_version_1.py
           python generate_version_2.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,6 +37,7 @@ jobs:
           cd ..
           git clone https://github.com/QCoDeS/qcodes_generate_test_db.git
           cd qcodes_generate_test_db
+          git checkout bumping-to-version-5
           python generate_version_0.py
           python generate_version_1.py
           python generate_version_2.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,6 +42,7 @@ jobs:
           python generate_version_2.py
           python generate_version_3.py
           python generate_version_4a.py
+          python generate_version_4.py
         displayName: "Generate db fixtures"
         condition: succeededOrFailed()
       - script: |

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -341,11 +341,8 @@ class DataSet(Sized):
     @property
     def snapshot_raw(self) -> Optional[str]:
         """Snapshot of the run as a JSON-formatted string (or None)"""
-        if is_column_in_table(self.conn, "runs", "snapshot"):
-            return select_one_where(self.conn, "runs", "snapshot",
-                                    "run_id", self.run_id)
-        else:
-            return None
+        return select_one_where(self.conn, "runs", "snapshot",
+                                "run_id", self.run_id)
 
     @property
     def number_of_results(self):

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -80,13 +80,14 @@ def _appropriate_kwargs(plottype: str,
 
 def plot_by_id(run_id: int,
                axes: Optional[Union[matplotlib.axes.Axes,
-                              Sequence[matplotlib.axes.Axes]]]=None,
+                              Sequence[matplotlib.axes.Axes]]] = None,
                colorbars: Optional[Union[matplotlib.colorbar.Colorbar,
                                    Sequence[
-                                       matplotlib.colorbar.Colorbar]]]=None,
-               rescale_axes: bool=True,
-               auto_color_scale: Optional[bool]=None,
-               cutoff_percentile: Optional[Union[Tuple[Number, Number], Number]]=None,
+                                       matplotlib.colorbar.Colorbar]]] = None,
+               rescale_axes: bool = True,
+               auto_color_scale: Optional[bool] = None,
+               cutoff_percentile: Optional[Union[Tuple[Number, Number],
+                                                 Number]] = None,
                **kwargs) -> AxesTupleList:
     """
     Construct all plots for a given run
@@ -269,7 +270,8 @@ def plot_by_id(run_id: int,
 
 
 def _get_label_of_data(data_dict: Dict[str, Any]) -> str:
-    return data_dict['label'] if data_dict['label'] != '' else data_dict['name']
+    return data_dict['label'] if data_dict['label'] != '' \
+        else data_dict['name']
 
 
 def _make_axis_label(label: str, unit: str) -> str:
@@ -288,7 +290,7 @@ def _make_label_for_data_axis(data: List[Dict[str, Any]], axis_index: int
 
 def _set_data_axes_labels(ax: matplotlib.axes.Axes,
                           data: List[Dict[str, Any]],
-                          cax: Optional[matplotlib.colorbar.Colorbar]=None
+                          cax: Optional[matplotlib.colorbar.Colorbar] = None
                           ) -> None:
     ax.set_xlabel(_make_label_for_data_axis(data, 0))
     ax.set_ylabel(_make_label_for_data_axis(data, 1))
@@ -299,7 +301,7 @@ def _set_data_axes_labels(ax: matplotlib.axes.Axes,
 
 def plot_2d_scatterplot(x: np.ndarray, y: np.ndarray, z: np.ndarray,
                         ax: matplotlib.axes.Axes,
-                        colorbar: matplotlib.colorbar.Colorbar=None,
+                        colorbar: matplotlib.colorbar.Colorbar = None,
                         **kwargs) -> AxesTuple:
     """
     Make a 2D scatterplot of the data. ``**kwargs`` are passed to matplotlib's
@@ -355,7 +357,7 @@ def plot_on_a_plain_grid(x: np.ndarray,
                          y: np.ndarray,
                          z: np.ndarray,
                          ax: matplotlib.axes.Axes,
-                         colorbar: matplotlib.colorbar.Colorbar=None,
+                         colorbar: matplotlib.colorbar.Colorbar = None,
                          **kwargs
                          ) -> AxesTuple:
     """
@@ -559,20 +561,22 @@ def _make_rescaled_ticks_and_units(data_dict: Dict[str, Any]) \
 
 def _rescale_ticks_and_units(ax: matplotlib.axes.Axes,
                              data: List[Dict[str, Any]],
-                             cax: matplotlib.colorbar.Colorbar=None):
+                             cax: matplotlib.colorbar.Colorbar = None):
     """
     Rescale ticks and units for the provided axes as described in
     :meth:`~_make_rescaled_ticks_and_units`
     """
     # for x axis
     if not _is_string_valued_array(data[0]['data']):
-        x_ticks_formatter, new_x_label = _make_rescaled_ticks_and_units(data[0])
+        x_ticks_formatter, new_x_label = \
+            _make_rescaled_ticks_and_units(data[0])
         ax.xaxis.set_major_formatter(x_ticks_formatter)
         ax.set_xlabel(new_x_label)
 
     # for y axis
     if not _is_string_valued_array(data[1]['data']):
-        y_ticks_formatter, new_y_label = _make_rescaled_ticks_and_units(data[1])
+        y_ticks_formatter, new_y_label = \
+            _make_rescaled_ticks_and_units(data[1])
         ax.yaxis.set_major_formatter(y_ticks_formatter)
         ax.set_ylabel(new_y_label)
 

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -227,6 +227,7 @@ def _convert_complex(text: bytes) -> complex_type_union:
     out.seek(0)
     return np.load(out)[0]
 
+
 this_session_default_encoding = sys.getdefaultencoding()
 
 
@@ -267,8 +268,8 @@ def _convert_numeric(value: bytes) -> Union[float, int, str]:
     if np.isinf(numeric):
         return numeric
 
-    # If it is not 'nan' and not 'inf', then we need to see if the value is really an
-    # integer or with floating point digits
+    # If it is not 'nan' and not 'inf', then we need to see if the value is
+    # really an integer or with floating point digits
     numeric_int = int(numeric)
     if numeric != numeric_int:
         return numeric
@@ -403,7 +404,7 @@ def connect(name: str, debug: bool = False,
     return conn
 
 
-def perform_db_upgrade(conn: ConnectionPlus, version: int=-1) -> None:
+def perform_db_upgrade(conn: ConnectionPlus, version: int = -1) -> None:
     """
     This is intended to perform all upgrades as needed to bring the
     db from version 0 to the most current version (or the version specified).
@@ -571,7 +572,8 @@ def _2to3_get_deps(conn: ConnectionPlus) -> DefaultDict[int, List[int]]:
     return results
 
 
-def _2to3_get_dependencies(conn: ConnectionPlus) -> DefaultDict[int, List[int]]:
+def _2to3_get_dependencies(conn: ConnectionPlus
+                           ) -> DefaultDict[int, List[int]]:
     query = """
             SELECT dependent, independent
             FROM dependencies
@@ -806,6 +808,7 @@ def perform_db_upgrade_3_to_4(conn: ConnectionPlus) -> None:
             cur.execute(sql, (json_str, run_id))
             log.debug(f"Upgrade in transition, run number {run_id}: OK")
 
+
 def _latest_available_version() -> int:
     """Return latest available database schema version"""
     return len(_UPGRADE_ACTIONS)
@@ -945,7 +948,7 @@ def make_connection_plus_from(conn: Union[sqlite3.Connection, ConnectionPlus]
     return conn_plus
 
 
-def init_db(conn: ConnectionPlus)->None:
+def init_db(conn: ConnectionPlus) -> None:
     with atomic(conn) as conn:
         transaction(conn, _experiment_table_schema)
         transaction(conn, _runs_table_schema)
@@ -1256,11 +1259,11 @@ def length(conn: ConnectionPlus,
         return _len
 
 
-def _build_data_query( table_name: str,
-             columns: List[str],
-             start: Optional[int] = None,
-             end: Optional[int] = None,
-             ) -> str:
+def _build_data_query(table_name: str,
+                      columns: List[str],
+                      start: Optional[int] = None,
+                      end: Optional[int] = None,
+                      ) -> str:
 
     _columns = ",".join(columns)
     query = f"""
@@ -1316,9 +1319,9 @@ def get_data(conn: ConnectionPlus,
 
 def get_parameter_data(conn: ConnectionPlus,
                        table_name: str,
-                       columns: Sequence[str]=(),
-                       start: Optional[int]=None,
-                       end: Optional[int]=None) -> \
+                       columns: Sequence[str] = (),
+                       start: Optional[int] = None,
+                       end: Optional[int] = None) -> \
         Dict[str, Dict[str, np.ndarray]]:
     """
     Get data for one or more parameters and its dependencies. The data
@@ -1404,8 +1407,8 @@ def get_parameter_data(conn: ConnectionPlus,
         # faster than transposing the data using np.array.transpose
         res_t = map(list, zip(*res))
         output[output_param] = {name: np.array(column_data)
-                         for name, column_data
-                         in zip(param_names, res_t)}
+                                for name, column_data
+                                in zip(param_names, res_t)}
 
     return output
 
@@ -1747,7 +1750,7 @@ def get_non_dependencies(conn: ConnectionPlus,
 
 
 def get_parameter_dependencies(conn: ConnectionPlus, param: str,
-                              run_id: int) -> List[ParamSpec]:
+                               run_id: int) -> List[ParamSpec]:
     """
     Given a parameter name return a list of ParamSpecs where the first
     element is the ParamSpec of the given parameter and the rest of the
@@ -1774,9 +1777,9 @@ def get_parameter_dependencies(conn: ConnectionPlus, param: str,
 def new_experiment(conn: ConnectionPlus,
                    name: str,
                    sample_name: str,
-                   format_string: Optional[str]="{}-{}-{}",
-                   start_time: Optional[float]=None,
-                   end_time: Optional[float]=None,
+                   format_string: Optional[str] = "{}-{}-{}",
+                   start_time: Optional[float] = None,
+                   end_time: Optional[float] = None,
                    ) -> int:
     """
     Add new experiment to container.
@@ -1831,7 +1834,7 @@ def mark_run_complete(conn: ConnectionPlus, run_id: int):
     atomic_transaction(conn, query, time.time(), True, run_id)
 
 
-def completed(conn: ConnectionPlus, run_id)->bool:
+def completed(conn: ConnectionPlus, run_id) -> bool:
     """ Check if the run scomplete
 
     Args:
@@ -1998,7 +2001,7 @@ def get_last_experiment(conn: ConnectionPlus) -> Optional[int]:
 
 
 def get_runs(conn: ConnectionPlus,
-             exp_id: Optional[int] = None)->List[sqlite3.Row]:
+             exp_id: Optional[int] = None) -> List[sqlite3.Row]:
     """ Get a list of runs.
 
     Args:
@@ -2367,7 +2370,8 @@ def add_parameter(conn: ConnectionPlus,
 
 def _add_parameters_to_layout_and_deps(conn: ConnectionPlus,
                                        formatted_name: str,
-                                       *parameter: ParamSpec) -> sqlite3.Cursor:
+                                       *parameter: ParamSpec
+                                       ) -> sqlite3.Cursor:
     # get the run_id
     sql = f"""
     SELECT run_id FROM runs WHERE result_table_name="{formatted_name}";
@@ -2473,9 +2477,10 @@ def _create_run_table(conn: ConnectionPlus,
 
 def create_run(conn: ConnectionPlus, exp_id: int, name: str,
                guid: str,
-               parameters: Optional[List[ParamSpec]]=None,
+               parameters: Optional[List[ParamSpec]] = None,
                values:  List[Any] = None,
-               metadata: Optional[Dict[str, Any]]=None)->Tuple[int, int, str]:
+               metadata: Optional[Dict[str, Any]] = None
+               ) -> Tuple[int, int, str]:
     """ Create a single run for the experiment.
 
 

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -8,7 +8,8 @@ import pytest
 import numpy as np
 
 import qcodes.tests.dataset
-from qcodes.dataset.sqlite_base import get_experiments
+from qcodes.dataset.sqlite_base import get_experiments, \
+    get_db_version_and_newest_available_version
 from qcodes.dataset.experiment_container import Experiment
 from qcodes.dataset.data_set import (DataSet, load_by_guid, load_by_counter,
                                      load_by_id)
@@ -447,6 +448,8 @@ def test_old_versions_not_touched(two_empty_temp_db_connections,
     target_path = path_to_dbfile(target_conn)
     source_path = path_to_dbfile(source_conn)
 
+    _, new_v = get_db_version_and_newest_available_version(source_path)
+
     fixturepath = os.sep.join(qcodes.tests.dataset.__file__.split(os.sep)[:-1])
     fixturepath = os.path.join(fixturepath,
                                'fixtures', 'db_files', 'version2',
@@ -461,7 +464,7 @@ def test_old_versions_not_touched(two_empty_temp_db_connections,
         with pytest.warns(UserWarning) as warning:
             extract_runs_into_db(fixturepath, target_path, 1)
             expected_mssg = ('Source DB version is 2, but this '
-                             'function needs it to be in version 4. '
+                             f'function needs it to be in version {new_v}. '
                              'Run this function again with '
                              'upgrade_source_db=True to auto-upgrade '
                              'the source DB file.')
@@ -484,7 +487,7 @@ def test_old_versions_not_touched(two_empty_temp_db_connections,
         with pytest.warns(UserWarning) as warning:
             extract_runs_into_db(source_path, fixturepath, 1)
             expected_mssg = ('Target DB version is 2, but this '
-                             'function needs it to be in version 4. '
+                             f'function needs it to be in version {new_v}. '
                              'Run this function again with '
                              'upgrade_target_db=True to auto-upgrade '
                              'the target DB file.')

--- a/qcodes/tests/dataset/test_datasaver.py
+++ b/qcodes/tests/dataset/test_datasaver.py
@@ -50,12 +50,12 @@ def test_default_callback():
             'run_tables_subscription_min_count': 2}
 
         test_set = qc.new_data_set("test-dataset")
-        test_set.add_metadata('snapshot', 123)
+        test_set.add_metadata('snapshot', 'reasonable_snapshot')
         DataSaver(dataset=test_set, write_period=0,
                   interdeps=InterDependencies_)
         test_set.mark_started()
         test_set.mark_completed()
-        assert CALLBACK_SNAPSHOT == 123
+        assert CALLBACK_SNAPSHOT == 'reasonable_snapshot'
         assert CALLBACK_RUN_ID > 0
         assert CALLBACK_COUNT > 0
     finally:


### PR DESCRIPTION
Make `snapshot` column (of type "TEXT") always present in `runs` table. This way it becomes part of the stable schema, not a "metadata" column anymore.

Relies on version 4 database generator from here https://github.com/QCoDeS/qcodes_generate_test_db/pull/3.

Also couldn't resist fixing some of the style stuff.

ToDo:
- [x] remove checking out branch of `qcodes_generate_test_db`
- [x] update the hash in `qcodes_generate_test_db` to really the latest hash before merging this PR