### PR TITLE
Keysight b1500: Edit example notebook to set averaging during sampling measurement.

### DIFF
--- a/docs/examples/driver_examples/Qcodes example with Keysight B1500 Parameter Analyzer.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Keysight B1500 Parameter Analyzer.ipynb
@@ -500,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,6 +509,22 @@
     "                       compl_polarity=None, \n",
     "                       min_compliance_range=constants.IOutputRange.AUTO\n",
     "                      )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set the averaging to 1 otherwise the measurement takes 10 times more time. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b1500.use_nplc_for_high_speed_adc(n=1)"
    ]
   },
   {
@@ -1086,7 +1102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.6.9"
   },
   "nbsphinx": {
    "execute": "never"


### PR DESCRIPTION
Sampling measurement is taking a lot of time (~5 hrs) because the example notebook does not specify to set the averaging to 1. Setting this to one before starting sampling measurement is a default case scenario hence it makes sense to add it in the example notebook. 

Here, we explicitly specify in the example notebook to set the averaging to 1 before starting the sampling measurement. 

@astafan8 
