### PR TITLE
Alazar: refactor `AcquisitionInterface` out of `AcquisitionController`

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -874,24 +874,20 @@ class AcquisitionInterface:
 
     The basic structure of an acquisition is:
 
-        - Call to AlazarTech_ATS.acquire internal configuration
-        - Call to acquisitioncontroller.pre_start_capture
+        - Call to :meth:`AlazarTech_ATS.acquire` internal configuration
+        - Call to :meth:`AcquisitionInterface.pre_start_capture`
         - Call to the start capture of the Alazar board
-        - Call to acquisitioncontroller.pre_acquire
+        - Call to :meth:`AcquisitionInterface.pre_acquire
         - Loop over all buffers that need to be acquired
           dump each buffer to acquisitioncontroller.handle_buffer
           (only if buffers need to be recycled to finish the acquisiton)
-        - Dump remaining buffers to acquisitioncontroller.handle_buffer
+        - Dump remaining buffers to :meth:`AcquisitionInterface.handle_buffer`
           alazar internals
-        - Return acquisitioncontroller.post_acquire
-
-    Attributes:
-        _alazar: a reference to the alazar instrument driver
+        - Return return value from :meth:`AcquisitionController.post_acquire`
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
 
     def pre_start_capture(self):
         """
@@ -939,8 +935,8 @@ class AcquisitionInterface:
         """
         This method is called when a buffer is completed. It can be used
         if you want to implement an event that happens for each buffer.
-        You will probably want to combine this with `AUX_IN_TRIGGER_ENABLE` to wait
-        before starting capture of the next buffer.
+        You will probably want to combine this with `AUX_IN_TRIGGER_ENABLE`
+        to wait before starting capture of the next buffer.
 
         Args:
             buffers_completed: how many buffers have been completed and copied
@@ -951,25 +947,9 @@ class AcquisitionInterface:
 
 class AcquisitionController(Instrument, AcquisitionInterface):
     """
-    This class represents all choices that the end-user has to make regarding
-    the data-acquisition. this class should be subclassed to program these
-    choices.
-
-    The basic structure of an acquisition is:
-
-        - Call to AlazarTech_ATS.acquire internal configuration
-        - Call to acquisitioncontroller.pre_start_capture
-        - Call to the start capture of the Alazar board
-        - Call to acquisitioncontroller.pre_acquire
-        - Loop over all buffers that need to be acquired
-          dump each buffer to acquisitioncontroller.handle_buffer
-          (only if buffers need to be recycled to finish the acquisiton)
-        - Dump remaining buffers to acquisitioncontroller.handle_buffer
-          alazar internals
-        - Return acquisitioncontroller.post_acquire
-
-    Attributes:
-        _alazar: a reference to the alazar instrument driver
+    Compatiblillity class. The methods of :class:`AcquisitionController`
+    have been extracted. This class is the base class fro AcquisitionInterfaces
+    that are intended to be QCoDeS instruments at the same time.
     """
 
     def __init__(self, name, alazar_name, **kwargs):

--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -877,7 +877,7 @@ class AcquisitionInterface:
         - Call to :meth:`AlazarTech_ATS.acquire` internal configuration
         - Call to :meth:`AcquisitionInterface.pre_start_capture`
         - Call to the start capture of the Alazar board
-        - Call to :meth:`AcquisitionInterface.pre_acquire
+        - Call to :meth:`AcquisitionInterface.pre_acquire`
         - Loop over all buffers that need to be acquired
           dump each buffer to acquisitioncontroller.handle_buffer
           (only if buffers need to be recycled to finish the acquisiton)


### PR DESCRIPTION
The Alazar `AcquistionController` is an interface for the alazar ats instrument, that takes care of handling the buffer data. In the current implementation this interface is a qcodes instrument.

In my opinion this is an unnecessary coupling between pure number crunching code and qcodes instruments. I therefore suggest to refactor an `AcquisitionInterface` out of the `AcquisitionController`, which only contains the interface methods.
By letting the `AcquistionController` inherit from `AcquistionInterface` and `Instrument` the original functionality should stay untouched.

Additionally I removed the `NotImplementedError`s from some of the methods, which don't need to be implemented.
