### PR TITLE
Close instruments in tests.

### DIFF
--- a/qcodes/tests/drivers/test_Keithley_2450.py
+++ b/qcodes/tests/drivers/test_Keithley_2450.py
@@ -28,6 +28,7 @@ def test_wrong_mode(caplog):
         instrument = Keithley2450('wrong_mode', address='GPIB::1::INSTR', visalib=visalib)
         assert "The instrument is in an unsupported language mode." in caplog.text
         assert list(instrument.parameters.keys()) == ["IDN", "timeout"]
+        instrument.close()
 
 
 def test_change_source_function(k2450):

--- a/qcodes/tests/drivers/test_Keithley_2450.py
+++ b/qcodes/tests/drivers/test_Keithley_2450.py
@@ -8,7 +8,7 @@ import qcodes.instrument.sims as sims
 visalib = sims.__file__.replace('__init__.py', 'Keithley_2450.yaml@sim')
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def k2450():
     """
     Create a Keithley 2450 instrument
@@ -107,7 +107,8 @@ def test_reset_sweep_on_source_change(k2450):
     """
     If we change the source function, we need to run the sweep setup again
     """
-
+    # first set sense to a mode where we are allowed to change source
+    k2450.sense.function('current')
     k2450.source.function("voltage")
     k2450.source.sweep_setup(0, 1, 10)
     assert np.alltrue(k2450.source.get_sweep_axis() == np.linspace(0, 1, 10))

--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -33,8 +33,10 @@ def s46_six():
     """
     driver = S46('s46_six', address='GPIB::2::INSTR', visalib=visalib)
 
-    yield driver
-    driver.close()
+    try:
+        yield driver
+    finally:
+        driver.close()
 
 
 @pytest.fixture(scope='module')
@@ -44,8 +46,10 @@ def s46_four():
     """
     driver = S46('s46_four', address='GPIB::3::INSTR', visalib=visalib)
 
-    yield driver
-    driver.close()
+    try:
+        yield driver
+    finally:
+        driver.close()
 
 
 def test_runtime_error_on_bad_init():
@@ -66,8 +70,9 @@ def test_query_close_once_at_init(caplog):
     Test that, during initialisation, we query the closed channels only once
     """
     with caplog.at_level(logging.DEBUG):
-        S46('s46_test_query_once', address='GPIB::2::INSTR', visalib=visalib)
+        inst = S46('s46_test_query_once', address='GPIB::2::INSTR', visalib=visalib)
         assert caplog.text.count(":CLOS?") == 1
+        inst.close()
 
 
 def test_init_six(s46_six, caplog):

--- a/qcodes/tests/drivers/test_keysight_34465a.py
+++ b/qcodes/tests/drivers/test_keysight_34465a.py
@@ -11,10 +11,10 @@ def driver():
     keysight_sim = Keysight_34465A('keysight_34465A_sim',
                                    address='GPIB::1::INSTR',
                                    visalib=visalib)
-
-    yield keysight_sim
-
-    keysight_sim.close()
+    try:
+        yield keysight_sim
+    finally:
+        keysight_sim.close()
 
 
 def test_init(driver):
@@ -54,9 +54,29 @@ def test_set_get_autorange(driver):
 
 
 def test_display_text(driver):
-    assert "" == driver.display.text()
 
-    driver.display.text("qwe")
-    assert "qwe" == driver.display.text()
+    original_text = driver.display.text()
+    assert original_text == ""
+
+    new_text = "qwe"
+    driver.display.text(new_text)
+    assert driver.display.text() == new_text
 
     driver.display.clear()
+    # pyvisa-sim always has a response so read here even if the instrument
+    # normally doesn't return anything from the visa clear command.
+    res = driver.visa_handle.read()
+    # since the clear function also calls `text.get` behind the scenes
+    # after calling clear on the instrument this read will be out of sync
+    # and return the result from the read command. However, this is the
+    # unprocessed string from the device so it will contain an extra set of
+    # quotation marks.
+    assert res == f'"{new_text}"'
+
+    # since pyvisa sim does not actually implement the clear
+    # command we have to manually reset the text to avoid leaking state from
+    # this test
+    driver.display.text(original_text)
+    restored_text = driver.display.text()
+    assert restored_text == original_text
+

--- a/qcodes/tests/drivers/test_zihdawg8.py
+++ b/qcodes/tests/drivers/test_zihdawg8.py
@@ -59,7 +59,7 @@ class TestZIHDAWG8(unittest.TestCase):
                           return_value=3 * (MagicMock(),)), \
              patch.object(ZIHDAWG8, 'download_device_node_tree',
                           return_value=self.node_tree):
-            hdawg8 = ZIHDAWG8('Name', 'dev-test')
+            hdawg8 = ZIHDAWG8('hdawg8', 'dev-test')
 
             self.assertIn('system_awg_channelgrouping', hdawg8.parameters)
             with self.assertRaises(ValueError):
