### PR TITLE
update m4i docstrings

### DIFF
--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -750,9 +750,9 @@ class M4i(Instrument):
     # interleaves the data)
     def multiple_trigger_acquisition(self, mV_range, memsize, seg_size, posttrigger_size):
         """ Acquire traces with the SPC_REC_STD_MULTI mode
-        
+
         This method does not update the triggering properties.
-        
+
         Args:
             mV_range (float): Input range used for coversion to voltage
             memsize (int): Size of total buffer to acquire
@@ -760,7 +760,7 @@ class M4i(Instrument):
             posttrigger_size (int): Size of the if post trigger buffer
         Returns:
             Array with measured voltages
-        
+
         """
         self.card_mode(pyspcm.SPC_REC_STD_MULTI)  # multi
 
@@ -869,8 +869,18 @@ class M4i(Instrument):
         return voltages
 
     def single_trigger_acquisition(self, mV_range, memsize, posttrigger_size):
+        """ Acquire traces with the SPC_REC_STD_SINGLE mode
 
-        self.card_mode(pyspcm.SPC_REC_STD_SINGLE)  # single
+        This method does not update the triggering properties.
+
+        Args:
+            mV_range (float): Input range used for coversion to voltage
+            memsize (int): Size of total buffer to acquire
+            posttrigger_size (int): Size of the if post trigger buffer
+        Returns:
+            Array with measured voltages
+        """
+        self.card_mode(pyspcm.SPC_REC_STD_SINGLE)
 
         # set memsize and posttrigger
         self.data_memory_size(memsize)

--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -749,7 +749,19 @@ class M4i(Instrument):
     # TODO: the data also needs to be organized nicely (currently it
     # interleaves the data)
     def multiple_trigger_acquisition(self, mV_range, memsize, seg_size, posttrigger_size):
-
+        """ Acquire traces with the SPC_REC_STD_MULTI mode
+        
+        This method does not update the triggering properties.
+        
+        Args:
+            mV_range (float): Input range used for coversion to voltage
+            memsize (int): Size of total buffer to acquire
+            seg_size (int): Size of segments to record
+            posttrigger_size (int): Size of the if post trigger buffer
+        Returns:
+            Array with measured voltages
+        
+        """
         self.card_mode(pyspcm.SPC_REC_STD_MULTI)  # multi
 
         self.data_memory_size(memsize)
@@ -976,7 +988,8 @@ class M4i(Instrument):
                                               verbose=0, post_trigger=None):
         """ Acquire data using block averaging and hardware triggering
 
-        To read out multiple channels, use `initialize_channels`
+        To read out multiple channels, use `initialize_channels`. This methods updates
+        the external_trigger_mode and trigger_or_mask parameters.
 
         Args:
             mV_range (float)


### PR DESCRIPTION
The m4i acquisition methods do not all set properties for the triggering in the same way. Fixing this would be backwards incompatible. This PR at least updates some of the docstrings.


@astafan8 
