### PR TITLE
 Feature: Added instrument paramater snapshot_exclude 

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -202,7 +202,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             except:
                 # really log this twice. Once verbose for the UI and once
                 # at lower level with more info for file based loggers
-                logging.info("Snapshot: Could not update parameter: {}".format(name))
+                self.log.warning(f"Snapshot: Could not update parameter: {name}")
                 self.log.info(f"Details for Snapshot:", exc_info=True)
                 snap['parameters'][name] = param.snapshot(update=False)
 

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -160,7 +160,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
                       ) -> Dict:
         """
         State of the instrument as a JSON-compatible dict (everything that
-        the custom JSON encoder class :class:'qcodes.utils.helpers.NumpyJSONEncoder'
+        the custom JSON encoder class
+        :class:'qcodes.utils.helpers.NumpyJSONEncoder'
         supports).
 
         Args:
@@ -202,7 +203,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             except:
                 # really log this twice. Once verbose for the UI and once
                 # at lower level with more info for file based loggers
-                self.log.warning(f"Snapshot: Could not update parameter: {name}")
+                self.log.warning(f"Snapshot: Could not update "
+                                 f"parameter: {name}")
                 self.log.info(f"Details for Snapshot:", exc_info=True)
                 snap['parameters'][name] = param.snapshot(update=False)
 

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -1,6 +1,7 @@
 """Ethernet instrument driver class based on sockets."""
 import socket
 import logging
+from typing import Dict, Sequence, Optional
 
 from .base import Instrument
 
@@ -191,7 +192,7 @@ class IPInstrument(Instrument):
     def __del__(self):
         self.close()
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update=False, params_to_skip_update: Optional[Sequence[str]] = None):
         """
         State of the instrument as a JSON-compatible dict (everything that
         the custom JSON encoder class :class:'qcodes.utils.helpers.NumpyJSONEncoder'
@@ -200,11 +201,17 @@ class IPInstrument(Instrument):
         Args:
             update (bool): If True, update the state by querying the
                 instrument. If False, just use the latest values in memory.
+            params_to_skip_update: List of parameter names that will be skipped
+                in update even if update is True. This is useful if you have
+                parameters that are slow to update but can be updated in a
+                different way (as in the qdac). If you want to skip the
+                update of certain parameters in all snapshots, use the
+                `snapshot_get`  attribute of those parameters: instead.
 
         Returns:
             dict: base snapshot
         """
-        snap = super().snapshot_base(update=update)
+        snap = super().snapshot_base(update=update, params_to_skip_update=params_to_skip_update)
 
         snap['port'] = self._port
         snap['confirmation'] = self._confirmation

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -192,7 +192,7 @@ class IPInstrument(Instrument):
     def __del__(self):
         self.close()
 
-    def snapshot_base(self, update=False, params_to_skip_update: Optional[Sequence[str]] = None):
+    def snapshot_base(self, update=False, params_to_skip_update: Optional[Sequence[str]] = None) -> Dict:
         """
         State of the instrument as a JSON-compatible dict (everything that
         the custom JSON encoder class :class:'qcodes.utils.helpers.NumpyJSONEncoder'

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -211,7 +211,9 @@ class IPInstrument(Instrument):
         Returns:
             dict: base snapshot
         """
-        snap = super().snapshot_base(update=update, params_to_skip_update=params_to_skip_update)
+        snap = super().snapshot_base(
+            update=update,
+            params_to_skip_update=params_to_skip_update)
 
         snap['port'] = self._port
         snap['confirmation'] = self._confirmation

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -159,7 +159,6 @@ class _BaseParameter(Metadatable):
         snapshot_exclude (Optional[bool]): True prevents parameter to be
             included in the snapshot. Useful if there are many of the same
             parameter which are clogging up the snapshot.
-
             Default False
 
         step (Optional[Union[int, float]]): max increment of parameter value.

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -156,6 +156,11 @@ class _BaseParameter(Metadatable):
         snapshot_value (Optional[bool]): False prevents parameter value to be
             stored in the snapshot. Useful if the value is large.
 
+        snapshot_exclude (Optional[bool]): True prevents parameter to be
+            included in the snapshot. Useful if there are many of the same parameter
+            which are clogging up the snapshot.
+            Default False
+
         step (Optional[Union[int, float]]): max increment of parameter value.
             Larger changes are broken into multiple steps this size.
             When combined with delays, this acts as a ramp.
@@ -223,6 +228,7 @@ class _BaseParameter(Metadatable):
                  get_parser: Optional[Callable]=None,
                  set_parser: Optional[Callable]=None,
                  snapshot_value: bool=True,
+                 snapshot_exclude: bool=False,
                  max_val_age: Optional[float]=None,
                  vals: Optional[Validator]=None,
                  **kwargs) -> None:
@@ -237,6 +243,7 @@ class _BaseParameter(Metadatable):
         self._instrument = instrument
         self._snapshot_get = snapshot_get
         self._snapshot_value = snapshot_value
+        self.snapshot_exclude = snapshot_exclude
 
         if not isinstance(vals, (Validator, type(None))):
             raise TypeError('vals must be None or a Validator')
@@ -368,6 +375,9 @@ class _BaseParameter(Metadatable):
         Returns:
             dict: base snapshot
         """
+        if self.snapshot_exclude:
+            warnings.warn(
+                f"Parameter ({self.name}) is used in the snapshot while it should be excluded from the snapshot")
 
         if hasattr(self, 'get') and self._snapshot_get \
                 and self._snapshot_value and update:
@@ -870,6 +880,11 @@ class Parameter(_BaseParameter):
         snapshot_value (Optional[bool]): False prevents parameter value to be
             stored in the snapshot. Useful if the value is large.
 
+        snapshot_exclude (Optional[bool]): True prevents parameter to be
+            included in the snapshot. Useful if there are many of the same parameter
+            which are clogging up the snapshot.
+            Default False
+
         step (Optional[Union[int, float]]): max increment of parameter value.
             Larger changes are broken into multiple steps this size.
             When combined with delays, this acts as a ramp.
@@ -1271,6 +1286,11 @@ class ArrayParameter(_BaseParameter):
             snapshot. Unlike Parameter this defaults to False as
             ArrayParameters are potentially huge.
 
+        snapshot_exclude (Optional[bool]): True prevents parameter to be
+            included in the snapshot. Useful if there are many of the same parameter
+            which are clogging up the snapshot.
+            Default False
+
         metadata (Optional[dict]): extra information to include with the
             JSON snapshot of the parameter
     """
@@ -1288,9 +1308,10 @@ class ArrayParameter(_BaseParameter):
                  docstring: Optional[str]=None,
                  snapshot_get: bool=True,
                  snapshot_value: bool=False,
+                 snapshot_exclude: bool=False,
                  metadata: Optional[dict]=None) -> None:
         super().__init__(name, instrument, snapshot_get, metadata,
-                         snapshot_value=snapshot_value)
+                         snapshot_value=snapshot_value, snapshot_exclude=snapshot_exclude)
 
         if hasattr(self, 'set'):
             # TODO (alexcjohnson): can we support, ala Combine?
@@ -1465,6 +1486,11 @@ class MultiParameter(_BaseParameter):
             snapshot. Unlike Parameter this defaults to False as
             MultiParameters are potentially huge.
 
+        snapshot_exclude (Optional[bool]): True prevents parameter to be
+            included in the snapshot. Useful if there are many of the same parameter
+            which are clogging up the snapshot.
+            Default False
+
         metadata (Optional[dict]): extra information to include with the
             JSON snapshot of the parameter
     """
@@ -1483,9 +1509,10 @@ class MultiParameter(_BaseParameter):
                  docstring: str=None,
                  snapshot_get: bool=True,
                  snapshot_value: bool=False,
+                 snapshot_exclude: bool=False,
                  metadata: Optional[dict]=None) -> None:
         super().__init__(name, instrument, snapshot_get, metadata,
-                         snapshot_value=snapshot_value)
+                         snapshot_value=snapshot_value, snapshot_exclude=snapshot_exclude)
 
         self._meta_attrs.extend(['setpoint_names', 'setpoint_labels',
                                  'setpoint_units', 'names', 'labels', 'units'])

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -157,8 +157,9 @@ class _BaseParameter(Metadatable):
             stored in the snapshot. Useful if the value is large.
 
         snapshot_exclude (Optional[bool]): True prevents parameter to be
