### PR TITLE
Feature: Instruments snapshot exclude parameters

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -173,7 +173,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
                 different way (as in the qdac). If you want to skip the
                 update of certain parameters in all snapshots, use the
                 `snapshot_get`  attribute of those parameters instead.
-            params_to_exclude: Sequence[str] = None
+            params_to_exclude: List of parameter names that not will be included
+                into the snapshot
 
         Returns:
             dict: base snapshot

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -1,6 +1,7 @@
 """Ethernet instrument driver class based on sockets."""
 import socket
 import logging
+from typing import Dict, Sequence, Optional
 
 from .base import Instrument
 
@@ -191,20 +192,32 @@ class IPInstrument(Instrument):
     def __del__(self):
         self.close()
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update=False,
+                      params_to_skip_update: Optional[Sequence[str]] = None,
+                      params_to_exclude: Sequence[str] = None
+                      ) -> Dict:
         """
         State of the instrument as a JSON-compatible dict (everything that
         the custom JSON encoder class :class:'qcodes.utils.helpers.NumpyJSONEncoder'
         supports).
 
         Args:
-            update (bool): If True, update the state by querying the
+            update: If True, update the state by querying the
                 instrument. If False, just use the latest values in memory.
+            params_to_skip_update: List of parameter names that will be skipped
+                in update even if update is True. This is useful if you have
+                parameters that are slow to update but can be updated in a
+                different way (as in the qdac). If you want to skip the
+                update of certain parameters in all snapshots, use the
+                `snapshot_get`  attribute of those parameters: instead.
+            params_to_exclude: Sequence[str] = None) -> Dict:
 
         Returns:
             dict: base snapshot
         """
-        snap = super().snapshot_base(update=update)
+        snap = super().snapshot_base(update=update,
+                                     params_to_skip_update=params_to_skip_update,
+                                     params_to_exclude=params_to_exclude)
 
         snap['port'] = self._port
         snap['confirmation'] = self._confirmation

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -210,7 +210,8 @@ class IPInstrument(Instrument):
                 different way (as in the qdac). If you want to skip the
                 update of certain parameters in all snapshots, use the
                 `snapshot_get`  attribute of those parameters: instead.
-            params_to_exclude: Sequence[str] = None) -> Dict:
+            params_to_exclude: List of parameter names that not will be included
+                into the snapshot
 
         Returns:
             dict: base snapshot

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -231,7 +231,8 @@ class VisaInstrument(Instrument):
         return response
 
     def snapshot_base(self, update: bool = True,
-                      params_to_skip_update: Optional[Sequence[str]] = None
+                      params_to_skip_update: Optional[Sequence[str]] = None,
+                      params_to_exclude: Sequence[str] = None
                       ) -> Dict:
         """
         State of the instrument as a JSON-compatible dict (everything that
@@ -247,11 +248,14 @@ class VisaInstrument(Instrument):
                 different way (as in the qdac). If you want to skip the
                 update of certain parameters in all snapshots, use the
                 `snapshot_get`  attribute of those parameters instead.
+            params_to_exclude: List of parameter names that not will be included
+                into the snapshot
         Returns:
             dict: base snapshot
         """
         snap = super().snapshot_base(update=update,
-                                     params_to_skip_update=params_to_skip_update)
+                                     params_to_skip_update=params_to_skip_update,
+                                     params_to_exclude=params_to_exclude)
 
         snap['address'] = self._address
         snap['terminator'] = self._terminator

--- a/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
+++ b/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
@@ -64,14 +64,16 @@ class ZIHDAWG8(Instrument):
         self._compiler_sleep_time = 0.01
 
     def snapshot_base(self, update: bool = True,
-                      params_to_skip_update: Optional[Sequence[str]] = None
+                      params_to_skip_update: Optional[Sequence[str]] = None,
+                      params_to_exclude: Sequence[str] = None
                       ) -> Dict:
         """ Override the base method to ignore 'feature_code' by default."""
         params_to_skip = ['features_code']
         if params_to_skip_update is not None:
             params_to_skip += list(params_to_skip_update)
         return super(ZIHDAWG8, self).snapshot_base(update=update,
-                                                   params_to_skip_update=params_to_skip)
+                                                   params_to_skip_update=params_to_skip,
+                                                   params_to_exclude=params_to_exclude)
 
     def snapshot(self, update=True):
         """ Override base method to make update default True."""

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1653,7 +1653,8 @@ class ZIUHFLI(Instrument):
                            )
 
     def snapshot_base(self, update: bool = True,
-                      params_to_skip_update: Optional[Sequence[str]] = None
+                      params_to_skip_update: Optional[Sequence[str]] = None,
+                      params_to_exclude: Sequence[str] = None
                       ) -> Dict:
         """ Override the base method to ignore 'sweeper_sweeptime' if no signals selected."""
         params_to_skip = []
@@ -1662,7 +1663,8 @@ class ZIUHFLI(Instrument):
         if params_to_skip_update is not None:
             params_to_skip += list(params_to_skip_update)
         return super(ZIUHFLI, self).snapshot_base(update=update,
-                                                   params_to_skip_update=params_to_skip)
+                                                  params_to_skip_update=params_to_skip,
+                                                  params_to_exclude=params_to_exclude)
 
 
     def _setter(self, module, number, mode, setting, value):

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -158,7 +158,8 @@ class SR86xBuffer(InstrumentChannel):
             )
 
     def snapshot_base(self, update: bool = False,
-                      params_to_skip_update: Optional[Sequence[str]] = None
+                      params_to_skip_update: Optional[Sequence[str]] = None,
+                      params_to_exclude: Sequence[str] = None
                       ) -> Dict:
         if params_to_skip_update is None:
             params_to_skip_update = []
