### PR TITLE
Remove out of date todo with metadata columns

### DIFF
--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1399,8 +1399,7 @@ def get_metadata_from_run_id(conn: ConnectionPlus, run_id: int) -> Dict:
     """
     Get all metadata associated with the specified run
     """
-    # TODO: promote snapshot to be present at creation time
-    non_metadata = RUNS_TABLE_COLUMNS + ['snapshot']
+    non_metadata = RUNS_TABLE_COLUMNS
 
     metadata = {}
     possible_tags = []


### PR DESCRIPTION
Snapshot is now in RUNS_TABLE_COLUMNS so this todo can go.

Noticed this as part of #1605 
