### PR TITLE
Don't get db location from config if conn supplied

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -28,7 +28,7 @@ from qcodes.dataset.sqlite.queries import add_parameter, create_run, \
 from qcodes.dataset.sqlite.query_helpers import select_one_where, length, \
     insert_many_values, insert_values, VALUE, one
 from qcodes.dataset.sqlite.database import get_DB_location, connect, \
-    init_conn
+    conn_from_dbpath_or_conn
 from qcodes.instrument.parameter import _BaseParameter
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.dependencies import (InterDependencies_,
@@ -237,7 +237,7 @@ class DataSet(Sized):
                              "been passed together with non-None values. "
                              "This is not allowed.")
 
-        self.conn, self._path_to_db = init_conn(conn, path_to_db)
+        self.conn = conn_from_dbpath_or_conn(conn, path_to_db)
 
         self.conn = make_connection_plus_from(conn) if conn is not None else \
             connect(self.path_to_db)
@@ -294,7 +294,7 @@ class DataSet(Sized):
 
     @property
     def path_to_db(self):
-        return self._path_to_db
+        return self.conn.path_to_dbfile
 
     @property
     def name(self):

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -24,11 +24,11 @@ from qcodes.dataset.sqlite.queries import add_parameter, create_run, \
     get_sample_name_from_experiment_id, get_guid_from_run_id, \
     get_runid_from_guid, get_run_timestamp_from_run_id, get_run_description,\
     get_completed_timestamp_from_run_id, update_run_description, run_exists,\
-    remove_trigger, set_run_timestamp, get_db_location_from_conn
+    remove_trigger, set_run_timestamp
 from qcodes.dataset.sqlite.query_helpers import select_one_where, length, \
     insert_many_values, insert_values, VALUE, one
 from qcodes.dataset.sqlite.database import get_DB_location, connect, \