@@ -169,7 +170,9 @@ class SR86xBuffer(InstrumentChannel):
         params_to_skip_update = list(params_to_skip_update)
         params_to_skip_update.append('count_capture_kilobytes')
 
-        snapshot = super().snapshot_base(update, params_to_skip_update)
+        snapshot = super().snapshot_base(update=update,
+                                         params_to_skip_update=params_to_skip_update,
+                                         params_to_exclude=params_to_exclude)
         return snapshot
 
     def _set_capture_len_parser(self, capture_length_in_kb: int) -> int:

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -493,7 +493,8 @@ class SnapShotTestInstrument(Instrument):
     """
 
     def __init__(self, name: str, params: Sequence[str] = ('v1', 'v2', 'v3'),
-                 params_to_skip: Sequence[str] = ('v2')):
+                 params_to_skip: Sequence[str] = ['v2'],
+                 params_to_exclude: Sequence[str] = None):
 
         super().__init__(name)
 
@@ -502,6 +503,7 @@ class SnapShotTestInstrument(Instrument):
                              'of params')
 
         self._params_to_skip = params_to_skip
+        self._params_to_exclude = params_to_exclude
         self._params = params
 
         # dict to keep track of how many time 'get' has been called on each
@@ -520,10 +522,14 @@ class SnapShotTestInstrument(Instrument):
         return val
 
     def snapshot_base(self, update: bool = True,
-                      params_to_skip_update: Optional[Sequence[str]] = None
+                      params_to_skip_update: Optional[Sequence[str]] = None,
+                      params_to_exclude: Sequence[str] = None
                       ) -> Dict:
         if params_to_skip_update is None:
             params_to_skip_update = self._params_to_skip
+        if params_to_exclude is None:
+            params_to_exclude = self._params_to_exclude
+
         snap = super().snapshot_base(
-            update=update, params_to_skip_update=params_to_skip_update)
+            update=update, params_to_skip_update=params_to_skip_update, params_to_exclude=params_to_exclude)
         return snap

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -10,7 +10,8 @@ import pytest
                          [(['v1', 'v2', 'v3', 'v4'], ['v1']),
                           (['v1', 'v2', 'v3', 'v4'], ['v2']),
                           (['v1', 'v2', 'v3', 'v4'], ['v3']),
-                          (['v1', 'v2', 'v3', 'v4'], ['v4'])])
+                          (['v1', 'v2', 'v3', 'v4'], ['v4']),
+                          (['v1', 'v2', 'v3', 'v4'], [])])
 def test_snapshot_skip_params_update(request, params, params_to_skip):
     """
     Test that params_to_skip_update works as expected, in particular that only
@@ -27,7 +28,6 @@ def test_snapshot_skip_params_update(request, params, params_to_skip):
                                   params_to_skip=params_to_skip)
     request.addfinalizer(inst.close)
 
-
     assert list(inst._get_calls.values()) == [0, 0, 0, 0]
 
     inst.snapshot(update=False)
@@ -37,6 +37,41 @@ def test_snapshot_skip_params_update(request, params, params_to_skip):
     inst.snapshot(update=True)
 
     expected_list = [1, 1, 1, 1]
-    expected_list[params.index(params_to_skip[0])] = 0
+    if params_to_skip:
+        expected_list[params.index(params_to_skip[0])] = 0
 
     assert list(inst._get_calls.values()) == expected_list
+
+
+@pytest.mark.parametrize("params,params_to_exclude",
+                         [(['v1', 'v2', 'v3', 'v4'], ['v1']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v2']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v3']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v4']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v1', 'v2']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v5']),  # param_to_exclude does not exist
+                          (['v1', 'v2', 'v3', 'v4'], [])])
+def test_snapshot_exclude_params(request, params, params_to_exclude):
+    """
+    Test that params_to_exclude works as expected, in particular that only
+    the parameters given by that variable are excluded from the snapshot.
+
+    This test does not directly call snapshot_base, because this is the way a
+    driver will work "in the wild"; the params_to_exclude update are baked into
+    the driver (in this case passed to the constructor) and the driver only
+    calls :meth:`snapshot`
+    """
+
+    inst = SnapShotTestInstrument('inst',
+                                  params=params,
+                                  params_to_skip=[],
+                                  params_to_exclude=params_to_exclude)
+
+    params.insert(0, "IDN")  # Is added by default to a instrument
+    request.addfinalizer(inst.close)
+
+    snap = inst.snapshot()
+    snap_params = [x for x in snap["parameters"]]
+    params = [x for x in params if x not in params_to_exclude]
+
+    assert snap_params == params


### PR DESCRIPTION
Changes proposed in this pull request:
- Added way to exclude parameters from the instruments snapshot
- Added another test case to the param_to_skip_update of the instruments snapshot test

At the DiCarlo lab, we use a couple of devices which have many (instruments) parameters (E.g., QWG, HDAWG8, UHFQC). Most of these parameters are not useful for us to log (or backup) via the snapshot feature. There are so many useless parameters that we have problems with backing up all the information. With this feature, the user or device manufacture can specify which parameters not to include.

This code is tested on our devices, and I added tests to the snapshot tests.   

@WilliamHPNielsen, @AdriaanRol 