### PR TITLE
Update conda env to python 3.7

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,14 +1,13 @@
 name: qcodes
 channels:
  - defaults
- - conda-forge
 dependencies:
- - python=3.6.9
+ - python=3.7.4
  - pip
  - numpy=1.16.4 # numpy 1.16.0 .. 1.16.2 may fail our tests due to https://github.com/numpy/numpy/issues/13089
  - matplotlib=3.1
  - pyqtgraph=0.10.0
- - pyvisa=1.10
+ - conda-forge::pyvisa=1.10
  - h5py=2.9.0
  - pyqt=5.9
  - QtPy
@@ -28,11 +27,12 @@ dependencies:
  - pandas
  - testpath>=0.4.2 # 0.4.1 is bad due to https://github.com/conda-forge/testpath-feedstock/issues/7
  - tqdm
- - dataclasses  # this won't be needed when we move to python 3.7
  - tabulate
  - applicationinsights
  - pandoc
+ - contextlib2 # for broadbean
+ - conda-forge::websockets=8.0.2
+ - conda-forge::schema
  - pip:
-    - websockets==8.0.2
     - broadbean>=0.9.1
     - ruamel.yaml


### PR DESCRIPTION
I think its about time to switch the default env to 3.7


This also upgrades pyvisa to the latest version and move most deps to conda-forge
