### PR TITLE
Fix docstrings qcodes.utils: comand, deprecate, helpers, magic and metadata

### DIFF
--- a/qcodes/utils/command.py
+++ b/qcodes/utils/command.py
@@ -10,12 +10,13 @@ class Command:
     Create a callable command from a string or function.
 
     Args:
-        arg_count (int): the number of arguments to the command
+        arg_count (int): The number of arguments to the command.
 
-        cmd (Optional[Union[str, Callable]]): If a function, it will be called directly
-            when the command is invoked. If a string, it should contain
-            positional fields to ``.format`` like ``'{}'`` or ``'{0}'``,
-            and it will be passed on to ``exec_str`` after formatting
+        cmd (Optional[Union[str, Callable]]): If a function, it will be
+            called directly when the command is invoked. If a string,
+            it should contain positional fields to ``.format`` like ``'{}'``
+            or ``'{0}'``, and it will be passed on to ``exec_str`` after
+            formatting.
 
         exec_str (Optional[Callable]): If provided, should be a callable
             taking one parameter, the ``cmd`` string after parameters
@@ -26,22 +27,22 @@ class Command:
             function should accept all the arguments in order, and
             return a tuple of values.
 
-        output_parser (Optional[Callable]): transform the return value of the
+        output_parser (Optional[Callable]): Transform the return value of the
             command.
 
         no_cmd_function (Optional[Callable]): If provided and we cannot
             create a command to return, we won't throw an error on constructing
             the command. Instead, we call this function when the command is
             invoked, and it should probably throw an error of its own (eg
-            ``NotImplementedError``)
+            ``NotImplementedError``).
 
 
     Raises:
-        TypeError: if no_cmd_function is not the expected type
-        TypeError: if input_parser is not the expected type
-        TypeError: if output_parser is not the expected type
-        TypeError: if exec_string is not the expected type
-        NoCommandError: if no cmd is found no_cmd_function is missing
+        TypeError: If no_cmd_function is not the expected type.
+        TypeError: If input_parser is not the expected type.
+        TypeError: If output_parser is not the expected type.
+        TypeError: If exec_string is not the expected type.
+        NoCommandError: If no cmd is found no_cmd_function is missing.
     """
 
     def __init__(self, arg_count, cmd=None, exec_str=None, input_parser=None,
@@ -114,7 +115,7 @@ class Command:
             raise TypeError('cmd must be a string or function with ' +
                             '{} args'.format(arg_count))
 
-    # wrappers that may or may not be used in constructing call
+    # Wrappers that may or may not be used in constructing call
     # these functions are not very DRY at all - this could be condensed
     # by composing them from a smaller set. But this is our hot path
     # during acquisition Loops, so for performance I wanted to minimize

--- a/qcodes/utils/deprecate.py
+++ b/qcodes/utils/deprecate.py
@@ -7,6 +7,14 @@ def deprecate(
         reason: Optional[str] = None,
         alternative: Optional[str] = None
 ) -> Callable:
+    """
+    A utility function to decorate deprecated functions and classes.
+
+    Args:
+        reason: The reason of deprecation.
+        alternative: The alternative function or class to put in use instead of
+                     the deprecated one. 
+    """
     def actual_decorator(func: Callable) -> Callable:
         @wraps(func)
         def decorated_func(*args, **kwargs):

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -29,29 +29,29 @@ log = logging.getLogger(__name__)
 class NumpyJSONEncoder(json.JSONEncoder):
     """
     This JSON encoder adds support for serializing types that the built-in
-    `json` module does not support out-of-the-box. See the docstring of the
-    `default` method for the description of all conversions.
+    ``json`` module does not support out-of-the-box. See the docstring of the
+    ``default`` method for the description of all conversions.
     """
 
     def default(self, obj):
         """
         List of conversions that this encoder performs:
-        * `numpy.generic` (all integer, floating, and other types) gets
-        converted to its python equivalent using its `item` method (see
-        `numpy` docs for more information,
-        https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html)
-        * `numpy.ndarray` gets converted to python list using its `tolist`
-        method
-        * complex number (a number that conforms to `numbers.Complex` ABC) gets
-        converted to a dictionary with fields "re" and "im" containing floating
+        * ``numpy.generic`` (all integer, floating, and other types) gets
+        converted to its python equivalent using its ``item`` method (see
+        ``numpy`` docs for more information,
+        https://docs.scipy.org/doc/numpy/reference/arrays.scalars.html).
+        * ``numpy.ndarray`` gets converted to python list using its ``tolist``
+        method.
+        * Complex number (a number that conforms to ``numbers.Complex`` ABC) gets
+        converted to a dictionary with fields ``re`` and ``im`` containing floating
         numbers for the real and imaginary parts respectively, and a field
-        "__dtype__" containing value "complex"
-        * object with a `_JSONEncoder` method get converted the return value of
-        that method
-        * objects which support the pickle protocol get converted using the
-        data provided by that protocol
-        * other objects which cannot be serialized get converted to their
-        string representation (suing the `str` function)
+        ``__dtype__`` containing value ``complex``.
+        * Object with a ``_JSONEncoder`` method get converted the return value of
+        that method.
+        * Objects which support the pickle protocol get converted using the
+        data provided by that protocol.
+        * Other objects which cannot be serialized get converted to their
+        string representation (suing the ``str`` function).
         """
         if isinstance(obj, np.generic) \
                 and not isinstance(obj, np.complexfloating):

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -88,7 +88,7 @@ class NumpyJSONEncoder(json.JSONEncoder):
 
 
 def tprint(string, dt=1, tag='default'):
-    """ Print progress of a loop every dt seconds """
+    """ Print progress of a loop every dt seconds. """
     ptime = _tprint_times.get(tag, 0)
     if (time.time() - ptime) > dt:
         print(string)
@@ -100,7 +100,7 @@ def is_sequence(obj):
     Test if an object is a sequence.
 
     We do not consider strings or unordered collections like sets to be
-    sequences, but we do accept iterators (such as generators)
+    sequences, but we do accept iterators (such as generators).
     """
     return (isinstance(obj, (Iterator, Sequence, np.ndarray)) and
             not isinstance(obj, (str, bytes, io.IOBase)))
@@ -116,16 +116,16 @@ def is_sequence_of(obj: Any,
     Test if object is a sequence of entirely certain class(es).
 
     Args:
-        obj: the object to test.
-        types: allowed type(s). if omitted, we just test the depth/shape.
-        depth: level of nesting, ie if ``depth=2`` we expect a sequence of
-            sequences. Default 1 unless ``shape`` is supplied.
-        shape: the shape of the sequence, ie its length in each dimension.
-            If ``depth`` is omitted, but ``shape`` included, we set
-            ``depth = len(shape)``
+        obj: The object to test.
+        types: Allowed type(s). If omitted, we just test the depth/shape.
+        depth: Level of nesting, ie if ``depth=2`` we expect a sequence of
+               sequences. Default 1 unless ``shape`` is supplied.
+        shape: The shape of the sequence, ie its length in each dimension.
+               If ``depth`` is omitted, but ``shape`` included, we set
+               ``depth = len(shape)``.
 
     Returns:
-        bool, True if every item in ``obj`` matches ``types``
+        bool: ``True`` if every item in ``obj`` matches ``types``.
     """
     if not is_sequence(obj):
         return False
@@ -155,19 +155,19 @@ def is_sequence_of(obj: Any,
     return True
 
 
-def is_function(f, arg_count, coroutine=False):
+def is_function(f: Callable, arg_count: int, coroutine: bool=False) -> bool:
     """
     Check and require a function that can accept the specified number of
     positional arguments, which either is or is not a coroutine
-    type casting "functions" are allowed, but only in the 1-argument form
+    type casting "functions" are allowed, but only in the 1-argument form.
 
     Args:
-        f (Callable): function to check
-        arg_count (int): number of argument f should accept
-        coroutine (bool): is a coroutine. Default: False
+        f: Function to check.
+        arg_count: Number of argument f should accept.
+        coroutine: Is a coroutine.
 
     Return:
-        bool: is function and accepts the specified number of arguments
+        bool: is function and accepts the specified number of arguments.
 
     """
     if not isinstance(arg_count, int) or arg_count < 0:
@@ -217,7 +217,7 @@ def deep_update(dest, update):
     Recursively update one JSON structure with another.
 
     Only dives into nested dicts; lists get replaced completely.
-    If the original value is a dict and the new value is not, or vice versa,
+    If the original value is a dictionary and the new value is not, or vice versa,
     we also replace the value completely.
     """
     for k, v_update in update.items():

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -7,7 +7,8 @@ import time
 import os
 from collections.abc import Iterator, Sequence, Mapping
 from copy import deepcopy
-from typing import Dict, Any, TypeVar, Type, List, Tuple, Union, Optional, cast
+from typing import Dict, Any, TypeVar, Type, List, Tuple, Union, Optional, cast, \
+                    Callable, SupportsAbs
 from contextlib import contextmanager
 from asyncio import iscoroutinefunction
 from inspect import signature
@@ -233,7 +234,7 @@ def deep_update(dest, update):
 # a) we don't want to require that as a dep so low level
 # b) I'd like to be more flexible with the sign of step
 def permissive_range(start: Union[int, float], stop: Union[int, float],
-                     step:Optional[Union[int, float]]) -> np.ndarray:
+                     step: SupportsAbs[float]) -> np.ndarray:
     """
     Returns a range (as a list of values) with floating point steps.
     Always starts at start and moves toward stop, regardless of the

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -232,15 +232,17 @@ def deep_update(dest, update):
 # could use numpy.arange here, but
 # a) we don't want to require that as a dep so low level
 # b) I'd like to be more flexible with the sign of step
-def permissive_range(start, stop, step):
+def permissive_range(start: Union[int, float], stop: Union[int, float],
+                     step:Optional[Union[int, float]]) -> np.ndarray:
     """
-    returns range (as a list of values) with floating point step
+    Returns a range (as a list of values) with floating point steps.
+    Always starts at start and moves toward stop, regardless of the
+    sign of step.
 
-    inputs:
-        start, stop, step
-
-    always starts at start and moves toward stop,
-    regardless of the sign of step
+    Args:
+        start: The starting value of the range.
+        stop: The end value of the range.
+        step: Spacing between the values.
     """
     signed_step = abs(step) * (1 if stop > start else -1)
     # take off a tiny bit for rounding errors
@@ -255,20 +257,22 @@ def permissive_range(start, stop, step):
 # numpy is a dependency anyways.
 # Furthermore the sweep allows to take a number of points and generates
 # an array with endpoints included, which is more intuitive to use in a sweep.
-def make_sweep(start, stop, step=None, num=None):
+def make_sweep(start: Union[int, float], stop: Union[int, float],
+               step: Optional[Union[int, float]]=None, num: Optional[int]=None
+               ) -> np.ndarray:
     """
     Generate numbers over a specified interval.
-    Requires `start` and `stop` and (`step` or `num`)
-    The sign of `step` is not relevant.
+    Requires ``start`` and ``stop`` and (``step`` or ``num``).
+    The sign of ``step`` is not relevant.
 
     Args:
-        start (Union[int, float]): The starting value of the sequence.
-        stop (Union[int, float]): The end value of the sequence.
-        step (Optional[Union[int, float]]):  Spacing between values.
-        num (Optional[int]): Number of values to generate.
+        start: The starting value of the sequence.
+        stop: The end value of the sequence.
+        step:  Spacing between values.
+        num: Number of values to generate.
 
     Returns:
-        numpy.ndarray: numbers over a specified interval as a ``numpy.linspace``
+        numpy.ndarray: numbers over a specified interval as a ``numpy.linspace``.
 
     Examples:
         >>> make_sweep(0, 10, num=5)
@@ -302,8 +306,8 @@ def make_sweep(start, stop, step=None, num=None):
 
 def wait_secs(finish_clock):
     """
-    calculate the number of seconds until a given clock time
-    The clock time should be the result of time.perf_counter()
+    Calculate the number of seconds until a given clock time.
+    The clock time should be the result of ``time.perf_counter()``.
     Does NOT wait for this time.
     """
     delay = finish_clock - time.perf_counter()
@@ -316,8 +320,8 @@ def wait_secs(finish_clock):
 class LogCapture():
 
     """
-    context manager to grab all log messages, optionally
-    from a specific logger
+    Context manager to grab all log messages, optionally
+    from a specific logger.
 
     usage::
 
@@ -354,8 +358,8 @@ class LogCapture():
 
 def make_unique(s, existing):
     """
-    make string s unique, able to be added to a sequence `existing` of
-    existing names without duplication, by appending _<int> to it if needed
+    Make string `s` unique, able to be added to a sequence `existing` of
+    existing names without duplication, by ``appending _<int>`` to it if needed.
     """
     n = 1
     s_out = s

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -375,28 +375,28 @@ def make_unique(s, existing):
 class DelegateAttributes:
     """
     Mixin class to create attributes of this object by
-    delegating them to one or more dicts and/or objects
+    delegating them to one or more dictionaries and/or objects.
 
-    Also fixes __dir__ so the delegated attributes will show up
-    in dir() and autocomplete
+    Also fixes ``__dir__`` so the delegated attributes will show up
+    in ``dir()`` and ``autocomplete``.
 
 
     Attributes:
-        delegate_attr_dicts (list): a list of names (strings) of dictionaries
-            which are (or will be) attributes of self, whose keys should
-            be treated as attributes of self
-        delegate_attr_objects (list): a list of names (strings) of objects
-            which are (or will be) attributes of self, whose attributes
-            should be passed through to self
-        omit_delegate_attrs (list): a list of attribute names (strings)
-            to *not* delegate to any other dict or object
+        delegate_attr_dicts (list): A list of names (strings) of dictionaries
+            which are (or will be) attributes of ``self``, whose keys should
+            be treated as attributes of ``self``.
+        delegate_attr_objects (list): A list of names (strings) of objects
+            which are (or will be) attributes of ``self``, whose attributes
+            should be passed through to ``self``.
+        omit_delegate_attrs (list): A list of attribute names (strings)
+            to *not* delegate to any other dictionary or object.
 
-    any `None` entry is ignored
+    Any ``None`` entry is ignored.
 
-    attribute resolution order:
-        1. real attributes of this object
-        2. keys of each dict in delegate_attr_dicts (in order)
-        3. attributes of each object in delegate_attr_objects (in order)
+    Attribute resolution order:
+        1. Real attributes of this object.
+        2. Keys of each dictionary in ``delegate_attr_dicts`` (in order).
+        3. Attributes of each object in ``delegate_attr_objects`` (in order).
     """
     delegate_attr_dicts: List[str] = []
     delegate_attr_objects: List[str] = []
@@ -455,12 +455,12 @@ class DelegateAttributes:
 
 def strip_attrs(obj, whitelist=()):
     """
-    Irreversibly remove all direct instance attributes of obj, to help with
+    Irreversibly remove all direct instance attributes of object, to help with
     disposal, breaking circular references.
 
     Args:
-        obj:  object to be stripped
-        whitelist (list): list of names that are not stripped from the object
+        obj: Object to be stripped.
+        whitelist (list): List of names that are not stripped from the object.
     """
     try:
         lst = set(list(obj.__dict__.keys())) - set(whitelist)
@@ -475,20 +475,23 @@ def strip_attrs(obj, whitelist=()):
         pass
 
 
-def compare_dictionaries(dict_1, dict_2,
-                         dict_1_name='d1',
-                         dict_2_name='d2', path=""):
+def compare_dictionaries(dict_1: Dict, dict_2: Dict,
+                         dict_1_name: Optional[str]='d1',
+                         dict_2_name: Optional[str]='d2',
+                         path: str="") -> Tuple[bool, str]:
     """
-    Compare two dictionaries recursively to find non matching elements
+    Compare two dictionaries recursively to find non matching elements.
 
     Args:
-        dict_1: dictionary 1
-        dict_2: dictionary 2
-        dict_1_name: optional name used in the differences string
-        dict_2_name: ''
+        dict_1: First dictionary to compare.
+        dict_2: Second dictionary to compare.
+        dict_1_name: Optional name of the first dictionary used in the
+                     differences string.
+        dict_2_name: Optional name of the second dictionary used in the
+                     differences string.
     Returns:
-        Tuple[bool, str]: Are the dicts equal and the difference rendered as
-        a string.
+        Tuple: Are the dicts equal and the difference rendered as
+               a string.
 
     """
     err = ''
@@ -553,7 +556,7 @@ def foreground_qt_window(window):
     as in the example below.
 
     Args:
-        window: handle to qt window to foreground
+        window: Handle to qt window to foreground.
     Examples:
         >>> Qtplot.qt_helpers.foreground_qt_window(plot.win)
     """
@@ -584,7 +587,7 @@ def add_to_spyder_UMR_excludelist(modulename: str):
     store global attributes such as default station, monitor and list of
     instruments. This "feature" can be disabled by the
     gui. Unfortunately this cannot be disabled in a natural way
-    programmatically so in this hack we replace the global __umr__ instance
+    programmatically so in this hack we replace the global ``__umr__`` instance
     with a new one containing the module we want to exclude. This will do
     nothing if Spyder is not found.
     TODO is there a better way to detect if we are in spyder?
@@ -628,14 +631,11 @@ def attribute_set_to(object_: Any, attribute_name: str, new_value: Any):
     manager.
 
     Args:
-        object_
-            The object which attribute value is to be changed
-        attribute_name
-            The name of the attribute that is to be changed
-        new_value
-            The new value to which the attribute of the object is to be changed
+        object_: The object which attribute value is to be changed.
+        attribute_name: The name of the attribute that is to be changed.
+        new_value: The new value to which the attribute of the object is
+                   to be changed.
     """
-
     old_value = getattr(object_, attribute_name)
     setattr(object_, attribute_name, new_value)
     try:
@@ -644,7 +644,7 @@ def attribute_set_to(object_: Any, attribute_name: str, new_value: Any):
         setattr(object_, attribute_name, old_value)
 
 
-def partial_with_docstring(func, docstring, **kwargs):
+def partial_with_docstring(func: Callable, docstring: str, **kwargs):
     """
     We want to have a partial function which will allow us access the docstring
     through the python built-in help function. This is particularly important
@@ -660,8 +660,8 @@ def partial_with_docstring(func, docstring, **kwargs):
     >>> help(g) # this will print an unhelpful message
 
     Args:
-        func (Callable)
-        docstring (str)
+        func: A function that its docstring will be accessed.
+        docstring: The docstring of the corresponding function.
     """
     ex = partial(func, **kwargs)
 
@@ -677,9 +677,9 @@ def create_on_off_val_mapping(on_val: Any = True, off_val: Any = False
                               ) -> Dict:
     """
     Returns a value mapping which maps inputs which reasonably mean "on"/"off"
-    to the specified on_val/off_val which are to be sent to the
+    to the specified ``on_val``/``off_val`` which are to be sent to the
     instrument. This value mapping is such that, when inverted,
-    on_val/off_val are mapped to boolean True/False.
+    ``on_val``/``off_val`` are mapped to boolean ``True``/``False``.
     """
     # Here are the lists of inputs which "reasonably" mean the same as
     # "on"/"off" (note that True/False values will be added below, and they
@@ -707,7 +707,8 @@ def create_on_off_val_mapping(on_val: Any = True, off_val: Any = False
 
 
 def abstractmethod(funcobj):
-    """A decorator indicating abstract methods.
+    """
+    A decorator indicating abstract methods.
 
     This is heavily inspired by the decorator of the same name in
     the ABC standard library. But we make our own version because
@@ -752,7 +753,7 @@ def checked_getattr(instance: Any,
                     attribute: str,
                     expected_type: Type[X]) -> X:
     """
-    Like `getattr` but raises type error if not of expected type.
+    Like ``getattr`` but raises type error if not of expected type.
     """
     attr: Any = getattr(instance, attribute)
     if not isinstance(attr, expected_type):

--- a/qcodes/utils/magic.py
+++ b/qcodes/utils/magic.py
@@ -16,24 +16,26 @@ class QCoDeSMagic(Magics):
     @line_cell_magic
     def measurement(self, line, cell=None):
         """
-        Create qcodes.Loop measurement mimicking Python `for` syntax via
+        Create ``qcodes.Loop`` measurement mimicking Python ``for`` syntax via
         iPython magic.
+
         Upon execution of a notebook cell, the code is transformed from the
         for loop structure to a QCoDeS Loop before being executed.
-        Can be run by having %%measurement in the first line of a cell,
-        followed by the measurement name (see below for an example)
+        Can be run by having ``%%measurement`` in the first line of a cell,
+        followed by the measurement name (see below for an example).
 
-        The for loop syntax differs slightly from a Python `for` loop,
-        as it uses `for {iterable}` instead of `for {element} in {iterable}`.
-        The reason is that `{element}` cannot be accessed (yet) in QCoDeS loops.
+        The for loop syntax differs slightly from a Python ``for`` loop,
+        as it uses ``for {iterable}`` instead of ``for {element} in {iterable}``.
+        The reason is that ``{element}`` cannot be accessed (yet) in QCoDeS loops.
 
         Comments (#) are ignored in the loop.
         Any code after the loop will also be run, if separated by a blank
         line from the loop.
-        The Loop object is by default stored in a variable named `loop`,
-        and the dataset in `data`, and these can be overridden using options.
+
+        The Loop object is by default stored in a variable named ``loop``,
+        and the dataset in ``data``, and these can be overridden using options.
         Must be run in a Jupyter Notebook.
-        Delays can be provided in a loop by adding `-d {delay}` after `for`
+        Delays can be provided in a loop by adding ``-d {delay}`` after ``for``.
 
         The following options can be passed along with the measurement name
         (e.g. ``%%measurement -px -d data_name {measurement_name})``::
@@ -142,12 +144,12 @@ class QCoDeSMagic(Magics):
 
 def register_magic_class(cls=QCoDeSMagic, magic_commands=True):
     """
-    Registers a iPython magic class
+    Registers a iPython magic class.
 
     Args:
-        cls: magic class to register
-        magic_commands (List): list of magic commands within the class to
-            register. If not specified, all magic commands are registered
+        cls: Magic class to register.
+        magic_commands (List): List of magic commands within the class to
+            register. If not specified, all magic commands are registered.
 
     """
 

--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -31,24 +31,24 @@ class Metadatable:
 
     def load_metadata(self, metadata):
         """
-        Load metadata into this classes metadata dict.
+        Load metadata into this classes metadata dictionary.
 
         Args:
-            metadata (dict): metadata to load
+            metadata (dict): Metadata to load.
         """
         deep_update(self.metadata, metadata)
 
-    def snapshot(self, update=False):
+    def snapshot(self, update: bool=False):
         """
         Decorate a snapshot dictionary with metadata.
         DO NOT override this method if you want metadata in the snapshot
         instead, override :meth:`snapshot_base`.
 
         Args:
-            update (bool): Passed to snapshot_base
+            update: Passed to snapshot_base.
 
         Returns:
-            dict: base snapshot
+            dict: Base snapshot.
         """
 
         snap = self.snapshot_base(update=update)
@@ -61,7 +61,7 @@ class Metadatable:
     def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None):
         """
-        override this with the primary information for a subclass
+        Override this with the primary information for a subclass.
         """
         return {}
 


### PR DESCRIPTION
This PR proposes fixes for the docstrings of:

- qcodes.utils.command
- qcodes.utils.deprecate
- qcodes.utils.helpers
- qcodes.utils.magic
- qcodes.utils.metadata

@astafan8
