### PR TITLE
Lakeshore 325: adding two attri: resistance and heater_output

### DIFF
--- a/docs/examples/driver_examples/Qcodes example with Lakeshore 325.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Lakeshore 325.ipynb
@@ -39,7 +39,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to: LSCI 325 (serial:LSA2251, firmware:1.8/1.1) in 0.15s\n"
+      "Connected to: LSCI 325 (serial:LSA2251, firmware:1.8/1.1) in 0.29s\n"
      ]
     }
    ],
@@ -3645,6 +3645,76 @@
     "lake.heater_1.setpoint(15.0)  # <- temperature \n",
     "live_plot_temperature_reading(lake.sensor_a, n_reads=400)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying the resistance and heater output "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "25"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# to get the resistance of the system (25 or 50 Ohm)\n",
+    "lake.heater_1.resistance()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "50"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# to set the resistance of the system (25 or 50 Ohm)\n",
+    "lake.heater_1.resistance(50)\n",
+    "lake.heater_1.resistance()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lake.heater_1.heater_output() # in %, 50 means 50%"
+   ]
   }
  ],
  "metadata": {
@@ -3663,7 +3733,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   },
   "nbsphinx": {
    "execute": "never"

--- a/docs/examples/driver_examples/Qcodes example with Lakeshore 325.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Lakeshore 325.ipynb
@@ -3713,76 +3713,9 @@
     }
    ],
    "source": [
+    "# output in percent (%) of current or power, depending on setting, which can be queried by lake.heater_1.output_metric()\n",
     "lake.heater_1.heater_output() # in %, 50 means 50%"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "25"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "lake.heater_1.resistance(25)\n",
-    "lake.heater_1.resistance()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'current'"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "lake.heater_1.output_metric()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Kelvin'"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "lake.heater_1.unit()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/examples/driver_examples/Qcodes example with Lakeshore 325.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Lakeshore 325.ipynb
@@ -39,7 +39,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Connected to: LSCI 325 (serial:LSA2251, firmware:1.8/1.1) in 0.29s\n"
+      "Connected to: LSCI 325 (serial:LSA2251, firmware:1.8/1.1) in 1.30s\n"
      ]
     }
    ],
