### PR TITLE
Add a method on the channel parameter to check if it is closed.

### DIFF
--- a/qcodes/instrument/sims/Keithley_s46.yaml
+++ b/qcodes/instrument/sims/Keithley_s46.yaml
@@ -39,13 +39,11 @@ devices:
           q: ":CLOS?"
           r: "(@1,8,13)"
         setter:
-          q: ":CLOS {}"
-          r: ""
+          q: ":close {}"
 
       open:
         setter:
-          q: ":OPEN {}"
-          r: ""
+          q: ":open {}"
 
   device four:
     eom:

--- a/qcodes/instrument_drivers/tektronix/Keithley_s46.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_s46.py
@@ -106,6 +106,14 @@ class S46Parameter(Parameter):
                                "that is not attached to an instrument.")
         self._instrument.write(f":{new_state} (@{self._channel_number})")
 
+    def is_closed(self) -> bool:
+        """
+        A public method to query the channel state without relying on string comparison.
+
+        Returns: True if channels is closed, False otherwise.
+        """
+        return self.get() == "close"
+
     @property
     def channel_number(self) -> int:
         return self._channel_number

--- a/qcodes/instrument_drivers/tektronix/Keithley_s46.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_s46.py
@@ -108,8 +108,6 @@ class S46Parameter(Parameter):
 
     def is_closed(self) -> bool:
         """
-        A public method to query the channel state without relying on string comparison.
-
         Returns: True if channels is closed, False otherwise.
         """
         return self.get() == "close"

--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -159,3 +159,16 @@ def test_locking_mechanism(s46_six):
     # Upon opening C1 we should be able to close C2
     s46_six.C1("open")
     s46_six.C2("close")
+
+
+def test_is_closed(s46_six):
+    """
+    Test the `is_closed` public method
+    """
+    assert s46_six.A1.is_closed()
+    assert s46_six.B2.is_closed()
+    assert s46_six.C1.is_closed()
+
+    assert not s46_six.A2.is_closed()
+    assert not s46_six.B4.is_closed()
+    assert not s46_six.C6.is_closed()

--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -172,4 +172,3 @@ def test_is_closed(s46_six):
     assert not s46_six.A2.is_closed()
     assert not s46_six.B4.is_closed()
     assert not s46_six.C6.is_closed()
-

--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -75,19 +75,6 @@ def test_query_close_once_at_init(caplog):
         inst.close()
 
 
-def test_is_closed(s46_six):
-    """
-    Test the `is_closed` public method
-    """
-    assert s46_six.A1.is_closed()
-    assert s46_six.B2.is_closed()
-    assert s46_six.C1.is_closed()
-
-    assert not s46_six.A2.is_closed()
-    assert not s46_six.B4.is_closed()
-    assert not s46_six.C6.is_closed()
-
-
 def test_init_six(s46_six, caplog):
     """
     Test that the six channel instrument initializes correctly.
@@ -172,3 +159,17 @@ def test_locking_mechanism(s46_six):
     # Upon opening C1 we should be able to close C2
     s46_six.C1("open")
     s46_six.C2("close")
+
+
+def test_is_closed(s46_six):
+    """
+    Test the `is_closed` public method
+    """
+    assert s46_six.A1.is_closed()
+    assert s46_six.B2.is_closed()
+    assert s46_six.C1.is_closed()
+
+    assert not s46_six.A2.is_closed()
+    assert not s46_six.B4.is_closed()
+    assert not s46_six.C6.is_closed()
+

--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -75,6 +75,19 @@ def test_query_close_once_at_init(caplog):
         inst.close()
 
 
+def test_is_closed(s46_six):
+    """
+    Test the `is_closed` public method
+    """
+    assert s46_six.A1.is_closed()
+    assert s46_six.B2.is_closed()
+    assert s46_six.C1.is_closed()
+
+    assert not s46_six.A2.is_closed()
+    assert not s46_six.B4.is_closed()
+    assert not s46_six.C6.is_closed()
+
+
 def test_init_six(s46_six, caplog):
     """
     Test that the six channel instrument initializes correctly.
@@ -159,16 +172,3 @@ def test_locking_mechanism(s46_six):
     # Upon opening C1 we should be able to close C2
     s46_six.C1("open")
     s46_six.C2("close")
-
-
-def test_is_closed(s46_six):
-    """
-    Test the `is_closed` public method
-    """
-    assert s46_six.A1.is_closed()
-    assert s46_six.B2.is_closed()
-    assert s46_six.C1.is_closed()
-
-    assert not s46_six.A2.is_closed()
-    assert not s46_six.B4.is_closed()
-    assert not s46_six.C6.is_closed()


### PR DESCRIPTION
Currently, to check if a channel on the Keithley S46 is closed we have to write the following: 

```python
s46.A1.get() == "close"
```

This can be error prone: typos can cause this code to fail (e.g. 'closed' instead of 'close', 'Close' with a capital C, accidental spaces, etc). 

Furthermore, a bug of this nature can go unnoticed for a long time and might be hard to track down, as the code above will not generate an exception when 'close' is spelled wrong. 

The following code is much more robust

```python
s46.A1.is_closed()
```

An understandable error message will be thrown when the above code is run with a typo in the method name.