-    get_DB_debug
+    get_DB_debug, path_to_dbfile
 from qcodes.instrument.parameter import _BaseParameter
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.dependencies import (InterDependencies_,
@@ -293,7 +293,7 @@ class DataSet(Sized):
             raise ValueError('Received BOTH conn and path_to_db. Please '
                              'provide only one or the other.')
         if conn is not None:
-            path_to_db = get_db_location_from_conn(conn)
+            path_to_db = path_to_dbfile(conn)
         else:
             path_to_db = path_to_db or get_DB_location()
         conn = conn or connect(path_to_db, get_DB_debug())

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -239,9 +239,6 @@ class DataSet(Sized):
 
         self.conn = conn_from_dbpath_or_conn(conn, path_to_db)
 
-        self.conn = make_connection_plus_from(conn) if conn is not None else \
-            connect(self.path_to_db)
-
         self._run_id = run_id
         self._debug = False
         self.subscribers: Dict[str, _Subscriber] = {}

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -28,7 +28,7 @@ from qcodes.dataset.sqlite.queries import add_parameter, create_run, \
 from qcodes.dataset.sqlite.query_helpers import select_one_where, length, \
     insert_many_values, insert_values, VALUE, one
 from qcodes.dataset.sqlite.database import get_DB_location, connect, \
-    get_DB_debug, path_to_dbfile
+    init_conn
 from qcodes.instrument.parameter import _BaseParameter
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.dependencies import (InterDependencies_,
@@ -237,7 +237,7 @@ class DataSet(Sized):
                              "been passed together with non-None values. "
                              "This is not allowed.")
 
-        self.conn, self._path_to_db = self._init_conn(conn, path_to_db)
+        self.conn, self._path_to_db = init_conn(conn, path_to_db)
 
         self.conn = make_connection_plus_from(conn) if conn is not None else \
             connect(self.path_to_db)
@@ -287,17 +287,6 @@ class DataSet(Sized):
                 self._interdeps = InterDependencies_()
             self._metadata = get_metadata_from_run_id(self.conn, self.run_id)
 
-    @staticmethod
-    def _init_conn(conn, path_to_db):
-        if path_to_db is not None and conn is not None:
-            raise ValueError('Received BOTH conn and path_to_db. Please '
-                             'provide only one or the other.')
-        if conn is not None:
-            path_to_db = path_to_dbfile(conn)
-        else:
-            path_to_db = path_to_db or get_DB_location()
-        conn = conn or connect(path_to_db, get_DB_debug())
-        return conn, path_to_db
 
     @property
     def run_id(self):

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -232,11 +232,6 @@ class DataSet(Sized):
             metadata: metadata to insert into the dataset. Ignored if run_id
               is provided.
         """
-        if path_to_db is not None and conn is not None:
-            raise ValueError("Both `path_to_db` and `conn` arguments have "
-                             "been passed together with non-None values. "
-                             "This is not allowed.")
-
         self.conn = conn_from_dbpath_or_conn(conn, path_to_db)
 
         self._run_id = run_id

--- a/qcodes/dataset/database.py
+++ b/qcodes/dataset/database.py
@@ -7,7 +7,8 @@ removed soon.
 import warnings
 
 from .sqlite.database import get_DB_debug, get_DB_location, \
-    initialise_database, initialise_or_create_database_at, path_to_dbfile
+    initialise_database, initialise_or_create_database_at
+from .sqlite.connection import path_to_dbfile
 
 warnings.warn('The module `qcodes.dataset.database` is deprecated.\n'
               'Public features are available at the import of `qcodes`.\n'

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -12,7 +12,7 @@ from qcodes.dataset.sqlite.queries import new_experiment as ne, \
     get_experiment_name_from_experiment_id, get_runid_from_expid_and_counter, \
     get_sample_name_from_experiment_id
 from qcodes.dataset.sqlite.database import get_DB_location, get_DB_debug, \
-    connect, path_to_dbfile
+    connect, init_conn
 from qcodes.dataset.sqlite.query_helpers import select_one_where
 
 
@@ -47,7 +47,7 @@ class Experiment(Sized):
               to the DB file specified in the config is made
         """
 
-        self.conn, self._path_to_db = self._init_conn(conn, path_to_db)
+        self.conn, self._path_to_db = init_conn(conn, path_to_db)
 
         max_id = len(get_experiments(self.conn))
 
@@ -72,18 +72,6 @@ class Experiment(Sized):
             name = name or f"experiment_{max_id+1}"
             sample_name = sample_name or "some_sample"
             self._exp_id = ne(self.conn, name, sample_name, format_string)
-
-    @staticmethod
-    def _init_conn(conn, path_to_db):
-        if path_to_db is not None and conn is not None:
-            raise ValueError('Received BOTH conn and path_to_db. Please '
-                             'provide only one or the other.')
-        if conn is not None:
-            path_to_db = path_to_dbfile(conn)
-        else:
-            path_to_db = path_to_db or get_DB_location()
-        conn = conn or connect(path_to_db, get_DB_debug())
-        return conn, path_to_db
 
     @property
     def exp_id(self) -> int:

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -10,9 +10,9 @@ from qcodes.dataset.sqlite.queries import new_experiment as ne, \
     finish_experiment, get_run_counter, get_runs, get_last_run, \
     get_last_experiment, get_experiments, \
     get_experiment_name_from_experiment_id, get_runid_from_expid_and_counter, \
-    get_sample_name_from_experiment_id, get_db_location_from_conn
+    get_sample_name_from_experiment_id
 from qcodes.dataset.sqlite.database import get_DB_location, get_DB_debug, \
-    connect
+    connect, path_to_dbfile
 from qcodes.dataset.sqlite.query_helpers import select_one_where
 
 
@@ -79,7 +79,7 @@ class Experiment(Sized):
             raise ValueError('Received BOTH conn and path_to_db. Please '
                              'provide only one or the other.')
         if conn is not None:
-            path_to_db = get_db_location_from_conn(conn)
+            path_to_db = path_to_dbfile(conn)
         else:
             path_to_db = path_to_db or get_DB_location()
         conn = conn or connect(path_to_db, get_DB_debug())

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -12,7 +12,7 @@ from qcodes.dataset.sqlite.queries import new_experiment as ne, \
     get_experiment_name_from_experiment_id, get_runid_from_expid_and_counter, \
     get_sample_name_from_experiment_id
 from qcodes.dataset.sqlite.database import get_DB_location, get_DB_debug, \
-    connect, init_conn
+    connect, conn_from_dbpath_or_conn
 from qcodes.dataset.sqlite.query_helpers import select_one_where
 
 
@@ -47,7 +47,7 @@ class Experiment(Sized):
               to the DB file specified in the config is made
         """
 
-        self.conn, self._path_to_db = init_conn(conn, path_to_db)
+        self.conn = conn_from_dbpath_or_conn(conn, path_to_db)
 
         max_id = len(get_experiments(self.conn))
 
@@ -79,7 +79,7 @@ class Experiment(Sized):
 
     @property
     def path_to_db(self) -> str:
-        return self._path_to_db
+        return self.conn.path_to_dbfile
 
     @property
     def name(self) -> str:

--- a/qcodes/dataset/sqlite/connection.py
+++ b/qcodes/dataset/sqlite/connection.py
@@ -30,7 +30,7 @@ class ConnectionPlus(wrapt.ObjectProxy):
         path_to_dbfile: Path to the database file of the connection.
     """
     atomic_in_progress: bool = False
-    path_to_dbfile = None
+    path_to_dbfile = ''
 
     def __init__(self, sqlite3_connection: sqlite3.Connection):
         super(ConnectionPlus, self).__init__(sqlite3_connection)

--- a/qcodes/dataset/sqlite/connection.py
+++ b/qcodes/dataset/sqlite/connection.py
@@ -161,6 +161,8 @@ def path_to_dbfile(conn: Union[ConnectionPlus, sqlite3.Connection]) -> str:
     """
     Return the path of the database file that the conn object is connected to
     """
+    # according to https://www.sqlite.org/pragma.html#pragma_database_list
+    # the 3th element (1 indexed) is the path
     cursor = conn.cursor()
     cursor.execute("PRAGMA database_list")
     row = cursor.fetchall()[0]

--- a/qcodes/dataset/sqlite/connection.py
+++ b/qcodes/dataset/sqlite/connection.py
@@ -27,8 +27,10 @@ class ConnectionPlus(wrapt.ObjectProxy):
         atomic_in_progress: a bool describing whether the connection is
             currently in the middle of an atomic block of transactions, thus
             allowing to nest `atomic` context managers
+        path_to_dbfile: Path to the database file of the connection.
     """
     atomic_in_progress: bool = False
+    path_to_dbfile = None
 
     def __init__(self, sqlite3_connection: sqlite3.Connection):
         super(ConnectionPlus, self).__init__(sqlite3_connection)
@@ -36,6 +38,8 @@ class ConnectionPlus(wrapt.ObjectProxy):
         if isinstance(sqlite3_connection, ConnectionPlus):
             raise ValueError('Attempted to create `ConnectionPlus` from a '
                              '`ConnectionPlus` object which is not allowed.')
+
+        self.path_to_dbfile = path_to_dbfile(sqlite3_connection)
 
 
 def make_connection_plus_from(conn: Union[sqlite3.Connection, ConnectionPlus]
@@ -151,3 +155,14 @@ def atomic_transaction(conn: ConnectionPlus,
     with atomic(conn) as atomic_conn:
         c = transaction(atomic_conn, sql, *args)
     return c
+
+
+def path_to_dbfile(conn: Union[ConnectionPlus, sqlite3.Connection]) -> str:
+    """
+    Return the path of the database file that the conn object is connected to
+    """
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA database_list")
+    row = cursor.fetchall()[0]
+
+    return row[2]

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -6,7 +6,7 @@ database version and possibly perform database upgrades.
 import io
 import sqlite3
 import sys
-from os.path import expanduser
+from os.path import expanduser, normpath
 from typing import Union, Tuple
 
 import numpy as np
@@ -190,7 +190,7 @@ def get_db_version_and_newest_available_version(path_to_db: str) -> Tuple[int,
 
 
 def get_DB_location() -> str:
-    return expanduser(qcodes.config["core"]["db_location"])
+    return normpath(expanduser(qcodes.config["core"]["db_location"]))
 
 
 def get_DB_debug() -> bool:

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -236,3 +236,15 @@ def path_to_dbfile(conn: ConnectionPlus) -> str:
     row = cursor.fetchall()[0]
 
     return row[2]
+
+
+def init_conn(conn, path_to_db):
+    if path_to_db is not None and conn is not None:
+        raise ValueError('Received BOTH conn and path_to_db. Please '
+                         'provide only one or the other.')
+    if conn is not None:
+        path_to_db = path_to_dbfile(conn)
+    else:
+        path_to_db = path_to_db or get_DB_location()
+    conn = conn or connect(path_to_db, get_DB_debug())
+    return conn, path_to_db

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -242,9 +242,11 @@ def init_conn(conn, path_to_db):
     if path_to_db is not None and conn is not None:
         raise ValueError('Received BOTH conn and path_to_db. Please '
                          'provide only one or the other.')
+
     if conn is not None:
         path_to_db = path_to_dbfile(conn)
-    else:
-        path_to_db = path_to_db or get_DB_location()
-    conn = conn or connect(path_to_db, get_DB_debug())
+    if path_to_db is None:
+        path_to_db = get_DB_location()
+    if conn is None:
+        conn = connect(path_to_db, get_DB_debug())
     return conn, path_to_db

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -229,7 +229,7 @@ def initialise_or_create_database_at(db_file_with_abs_path: str) -> None:
 
 def conn_from_dbpath_or_conn(conn: Optional[ConnectionPlus],
                              path_to_db: Optional[str]) \
-        -> Tuple[ConnectionPlus, str]:
+        -> ConnectionPlus:
     """
     A small helper function to abstract the logic needed for functions
     that take either a `ConnectionPlus` or the path to a db file.
@@ -249,6 +249,13 @@ def conn_from_dbpath_or_conn(conn: Optional[ConnectionPlus],
                          'provide only one or the other.')
     if conn is None and path_to_db is None:
         path_to_db = get_DB_location()
-    if conn is None:
+
+    if conn is None and path_to_db is not None:
         conn = connect(path_to_db, get_DB_debug())
+    elif conn is not None:
+        conn = conn
+    else:
+        # this should be impossible but left here to keep mypy happy.
+        raise RuntimeError("Could not obtain a connection from"
+                           "supplied information.")
     return conn

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -241,7 +241,7 @@ def conn_from_dbpath_or_conn(conn: Optional[ConnectionPlus],
         path_to_db: The path to a db file.
 
     Returns:
-        Tuple of `ConnectionPlus` and path to db file.
+        A `ConnectionPlus` object
     """
 
     if path_to_db is not None and conn is not None:

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1602,4 +1602,6 @@ def get_db_location_from_conn(conn: ConnectionPlus) -> str:
     if len(curr_table) > 1:
         raise RuntimeError("Connected to more than one DB file. "
                            "Does not know how to handle this")
+    # according to https://www.sqlite.org/pragma.html#pragma_database_list
+    # the 3th element (1 indexed) is the path
     return curr_table[0][2]

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1590,18 +1590,3 @@ def remove_trigger(conn: ConnectionPlus, trigger_id: str) -> None:
         name: id of the trigger
     """
     transaction(conn, f"DROP TRIGGER IF EXISTS {trigger_id};")
-
-
-def get_db_location_from_conn(conn: ConnectionPlus) -> str:
-    """
-    Get the path to a db file from the connection.
-    """
-    cursor = conn.cursor()
-    cursor.execute("PRAGMA database_list;")
-    curr_table = cursor.fetchall()
-    if len(curr_table) > 1:
-        raise RuntimeError("Connected to more than one DB file. "
-                           "Does not know how to handle this")
-    # according to https://www.sqlite.org/pragma.html#pragma_database_list
-    # the 3th element (1 indexed) is the path
-    return curr_table[0][2]

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1590,3 +1590,16 @@ def remove_trigger(conn: ConnectionPlus, trigger_id: str) -> None:
         name: id of the trigger
     """
     transaction(conn, f"DROP TRIGGER IF EXISTS {trigger_id};")
+
+
+def get_db_location_from_conn(conn: ConnectionPlus) -> str:
+    """
+    Get the path to a db file from the connection.
+    """
+    cursor = conn.cursor()
+    cursor.execute("PRAGMA database_list;")
+    curr_table = cursor.fetchall()
+    if len(curr_table) > 1:
+        raise RuntimeError("Connected to more than one DB file. "
+                           "Does not know how to handle this")
+    return curr_table[0][2]

--- a/qcodes/tests/dataset/temporary_databases.py
+++ b/qcodes/tests/dataset/temporary_databases.py
@@ -31,7 +31,7 @@ def empty_temp_db():
 @pytest.fixture(scope='function')
 def empty_temp_db_connection():
     """
-    Yield the paths of an empty file.
+    Yield connection to an empty temporary DB file.
     """
     with tempfile.TemporaryDirectory() as tmpdirname:
         path = os.path.join(tmpdirname, 'source.db')

--- a/qcodes/tests/dataset/temporary_databases.py
+++ b/qcodes/tests/dataset/temporary_databases.py
@@ -29,6 +29,20 @@ def empty_temp_db():
 
 
 @pytest.fixture(scope='function')
+def empty_temp_db_connection():
+    """
+    Yield the paths of an empty file.
+    """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        path = os.path.join(tmpdirname, 'source.db')
+        conn = connect(path)
+        try:
+            yield conn
+        finally:
+            conn.close()
+
+
+@pytest.fixture(scope='function')
 def two_empty_temp_db_connections():
     """
     Yield the paths of two empty files. Meant for use with the

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -11,8 +11,8 @@ import qcodes.tests.dataset
 from qcodes.dataset.experiment_container import Experiment
 from qcodes.dataset.data_set import (DataSet, load_by_guid, load_by_counter,
                                      load_by_id)
-from qcodes.dataset.sqlite.database import path_to_dbfile, \
-    get_db_version_and_newest_available_version
+from qcodes.dataset.sqlite.database import get_db_version_and_newest_available_version
+from qcodes.dataset.sqlite.connection import path_to_dbfile
 from qcodes.dataset.database_extract_runs import extract_runs_into_db
 from qcodes.dataset.sqlite.queries import get_experiments
 from qcodes.tests.dataset.temporary_databases import two_empty_temp_db_connections

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -61,7 +61,7 @@ def test_has_attributes_after_init():
     (run_id is None / run_id is not None)
     """
 
-    attrs = ['path_to_db', '_path_to_db', 'conn', '_run_id', 'run_id',
+    attrs = ['path_to_db', 'conn', '_run_id', 'run_id',
              '_debug', 'subscribers', '_completed', 'name', 'table_name',
              'guid', 'number_of_results', 'counter', 'parameters',
              'paramspecs', 'exp_id', 'exp_name', 'sample_name',

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -201,10 +201,9 @@ def test_create_dataset_from_non_existing_run_id(non_existing_run_id):
 
 
 def test_create_dataset_pass_both_connection_and_path_to_db(experiment):
-    with pytest.raises(ValueError, match="Both `path_to_db` and `conn` "
-                                         "arguments have been passed together "
-                                         "with non-None values. This is not "
-                                         "allowed."):
+    with pytest.raises(ValueError, match="Received BOTH conn and path_to_db. "
+                                         "Please provide only one or "
+                                         "the other."):
         some_valid_connection = experiment.conn
         _ = DataSet(path_to_db="some valid path", conn=some_valid_connection)
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -22,9 +22,11 @@ from qcodes.tests.common import error_caused_by
 from qcodes.dataset.sqlite.database import get_DB_location
 from qcodes.dataset.data_set import CompletedError, DataSet
 from qcodes.dataset.guids import parse_guid
+from qcodes.dataset.sqlite.connection import path_to_dbfile
 # pylint: disable=unused-import
 from qcodes.tests.dataset.temporary_databases import (empty_temp_db,
-                                                      experiment, dataset)
+                                                      experiment, dataset,
+                                                      empty_temp_db_connection)
 from qcodes.tests.dataset.dataset_fixtures import scalar_dataset, \
     scalar_dataset_with_nulls, array_dataset_with_nulls, \
     array_dataset, multi_dataset, array_in_scalar_dataset, array_in_str_dataset, \
@@ -80,6 +82,19 @@ def test_has_attributes_after_init():
     for attr in attrs:
         assert hasattr(ds, attr)
         getattr(ds, attr)
+
+
+def test_dataset_location(empty_temp_db_connection):
+    """
+    Test that an dataset and experiment points to the correct db file when
+    a connection is supplied.
+    """
+    exp = new_experiment("test", "test1", conn=empty_temp_db_connection)
+    ds = DataSet(conn=empty_temp_db_connection)
+    assert path_to_dbfile(empty_temp_db_connection) == \
+           empty_temp_db_connection.path_to_dbfile
+    assert exp.path_to_db == empty_temp_db_connection.path_to_dbfile
+    assert ds.path_to_db == empty_temp_db_connection.path_to_dbfile
 
 
 @pytest.mark.usefixtures("experiment")

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -112,7 +112,7 @@ def test_has_attributes_after_init():
     """
 
     attrs = ['name', 'exp_id', '_exp_id', 'sample_name', 'last_counter',
-             'path_to_db', '_path_to_db', 'conn', 'started_at',
+             'path_to_db', 'conn', 'started_at',
              'finished_at', 'format_string']
 
     # This creates an experiment in the db

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -18,7 +18,8 @@ from qcodes.dataset.descriptions.param_spec import ParamSpec
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 import qcodes.dataset.descriptions.versioning.serialization as serial
-from qcodes.dataset.sqlite.database import get_DB_location, path_to_dbfile
+from qcodes.dataset.sqlite.connection import path_to_dbfile
+from qcodes.dataset.sqlite.database import get_DB_location
 from qcodes.dataset.guids import generate_guid
 from qcodes.dataset.data_set import DataSet
 # pylint: disable=unused-import
@@ -59,6 +60,7 @@ def test_path_to_dbfile():
         conn = mut_db.connect(tempdb)
         try:
             assert path_to_dbfile(conn) == tempdb
+            assert conn.path_to_dbfile == tempdb
         finally:
             conn.close()
 

--- a/qcodes/tests/dataset/test_sqlite_connection.py
+++ b/qcodes/tests/dataset/test_sqlite_connection.py
@@ -43,6 +43,7 @@ def test_connection_plus():
     sqlite_conn = sqlite3.connect(':memory:')
     conn_plus = ConnectionPlus(sqlite_conn)
 
+    assert conn_plus.path_to_dbfile == ''
     assert isinstance(conn_plus, ConnectionPlus)
     assert isinstance(conn_plus, sqlite3.Connection)
     assert False is conn_plus.atomic_in_progress
@@ -57,6 +58,7 @@ def test_make_connection_plus_from_sqlite3_connection():
     conn = sqlite3.connect(':memory:')
     conn_plus = make_connection_plus_from(conn)
 
+    assert conn_plus.path_to_dbfile == ''
     assert isinstance(conn_plus, ConnectionPlus)
     assert False is conn_plus.atomic_in_progress
     assert conn_plus is not conn
@@ -66,6 +68,7 @@ def test_make_connection_plus_from_connecton_plus():
     conn = ConnectionPlus(sqlite3.connect(':memory:'))
     conn_plus = make_connection_plus_from(conn)
 
+    assert conn_plus.path_to_dbfile == ''
     assert isinstance(conn_plus, ConnectionPlus)
     assert conn.atomic_in_progress is conn_plus.atomic_in_progress
     assert conn_plus is conn


### PR DESCRIPTION
The conn could point to any file on disk so this will in general not be correct.
Fix this by looking up the db path from the connection supplied and using that rather than relying on the config. Only fall back to config if no path or conn is supplied. 

Also fix a small issue where the path separators could be inconsistent if the incorrect platform dependent path sepeartor was used in the config file. e.g. on windows `~/experiments.db` would previously expand to `c:\\users\\username/experiments.db` 

Another issue discovered as part of #1605 

This should preferably have a test. 