@@ -3715,6 +3715,74 @@
    "source": [
     "lake.heater_1.heater_output() # in %, 50 means 50%"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "25"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lake.heater_1.resistance(25)\n",
+    "lake.heater_1.resistance()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'current'"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lake.heater_1.output_metric()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Kelvin'"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lake.heater_1.unit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/qcodes/instrument_drivers/Lakeshore/Model_325.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_325.py
@@ -361,7 +361,7 @@ class Model_325_Heater(InstrumentChannel):
 
         self.add_parameter(
             "unit",
-            vals=Enum("Kelvin", "Celsius", "Sensor Units"),
+            # vals=Enum("Kelvin", "Celsius", "Sensor Units"),
             val_mapping={
                 "Kelvin": "1",
                 "Celsius": "2",
@@ -378,7 +378,7 @@ class Model_325_Heater(InstrumentChannel):
 
         self.add_parameter(
             "output_metric",
-            vals=Enum("current", "power"),
+            # vals=Enum("current", "power"),
             val_mapping={
                 "current": "1",
                 "power": "2",
@@ -476,7 +476,7 @@ class Model_325_Heater(InstrumentChannel):
             "resistance",
             get_cmd=f"HTRRES? {self._loop}",
             set_cmd=f"HTRRES {self._loop} {{}}",
-            vals=Enum(25, 50),
+            # vals=Enum(25, 50),
             val_mapping={
                 25: 1,
                 50: 2,

--- a/qcodes/instrument_drivers/Lakeshore/Model_325.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_325.py
@@ -19,7 +19,7 @@ def read_curve_file(curve_file: TextIO) -> dict:
     curve data.
     """
 
-    def split_data_line(line: str, parser: type=str) -> List[str]:
+    def split_data_line(line: str, parser: type = str) -> List[str]:
         return [parser(i) for i in line.split("  ") if i != ""]
 
     def strip(strings: Iterable[str]) -> Tuple:
@@ -75,7 +75,7 @@ class Model_325_Curve(InstrumentChannel):
     valid_sensor_units = ["mV", "V", "Ohm", "log Ohm"]
     temperature_key = "Temperature (K)"
 
-    def __init__(self, parent: 'Model_325', index: int) ->None:
+    def __init__(self, parent: 'Model_325', index: int) -> None:
 
         self._index = index
         name = f"curve_{index}"
@@ -176,7 +176,7 @@ class Model_325_Curve(InstrumentChannel):
 
         return sensor_unit
 
-    def set_data(self, data_dict: dict, sensor_unit: str=None) ->None:
+    def set_data(self, data_dict: dict, sensor_unit: str = None) -> None:
         """
         Set the curve data according to the values found the the dictionary.
 
@@ -220,7 +220,7 @@ class Model_325_Sensor(InstrumentChannel):
         128: "sensor units overrang"
     }
 
-    def __init__(self, parent: 'Model_325', name: str, inp: str) ->None:
+    def __init__(self, parent: 'Model_325', name: str, inp: str) -> None:
 
         if inp not in ["A", "B"]:
             raise ValueError("Please either specify input 'A' or 'B'")
@@ -280,7 +280,7 @@ class Model_325_Sensor(InstrumentChannel):
             vals=Numbers(min_value=1, max_value=35)
         )
 
-    def decode_sensor_status(self, sum_of_codes: int) ->str:
+    def decode_sensor_status(self, sum_of_codes: int) -> str:
         """
         The sensor status is one of the status codes, or a sum thereof. Multiple
         status are possible as they are not necessarily mutually exclusive.
@@ -317,7 +317,7 @@ class Model_325_Sensor(InstrumentChannel):
         return terms
 
     @property
-    def curve(self) ->Model_325_Curve:
+    def curve(self) -> Model_325_Curve:
         parent = cast(Model_325, self.parent)
         return Model_325_Curve(parent,  self.curve_index())
 
@@ -331,7 +331,7 @@ class Model_325_Heater(InstrumentChannel):
         name (str)
         loop (int): Either 1 or 2
     """
-    def __init__(self, parent: 'Model_325', name: str, loop: int) ->None:
+    def __init__(self, parent: 'Model_325', name: str, loop: int) -> None:
 
         if loop not in [1, 2]:
             raise ValueError("Please either specify loop 1 or 2")
@@ -470,6 +470,24 @@ class Model_325_Heater(InstrumentChannel):
         self.add_parameter(
             "is_ramping",
             get_cmd=f"RAMPST? {self._loop}"
+        )
+
+        self.add_parameter(
+            "resistance",
+            get_cmd=f"HTRRES? {self._loop}",
+            set_cmd=f"HTRRES {self._loop} {{}}",
+            vals=Enum(25, 50),
+            val_mapping={
+                25: 1,
+                50: 2,
+            },
+            unit="Ohm"
+        )
+
+        self.add_parameter(
+            "heater_output",
+            get_cmd=f"HTR? {self._loop}",
+            get_parser=float
         )
 
 

--- a/qcodes/instrument_drivers/Lakeshore/Model_325.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_325.py
@@ -88,7 +88,6 @@ class Model_325_Curve(InstrumentChannel):
 
         self.add_parameter(
             "format",
-            vals=Enum(1, 2, 3, 4),
             val_mapping={
                 f"{unt}/K": i+1 for i, unt in enumerate(self.valid_sensor_units)
             },
@@ -102,7 +101,6 @@ class Model_325_Curve(InstrumentChannel):
 
         self.add_parameter(
             "coefficient",
-            vals=Enum(1, 2),
             val_mapping={
                 "negative": 1,
                 "positive": 2
@@ -232,7 +230,7 @@ class Model_325_Sensor(InstrumentChannel):
             'temperature',
             get_cmd='KRDG? {}'.format(self._input),
             get_parser=float,
-            label='Temerature',
+            label='Temperature',
             unit='K'
         )
 
@@ -361,7 +359,6 @@ class Model_325_Heater(InstrumentChannel):
 
         self.add_parameter(
             "unit",
-            # vals=Enum("Kelvin", "Celsius", "Sensor Units"),
             val_mapping={
                 "Kelvin": "1",
                 "Celsius": "2",
@@ -378,7 +375,6 @@ class Model_325_Heater(InstrumentChannel):
 
         self.add_parameter(
             "output_metric",
-            # vals=Enum("current", "power"),
             val_mapping={
                 "current": "1",
                 "power": "2",
@@ -476,18 +472,20 @@ class Model_325_Heater(InstrumentChannel):
             "resistance",
             get_cmd=f"HTRRES? {self._loop}",
             set_cmd=f"HTRRES {self._loop} {{}}",
-            # vals=Enum(25, 50),
             val_mapping={
                 25: 1,
                 50: 2,
             },
+            label='Resistance',
             unit="Ohm"
         )
 
         self.add_parameter(
             "heater_output",
             get_cmd=f"HTR? {self._loop}",
-            get_parser=float
+            get_parser=float,
+            label='Heater Output',
+            unit="%"
         )
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- In Lakeshore/Model_325.py  a new parameter "resistance" was added to obtain the resistance of the system
- In Lakeshore/Model_325.py, a new parameter "heater_output" was added to get the heater output (in %) of the system
- added examples to driver_examples/Qcodes example with Lakeshore 325.ipynb for the two new parameters
- minor formatting issue
@sohailc
