### PR TITLE
feat: Add basic driver for Keysight N6705B

### DIFF
--- a/qcodes/instrument/sims/Keysight_N6705B.yaml
+++ b/qcodes/instrument/sims/Keysight_N6705B.yaml
@@ -1,0 +1,17 @@
+spec: "1.0"
+devices:
+  N6705B:
+    eom:
+      GPIB INSTR:
+        q: "\n"
+        r: "\n"
+    error: ERROR
+    dialogues:
+      - q: "*RST"
+      - q: "*CLS"
+      - q: "*IDN?"
+        r: "Agilent Technologies,N6705B,MY50001897,D.01.08"
+
+resources:
+  GPIB::1::INSTR:
+    device: N6705B

--- a/qcodes/instrument_drivers/Keysight/Keysight_N6705B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N6705B.py
@@ -1,0 +1,83 @@
+from qcodes import VisaInstrument
+from qcodes import Instrument
+from qcodes.instrument.channel import InstrumentChannel
+from typing import List, Dict, Optional
+
+
+class N6705BChannel(InstrumentChannel):
+    def __init__(self, parent: Instrument, name: str, chan: int) -> None:
+        if chan not in [1, 2, 3, 4]:
+            raise ValueError('Invalid channel specified')
+
+        super().__init__(parent, name)
+
+        self.add_parameter('source_voltage',
+                           label="Channel {} Voltage".format(chan),
+                           get_cmd='SOURCE:VOLT? (@{:d})'.format(chan),
+                           get_parser=float,
+                           set_cmd='SOURCE:VOLT {{:.8G}}, (@{:d})'.format(chan),
+                           unit='V')
+
+        self.add_parameter('source_current',
+                           label="Channel {} Current".format(chan),
+                           get_cmd='SOURCE:CURR? (@{:d})'.format(chan),
+                           get_parser=float,
+                           set_cmd='SOURCE:CURR {{:.8G}}, (@{:d})'.format(chan),
+                           unit='A')
+        self.add_parameter('voltage_limit',
+                           get_cmd='SOUR:VOLT:PROT? (@{:d})'.format(chan),
+                           get_parser=float,
+                           set_cmd='SOUR:VOLT:PROT {{:.8G}}, @({:d})'.format(chan),
+                           label='Channel {} Voltage Limit'.format(chan),
+                           unit='V')
+
+        self.add_parameter('current_limit',
+                           get_cmd='SOUR:CURR:PROT? (@{:d})'.format(chan),
+                           get_parser=float,
+                           set_cmd='SOUR:CURR:PROT {{:.8G}}, (@{:d})'.format(chan),
+                           label='Channel {} Current Limit',
+                           unit='A')
+
+        self.add_parameter('voltage',
+                           get_cmd='MEAS:VOLT? (@{:d})'.format(chan),
+                           get_parser=float,
+                           label='Channel {} Voltage'.format(chan),
+                           unit='V')
+
+        self.add_parameter('current',
+                           get_cmd='MEAS:CURR? (@{:d})'.format(chan),
+                           get_parser=float,
+                           label='Channel {} Current'.format(chan),
+                           unit='A')
+
+        self.add_parameter('enable',
+                           get_cmd='OUTP:STAT (@{:d})?'.format(chan),
+                           set_cmd='OUTP:STAT {{:d}}, (@{:d})'.format(chan),
+                           val_mapping={'on':  1, 'off': 0})
+
+        self.add_parameter('source_mode',
+                           get_cmd=':OUTP:PMOD? (@{:d})'.format(chan),
+                           set_cmd=':OUTP:PMOD {{:s}}, (@{:d})'.format(chan),
+                           val_mapping={'current': 'CURR', 'voltage': 'VOLT'})
+
+        self.channel = chan
+
+
+class N6705B(VisaInstrument):
+    def __init__(self, name, address, **kwargs) -> None:
+        super().__init__(name, address, terminator='\n', **kwargs)
+        self.channels:  List[N6705BChannel] = []
+        for ch_num in [1, 2, 3, 4]:
+            ch_name = "ch{:d}".format(ch_num)
+            channel = N6705BChannel(self, ch_name, ch_num)
+            self.add_submodule(ch_name, channel)
+            self.channels.append(channel)
+
+        self.connect_message()
+
+    def get_idn(self) -> Dict[str, Optional[str]]:
+        IDN = self.ask_raw('*IDN?')
+        vendor, model, serial, firmware = map(str.strip, IDN.split(','))
+        IDN = {'vendor': vendor, 'model': model,
+               'serial': serial, 'firmware': firmware}
+        return IDN

