### PR TITLE
Dev / log install info

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -500,6 +500,7 @@ class Instrument(InstrumentBase, AbstractInstrument):
                    '(serial:{serial}, firmware:{firmware}) '
                    'in {t:.2f}s'.format(t=t, **idn))
         print(con_msg)
+        self.log.info(con_msg)
 
     def __repr__(self):
         """Simplified repr giving just the class and name."""

--- a/qcodes/logger/__init__.py
+++ b/qcodes/logger/__init__.py
@@ -11,9 +11,8 @@ and functions to extract log messages to :class:`pandas.DataFrame` s
 
 
 from .logger import (get_console_handler, get_file_handler, get_level_name,
-                     get_level_code, start_logger,
+                     get_level_code, get_log_file_name, start_logger,
                      start_command_history_logger, start_all_logging,
                      handler_level, console_level, LogCapture)
 from .instrument_logger import filter_instrument
 from .log_analysis import capture_dataframe
-

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -19,8 +19,9 @@ from copy import copy
 from typing import Optional, Union, Sequence
 
 import qcodes as qc
+import qcodes.utils.installation_info as ii
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 LevelType = Union[int, str]
 
@@ -195,6 +196,8 @@ def start_logger() -> None:
 
     log.info("QCoDes logger setup completed")
 
