### PR TITLE
Add jumbo frames and reference clock source parameters to ZIUHFLI

### DIFF
--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1640,7 +1640,7 @@ class ZIUHFLI(Instrument):
                            get_cmd=partial(self.daq.getInt,
                                            f"/{self.device}/system/extclk"),
                            val_mapping=create_on_off_val_mapping(),
-                           docstring="Set the 10 MHz reference clock source."
+                           docstring="Set the clock source to external 10 MHz reference clock."
                            )
 
         self.add_parameter('jumbo_frames_enabled',

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1643,7 +1643,7 @@ class ZIUHFLI(Instrument):
                            docstring="Set the 10 MHz reference clock source."
                            )
 
-        self.add_parameter('jumbo_frames',
+        self.add_parameter('jumbo_frames_enabled',
                            set_cmd=partial(self.daq.setInt,
                                            f"/{self.device}/system/jumbo"),
                            get_cmd=partial(self.daq.getInt,

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1634,7 +1634,7 @@ class ZIUHFLI(Instrument):
 
         ########################################
         # SYSTEM PARAMETERS
-        self.add_parameter('external_clock_source',
+        self.add_parameter('external_clock_enabled',
                            set_cmd=partial(self.daq.setInt,
                                            f"/{self.device}/system/extclk"),
                            get_cmd=partial(self.daq.getInt,

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -659,6 +659,7 @@ class Scope(MultiParameter):
 
         return (ch1data, ch2data)
 
+
 class ZIUHFLI(Instrument):
     """
     QCoDeS driver for ZI UHF-LI.
@@ -715,7 +716,7 @@ class ZIUHFLI(Instrument):
                                docstring="Connects the demodulator with the "
                                          "supplied oscillator.",
                                get_cmd=partial(self._getter, 'demods',
-                                               oscs - 1, 0, 'oscselet'),
+                                               oscs - 1, 0, 'oscselect'),
                                set_cmd=partial(self._setter, 'demods',
                                                oscs - 1, 0, 'oscselect'),
                                val_mapping={i + 1: i for i in
@@ -1631,6 +1632,25 @@ class ZIUHFLI(Instrument):
                            parameter_class=Scope,
                            )
 
+        ########################################
+        # SYSTEM PARAMETERS
+        self.add_parameter('external_clock_source',
+                           set_cmd=partial(self.daq.setInt,
+                                           f"/{self.device}/system/extclk"),
+                           get_cmd=partial(self.daq.getInt,
+                                           f"/{self.device}/system/extclk"),
+                           val_mapping=create_on_off_val_mapping(),
+                           docstring="Set the 10 MHz reference clock source."
+                           )
+
+        self.add_parameter('jumbo_frames',
+                           set_cmd=partial(self.daq.setInt,
+                                           f"/{self.device}/system/jumbo"),
+                           get_cmd=partial(self.daq.getInt,
+                                           f"/{self.device}/system/jumbo"),
+                           val_mapping=create_on_off_val_mapping(),
+                           docstring="Enable jumbo frames on the TCP/IP interface"
+                           )
 
     def _setter(self, module, number, mode, setting, value):
         """


### PR DESCRIPTION
Changes proposed in this pull request:
- Add parameter to enable TCP/IP jumbo frames
- Add parameter to set the reference clock source
- Fix typo in demod{N}_ oscillator parameters


@WilliamHPNielsen 
