### PR TITLE
Mj2 gain validator to narrow

### DIFF
--- a/qcodes/instrument_drivers/QuTech/M2j.py
+++ b/qcodes/instrument_drivers/QuTech/M2j.py
@@ -38,8 +38,8 @@ class M2j(Instrument):
                            label='gain',
                            set_cmd=self._set_gain,
                            unit='dB',
-                           vals=Numbers(min_value=33, max_value=55),
-                           docstring='Amplifier gain in dB, range 33 to 55 dB')
+                           vals=Numbers(min_value=33, max_value=110),
+                           docstring='Amplifier gain in dB, range 33 to 110 dB')
 
         self.add_parameter('RF_level',
                            label='RF level',

--- a/qcodes/tests/drivers/test_m2j.py
+++ b/qcodes/tests/drivers/test_m2j.py
@@ -13,7 +13,7 @@ class TestM2j(unittest.TestCase):
         spi_rack = MagicMock()
         m2j = M2j('test', spi_rack, 42)
         gain_too_low = 32
-        gain_too_high = 56
+        gain_too_high = 111
         with self.assertRaises(ValueError):
             m2j.gain.set(gain_too_low)
         with self.assertRaises(ValueError):
@@ -33,7 +33,7 @@ class TestM2j(unittest.TestCase):
         spi_rack = MagicMock()
         m2j = M2j('test_float', spi_rack, 42)
         gain_too_low = 32.5
-        gain_too_high = 55.1
+        gain_too_high = 111.1
         with self.assertRaises(ValueError):
             m2j.gain.set(gain_too_low)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Changes proposed in this pull request:
- Move upper limit on M2j gain parameter from 55 to 110 


@astafan8 
