### PR TITLE
Tektronix DPO7200xx / bugfix / measurement should return floating point values

### DIFF
--- a/qcodes/instrument/sims/Tektronix_DPO7200xx.yaml
+++ b/qcodes/instrument/sims/Tektronix_DPO7200xx.yaml
@@ -53,6 +53,13 @@ devices:
           r: "CH1"
         setter:
           q: "MEASUrement:MEAS1:SOUrce2 {}"
+      adjust_measurement_type:
+        setter:
+          q: "MEASUrement:MEAS0:TYPe amplitude"
+      get_measurement_value:
+        getter:
+          q: "MEASUrement:MEAS0:VALue?"
+          r: "0.01"
 
 
 resources:

--- a/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -749,6 +749,7 @@ class TektronixDPOMeasurement(InstrumentChannel):
             self.add_parameter(
                 measurement,
                 get_cmd=partial(self._measure, measurement),
+                get_parser=float,
                 unit=unit
             )
 

--- a/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
+++ b/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
@@ -47,3 +47,8 @@ def test_adjust_timer(tektronix_dpo):
     # than 1E-3 seconds to return. Since the sleep time is not critical
     # to the microsecond, we don't care that we sometimes retrieve
     # measurements slightly sooner then 'minimum_adjustment_time'
+
+
+def test_measurements_return_float(tektronix_dpo):
+    amplitude = tektronix_dpo.measurement[0].amplitude()
+    assert isinstance(amplitude, float)


### PR DESCRIPTION
This PR includes a bugfix. The measurement module returned strings instead of floats as measured value. Obviously, I forgot to include a get_parser. 