-            included in the snapshot. Useful if there are many of the same parameter
-            which are clogging up the snapshot.
+            included in the snapshot. Useful if there are many of the same
+            parameter which are clogging up the snapshot.
+
             Default False
 
         step (Optional[Union[int, float]]): max increment of parameter value.
@@ -377,7 +378,8 @@ class _BaseParameter(Metadatable):
         """
         if self.snapshot_exclude:
             warnings.warn(
-                f"Parameter ({self.name}) is used in the snapshot while it should be excluded from the snapshot")
+                f"Parameter ({self.name}) is used in the snapshot while it "
+                f"should be excluded from the snapshot")
 
         if hasattr(self, 'get') and self._snapshot_get \
                 and self._snapshot_value and update:
@@ -881,8 +883,8 @@ class Parameter(_BaseParameter):
             stored in the snapshot. Useful if the value is large.
 
         snapshot_exclude (Optional[bool]): True prevents parameter to be
-            included in the snapshot. Useful if there are many of the same parameter
-            which are clogging up the snapshot.
+            included in the snapshot. Useful if there are many of the same
+            parameter which are clogging up the snapshot.
             Default False
 
         step (Optional[Union[int, float]]): max increment of parameter value.
@@ -1287,8 +1289,9 @@ class ArrayParameter(_BaseParameter):
             ArrayParameters are potentially huge.
 
         snapshot_exclude (Optional[bool]): True prevents parameter to be
-            included in the snapshot. Useful if there are many of the same parameter
-            which are clogging up the snapshot.
+            included in the snapshot. Useful if there are many of the same
+            parameter which are clogging up the snapshot.
+
             Default False
 
         metadata (Optional[dict]): extra information to include with the
@@ -1311,7 +1314,8 @@ class ArrayParameter(_BaseParameter):
                  snapshot_exclude: bool=False,
                  metadata: Optional[dict]=None) -> None:
         super().__init__(name, instrument, snapshot_get, metadata,
-                         snapshot_value=snapshot_value, snapshot_exclude=snapshot_exclude)
+                         snapshot_value=snapshot_value,
+                         snapshot_exclude=snapshot_exclude)
 
         if hasattr(self, 'set'):
             # TODO (alexcjohnson): can we support, ala Combine?
@@ -1487,8 +1491,8 @@ class MultiParameter(_BaseParameter):
             MultiParameters are potentially huge.
 
         snapshot_exclude (Optional[bool]): True prevents parameter to be
-            included in the snapshot. Useful if there are many of the same parameter
-            which are clogging up the snapshot.
+            included in the snapshot. Useful if there are many of the same
+            parameter which are clogging up the snapshot.
             Default False
 
         metadata (Optional[dict]): extra information to include with the
@@ -1512,7 +1516,8 @@ class MultiParameter(_BaseParameter):
                  snapshot_exclude: bool=False,
                  metadata: Optional[dict]=None) -> None:
         super().__init__(name, instrument, snapshot_get, metadata,
-                         snapshot_value=snapshot_value, snapshot_exclude=snapshot_exclude)
+                         snapshot_value=snapshot_value,
+                         snapshot_exclude=snapshot_exclude)
 
         self._meta_attrs.extend(['setpoint_names', 'setpoint_labels',
                                  'setpoint_units', 'names', 'labels', 'units'])

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -77,4 +77,7 @@ def test_snapshot_exclude_params(request, params, params_to_exclude):
     assert all(elem not in snap_params for elem in params_to_exclude), f"Parameter(s) is not excluded from the " \
         f"snapshot. expected: {params}, actual: {snap_params}"
 
+    assert snap_params == params, f"Snapshot does not contain the expected parameters" \
+        f"expected: {params}, actual: {snap_params}"
+
 

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -10,7 +10,8 @@ import pytest
                          [(['v1', 'v2', 'v3', 'v4'], ['v1']),
                           (['v1', 'v2', 'v3', 'v4'], ['v2']),
                           (['v1', 'v2', 'v3', 'v4'], ['v3']),
-                          (['v1', 'v2', 'v3', 'v4'], ['v4'])])
+                          (['v1', 'v2', 'v3', 'v4'], ['v4']),
+                          (['v1', 'v2', 'v3', 'v4'], [])])
 def test_snapshot_skip_params_update(request, params, params_to_skip):
     """
     Test that params_to_skip_update works as expected, in particular that only
