### PR TITLE
fix bug in on_off_mapping

### DIFF
--- a/qcodes/instrument_drivers/Keysight/Keysight_E8267D.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_E8267D.py
@@ -63,7 +63,7 @@ class Keysight_E8267D(VisaInstrument):
         # .upper val for Enum or string
         on_off_validator = vals.Enum('on', 'On', 'ON',
                                      'off', 'Off', 'OFF')
-        on_off_mapping = create_on_off_val_mapping(0, 1)
+        on_off_mapping = create_on_off_val_mapping(1, 0)
 
         self.add_parameter(name='frequency',
                            label='Frequency',


### PR DESCRIPTION
Fixes issue introduced with #1554. The constructor for the on-off value mapping has the order of arguments reversed.

@astafan8 