@@ -92,6 +92,7 @@ class TestZIHDAWG8(unittest.TestCase):
             self.assertEqual('awgs_1_waveform_memoryusage',
                              hdawg8.awgs_1_waveform_memoryusage.name)
             self.assertIsNone(hdawg8.awgs_1_waveform_memoryusage.vals)
+            hdawg8.close()
 
     def test_generate_csv_sequence_program(self):
         expected = textwrap.dedent("""

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -10,6 +10,7 @@ import qcodes as qc
 
 TEST_LOG_MESSAGE = 'test log message'
 
+
 @pytest.fixture
 def remove_root_handlers():
     root_logger = logging.getLogger()
@@ -203,7 +204,7 @@ def test_channels(model372):
     # rerun with instrument filter
     with logger.LogCapture(level=logging.DEBUG) as logs_filtered,\
             logger.filter_instrument(inst,
-                                    handler=logs_filtered.string_handler):
+                                     handler=logs_filtered.string_handler):
         inst.sample_heater.set_range_from_temperature(0.1)
 
     logs_filtered = [l for l in logs_filtered.value.splitlines()
@@ -231,3 +232,4 @@ def test_channels_nomessages(model372):
     logs = [l for l in logs.value.splitlines()
             if '[lakeshore' in l]
     assert len(logs) == 0
+    mock.close()

--- a/qcodes/tests/test_visa.py
+++ b/qcodes/tests/test_visa.py
@@ -19,7 +19,7 @@ class MockVisa(VisaInstrument):
 
 
 class MockVisaHandle:
-    '''
+    """
     mock the API needed for a visa handle that throws lots of errors:
 
     - any write command sets a single "state" variable to a float
@@ -28,7 +28,7 @@ class MockVisaHandle:
     - 0 results in a return code for visa timeout
     - any ask command returns the state
     - a state > 10 throws an error
-    '''
+    """
     def __init__(self):
         self.state = 0
         self.closed = False
@@ -134,28 +134,32 @@ class TestVisaInstrument(TestCase):
 
         rm_mock.return_value = MockRM()
 
-        MockBackendVisaInstrument('name')
+        inst = MockBackendVisaInstrument('name')
         self.assertEqual(rm_mock.call_count, 1)
         self.assertEqual(rm_mock.call_args, ((),))
         self.assertEqual(address_opened[0], None)
+        inst.close()
 
-        MockBackendVisaInstrument('name2', address='ASRL2')
+        inst = MockBackendVisaInstrument('name2', address='ASRL2')
         self.assertEqual(rm_mock.call_count, 2)
         self.assertEqual(rm_mock.call_args, ((),))
         self.assertEqual(address_opened[0], 'ASRL2')
+        inst.close()
 
         # this one raises a warning
         with warnings.catch_warnings(record=True) as w:
-            MockBackendVisaInstrument('name3', address='ASRL3@py')
+            inst = MockBackendVisaInstrument('name3', address='ASRL3@py')
             self.assertTrue(len(w) == 1)
             self.assertTrue('use the visalib' in str(w[-1].message))
 
         self.assertEqual(rm_mock.call_count, 3)
         self.assertEqual(rm_mock.call_args, (('@py',),))
         self.assertEqual(address_opened[0], 'ASRL3')
+        inst.close()
 
         # this one doesn't
-        MockBackendVisaInstrument('name4', address='ASRL4', visalib='@py')
+        inst = MockBackendVisaInstrument('name4', address='ASRL4', visalib='@py')
         self.assertEqual(rm_mock.call_count, 4)
         self.assertEqual(rm_mock.call_args, (('@py',),))
         self.assertEqual(address_opened[0], 'ASRL4')
+        inst.close()

--- a/qcodes/tests/test_wrong_address.py
+++ b/qcodes/tests/test_wrong_address.py
@@ -1,4 +1,3 @@
-import logging
 import re
 
 import pytest
@@ -10,8 +9,6 @@ from qcodes.tests.common import error_caused_by
 
 
 visalib = sims.__file__.replace('__init__.py', 'Keysight_34465A.yaml@sim')
-
-logging.basicConfig(level=logging.DEBUG)
 
 
 def test_wrong_address():

--- a/qcodes/tests/test_wrong_address.py
+++ b/qcodes/tests/test_wrong_address.py
@@ -22,6 +22,7 @@ def test_wrong_address():
 
     right_address = 'GPIB::1::INSTR'  # from the simulation yaml file
 
-    _ = Keysight_34465A('keysight_34465A_sim',
-                        address=right_address,
-                        visalib=visalib)
+    inst = Keysight_34465A('keysight_34465A_sim',
+                           address=right_address,
+                           visalib=visalib)
+    inst.close()


### PR DESCRIPTION
This avoids a bunch of warnings from pytest. 

Furthermore fix a test that depended on the state of the simulated instrument when being run.
This is caused by pyvisa-sim remembering state even when closing instruments