### PR TITLE
Fix 3.6 wheels by always depending on dataclasses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,12 +30,9 @@ install_requires = [
     'pandas',
     'tabulate',
     'tqdm',
-    'applicationinsights'
+    'applicationinsights',
+    'dataclasses' # can be removed once we drop support for python 3.6
 ]
-
-if sys.version_info.minor < 7:
-    install_requires.append('dataclasses')
-
 
 setup(name='qcodes',
       version=versioneer.get_version(),


### PR DESCRIPTION
This will unconditionally install dataclasses but python 3.7 will normally prefer the std lib version over the site-package as site-packages is later in the path than the standard library 