### PR TITLE
Give all upgraders a progress bar

### DIFF
--- a/qcodes/dataset/sqlite/db_upgrades/__init__.py
+++ b/qcodes/dataset/sqlite/db_upgrades/__init__.py
@@ -17,6 +17,7 @@ from functools import wraps
 from typing import Dict, Callable
 
 import numpy as np
+from tqdm import tqdm
 
 from qcodes.dataset.guids import generate_guid
 from qcodes.dataset.sqlite.connection import ConnectionPlus, \
@@ -142,7 +143,10 @@ def perform_db_upgrade_0_to_1(conn: ConnectionPlus) -> None:
             cur = transaction(conn, 'SELECT run_id FROM runs')
             run_ids = [r[0] for r in many_many(cur, 'run_id')]
 
-            for run_id in run_ids:
+            pbar = tqdm(range(1, len(run_ids) + 1))
+            pbar.set_description("Upgrading database; v0 -> v1")
+
+            for run_id in pbar:
                 query = f"""
                         SELECT run_timestamp
                         FROM runs
@@ -175,6 +179,9 @@ def perform_db_upgrade_1_to_2(conn: ConnectionPlus) -> None:
     cur = atomic_transaction(conn, sql)
     n_run_tables = len(cur.fetchall())
 
+    pbar = tqdm(range(1))
+    pbar.set_description("Upgrading database; v1 -> v2")
+
     if n_run_tables == 1:
         _IX_runs_exp_id = """
                           CREATE INDEX
@@ -187,8 +194,11 @@ def perform_db_upgrade_1_to_2(conn: ConnectionPlus) -> None:
                         ON runs (guid DESC)
                         """
         with atomic(conn) as conn:
-            transaction(conn, _IX_runs_exp_id)
-            transaction(conn, _IX_runs_guid)
+            # iterate through the pbar for the sake of the side effect; it
+            # prints that the database is being upgraded
+            for _ in pbar:
+                transaction(conn, _IX_runs_exp_id)
+                transaction(conn, _IX_runs_guid)
     else:
         raise RuntimeError(f"found {n_run_tables} runs tables expected 1")
 
@@ -233,7 +243,12 @@ def perform_db_upgrade_4_to_5(conn: ConnectionPlus) -> None:
     with snapshot information.
     """
     with atomic(conn) as conn:
-        insert_column(conn, 'runs', 'snapshot', 'TEXT')
+        pbar = tqdm(range(1))
+        pbar.set_description("Upgrading database; v4 -> v5")
+        # iterate through the pbar for the sake of the side effect; it
+        # prints that the database is being upgraded
+        for _ in pbar:
+            insert_column(conn, 'runs', 'snapshot', 'TEXT')
 
 
 @upgrader
@@ -263,18 +278,24 @@ def perform_db_upgrade_6_to_7(conn: ConnectionPlus) -> None:
     n_run_tables = len(cur.fetchall())
 
     if n_run_tables == 1:
-        with atomic(conn) as conn:
-            sql = "ALTER TABLE runs ADD COLUMN captured_run_id"
-            transaction(conn, sql)
-            sql = "ALTER TABLE runs ADD COLUMN captured_counter"
-            transaction(conn, sql)
 
-            sql = f"""
-                    UPDATE runs
-                    SET captured_run_id = run_id,
-                        captured_counter = result_counter
-                    """
-            transaction(conn, sql)
+        pbar = tqdm(range(1))
+        pbar.set_description("Upgrading database; v6 -> v7")
+        # iterate through the pbar for the sake of the side effect; it
+        # prints that the database is being upgraded
+        for _ in pbar:
+            with atomic(conn) as conn:
+                sql = "ALTER TABLE runs ADD COLUMN captured_run_id"
+                transaction(conn, sql)
+                sql = "ALTER TABLE runs ADD COLUMN captured_counter"
+                transaction(conn, sql)
+
+                sql = f"""
+                        UPDATE runs
+                        SET captured_run_id = run_id,
+                            captured_counter = result_counter
+                        """
+                transaction(conn, sql)
     else:
         raise RuntimeError(f"found {n_run_tables} runs tables expected 1")
 
