### PR TITLE
Add functionalities to dpo measurement

### DIFF
--- a/docs/examples/driver_examples/QCodes example with Tektronix DPO 72004C.ipynb
+++ b/docs/examples/driver_examples/QCodes example with Tektronix DPO 72004C.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,24 +17,24 @@
     "from qcodes.dataset.plotting import plot_by_id\n",
     "from qcodes.dataset.experiment_container import new_experiment\n",
     "\n",
-    "from qcodes.instrument_drivers.tektronix.DPO7200xx import TektronixDPO7000xx"
+    "from qcodes.instrument_drivers.tektronix.DPO7200xx import TektronixDPO7000xx, TektronixDPOMeasurement"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to: TEKTRONIX DPO72004C (serial:C600651, firmware:CF:91.1CT FV:10.8.3 Build 3) in 0.44s\n"
+      "Connected to: TEKTRONIX DPO72004C (serial:C600862, firmware:CF:91.1CT FV:10.9.1 Build 16) in 0.66s\n"
      ]
     }
    ],
    "source": [
-    "tek = TektronixDPO7000xx(\"tek3\", \"TCPIP0::10.193.36.56::inst0::INSTR\")"
+    "tek = TektronixDPO7000xx(\"tek3\", \"TCPIP0::169.254.158.44::inst0::INSTR\")"
    ]
   },
   {
@@ -305,7 +305,7 @@
    ],
    "source": [
     "tek.waveform.is_binary()\n",
-    "# Setting is_binary to false will trasfer data in ascii mode. "
+    "# Setting is_binary to false will transfer data in ascii mode. "
    ]
   },
   {
@@ -457,6 +457,59 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tek.measurement[0].source1(\"CH1\")\n",
+    "tek.measurement[0].source2(\"CH2\")\n",
+    "tek.measurement[1].source1(\"CH2\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frequency of signal at channel CH1: 9.96E+09 Hz\n"
+     ]
+    }
+   ],
+   "source": [
+    "channel = tek.measurement[0].source1()\n",
+    "value = tek.measurement[0].frequency()\n",
+    "unit = tek.measurement[0].frequency.unit\n",
+    "\n",
+    "print(f\"Frequency of signal at channel {channel}: {value:.2E} {unit}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Frequency of signal at channel CH2: 9.98E+09 Hz\n"
+     ]
+    }
+   ],
+   "source": [
+    "channel = tek.measurement[1].source1()\n",
+    "value = tek.measurement[1].frequency()\n",
+    "unit = tek.measurement[1].frequency.unit\n",
+    "\n",
+    "print(f\"Frequency of signal at channel {channel}: {value:.2E} {unit}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
    "outputs": [
@@ -464,41 +517,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Frequency of signal at channel 1: 3.47020810701E+9 Hz\n"
+      "Amplitude of signal at channel CH1: 2.84E-01 V\n"
      ]
     }
    ],
    "source": [
-    "channel = 1\n",
+    "channel = tek.measurement[0].source1()\n",
+    "value = tek.measurement[0].amplitude()\n",
+    "unit = tek.measurement[0].amplitude.unit\n",
     "\n",
-    "tek.measurement[0].source1(f\"CH{channel}\")\n",
-    "value = tek.measurement[0].frequency()\n",
-    "unit = tek.measurement[0].frequency.unit\n",
-    "\n",
-    "print(f\"Frequency of signal at channel {channel}: {value} {unit}\")"
+    "print(f\"Amplitude of signal at channel {channel}: {value:.2E} {unit}\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Amplitude of signal at channel 1: 504.00000751019E-3 V\n"
+      "Amplitude of signal at channel CH2: 1.88E-01 V\n"
      ]
     }
    ],
    "source": [
-    "channel = 1\n",
+    "channel = tek.measurement[1].source1()\n",
+    "value = tek.measurement[1].amplitude()\n",
+    "unit = tek.measurement[1].amplitude.unit\n",
     "\n",
-    "tek.measurement[0].source1(f\"CH{channel}\")\n",
-    "value = tek.measurement[0].amplitude()\n",
-    "unit = tek.measurement[0].amplitude.unit\n",
-    "\n",
-    "print(f\"Amplitude of signal at channel {channel}: {value} {unit}\")"
+    "print(f\"Amplitude of signal at channel {channel}: {value:.2E} {unit}\")"
    ]
   },
   {
@@ -510,39 +559,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Amplitude of signal at channel 2: 508.00000756979E-3 V\n"
+      "Phase of signal at channel CH1 wrt channel CH2: 25.50738557245 °\n"
      ]
     }
    ],
    "source": [
-    "channel = 2\n",
-    "\n",
-    "tek.measurement[0].source1(f\"CH{channel}\")\n",
-    "value = tek.measurement[0].amplitude()\n",
-    "unit = tek.measurement[0].amplitude.unit\n",
-    "\n",
-    "print(f\"Amplitude of signal at channel {channel}: {value} {unit}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Phase of signal at channel 1 wrt channel 2: -74.92333140500 °\n"
-     ]
-    }
-   ],
-   "source": [
-    "channel1 = 1\n",
-    "channel2 = 2\n",
-    "\n",
-    "tek.measurement[0].source1(f\"CH{channel1}\")\n",
-    "tek.measurement[0].source2(f\"CH{channel2}\")\n",
+    "channel1 = tek.measurement[0].source1()\n",
+    "channel2 = tek.measurement[0].source2()\n",
     "value = tek.measurement[0].phase()\n",
     "unit = tek.measurement[0].phase.unit\n",
     "\n",
@@ -553,7 +576,93 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have verified that all measurements are indeed correct by examening the scope front panal "
+    "Here are all the availble measurements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('amplitude, area, burst, carea, cmean, crms, delay, distduty, extinctdb, '\n",
+      " 'extinctpct, extinctratio, eyeheight, eyewidth, fall, frequency, high, hits, '\n",
+      " 'low, maximum, mean, median, minimum, ncross, nduty, novershoot, nwidth, '\n",
+      " 'pbase, pcross, pctcross, pduty, peakhits, period, phase, pk2pk, pkpkjitter, '\n",
+      " 'pkpknoise, povershoot, ptop, pwidth, qfactor, rise, rms, rmsjitter, '\n",
+      " 'rmsnoise, sigma1, sigma2, sigma3, sixsigmajit, snratio, stddev, undefined, '\n",
+      " 'waveforms')\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pprint import pprint\n",
+    "print_string = \", \".join([i[0] for i in TektronixDPOMeasurement.measurements])\n",
+    "pprint(print_string)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Measurement statistics\n",
+    "\n",
+    "We can measure basic measurement statistics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The mean amplitude of signal at channel CH2: 0.284 V\n"
+     ]
+    }
+   ],
+   "source": [
+    "channel = tek.measurement[0].source1()\n",
+    "value = tek.measurement[0].amplitude.mean()\n",
+    "unit = tek.measurement[0].amplitude.unit\n",
+    "\n",
+    "print(f\"The mean amplitude of signal at channel {channel}: {value} {unit}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can do the same with all the measurement which are supported by the instrument. The following statistics are available: `mean`, `max`, `min`, `stdev`\n",
+    "\n",
+    "### Statistics control\n",
+    "\n",
+    "A seperate module controls statistics gathring: `tek.statistics`. For instance, The oscilloscope gathers statistics over a set of measurement values which are stored in a buffer. We can reset this buffer like so... "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tek.statistics.reset()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following parameters are available for staistics control: \n",
+    "\n",
+    "1. `mode`: This command controls the operation and display of measurement statistics and accepts the following arguments: `OFF` turns off all measurements. This is the default value. `ALL` turns on statistics and displays all statistics for each measurement. `VALUEMean` turns on statistics and displays the value and the mean (μ) of each measurement. `MINMax` turns on statistics and displays the min and max of each measurement. `MEANSTDdev` turns on statistics and displays the mean and standard deviation\n",
+    "of each measurement.\n",
+    "2. `time_constant`: This command sets or queries the time constant for mean and standard deviation statistical accumulations"
    ]
   },
   {
@@ -658,18 +767,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.7"
   },
   "nbsphinx": {
    "execute": "never"

--- a/qcodes/instrument/sims/Tektronix_DPO7200xx.yaml
+++ b/qcodes/instrument/sims/Tektronix_DPO7200xx.yaml
@@ -53,13 +53,36 @@ devices:
           r: "CH1"
         setter:
           q: "MEASUrement:MEAS1:SOUrce2 {}"
-      adjust_measurement_type:
+      adjust_measurement_type_meas_1:
         setter:
-          q: "MEASUrement:MEAS0:TYPe amplitude"
-      get_measurement_value:
+          q: "MEASUrement:MEAS1:TYPe amplitude"
+      adjust_measurement_type_meas_2:
+        setter:
+          q: "MEASUrement:MEAS2:TYPe frequency"
+      get_measurement_value_mean_1:
         getter:
-          q: "MEASUrement:MEAS0:VALue?"
+          q: "MEASUrement:MEAS1:VALue?"
           r: "0.01"
+      get_measurement_value_mean_2:
+        getter:
+          q: "MEASUrement:MEAS2:VALue?"
+          r: "0.01"
+      measurement1_state:
+        getter:
+          q: "MEASUrement:MEAS1:STATe?"
+          r: "1"
+        setter:
+          q: "MEASUrement:MEAS1:STATe {}"
+      measurement2_state:
+        getter:
+          q: "MEASUrement:MEAS2:STATe?"
+          r: "{}"
+        setter:
+          q: "MEASUrement:MEAS2:STATe {}"
+      get_measurement1_mean:
+        getter:
+          q: "MEASUrement:MEAS1:MEAN?"
+          r: "0.012"
 
 
 resources:

--- a/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -868,7 +868,7 @@ class TektronixDPOMeasurementStatistics(InstrumentChannel):
                 "1. OFF turns off all measurements. This is the default value "
                 "2. ALL turns on statistics and displays all statistics for "
                 "each measurement. "
-                "3 VALUEMean turns on statistics and displays the value and the "
+                "3. VALUEMean turns on statistics and displays the value and the "
                 "mean (μ) of each measurement. "
                 "4. MINMax turns on statistics and displays the min and max of "
                 "each measurement. "
@@ -881,7 +881,13 @@ class TektronixDPOMeasurementStatistics(InstrumentChannel):
             "time_constant",
             get_cmd="MEASUrement:STATIstics:WEIghting?",
             set_cmd="MEASUrement:STATIstics:WEIghting {}",
-            get_parser=int
+            get_parser=int,
+            docstring=textwrap.dedent(
+                "This command sets or queries the time constant for mean and "
+                "standard deviation statistical accumulations, which is equivalent "
+                "to selecting Measurement Setup from the Measure menu, clicking "
+                "the Statistics button and entering the desired Weight n= value."
+            )
         )
 
     def reset(self) -> None:

--- a/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -861,6 +861,19 @@ class TektronixDPOMeasurementStatistics(InstrumentChannel):
             vals=Enum(
                 "OFF", "ALL", "VALUEMean", "MINMax",
                 "MEANSTDdev"
+            ),
+            docstring=textwrap.dedent(
+                "This command controls the operation and display of measurement "
+                "statistics. "
+                "1. OFF turns off all measurements. This is the default value "
+                "2. ALL turns on statistics and displays all statistics for "
+                "each measurement. "
+                "3 VALUEMean turns on statistics and displays the value and the "
+                "mean (μ) of each measurement. "
+                "4. MINMax turns on statistics and displays the min and max of "
+                "each measurement. "
+                "5. MEANSTDdev turns on statistics and displays the mean and "
+                "standard deviation of each measurement."
             )
         )
 

--- a/qcodes/instrument_drivers/tektronix/DPO7200xx.py
+++ b/qcodes/instrument_drivers/tektronix/DPO7200xx.py
@@ -3,11 +3,12 @@ QCoDeS driver for the MSO/DPO5000/B, DPO7000/C,
 DPO70000/B/C/D/DX/SX, DSA70000/B/C/D, and
 MSO70000/C/DX Series Digital Oscilloscopes
 """
-import numpy as np
-from typing import Union, Callable
-from functools import partial
-import time
 import textwrap
+import time
+from functools import partial
+from typing import Union, Callable
+
+import numpy as np
 
 from qcodes import (
     Instrument, VisaInstrument, InstrumentChannel, ParameterWithSetpoints,
@@ -707,6 +708,7 @@ class TektronixDPOMeasurementParameter(Parameter):
     'TektronixDPOMeasurementStatistics'. Here we also find the method 'reset'
     to reset the values over which the statistics are gathered.
     """
+    # pylint: disable=method-hidden
     def _get(self, metric: str) -> float:
 
         if self.instrument.type.get_latest() != self.name:

--- a/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
+++ b/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
@@ -52,3 +52,11 @@ def test_adjust_timer(tektronix_dpo):
 def test_measurements_return_float(tektronix_dpo):
     amplitude = tektronix_dpo.measurement[0].amplitude()
     assert isinstance(amplitude, float)
+
+    mean_amplitude = tektronix_dpo.measurement[0].amplitude.mean()
+    assert isinstance(mean_amplitude, float)
+
+
+def test_measurement_sets_state(tektronix_dpo):
+    tektronix_dpo.measurement[1].frequency()
+    assert tektronix_dpo.measurement[1].state() == 1


### PR DESCRIPTION
We add the following functionalities to the measurement submodule of the driver:

1) Ability to gather measurement statistics: mean, max, min and standard deviation 
2) Automatically turn a measurement on when calling a measurement method (Set `state` to True) 
3) Ability to globally set the statistics mode, time constant and buffer resetting

@astafan8 Can you have a look, please? 
