### PR TITLE
Add option in get_parameter_data() to only return values of the top level parameter

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -761,7 +761,8 @@ class DataSet(Sized):
             self,
             *params: Union[str, ParamSpec, _BaseParameter],
             start: Optional[int] = None,
-            end: Optional[int] = None) -> Dict[str, Dict[str, numpy.ndarray]]:
+            end: Optional[int] = None,
+            include_setpoints = True) -> Dict[str, Dict[str, numpy.ndarray]]:
         """
         Returns the values stored in the DataSet for the specified parameters
         and their dependencies. If no paramerers are supplied the values will
@@ -789,6 +790,8 @@ class DataSet(Sized):
                 if None
             end: end value of selection range (by results count); ignored if
                 None
+            include_setpoints: if False, only return the values for the
+                top level parameters instead of the entire trees
 
         Returns:
             Dictionary from requested parameters to Dict of parameter names
@@ -801,7 +804,7 @@ class DataSet(Sized):
         else:
             valid_param_names = self._validate_parameters(*params)
         return get_parameter_data(self.conn, self.table_name,
-                                  valid_param_names, start, end)
+                                  valid_param_names, start, end, include_setpoints)
 
     def get_data_as_pandas_dataframe(self,
                                      *params: Union[str,

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -135,7 +135,8 @@ def get_parameter_data(conn: ConnectionPlus,
                        table_name: str,
                        columns: Sequence[str] = (),
                        start: Optional[int] = None,
-                       end: Optional[int] = None) -> \
+                       end: Optional[int] = None,
+                       include_setpoints = True) -> \
         Dict[str, Dict[str, np.ndarray]]:
     """
     Get data for one or more parameters and its dependencies. The data
@@ -161,6 +162,8 @@ def get_parameter_data(conn: ConnectionPlus,
             are returned.
         start: start of range; if None, then starts from the top of the table
         end: end of range; if None, then ends at the bottom of the table
+        include_setpoints: if False, only return the values for the
+            top level parameters instead of the entire trees
     """
     sql = """
     SELECT run_id FROM runs WHERE result_table_name = ?
@@ -179,8 +182,9 @@ def get_parameter_data(conn: ConnectionPlus,
     for output_param in columns:
         output_param_spec = interdeps._id_to_paramspec[output_param]
         # find all the dependencies of this param
-        paramspecs = [output_param_spec] \
-                   + list(interdeps.dependencies.get(output_param_spec, ()))
+        paramspecs = [output_param_spec]
+        if include_setpoints:
+            paramspecs += list(interdeps.dependencies.get(output_param_spec, ()))
         param_names = [param.name for param in paramspecs]
         types = [param.type for param in paramspecs]
 


### PR DESCRIPTION
Fixes #1601.

Changes proposed in this pull request:
- add `return_setpoints` option (defaulting to `True`) to `get_parameter_data()` in both `dataset.Dataset` and `dataset.sqlite.queries`

@astafan8 