@@ -27,7 +28,6 @@ def test_snapshot_skip_params_update(request, params, params_to_skip):
                                   params_to_skip=params_to_skip)
     request.addfinalizer(inst.close)
 
-
     assert list(inst._get_calls.values()) == [0, 0, 0, 0]
 
     inst.snapshot(update=False)
@@ -37,6 +37,44 @@ def test_snapshot_skip_params_update(request, params, params_to_skip):
     inst.snapshot(update=True)
 
     expected_list = [1, 1, 1, 1]
-    expected_list[params.index(params_to_skip[0])] = 0
+    if params_to_skip:
+        expected_list[params.index(params_to_skip[0])] = 0
 
     assert list(inst._get_calls.values()) == expected_list
+
+
+@pytest.mark.parametrize("params,params_to_exclude",
+                         [(['v1', 'v2', 'v3', 'v4'], ['v1']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v2']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v3']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v4']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v4']),
+                          (['v1', 'v2', 'v3', 'v4'], ['v1', 'v2']),
+                          (['v1', 'v2', 'v3', 'v4'], [])])
+def test_snapshot_exclude_params(request, params, params_to_exclude):
+    """
+    Test that params_to_exclude works as expected, in particular that only
+    the parameters given by that variable are excluded from the snapshot.
+    This test does not directly call snapshot_base, because this is the way a
+    driver will work "in the wild"; the params_to_exclude update are baked into
+    the driver (in this case passed to the constructor) and the driver only
+    calls :meth:`snapshot`
+    """
+
+    inst = SnapShotTestInstrument('inst',
+                                  params=params,
+                                  params_to_skip=[])
+
+    params.insert(0, "IDN")  # Is added by default to a instrument
+    request.addfinalizer(inst.close)
+    for param_exl in params_to_exclude:
+        inst.parameters[param_exl].snapshot_exclude = True
+
+    snap = inst.snapshot()
+    snap_params = [x for x in snap["parameters"]]
+    params = [x for x in params if x not in params_to_exclude]
+
+    assert all(elem not in snap_params for elem in params_to_exclude), f"Parameter(s) is not excluded from the " \
+        f"snapshot. expected: {params}, actual: {snap_params}"
+
+

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -74,10 +74,12 @@ def test_snapshot_exclude_params(request, params, params_to_exclude):
     snap_params = [x for x in snap["parameters"]]
     params = [x for x in params if x not in params_to_exclude]
 
-    assert all(elem not in snap_params for elem in params_to_exclude), f"Parameter(s) is not excluded from the " \
-        f"snapshot. expected: {params}, actual: {snap_params}"
+    assert all(elem not in snap_params for elem in params_to_exclude), \
+        f"Parameter(s) is not excluded from the snapshot. expected: " \
+        f"{params}, actual: {snap_params}"\
 
-    assert snap_params == params, f"Snapshot does not contain the expected parameters" \
-        f"expected: {params}, actual: {snap_params}"
+
+    assert snap_params == params, f"Snapshot does not contain the expected " \
+        f"parameters expected: {params}, actual: {snap_params}"
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Added a parameter to the instrument parameter to exclude it from the snapshot. 

Note that this is very similar to #1651, the goal is the same but it has a different implementation. To see the reason why we need this please look at #1651 which has a detailed problem description. This implementation was suggested by @jenshnielsen, which uses the instrument parameter to store the `snapshot_exclude` instead of providing a list to the snapshot function. 

@jenshnielsen, @AdriaanRol 