+    log_qcodes_versions(log)
+
 
 def start_command_history_logger(log_dir: Optional[str] = None) -> None:
     """
@@ -220,6 +223,22 @@ def start_command_history_logger(log_dir: Optional[str] = None) -> None:
     ipython.magic("%logstop")
     ipython.magic("%logstart -t -o {} {}".format(filename, "append"))
     log.info("Started logging IPython history")
+
+
+def log_qcodes_versions(logger: logging.Logger):
+    """
+    Log the version information relevant to QCoDeS. This function logs
+    the currently installed qcodes version, whether QCoDeS is installed in
+    editable mode, and the installed versions of QCoDeS' requirements.
+    """
+
+    qc_version = ii.get_qcodes_version()
+    qc_e_inst = ii.is_qcodes_installed_editably()
+    qc_req_vs = ii.get_qcodes_requirements_versions()
+
+    logger.info(f'QCoDeS version: {qc_version}')
+    logger.info(f'QCoDeS installed in editable mode: {qc_e_inst}')
+    logger.info(f'QCoDeS requirements versions: {qc_req_vs}')
 
 
 def start_all_logging() -> None:

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -1,0 +1,15 @@
+from qcodes.utils.installation_info import _pip_list_parser
+
+
+def test_pip_list_parser():
+
+    lines = ['Package Version              Location',
+             '------- -------------------- ----------------------------',
+             'qcodes  0.4.0+186.g6579bf8ae c:\\users\\user\\qcodes']
+
+    packages = _pip_list_parser(lines)
+
+    expected_packages = {'qcodes': {'version': '0.4.0+186.g6579bf8ae',
+                                    'location': 'c:\\users\\user\\qcodes'}}
+
+    assert packages == expected_packages

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -13,18 +13,18 @@ def test_get_qcodes_version():
 def test_get_qcodes_requirements():
     reqs = ii.get_qcodes_requirements()
 
-    assert type(reqs) == list
+    assert isinstance(reqs, list)
     assert len(reqs) > 0
 
 
 def test_get_qcodes_requirements_versions():
     req_vs = ii.get_qcodes_requirements_versions()
 
-    assert type(req_vs) == dict
+    assert isinstance(req_vs, dict)
     assert len(req_vs) > 0
 
 
 def test_is_qcodes_installed_editably():
     answer = ii.is_qcodes_installed_editably()
 
-    assert type(answer) == bool
+    assert isinstance(answer, bool)

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -2,20 +2,6 @@ import qcodes.utils.installation_info as ii
 import qcodes as qc
 
 
-def test_pip_list_parser():
-
-    lines = ['Package Version              Location',
-             '------- -------------------- ----------------------------',
-             'qcodes  0.4.0+186.g6579bf8ae c:\\users\\user\\qcodes']
-
-    packages = ii._pip_list_parser(lines)
-
-    expected_packages = {'qcodes': {'version': '0.4.0+186.g6579bf8ae',
-                                    'location': 'c:\\users\\user\\qcodes'}}
-
-    assert packages == expected_packages
-
-
 # The get_* functions from installation_info are hard to meaningfully test,
 # but we can at least test that they execute without errors
 
@@ -36,3 +22,9 @@ def test_get_qcodes_requirements_versions():
 
     assert type(req_vs) == dict
     assert len(req_vs) > 0
+
+
+def test_is_qcodes_installed_editably():
+    answer = ii.is_qcodes_installed_editably()
+
+    assert type(answer) == bool

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -1,4 +1,5 @@
-from qcodes.utils.installation_info import _pip_list_parser
+import qcodes.utils.installation_info as ii
+import qcodes as qc
 
 
 def test_pip_list_parser():
@@ -7,9 +8,31 @@ def test_pip_list_parser():
              '------- -------------------- ----------------------------',
              'qcodes  0.4.0+186.g6579bf8ae c:\\users\\user\\qcodes']
 
-    packages = _pip_list_parser(lines)
+    packages = ii._pip_list_parser(lines)
 
     expected_packages = {'qcodes': {'version': '0.4.0+186.g6579bf8ae',
                                     'location': 'c:\\users\\user\\qcodes'}}
 
     assert packages == expected_packages
+
+
+# The get_* functions from installation_info are hard to meaningfully test,
+# but we can at least test that they execute without errors
+
+
+def test_get_qcodes_version():
+    assert ii.get_qcodes_version() == qc.version.__version__
+
+
+def test_get_qcodes_requirements():
+    reqs = ii.get_qcodes_requirements()
+
+    assert type(reqs) == list
+    assert len(reqs) > 0
+
+
+def test_get_qcodes_requirements_versions():
+    req_vs = ii.get_qcodes_requirements_versions()
+
+    assert type(req_vs) == dict
+    assert len(req_vs) > 0

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -279,3 +279,18 @@ def test_instrument_connect_message():
     # to connect. We disregard that part here.
 
     assert expected_con_mssg in con_mss
+
+
+@pytest.mark.usefixtures("remove_root_handlers")
+def test_installation_info_logging():
+    """
+    Test that installation information is logged upon starting the logging
+    """
+    logger.start_logger()
+
+    with open(logger.get_log_file_name(), 'r') as f:
+        lines = f.readlines()
+
+    assert 'QCoDeS version:' in lines[-3]
+    assert 'QCoDeS installed in editable mode:' in lines[-2]
+    assert 'QCoDeS requirements versions:' in lines[-1]

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -23,6 +23,26 @@ def remove_root_handlers():
 
 
 @pytest.fixture
+def awg5208():
+
+    from qcodes.instrument_drivers.tektronix.AWG5208 import AWG5208
+    import qcodes.instrument.sims as sims
+    visalib = sims.__file__.replace('__init__.py',
+                                    'Tektronix_AWG5208.yaml@sim')
+
+    logger.start_logger()
+
+    inst = AWG5208('awg_sim',
+                   address='GPIB0::1::INSTR',
+                   visalib=visalib)
+
+    try:
+        yield inst
+    finally:
+        inst.close()
+
+
+@pytest.fixture
 def model372():
     import qcodes.instrument.sims as sims
     from qcodes.tests.drivers.test_lakeshore import Model_372_Mock
@@ -233,3 +253,29 @@ def test_channels_nomessages(model372):
             if '[lakeshore' in l]
     assert len(logs) == 0
     mock.close()
+
+
+@pytest.mark.usefixtures("remove_root_handlers", "awg5208")
+def test_instrument_connect_message():
+    """
+    Test that the connect_message method logs as expected
+
+    This test kind of belongs both here and in the tests for the instrument
+    code, but it is more conveniently written here
+    """
+
+    with open(logger.get_log_file_name(), 'r') as f:
+        lines = f.readlines()
+
+    con_mssg_log_line = lines[-1]
+
+    sep = logger.logger.LOGGING_SEPARATOR
+
+    con_mss = con_mssg_log_line.split(sep)[-1]
+    expected_con_mssg = ('Connected to: QCoDeS AWG5208 (serial:1000, '
+                         'firmware:0.1) in')
+
+    # the last part of the connect_message has info about how long it took
+    # to connect. We disregard that part here.
+
+    assert expected_con_mssg in con_mss

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -1,0 +1,44 @@
+"""
+This module contains helper functions that provide information about how
+QCoDeS is installed and about what other packages are installed along with
+QCoDeS
+"""
+from typing import Dict, List
+import subprocess
+
+
+def _pip_list_parser(pip_list_raw: List[str]) -> Dict[str, Dict[str, str]]:
+    """
+    Parse the raw output of pip list into a dict with package name keys and
+    a dict {'version': ..., 'location': ...} values
+
+    Args:
+        pip_list_raw: a list of strings, one line per list element
+    """
+    out: Dict[str, Dict[str, str]] = {}
+
+    # The first two lines are the header and header-content separator
+    for line in pip_list_raw[2:]:
+        fields = line.split()
+        pkg, ver = fields[0], fields[1]
+        if len(fields) == 3:
+            loc = fields[2]
+        else:
+            loc = ''
+
+        out.update({pkg: {'version': ver, 'location': loc}})
+
+    return out
+
+
+def is_qcodes_installed_editably() -> bool:
+    """
+    Return a boolean with the answer to the question 'is QCoDeS installed in
+    editable mode?'
+    """
+    pipproc = subprocess.run(['pip', 'list', '-e'], stdout=subprocess.PIPE)
+    lines = pipproc.stdout.decode('utf-8').split('\r\n')[:-1]
+
+    editable_packages = _pip_list_parser(lines)
+
+    return 'qcodes' in editable_packages

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -72,7 +72,7 @@ def get_qcodes_version() -> str:
     """
     Get the version of the currently installed QCoDeS
     """
-    return qcodes.version.__version__
+    return qcodes.version.__version__  # type: ignore
 
 
 def get_qcodes_requirements() -> List[str]:
@@ -113,7 +113,7 @@ def get_qcodes_requirements_versions() -> Dict[str, str]:
         if req_module in _PACKAGE_NAMES:
             req_pkg = _PACKAGE_NAMES[req_module]
         else:
-            req_module = req_module
+            req_pkg = req_module
         req_versions.update({req_pkg: mod.__version__})  # type: ignore
 
     return req_versions

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -8,6 +8,7 @@ import subprocess
 from pip._vendor import pkg_resources
 import importlib
 import json
+import logging
 
 import qcodes
 
@@ -21,6 +22,9 @@ _PACKAGE_NAMES = {v: k for k, v in _IMPORT_NAMES.items()}
 # library (e.g. dataclasses for python 3.6). Those should be excluded from
 # any version listing
 _BACKPORTED_PACKAGES = ['dataclasses']
+
+
+log = logging.getLogger(__name__)
 
 
 def is_qcodes_installed_editably() -> Optional[bool]:
@@ -37,7 +41,8 @@ def is_qcodes_installed_editably() -> Optional[bool]:
                                   stdout=subprocess.PIPE)
         e_pkgs = json.loads(pipproc.stdout.decode('utf-8'))
         answer = any([d["name"] == 'qcodes' for d in e_pkgs])
-    except:  # we actually do want a catch-all here
+    except Exception as e:  # we actually do want a catch-all here
+        log.warning('f{type(e)}: {str(e)}')
         answer = None
 
     return answer

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -31,13 +31,22 @@ def _pip_list_parser(pip_list_raw: List[str]) -> Dict[str, Dict[str, str]]:
     return out
 
 
+def _get_lines_from_pip_list_e() -> List[str]:
+    """
+    Return the output of `pip list -e` as a list of lines
+    """
+    pipproc = subprocess.run(['pip', 'list', '-e'], stdout=subprocess.PIPE)
+    lines = pipproc.stdout.decode('utf-8').split('\r\n')[:-1]
+
+    return lines
+
+
 def is_qcodes_installed_editably() -> bool:
     """
     Return a boolean with the answer to the question 'is QCoDeS installed in
     editable mode?'
     """
-    pipproc = subprocess.run(['pip', 'list', '-e'], stdout=subprocess.PIPE)
-    lines = pipproc.stdout.decode('utf-8').split('\r\n')[:-1]
+    lines = _get_lines_from_pip_list_e()
 
     editable_packages = _pip_list_parser(lines)
 

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -72,7 +72,7 @@ def get_qcodes_version() -> str:
     """
     Get the version of the currently installed QCoDeS
     """
-    return qcodes.version.__version__  # type: ignore
+    return qcodes.version.__version__
 
 
 def get_qcodes_requirements() -> List[str]:

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -5,6 +5,21 @@ QCoDeS
 """
 from typing import Dict, List
 import subprocess
