### PR TITLE
[WIP] Version the RunDescriber

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -265,15 +265,7 @@ class DataSet(Sized):
                                  f"the database")
             self._completed = completed(self.conn, self.run_id)
             run_desc = self._get_run_description_from_db()
-            if run_desc._old_style_deps:
-                # TODO: what if the old run had invalid interdep.s?
-                old_idps: InterDependencies = cast(InterDependencies,
-                                                   run_desc.interdeps)
-                self._interdeps = old_to_new(old_idps)
-            else:
-                new_idps: InterDependencies_ = cast(InterDependencies_,
-                                                    run_desc.interdeps)
-                self._interdeps = new_idps
+            self._interdeps = run_desc.interdeps
             self._metadata = get_metadata_from_run_id(self.conn, run_id)
             self._started = self.run_timestamp_raw is not None
 

--- a/qcodes/dataset/database_fix_functions.py
+++ b/qcodes/dataset/database_fix_functions.py
@@ -9,7 +9,7 @@ from typing import Dict, Sequence
 from tqdm import tqdm
 
 from qcodes.dataset.descriptions import RunDescriber
-from qcodes.dataset.dependencies import InterDependencies
+from qcodes.dataset.dependencies import InterDependencies, old_to_new
 from qcodes.dataset.sqlite_base import (ConnectionPlus, atomic,
                                         atomic_transaction,
                                         get_parameters,
@@ -99,7 +99,8 @@ def fix_wrong_run_descriptions(conn: ConnectionPlus,
     for run_id in run_ids:
         trusted_paramspecs = get_parameters(conn, run_id)
         trusted_desc = RunDescriber(
-                           interdeps=InterDependencies(*trusted_paramspecs))
+                            interdeps=old_to_new(
+                                InterDependencies(*trusted_paramspecs)))
 
         actual_desc_str = select_one_where(conn, "runs",
                                            "run_description",

--- a/qcodes/dataset/descriptions.py
+++ b/qcodes/dataset/descriptions.py
@@ -4,7 +4,7 @@ import json
 
 from qcodes.dataset.dependencies import (InterDependencies,
                                          InterDependencies_,
-                                         new_to_old)
+                                         new_to_old, old_to_new)
 SomeDeps = Union[InterDependencies, InterDependencies_]
 
 
@@ -21,18 +21,22 @@ class RunDescriber:
     itself.
     """
 
+    # we operate with two version numbers
+    # _version: the version of objects used inside this class
+    # _written_version: the version of objects we write to the DB
+    #
+    # We can not simply write the current version to disk, as some third-party
+    # applications may not handle that too well
+
+    _version = 1
+    _written_version = 0
+
     def __init__(self, interdeps: SomeDeps) -> None:
 
-        self._old_style_deps: bool
-
-        if isinstance(interdeps, InterDependencies_):
-            self._old_style_deps = False
-        elif isinstance(interdeps, InterDependencies):
-            self._old_style_deps = True
-        else:
+        if not isinstance(interdeps, InterDependencies_):
             raise ValueError('The interdeps arg must be of type: '
-                             'InterDependencies or InterDependencies_. '
-                             f' Got {type(interdeps)}.')
+                             'InterDependencies_. '
+                             f'Got {type(interdeps)}.')
 
         self.interdeps = interdeps
 
@@ -42,11 +46,10 @@ class RunDescriber:
         """
         ser = {}
         old_interdeps: InterDependencies
-        if not self._old_style_deps:
-            new_interdeps = cast(InterDependencies_, self.interdeps)
-            old_interdeps = new_to_old(new_interdeps)
-        else:
-            old_interdeps = cast(InterDependencies, self.interdeps)
+
+        new_interdeps = cast(InterDependencies_, self.interdeps)
+        old_interdeps = new_to_old(new_interdeps)
+
         ser['interdependencies'] = old_interdeps.serialize()
         return ser
 
@@ -55,12 +58,12 @@ class RunDescriber:
         """
         Make a RunDescriber object based on a serialized version of it
         """
-        # We must currently support new and old type InterDep.s objects
 
         idp: Union[InterDependencies, InterDependencies_]
 
         if cls._is_description_old_style(ser['interdependencies']):
-            idp = InterDependencies.deserialize(ser['interdependencies'])
+            idp = old_to_new(
+                InterDependencies.deserialize(ser['interdependencies']))
         else:
             idp = InterDependencies_.deserialize(ser['interdependencies'])
         rundesc = cls(interdeps=idp)

--- a/qcodes/tests/dataset/interdeps_fixtures.py
+++ b/qcodes/tests/dataset/interdeps_fixtures.py
@@ -1,0 +1,87 @@
+import pytest
+
+from qcodes.dataset.param_spec import (ParamSpec, ParamSpecBase)
+from qcodes.dataset.dependencies import InterDependencies_
+
+
+@pytest.fixture
+def some_paramspecbases():
+
+    psb1 = ParamSpecBase('psb1', paramtype='text', label='blah', unit='')
+    psb2 = ParamSpecBase('psb2', paramtype='array', label='', unit='V')
+    psb3 = ParamSpecBase('psb3', paramtype='array', label='', unit='V')
+    psb4 = ParamSpecBase('psb4', paramtype='numeric', label='number', unit='')
+
+    return (psb1, psb2, psb3, psb4)
+
+
+@pytest.fixture
+def some_paramspecs():
+    """
+    Some different paramspecs for testing. The idea is that we just add a
+    new group of paramspecs as the need arises
+    """
+
+    groups = {}
+
+    # A valid group. Corresponding to a heatmap with a text label at each point
+    first = {}
+    first['ps1'] = ParamSpec('ps1', paramtype='numeric', label='Raw Data 1',
+                             unit='V')
+    first['ps2'] = ParamSpec('ps2', paramtype='array', label='Raw Data 2',
+                             unit='V')
+    first['ps3'] = ParamSpec('ps3', paramtype='text', label='Axis 1',
+                             unit='', inferred_from=[first['ps1']])
+    first['ps4'] = ParamSpec('ps4', paramtype='numeric', label='Axis 2',
+                             unit='V', inferred_from=[first['ps2']])
+    first['ps5'] = ParamSpec('ps5', paramtype='numeric', label='Signal',
+                             unit='Conductance',
+                             depends_on=[first['ps3'], first['ps4']])
+    first['ps6'] = ParamSpec('ps6', paramtype='text', label='Goodness',
+                             unit='', depends_on=[first['ps3'], first['ps4']])
+    groups[1] = first
+
+    # a small, valid group
+    second = {}
+    second['ps1'] = ParamSpec('ps1', paramtype='numeric',
+                              label='setpoint', unit='Hz')
+    second['ps2'] = ParamSpec('ps2', paramtype='numeric', label='signal',
+                              unit='V', depends_on=[second['ps1']])
+    groups[2] = second
+
+    return groups
+
+
+@pytest.fixture
+def some_interdeps():
+    """
+    Some different InterDependencies_ objects for testing
+    """
+    idps_list = []
+    ps1 = ParamSpecBase('ps1', paramtype='numeric', label='Raw Data 1',
+                        unit='V')
+    ps2 = ParamSpecBase('ps2', paramtype='array', label='Raw Data 2',
+                        unit='V')
+    ps3 = ParamSpecBase('ps3', paramtype='text', label='Axis 1',
+                        unit='')
+    ps4 = ParamSpecBase('ps4', paramtype='numeric', label='Axis 2',
+                        unit='V')
+    ps5 = ParamSpecBase('ps5', paramtype='numeric', label='Signal',
+                        unit='Conductance')
+    ps6 = ParamSpecBase('ps6', paramtype='text', label='Goodness',
+                    unit='')
+
+    idps = InterDependencies_(dependencies={ps5: (ps3, ps4), ps6: (ps3, ps4)},
+                              inferences={ps4: (ps2,), ps3: (ps1,)})
+
+    idps_list.append(idps)
+
+    ps1 = ParamSpecBase('ps1', paramtype='numeric',
+                        label='setpoint', unit='Hz')
+    ps2 = ParamSpecBase('ps2', paramtype='numeric', label='signal',
+                        unit='V')
+    idps = InterDependencies_(dependencies={ps2: (ps1,)})
+
+    idps_list.append(idps)
+
+    return idps_list

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -257,8 +257,9 @@ def test_perform_actual_upgrade_2_to_3_some_runs():
         c = atomic_transaction(conn, sql)
         json_str = one(c, 'run_description')
 
-        desc = RunDescriber.from_json(json_str)
-        idp = desc.interdeps
+        unversioned_dict = json.loads(json_str)
+        idp = InterDependencies.deserialize(
+                unversioned_dict['interdependencies'])
         assert isinstance(idp, InterDependencies)
 
         # here we verify that the dependencies encoded in
@@ -341,8 +342,10 @@ def test_perform_upgrade_v2_v3_to_v4_fixes():
         c = atomic_transaction(conn, sql)
         json_str = one(c, 'run_description')
 
-        desc = RunDescriber.from_json(json_str)
-        idp = desc.interdeps
+        unversioned_dict = json.loads(json_str)
+        idp = InterDependencies.deserialize(
+                unversioned_dict['interdependencies'])
+
         assert isinstance(idp, InterDependencies)
 
         p0 = [p for p in idp.paramspecs if p.name == 'p0'][0]
@@ -404,8 +407,10 @@ def test_perform_upgrade_v2_v3_to_v4_fixes():
         c = atomic_transaction(conn, sql)
         json_str = one(c, 'run_description')
 
-        desc = RunDescriber.from_json(json_str)
-        idp = desc.interdeps
+        unversioned_dict = json.loads(json_str)
+        idp = InterDependencies.deserialize(
+                unversioned_dict['interdependencies'])
+
         assert isinstance(idp, InterDependencies)
 
         p0 = [p for p in idp.paramspecs if p.name == 'p0'][0]
@@ -486,8 +491,10 @@ def test_perform_upgrade_v3_to_v4():
         c = atomic_transaction(conn, sql)
         json_str = one(c, 'run_description')
 
-        desc = RunDescriber.from_json(json_str)
-        idp = desc.interdeps
+        unversioned_dict = json.loads(json_str)
+        idp = InterDependencies.deserialize(
+                unversioned_dict['interdependencies'])
+
         assert isinstance(idp, InterDependencies)
 
         p0 = [p for p in idp.paramspecs if p.name == 'p0'][0]

--- a/qcodes/tests/dataset/test_dependencies.py
+++ b/qcodes/tests/dataset/test_dependencies.py
@@ -13,52 +13,9 @@ from qcodes.dataset.dependencies import (InterDependencies,
 from qcodes.dataset.param_spec import ParamSpec, ParamSpecBase
 from qcodes.tests.common import error_caused_by
 # pylint: disable=unused-import
-from qcodes.tests.dataset.test_descriptions import some_paramspecs
-
-@pytest.fixture
-def some_paramspecbases():
-
-    psb1 = ParamSpecBase('psb1', paramtype='text', label='blah', unit='')
-    psb2 = ParamSpecBase('psb2', paramtype='array', label='', unit='V')
-    psb3 = ParamSpecBase('psb3', paramtype='array', label='', unit='V')
-    psb4 = ParamSpecBase('psb4', paramtype='numeric', label='number', unit='')
-
-    return (psb1, psb2, psb3, psb4)
-
-@pytest.fixture
-def some_interdeps():
-    """
-    Some different InterDependencies_ objects for testing
-    """
-    idps_list = []
-    ps1 = ParamSpecBase('ps1', paramtype='numeric', label='Raw Data 1',
-                        unit='V')
-    ps2 = ParamSpecBase('ps2', paramtype='array', label='Raw Data 2',
-                        unit='V')
-    ps3 = ParamSpecBase('ps3', paramtype='text', label='Axis 1',
-                        unit='')
-    ps4 = ParamSpecBase('ps4', paramtype='numeric', label='Axis 2',
-                        unit='V')
-    ps5 = ParamSpecBase('ps5', paramtype='numeric', label='Signal',
-                        unit='Conductance')
-    ps6 = ParamSpecBase('ps6', paramtype='text', label='Goodness',
-                    unit='')
-
-    idps = InterDependencies_(dependencies={ps5: (ps3, ps4), ps6: (ps3, ps4)},
-                              inferences={ps4: (ps2,), ps3: (ps1,)})
-
-    idps_list.append(idps)
-
-    ps1 = ParamSpecBase('ps1', paramtype='numeric',
-                        label='setpoint', unit='Hz')
-    ps2 = ParamSpecBase('ps2', paramtype='numeric', label='signal',
-                        unit='V')
-    idps = InterDependencies_(dependencies={ps2: (ps1,)})
-
-    idps_list.append(idps)
-
-    return idps_list
-
+from qcodes.tests.dataset.interdeps_fixtures import (some_paramspecs,
+                                                     some_paramspecbases,
+                                                     some_interdeps)
 
 def test_wrong_input_raises():
 

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -15,7 +15,7 @@ import numpy as np
 from unittest.mock import patch
 
 from qcodes.dataset.descriptions import RunDescriber
-from qcodes.dataset.dependencies import InterDependencies
+from qcodes.dataset.dependencies import InterDependencies, InterDependencies_
 import qcodes.dataset.sqlite_base as mut  # mut: module under test
 from qcodes.dataset.database import get_DB_location, path_to_dbfile
 from qcodes.dataset.guids import generate_guid
@@ -187,7 +187,7 @@ def test_update_runs_description(dataset):
         with pytest.raises(ValueError):
             mut.update_run_description(dataset.conn, dataset.run_id, idesc)
 
-    desc = RunDescriber(InterDependencies()).to_json()
+    desc = RunDescriber(InterDependencies_()).to_json()
     mut.update_run_description(dataset.conn, dataset.run_id, desc)
 
 


### PR DESCRIPTION
The description of a run is going to be subject to a lot of changes. Looking ahead, we should therefore
introduce a versioning system since the runs description is persisted to disk. This PR introduces such a versioning system.


Changes proposed in this pull request:
- Make a schema upgrade to ensure that the runs_description is always versioned
- Introduce the versioning in the `RunDescriber` object

Pending: 

- [ ] The schema upgrade part