@@ -287,4 +308,9 @@ def perform_db_upgrade_7_to_8(conn: ConnectionPlus) -> None:
     Add a new column to store the dataset's parents to the runs table.
     """
     with atomic(conn) as conn:
-        insert_column(conn, 'runs', 'parent_datasets', 'TEXT')
+        pbar = tqdm(range(1))
+        pbar.set_description("Upgrading database; v7 -> v8")
+        # iterate through the pbar for the sake of the side effect; it
+        # prints that the database is being upgraded
+        for _ in pbar:
+            insert_column(conn, 'runs', 'parent_datasets', 'TEXT')

--- a/qcodes/dataset/sqlite/db_upgrades/__init__.py
+++ b/qcodes/dataset/sqlite/db_upgrades/__init__.py
@@ -15,6 +15,7 @@ principle, the upgrade functions should not have dependecies from
 import logging
 from functools import wraps
 from typing import Dict, Callable
+import sys
 
 import numpy as np
 from tqdm import tqdm
@@ -143,7 +144,7 @@ def perform_db_upgrade_0_to_1(conn: ConnectionPlus) -> None:
             cur = transaction(conn, 'SELECT run_id FROM runs')
             run_ids = [r[0] for r in many_many(cur, 'run_id')]
 
-            pbar = tqdm(range(1, len(run_ids) + 1))
+            pbar = tqdm(range(1, len(run_ids) + 1), file=sys.stdout)
             pbar.set_description("Upgrading database; v0 -> v1")
 
             for run_id in pbar:
@@ -179,7 +180,7 @@ def perform_db_upgrade_1_to_2(conn: ConnectionPlus) -> None:
     cur = atomic_transaction(conn, sql)
     n_run_tables = len(cur.fetchall())
 
-    pbar = tqdm(range(1))
+    pbar = tqdm(range(1), file=sys.stdout)
     pbar.set_description("Upgrading database; v1 -> v2")
 
     if n_run_tables == 1:
@@ -243,7 +244,7 @@ def perform_db_upgrade_4_to_5(conn: ConnectionPlus) -> None:
     with snapshot information.
     """
     with atomic(conn) as conn:
-        pbar = tqdm(range(1))
+        pbar = tqdm(range(1), file=sys.stdout)
         pbar.set_description("Upgrading database; v4 -> v5")
         # iterate through the pbar for the sake of the side effect; it
         # prints that the database is being upgraded
@@ -279,7 +280,7 @@ def perform_db_upgrade_6_to_7(conn: ConnectionPlus) -> None:
 
     if n_run_tables == 1:
 
-        pbar = tqdm(range(1))
+        pbar = tqdm(range(1), file=sys.stdout)
         pbar.set_description("Upgrading database; v6 -> v7")
         # iterate through the pbar for the sake of the side effect; it
         # prints that the database is being upgraded