+from pip._vendor import pkg_resources
+import importlib
+
+import qcodes
+
+
+# sometimes a package is imported as something else than its package name
+# _IMPORT_NAMES maps package name to import name
+_IMPORT_NAMES = {'pyzmq': 'zmq'}
+_PACKAGE_NAMES = {v: k for k, v in _IMPORT_NAMES.items()}
+
+# sometimes we import non-versioned packages backported from the standard
+# library (e.g. dataclasses for python 3.6). Those should be excluded from
+# any version listing
+_BACKPORTED_PACKAGES = ['dataclasses']
 
 
 def _pip_list_parser(pip_list_raw: List[str]) -> Dict[str, Dict[str, str]]:
@@ -51,3 +66,54 @@ def is_qcodes_installed_editably() -> bool:
     editable_packages = _pip_list_parser(lines)
 
     return 'qcodes' in editable_packages
+
+
+def get_qcodes_version() -> str:
+    """
+    Get the version of the currently installed QCoDeS
+    """
+    return qcodes.version.__version__
+
+
+def get_qcodes_requirements() -> List[str]:
+    """
+    Return a list of the names of the packages that QCoDeS requires
+    """
+    qc_pkg = pkg_resources.working_set.by_key['qcodes']
+
+    requirements = [str(r) for r in qc_pkg.requires()]
+
+    package_names = [n.split('>')[0].split('=')[0] for n in requirements]
+
+    return package_names
+
+
+def get_qcodes_requirements_versions() -> Dict[str, str]:
+    """
+    Return a dictionary of the currently installed versions of the packages
+    that QCoDeS requires. The dict maps package name to version string.
+    """
+
+    req_names = get_qcodes_requirements()
+
+    req_modules = []
+
+    for req_name in req_names:
+        if req_name in _BACKPORTED_PACKAGES:
+            pass
+        elif req_name in _IMPORT_NAMES:
+            req_modules.append(_IMPORT_NAMES[req_name])
+        else:
+            req_modules.append(req_name)
+
+    req_versions = {}
+
+    for req_module in req_modules:
+        mod = importlib.import_module(req_module)
+        if req_module in _PACKAGE_NAMES:
+            req_pkg = _PACKAGE_NAMES[req_module]
+        else:
+            req_module = req_module
+        req_versions.update({req_pkg: mod.__version__})  # type: ignore
+
+    return req_versions


### PR DESCRIPTION
It can be very useful to have some basic information about the installation of qcodes in the logs.

This PR seeks to enrichen the log output with more useful info, in particular installation info. I am, however, not really sure about the logic when looking up the environment. It goes something like
 - First check if the installation is from pip or from source
 - If from pip:
   -  record the version number and call it a day
 - If from source
   - check if editable
   - compare `pip freeze` to `requirements.txt` (?)

The idea is to do all this as `qcodes.logger.start_logging` is called.

Or what do you think, @QCoDeS/core ? I'd like to make as few `subprocess` calls to `pip` as possible. 