### PR TITLE
Feature/m4i/exact sample rate

### DIFF
--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -1129,7 +1129,7 @@ class M4i(Instrument):
         pyspcm.spcm_dwDefTransfer_i64(
             self.hCard, buffer_type, direction, bytes_till_event, data_pointer, offset, buffer_length)
 
-    def __exact_sample_rate(self):
+    def _exact_sample_rate(self):
         """ Return exact sampling rate as a floating point number """
         sample_rate_hz = self.sample_rate()
         max_sample_rate = self.get_max_sample_rate()

--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -469,13 +469,13 @@ class M4i(Instrument):
                            set_cmd=partial(self._set_param32bit,
                                            pyspcm.SPC_SAMPLERATE),
                            docstring='write the sample rate for internal sample generation or read rate nearest to desired. This sample rate is rounded to an integer number.')
-                           
+
         self.add_parameter('exact_sample_rate',
                            label='sample rate',
                            get_cmd=self._exact_sample_rate,
                            unit='Hz',
-                           docstring='return the exact sampling rate in Hz. This is an integer divisor of the maximum sample rate')                           
-                           
+                           docstring='return the exact sampling rate in Hz. This is an integer divisor of the maximum sample rate')
+
         self.add_parameter('special_clock',
                            label='special clock',
                            get_cmd=partial(self._param32bit,
@@ -1135,7 +1135,7 @@ class M4i(Instrument):
         max_sample_rate = self.get_max_sample_rate()
         factor = int(np.round(max_sample_rate/sample_rate_hz))
         return max_sample_rate/factor
-    
+
     def get_max_sample_rate(self, verbose=0):
         """Return max sample rate."""
         # read type, function and sn and check for D/A card

--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -468,7 +468,14 @@ class M4i(Instrument):
                            unit='Hz',
                            set_cmd=partial(self._set_param32bit,
                                            pyspcm.SPC_SAMPLERATE),
-                           docstring='write the sample rate for internal sample generation or read rate nearest to desired')
+                           docstring='write the sample rate for internal sample generation or read rate nearest to desired. This sample rate is rounded to an integer number.')
+                           
+        self.add_parameter('exact_sample_rate',
+                           label='sample rate',
+                           get_cmd=self._exact_sample_rate,
+                           unit='Hz',
+                           docstring='return the exact sampling rate in Hz. This is an integer divisor of the maximum sample rate')                           
+                           
         self.add_parameter('special_clock',
                            label='special clock',
                            get_cmd=partial(self._param32bit,
@@ -1122,6 +1129,13 @@ class M4i(Instrument):
         pyspcm.spcm_dwDefTransfer_i64(
             self.hCard, buffer_type, direction, bytes_till_event, data_pointer, offset, buffer_length)
 
+    def __exact_sample_rate(self):
+        """ Return exact sampling rate as a floating point number """
+        sample_rate_hz = self.sample_rate()
+        max_sample_rate = self.get_max_sample_rate()
+        factor = int(np.round(max_sample_rate/sample_rate_hz))
+        return max_sample_rate/factor
+    
     def get_max_sample_rate(self, verbose=0):
         """Return max sample rate."""
         # read type, function and sn and check for D/A card


### PR DESCRIPTION
The M4i `sample_rate` parameter returns the sample rate, but rounded to an integer number of Hz. This PR adds a method to return the exact sample rate.

The original parameter is unchanged and naming is similar to the old parameter.

@astafan8 @jenshnielsen 