@@ -308,7 +309,7 @@ def perform_db_upgrade_7_to_8(conn: ConnectionPlus) -> None:
     Add a new column to store the dataset's parents to the runs table.
     """
     with atomic(conn) as conn:
-        pbar = tqdm(range(1))
+        pbar = tqdm(range(1), file=sys.stdout)
         pbar.set_description("Upgrading database; v7 -> v8")
         # iterate through the pbar for the sake of the side effect; it
         # prints that the database is being upgraded

--- a/qcodes/dataset/sqlite/db_upgrades/upgrade_2_to_3.py
+++ b/qcodes/dataset/sqlite/db_upgrades/upgrade_2_to_3.py
@@ -212,7 +212,7 @@ def upgrade_2_to_3(conn: ConnectionPlus) -> None:
         dependencies = _2to3_get_dependencies(conn)
 
         pbar = tqdm(range(1, no_of_runs+1))
-        pbar.set_description("Upgrading database")
+        pbar.set_description("Upgrading database; v2 -> v3")
 
         for run_id in pbar:
 

--- a/qcodes/dataset/sqlite/db_upgrades/upgrade_2_to_3.py
+++ b/qcodes/dataset/sqlite/db_upgrades/upgrade_2_to_3.py
@@ -2,6 +2,7 @@ import json
 import logging
 from collections import defaultdict
 from typing import Dict, DefaultDict, List, Sequence, Tuple
+import sys
 
 from tqdm import tqdm
 
@@ -211,7 +212,7 @@ def upgrade_2_to_3(conn: ConnectionPlus) -> None:
         layouts = _2to3_get_layouts(conn)
         dependencies = _2to3_get_dependencies(conn)
 
-        pbar = tqdm(range(1, no_of_runs+1))
+        pbar = tqdm(range(1, no_of_runs+1), file=sys.stdout)
         pbar.set_description("Upgrading database; v2 -> v3")
 
         for run_id in pbar:

--- a/qcodes/dataset/sqlite/db_upgrades/upgrade_3_to_4.py
+++ b/qcodes/dataset/sqlite/db_upgrades/upgrade_3_to_4.py
@@ -44,7 +44,7 @@ def upgrade_3_to_4(conn: ConnectionPlus) -> None:
         dependencies = _2to3_get_dependencies(conn)
 
         pbar = tqdm(range(1, no_of_runs+1))
-        pbar.set_description("Upgrading database")
+        pbar.set_description("Upgrading database; v3 -> v4")
 
         for run_id in pbar:
 

--- a/qcodes/dataset/sqlite/db_upgrades/upgrade_3_to_4.py
+++ b/qcodes/dataset/sqlite/db_upgrades/upgrade_3_to_4.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 
 from tqdm import tqdm
 
@@ -43,7 +44,7 @@ def upgrade_3_to_4(conn: ConnectionPlus) -> None:
         layouts = _2to3_get_layouts(conn)
         dependencies = _2to3_get_dependencies(conn)
 
-        pbar = tqdm(range(1, no_of_runs+1))
+        pbar = tqdm(range(1, no_of_runs+1), file=sys.stdout)
         pbar.set_description("Upgrading database; v3 -> v4")
 
         for run_id in pbar:

--- a/qcodes/dataset/sqlite/db_upgrades/upgrade_5_to_6.py
+++ b/qcodes/dataset/sqlite/db_upgrades/upgrade_5_to_6.py
@@ -27,7 +27,7 @@ def upgrade_5_to_6(conn: ConnectionPlus) -> None:
 
     with atomic(conn) as conn:
         pbar = tqdm(range(1, no_of_runs+1))
-        pbar.set_description("Upgrading database, version 5 -> 6")
+        pbar.set_description("Upgrading database; v5 -> v6")
 
         empty_idps_ser = InterDependencies()._to_dict()
 

--- a/qcodes/dataset/sqlite/db_upgrades/upgrade_5_to_6.py
+++ b/qcodes/dataset/sqlite/db_upgrades/upgrade_5_to_6.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 from tqdm import tqdm
 
@@ -26,7 +27,7 @@ def upgrade_5_to_6(conn: ConnectionPlus) -> None:
     # entire upgrade is one atomic transaction
 
     with atomic(conn) as conn:
-        pbar = tqdm(range(1, no_of_runs+1))
+        pbar = tqdm(range(1, no_of_runs+1), file=sys.stdout)
         pbar.set_description("Upgrading database; v5 -> v6")
 
         empty_idps_ser = InterDependencies()._to_dict()


### PR DESCRIPTION
All the DB upgrades should have a progress bar to make the output of the upgrading less confusing.

Changes proposed in this pull request:
- Add a progress bar to all updaters

This PR doesn't feel particularly DRY, but I could only think of complicated ways of adding the progress bar to the `upgrader` decorator.

@QCoDeS/core 
