### PR TITLE
Fix/weird travis test fail

### DIFF
--- a/qcodes/tests/dataset/helper_functions.py
+++ b/qcodes/tests/dataset/helper_functions.py
@@ -39,10 +39,10 @@ def verify_data_dict(data: Dict[str, Dict[str, np.ndarray]],
     """
     # check that all the expected parameters in the dict are
     # included in the list of parameters
-    assert all(param in parameter_names for param in list(data.keys())) is True
+    assert all(param in parameter_names for param in list(data.keys()))
     if dataframe is not None:
         assert all(param in parameter_names for
-                   param in list(dataframe.keys())) is True
+                   param in list(dataframe.keys()))
     for param in parameter_names:
         innerdata = data[param]
         verify_data_dict_for_single_param(innerdata,

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -354,9 +354,9 @@ def test_field_limit_exception(current_driver):
                 current_driver.cartesian(set_point)
 
             assert "field would exceed limit" in excinfo.value.args[0]
-            assert not all([a == b for a, b in zip(
+            assert (not all([a == b for a, b in zip(
                 current_driver.cartesian(), set_point
-            )])
+            )]))
 
 
 def test_cylindrical_poles(current_driver):
@@ -434,7 +434,7 @@ def test_ramp_rate_exception(current_driver):
 
 def test_reducing_field_ramp_limit_reduces_a_higher_ramp_rate(ami430):
     """
-    When reducing field_ramp_limit, the actual ramp_rate should also be 
+    When reducing field_ramp_limit, the actual ramp_rate should also be
     reduced if the new field_ramp_limit is lower than the actual ramp_rate
     now.
     """

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -354,7 +354,7 @@ def test_field_limit_exception(current_driver):
                 current_driver.cartesian(set_point)
 
             assert "field would exceed limit" in excinfo.value.args[0]
-            assert (not all([a == b for a, b in zip(
+            assert not(all([a == b for a, b in zip(
                 current_driver.cartesian(), set_point
             )]))
 

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -354,9 +354,9 @@ def test_field_limit_exception(current_driver):
                 current_driver.cartesian(set_point)
 
             assert "field would exceed limit" in excinfo.value.args[0]
-            assert not(all([a == b for a, b in zip(
-                current_driver.cartesian(), set_point
-            )]))
+            vals_and_setpoints = zip(current_driver.cartesian(), set_point)
+            belief = not(all([val == sp for val, sp in vals_and_setpoints]))
+            assert belief
 
 
 def test_cylindrical_poles(current_driver):


### PR DESCRIPTION
For some combinations of `pytest` version `4.6.1` and [we don't quite know what] version `?`, tests that use `assert all(...) is True` or `assert not all(...)` fail.

Since we can't really figure out which package versions to avoid, let's avoid using that syntax instead.

Changes proposed in this pull request:
- Reword two tests

@astafan8 
