### PR TITLE
Don't rewrite config file in exp container example

### DIFF
--- a/docs/examples/DataSet/The-Experiment-Container.ipynb
+++ b/docs/examples/DataSet/The-Experiment-Container.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "### The config file\n",
     "\n",
-    "We'll be modifying the config file in a second, so first a brief word about the config system.\n",
+    "We'll be showing how to modify the config file in a second, so first a brief word about the config system.\n",
     "\n",
     "Only one config file can be used at a time. The default config file should not be overwritten, so if you have any modifications, you should save the updated config file on your home directory **OR** in the current working directory of your script/notebook. The QCoDeS config system first looks in the current directory for a config file and then in the home directory for one and only then - if no config files where found - does it fall back to using the default one. The default config is located in `qcodes/qcodes/config`."
    ]
@@ -50,8 +50,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Using config file from /Users/william/sourcecodes/QCoDeS/qcodes/config/qcodesrc_schema.json\n",
-      "Database location: ./experiments.db\n"
+      "Using config file from C:\\Users\\jenielse\\qcodesrc.json\n",
+      "Database location: ~/experiments.db\n"
      ]
     }
    ],
@@ -94,14 +94,26 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Upgrading database: : 0it [00:00, ?it/s]\n",
+      "Upgrading database: : 0it [00:00, ?it/s]\n",
+      "Upgrading database, version 5 -> 6: : 0it [00:00, ?it/s]\n"
+     ]
+    }
+   ],
    "source": [
     "# point the config system to the new location\n",
     "configuration['core']['db_location'] = './exp_container_tutorial.db'\n",
-    "# now save the config file in home. \n",
+    "# now you could save the config file in home. \n",
     "# NOTE: This config file will \n",
-    "# from now on loaded by qcodes instead of the default.\n",
-    "configuration.save_to_home()\n",
+    "# then be used from now on loaded by \n",
+    "# qcodes instead of the default.\n",
+    "\n",
+    "# configuration.save_to_home()\n",
     "# create an empty database based on the config file\n",
     "initialise_database()"
    ]
@@ -122,7 +134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -140,7 +152,7 @@
        "[]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -158,7 +170,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,17 +179,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "second_exp#brand_new_sample#3@./exp_container_tutorial.db\n",
-       "---------------------------------------------------------"
+       "second_exp#brand_new_sample#3@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\exp_container_tutorial.db\n",
+       "-------------------------------------------------------------------------------------------------------------------"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -190,21 +202,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[first_exp#old_sample#1@./exp_container_tutorial.db\n",
-       " --------------------------------------------------,\n",
-       " second_exp#slightly_newer_sample#2@./exp_container_tutorial.db\n",
-       " --------------------------------------------------------------,\n",
-       " second_exp#brand_new_sample#3@./exp_container_tutorial.db\n",
-       " ---------------------------------------------------------]"
+       "[first_exp#old_sample#1@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\exp_container_tutorial.db\n",
+       " ------------------------------------------------------------------------------------------------------------,\n",
+       " second_exp#slightly_newer_sample#2@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\exp_container_tutorial.db\n",
+       " ------------------------------------------------------------------------------------------------------------------------,\n",
+       " second_exp#brand_new_sample#3@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\exp_container_tutorial.db\n",
+       " -------------------------------------------------------------------------------------------------------------------]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -224,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,17 +245,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "a_good_run #1@./exp_container_tutorial.db\n",
-       "-----------------------------------------"
+       "a_good_run #1@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\exp_container_tutorial.db\n",
+       "---------------------------------------------------------------------------------------------------"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,17 +266,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "a_nother_run #2@./exp_container_tutorial.db\n",
-       "-------------------------------------------"
+       "a_nother_run #2@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\exp_container_tutorial.db\n",
+       "-----------------------------------------------------------------------------------------------------"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,15 +312,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "second_exp#slightly_newer_sample#2@./exp_container_tutorial.db\n",
-      "--------------------------------------------------------------\n",
+      "second_exp#slightly_newer_sample#2@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\exp_container_tutorial.db\n",
+      "------------------------------------------------------------------------------------------------------------------------\n",
       "1-a_good_run-1--0\n",
       "2-a_nother_run-2--0\n"
      ]
@@ -326,6 +338,13 @@
    "source": [
     "In a similar way, we may of course add runs to the other two experiments. Now, the alert reader will have noticed that `exp_id` is a keyword argument in `new_data_set`. What is the default then? --The default is that the run is added to the experiment with the **highest** `exp_id` in the database."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -344,7 +363,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Modifying config is confusing and not needed. Even worse the examples are executed as part of the docs build so this may happen unnoticed