### PR TITLE
CI: Link commands in all scripts by their exit code, use mostly 'bash'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,53 +45,53 @@ jobs:
         displayName: "Add conda to PATH on Linux"
         condition: eq( variables['Agent.OS'], 'Linux' )
       - script: |
-          CALL conda update -n base conda -y
+          CALL conda update -n base conda -y &&
           CALL conda init --all
         displayName: "Conda setup on Windows"
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
       - bash: |
-          sudo conda update -n base conda -y
+          sudo conda update -n base conda -y &&
           sudo conda init bash
         displayName: "Conda setup on Linux"
         condition: eq( variables['Agent.OS'], 'Linux' )
       - bash: |
-          conda --version
-          conda env create --file environment.yml
-          source activate qcodes
-          pip install -r test_requirements.txt
-          pip install -r docs_requirements.txt
+          conda --version &&
+          conda env create --file environment.yml &&
+          source activate qcodes &&
+          pip install -r test_requirements.txt &&
+          pip install -r docs_requirements.txt &&
           pip install -e .
         displayName: "Install environment, qcodes"
       - bash: |
-          source activate qcodes
+          source activate qcodes &&
           mypy qcodes
         displayName: "mypy"
       - bash: |
-          source activate qcodes
-          cd ..
-          git clone https://github.com/QCoDeS/qcodes_generate_test_db.git
-          cd qcodes_generate_test_db
-          python generate_version_0.py
-          python generate_version_1.py
-          python generate_version_2.py
-          python generate_version_3.py
-          python generate_version_4a.py
-          python generate_version_4.py
-          python generate_version_5.py
-          python generate_version_6.py
+          source activate qcodes &&
+          cd .. &&
+          git clone https://github.com/QCoDeS/qcodes_generate_test_db.git &&
+          cd qcodes_generate_test_db &&
+          python generate_version_0.py &&
+          python generate_version_1.py &&
+          python generate_version_2.py &&
+          python generate_version_3.py &&
+          python generate_version_4a.py &&
+          python generate_version_4.py &&
+          python generate_version_5.py &&
+          python generate_version_6.py &&
           python generate_version_7.py
         displayName: "Generate db fixtures"
         condition: succeededOrFailed()
       - script: |
-          CALL C:\Miniconda\condabin\conda_hook.bat
-          CALL conda activate qcodes
-          cd qcodes
+          CALL C:\Miniconda\condabin\conda_hook.bat &&
+          CALL conda activate qcodes &&
+          cd qcodes &&
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc
         displayName: "Pytest on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))
       - bash: |
-          source activate qcodes
-          cd qcodes
+          source activate qcodes &&
+          cd qcodes &&
           xvfb-run --server-args="-screen 0 1024x768x24" pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc
         displayName: "Pytest on Linux"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Linux' ))
@@ -108,19 +108,20 @@ jobs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/qcodes/coverage.xml'
       - script: |
-          CALL C:\Miniconda\condabin\conda_hook.bat
-          CALL conda activate qcodes
-          cd docs
-          REM Turn warnings into errors
-          set SPHINXOPTS=-W -v
+          CALL C:\Miniconda\condabin\conda_hook.bat &&
+          CALL conda activate qcodes &&
+          cd docs &&
+          REM Turn warnings into errors &&
+          set SPHINXOPTS=-W -v &&
           make.bat htmlapi
         displayName: "Build docs on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))
       - script: |
-          source activate qcodes
-          cd docs
-          export SPHINXOPTS=-W -v
-          xvfb-run --server-args="-screen 0 1024x768x24" make htmlapi
+          source activate qcodes &&
+          cd docs &&
+          export SPHINXOPTS=-W -v &&
+          xvfb-run --server-args="-screen 0 1024x768x24" &&
+          make htmlapi
         displayName: "Build docs on Linux"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Linux' ))
       - task: PublishBuildArtifacts@1
