### PR TITLE
Avoid invalid escapse sequence by using raw string

### DIFF
--- a/qcodes/dataset/sqlite/__init__.py
+++ b/qcodes/dataset/sqlite/__init__.py
@@ -1,4 +1,4 @@
-"""
+r"""
 This module encapsulates QCoDeS database: its schema, structure, convenient
 and relevant queries, wrapping around :mod:`sqlite3`, etc.
 


### PR DESCRIPTION
This should fix a warning 