### PR TITLE
Bump sphinx to 2.1.0

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.0.1
+sphinx==2.1.0
 sphinx_rtd_theme
 sphinx-jsonschema
 nbsphinx


### PR DESCRIPTION
actually, there is hope that this will help with this error https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/results?buildId=1996 , as i've seen a possibly related [bug has been fixed](https://www.sphinx-doc.org/en/master/changes.html#release-2-1-0-released-jun-02-2019) `#6379: py domain: Module index (py-modindex.html) has duplicate titles`.