@@ -131,15 +132,15 @@ jobs:
           artifactName: 'qcodes_docs'
           publishLocation: 'Container'
       - script: |
-          cd ..
-          git config --global user.email "bot"
-          git config --global user.name "Documentation Bot"
-          git clone --single-branch --branch gh-pages git@github.com:QCoDeS/Qcodes.git gh-pages-dir
-          cd gh-pages-dir
-          rm -rf ./*
-          cp $(Build.Repository.LocalPath)/docs/_build/html/. . -R
-          git add -A
-          git commit -m "Generated gh-pages for $(Build.SourceVersion)"
+          cd .. &&
+          git config --global user.email "bot" &&
+          git config --global user.name "Documentation Bot" &&
+          git clone --single-branch --branch gh-pages git@github.com:QCoDeS/Qcodes.git gh-pages-dir &&
+          cd gh-pages-dir &&
+          rm -rf ./* &&
+          cp $(Build.Repository.LocalPath)/docs/_build/html/. . -R &&
+          git add -A &&
+          git commit -m "Generated gh-pages for $(Build.SourceVersion)" &&
           git push
         displayName: "Publish docs to gh-pages"
         condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.Reason'], 'IndividualCI'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,7 +119,7 @@ jobs:
       - bash: |
           source activate qcodes &&
           cd docs &&
-          export SPHINXOPTS=-W -v &&
+          export SPHINXOPTS="-W -v" &&
           xvfb-run --server-args="-screen 0 1024x768x24" \
             make htmlapi
         displayName: "Build docs on Linux"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,8 @@ jobs:
       - bash: |
           source activate qcodes &&
           cd qcodes &&
-          xvfb-run --server-args="-screen 0 1024x768x24" pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc
+          xvfb-run --server-args="-screen 0 1024x768x24" \
+            pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc
         displayName: "Pytest on Linux"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Linux' ))
       - task: PublishTestResults@2
@@ -120,8 +121,8 @@ jobs:
           source activate qcodes &&
           cd docs &&
           export SPHINXOPTS=-W -v &&
-          xvfb-run --server-args="-screen 0 1024x768x24" &&
-          make htmlapi
+          xvfb-run --server-args="-screen 0 1024x768x24" \
+            make htmlapi
         displayName: "Build docs on Linux"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Linux' ))
       - task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,8 +83,7 @@ jobs:
         displayName: "Generate db fixtures"
         condition: succeededOrFailed()
       - bash: |
-          C:\Miniconda\condabin\conda_hook.bat &&
-          conda activate qcodes &&
+          source activate qcodes &&
           cd qcodes &&
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc
         displayName: "Pytest on Windows"
@@ -109,8 +108,7 @@ jobs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/qcodes/coverage.xml'
       - bash: |
-          C:\Miniconda\condabin\conda_hook.bat &&
-          conda activate qcodes &&
+          source activate qcodes &&
           cd docs &&
           `#Turn warnings into errors` &&
           set SPHINXOPTS=-W -v &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -107,11 +107,12 @@ jobs:
         inputs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/qcodes/coverage.xml'
-      - bash: |
-          source activate qcodes &&
-          cd docs &&
-          `#Turn warnings into errors` &&
-          set SPHINXOPTS=-W -v &&
+      - script: |
+          CALL C:\Miniconda\condabin\conda_hook.bat && ^
+          CALL conda activate qcodes && ^
+          cd docs && ^
+          REM Turn warnings into errors && ^
+          set SPHINXOPTS=-W -v && ^
           make.bat htmlapi
         displayName: "Build docs on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,9 +44,9 @@ jobs:
       - bash: echo "##vso[task.prependpath]/usr/share/miniconda/bin"
         displayName: "Add conda to PATH on Linux"
         condition: eq( variables['Agent.OS'], 'Linux' )
-      - script: |
-          CALL conda update -n base conda -y && ^
-          CALL conda init --all
+      - bash: |
+          conda update -n base conda -y &&
+          conda init --all
         displayName: "Conda setup on Windows"
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
       - bash: |
@@ -82,10 +82,10 @@ jobs:
           python generate_version_7.py
         displayName: "Generate db fixtures"
         condition: succeededOrFailed()
-      - script: |
-          CALL C:\Miniconda\condabin\conda_hook.bat && ^
-          CALL conda activate qcodes && ^
-          cd qcodes && ^
+      - bash: |
+          C:\Miniconda\condabin\conda_hook.bat &&
+          conda activate qcodes &&
+          cd qcodes &&
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc
         displayName: "Pytest on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))
@@ -107,16 +107,16 @@ jobs:
         inputs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/qcodes/coverage.xml'
-      - script: |
-          CALL C:\Miniconda\condabin\conda_hook.bat && ^
-          CALL conda activate qcodes && ^
-          cd docs && ^
-          REM Turn warnings into errors && ^
-          set SPHINXOPTS=-W -v && ^
+      - bash: |
+          C:\Miniconda\condabin\conda_hook.bat &&
+          conda activate qcodes &&
+          cd docs &&
+          REM Turn warnings into errors &&
+          set SPHINXOPTS=-W -v &&
           make.bat htmlapi
         displayName: "Build docs on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))
-      - script: |
+      - bash: |
           source activate qcodes &&
           cd docs &&
           export SPHINXOPTS=-W -v &&
@@ -131,7 +131,7 @@ jobs:
           pathtoPublish: 'docs/_build/html'
           artifactName: 'qcodes_docs'
           publishLocation: 'Container'
-      - script: |
+      - bash: |
           cd .. &&
           git config --global user.email "bot" &&
           git config --global user.name "Documentation Bot" &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
         displayName: "Add conda to PATH on Linux"
         condition: eq( variables['Agent.OS'], 'Linux' )
       - script: |
-          CALL conda update -n base conda -y &&
+          CALL conda update -n base conda -y && ^
           CALL conda init --all
         displayName: "Conda setup on Windows"
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
@@ -83,9 +83,9 @@ jobs:
         displayName: "Generate db fixtures"
         condition: succeededOrFailed()
       - script: |
-          CALL C:\Miniconda\condabin\conda_hook.bat &&
-          CALL conda activate qcodes &&
-          cd qcodes &&
+          CALL C:\Miniconda\condabin\conda_hook.bat && ^
+          CALL conda activate qcodes && ^
+          cd qcodes && ^
           pytest --junitxml=test-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc
         displayName: "Pytest on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))
@@ -108,11 +108,11 @@ jobs:
           codeCoverageTool: Cobertura
           summaryFileLocation: '$(System.DefaultWorkingDirectory)/qcodes/coverage.xml'
       - script: |
-          CALL C:\Miniconda\condabin\conda_hook.bat &&
-          CALL conda activate qcodes &&
-          cd docs &&
-          REM Turn warnings into errors &&
-          set SPHINXOPTS=-W -v &&
+          CALL C:\Miniconda\condabin\conda_hook.bat && ^
+          CALL conda activate qcodes && ^
+          cd docs && ^
+          REM Turn warnings into errors && ^
+          set SPHINXOPTS=-W -v && ^
           make.bat htmlapi
         displayName: "Build docs on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ jobs:
           C:\Miniconda\condabin\conda_hook.bat &&
           conda activate qcodes &&
           cd docs &&
-          REM Turn warnings into errors &&
+          `#Turn warnings into errors` &&
           set SPHINXOPTS=-W -v &&
           make.bat htmlapi
         displayName: "Build docs on Windows"


### PR DESCRIPTION
There have been cases where within a `bash` or `script` step one command would fail with non-0 exit code but the command after that would continue to execute. This is not desired because, for example, we don't want to run `mypy` if the `"qcodes"` environment wasn't activated.

In this PR, we use `&&` to glue commands together so that non-0 exit code prevents continuation of execution of a command sequence. Moreover, most of the `script` steps got converted to `bash` steps.