### PR TITLE
Make Dataset.get_data() filter database rows where parameter values are NULL out

### DIFF
--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -100,7 +100,7 @@ def get_data(conn: ConnectionPlus,
             'Returning empty list.'
         )
         return [[]]
-   
+
     output = []
     for output_param in columns:
         res = get_single_parameter_values(conn,

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -111,7 +111,7 @@ def get_data(conn: ConnectionPlus,
         output.append(res)
 
     return output
-    
+
 
 def get_parameter_data(conn: ConnectionPlus,
                        table_name: str,

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -24,7 +24,7 @@ from qcodes.dataset.guids import parse_guid, generate_guid
 from qcodes.dataset.sqlite.connection import transaction, ConnectionPlus, \
     atomic_transaction, atomic
 from qcodes.dataset.sqlite.query_helpers import sql_placeholder_string, \
-    many_many, one, many, select_one_where, select_many_where, insert_values, \
+    many_many, one, many, one_many, select_one_where, select_many_where, insert_values, \
     insert_column, VALUES, update_where
 from qcodes.utils.deprecate import deprecate
 
@@ -124,12 +124,18 @@ def get_data(conn: ConnectionPlus,
             'Returning empty list.'
         )
         return [[]]
-    query = _build_data_query(table_name, columns, start, end)
-    c = atomic_transaction(conn, query)
-    res = many_many(c, *columns)
+   
+    output = []
+    for output_param in columns:
+        res = get_single_parameter_values(conn,
+                                          table_name,
+                                          output_param,
+                                          start=start,
+                                          end=end)
+        output.append(res)
 
-    return res
-
+    return output
+    
 
 def get_parameter_data(conn: ConnectionPlus,
                        table_name: str,
@@ -252,6 +258,62 @@ def get_values(conn: ConnectionPlus,
     """
     c = atomic_transaction(conn, sql)
     res = many_many(c, param_name)
+
+    return res
+
+
+def get_single_parameter_values(conn: ConnectionPlus,
+                                result_table_name: str,
+                                param_name: str,
+                                start: Optional[int] = None,
+                                end: Optional[int] = None) -> List[Any]:
+    """
+    Get the values of a single from a data table. The rows
+    retrieved are the rows where the 'param_name' column has
+    non-NULL values
+
+    Args:
+        conn: Connection to the DB file
+        result_table_name: The result table whence the values are to be
+            retrieved
+        param_name: Name of the column that holds the parameter
+        start: The (1-indexed) result to include as the first results to
+            be returned. None is equivalent to 1. If start > end, nothing
+            is returned.
+        end: The (1-indexed) result to include as the last result to be
+            returned. None is equivalent to "all the rest". If start > end,
+            nothing is returned.
+
+    Returns:
+        A list. The list index is row number.
+    """
+
+    offset = (start - 1) if start is not None else 0
+    limit = (end - offset) if end is not None else -1
+
+    if start is not None and end is not None and start > end:
+        limit = 0
+
+    # Note: if we use placeholders for the SELECT part, then we get rows
+    # back that have "?" as all their keys, making further data extraction
+    # impossible
+    #
+    # Also, placeholders seem to be ignored in the WHERE X IS NOT NULL line
+
+    sql_subquery = f"""
+                   (SELECT {param_name}
+                    FROM "{result_table_name}"
+                    WHERE {param_name} IS NOT NULL)
+                   """
+    sql = f"""
+          SELECT {param_name}
+          FROM {sql_subquery}
+          LIMIT {limit} OFFSET {offset}
+          """
+
+    cursor = conn.cursor()
+    cursor.execute(sql, ())
+    res = one_many(cursor, param_name)
 
     return res
 

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -73,30 +73,6 @@ def is_run_id_in_database(conn: ConnectionPlus,
     return {run_id: (run_id in existing_ids) for run_id in run_ids}
 
 
-def _build_data_query(table_name: str,
-                      columns: List[str],
-                      start: Optional[int] = None,
-                      end: Optional[int] = None,
-                      ) -> str:
-
-    _columns = ",".join(columns)
-    query = f"""
-            SELECT {_columns}
-            FROM "{table_name}"
-            """
-
-    start_specified = start is not None
-    end_specified = end is not None
-
-    where = ' WHERE' if start_specified or end_specified else ''
-    start_condition = f' rowid >= {start}' if start_specified else ''
-    end_condition = f' rowid <= {end}' if end_specified else ''
-    and_ = ' AND' if start_specified and end_specified else ''
-
-    query += where + start_condition + and_ + end_condition
-    return query
-
-
 def get_data(conn: ConnectionPlus,
              table_name: str,
              columns: List[str],

--- a/qcodes/dataset/sqlite/query_helpers.py
+++ b/qcodes/dataset/sqlite/query_helpers.py
@@ -66,7 +66,7 @@ def one_many(curr: sqlite3.Cursor, column: str) -> List[Any]:
     """
     res = curr.fetchall()
     results = [r[column] for r in res]
-    
+
     return results
 
 

--- a/qcodes/dataset/sqlite/query_helpers.py
+++ b/qcodes/dataset/sqlite/query_helpers.py
@@ -55,6 +55,21 @@ def many(curr: sqlite3.Cursor, *columns: str) -> List[Any]:
         return [res[0][c] for c in columns]
 
 
+def one_many(curr: sqlite3.Cursor, column: str) -> List[Any]:
+    """Get all values of a single column
+    Args:
+        curr: cursor to operate on
+        column: name of the column
+
+    Returns:
+        list of values
+    """
+    res = curr.fetchall()
+    results = [r[column] for r in res]
+    
+    return results
+
+
 def many_many(curr: sqlite3.Cursor, *columns: str) -> List[List[Any]]:
     """Get all values of many columns
     Args:

--- a/qcodes/dataset/sqlite_base.py
+++ b/qcodes/dataset/sqlite_base.py
@@ -17,7 +17,7 @@ from qcodes.dataset.sqlite.db_upgrades.version import get_user_version
 from qcodes.dataset.sqlite.db_upgrades.version import set_user_version
 from qcodes.dataset.sqlite.initial_schema import init_db
 from qcodes.dataset.sqlite.queries import is_run_id_in_database, \
-    _build_data_query, get_data, get_parameter_data, get_values, \
+    get_data, get_parameter_data, get_values, \
     get_parameter_tree_values, get_setpoints, \
     get_runid_from_expid_and_counter, \
     get_runid_from_guid, get_layout, get_layout_id, get_dependents, \


### PR DESCRIPTION
Fixes #1600.

Changes proposed in this pull request:
- implement the same database filter in get_data as is currently used in get_parameter_data
- implement new functions in sqlite.queries and sqlite.query_helpers that return all values for a single column

TODO:
- [ ] try to make output of get_data comply with tests
- [ ] assess if this should be move to a new function instead
- [ ] make new tests if needed

@jenshnielsen 