--- a/qcodes/instrument_drivers/Keysight/Keysight_N6705B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N6705B.py
@@ -12,55 +12,56 @@ class N6705BChannel(InstrumentChannel):
         super().__init__(parent, name)
 
         self.add_parameter('source_voltage',
-                           label="Channel {} Voltage".format(chan),
-                           get_cmd='SOURCE:VOLT? (@{:d})'.format(chan),
+                           label=f"Channel {chan} Voltage",
+                           get_cmd=f'SOURCE:VOLT? (@{chan})',
                            get_parser=float,
-                           set_cmd='SOURCE:VOLT {{:.8G}}, (@{:d})'.format(chan),
+                           set_cmd=f'SOURCE:VOLT {{:.8G}}, (@{chan})',
                            unit='V')
 
         self.add_parameter('source_current',
-                           label="Channel {} Current".format(chan),
-                           get_cmd='SOURCE:CURR? (@{:d})'.format(chan),
+                           label=f"Channel {chan} Current",
+                           get_cmd=f'SOURCE:CURR? (@{chan})',
                            get_parser=float,
-                           set_cmd='SOURCE:CURR {{:.8G}}, (@{:d})'.format(chan),
+                           set_cmd=f'SOURCE:CURR {{:.8G}}, (@{chan})',
                            unit='A')
         self.add_parameter('voltage_limit',
-                           get_cmd='SOUR:VOLT:PROT? (@{:d})'.format(chan),
+                           get_cmd=f'SOUR:VOLT:PROT? (@{chan})',
                            get_parser=float,
-                           set_cmd='SOUR:VOLT:PROT {{:.8G}}, @({:d})'.format(chan),
-                           label='Channel {} Voltage Limit'.format(chan),
+                           set_cmd=f'SOUR:VOLT:PROT {{:.8G}}, @({chan})',
+                           label=f'Channel {chan} Voltage Limit',
                            unit='V')
 
         self.add_parameter('current_limit',
-                           get_cmd='SOUR:CURR:PROT? (@{:d})'.format(chan),
+                           get_cmd=f'SOUR:CURR:PROT? (@{chan})',
                            get_parser=float,
-                           set_cmd='SOUR:CURR:PROT {{:.8G}}, (@{:d})'.format(chan),
-                           label='Channel {} Current Limit',
+                           set_cmd=f'SOUR:CURR:PROT {{:.8G}}, (@{chan})',
+                           label=f'Channel {chan} Current Limit',
                            unit='A')
 
         self.add_parameter('voltage',
-                           get_cmd='MEAS:VOLT? (@{:d})'.format(chan),
+                           get_cmd=f'MEAS:VOLT? (@{chan})',
                            get_parser=float,
-                           label='Channel {} Voltage'.format(chan),
+                           label=f'Channel {chan} Voltage',
                            unit='V')
 
         self.add_parameter('current',
-                           get_cmd='MEAS:CURR? (@{:d})'.format(chan),
+                           get_cmd=f'MEAS:CURR? (@{chan})',
                            get_parser=float,
-                           label='Channel {} Current'.format(chan),
+                           label=f'Channel {chan} Current',
                            unit='A')
 
         self.add_parameter('enable',
-                           get_cmd='OUTP:STAT (@{:d})?'.format(chan),
-                           set_cmd='OUTP:STAT {{:d}}, (@{:d})'.format(chan),
+                           get_cmd=f'OUTP:STAT (@{chan})?',
+                           set_cmd=f'OUTP:STAT {{:d}}, (@{chan})',
                            val_mapping={'on':  1, 'off': 0})
 
         self.add_parameter('source_mode',
-                           get_cmd=':OUTP:PMOD? (@{:d})'.format(chan),
-                           set_cmd=':OUTP:PMOD {{:s}}, (@{:d})'.format(chan),
+                           get_cmd=f':OUTP:PMOD? (@{chan})',
+                           set_cmd=f':OUTP:PMOD {{:s}}, (@{chan})',
                            val_mapping={'current': 'CURR', 'voltage': 'VOLT'})
 
         self.channel = chan
+        self.ch_name = name
 
 
 class N6705B(VisaInstrument):
@@ -68,7 +69,7 @@ class N6705B(VisaInstrument):
         super().__init__(name, address, terminator='\n', **kwargs)
         self.channels:  List[N6705BChannel] = []
         for ch_num in [1, 2, 3, 4]:
-            ch_name = "ch{:d}".format(ch_num)
+            ch_name = f"ch{ch_num}"
             channel = N6705BChannel(self, ch_name, ch_num)
             self.add_submodule(ch_name, channel)
             self.channels.append(channel)

--- a/qcodes/tests/drivers/test_Keysight_N6705B.py
+++ b/qcodes/tests/drivers/test_Keysight_N6705B.py
@@ -1,0 +1,30 @@
+import pytest
+import qcodes.instrument_drivers.Keysight.Keysight_N6705B as N6705B
+
+import qcodes.instrument.sims as sims
+
+visalib = sims.__file__.replace('__init__.py', 'Keysight_N6705B.yaml@sim')
+
+
+@pytest.fixture(scope='module')
+def driver():
+    driver = N6705B.N6705B('N6705B',
+                           address="GPIB::1::INSTR",
+                           visalib=visalib)
+    yield driver
+    driver.close()
+
+
+def test_idn(driver):
+    assert {'firmware': 'D.01.08',
+            'model': 'N6705B',
+            'serial': 'MY50001897',
+            'vendor': 'Agilent Technologies'} == driver.IDN()
+
+
+def test_channels(driver):
+    # Ensure each channel got instantiated
+    assert len(driver.channels) == 4
+    for (i, ch) in enumerate(driver.channels):
+        assert(ch.channel == i+1)
+        assert(ch.ch_name == f"ch{i+1}")


### PR DESCRIPTION
This is a bare bones driver for the Keysight N6705B DC power
supply.

Changes proposed in this pull request:
- Add basic driver for this power supply 


@astafan8 

Hey guys, could you have a quick look over this please. I had a quick look around but couldn't find a driver for this power supply.  I mostly copied the driver for the B296A. The programming manual is [here](http://literature.cdn.keysight.com/litweb/pdf/N6705-90902.pdf)