### PR TITLE
Add `Station.close_all_registered_instruments`

### DIFF
--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -275,9 +275,10 @@ class Station(Metadatable, DelegateAttributes):
         The instruments will stay registered as a component to the
         `Station`.
         """
-        for c in self.components.values():
-            if isinstance(c, Instrument):
-                c.close()
+        for k, v in self.components.items():
+            if isinstance(v, Instrument):
+                v.close()
+                self.remove_component(k)
 
     def load_config_file(self, filename: Optional[str] = None):
         """

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -266,7 +266,7 @@ class Station(Metadatable, DelegateAttributes):
     def close_all_registered_instruments(self) -> None:
         """
         Closes all instruments that are registered to this `Station`
-        object by calling the :meth:`Instrument.close`-method on
+        object by calling the :meth:`.base.Instrument.close`-method on
         each one.
         The instruments will stay registered as a component to the
         `Station`.

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -264,6 +264,13 @@ class Station(Metadatable, DelegateAttributes):
     delegate_attr_dicts = ['components']
 
     def close_all_registered_instruments(self) -> None:
+        """
+        Closes all instruments that are registered to this `Station`
+        object by calling the :meth:`Instrument.close`-method on
+        each one.
+        The instruments will stay registered as a component to the
+        `Station`.
+        """
         for k, v in self.components.items():
             if isinstance(v, Instrument):
                 inst = cast(Instrument, v)

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -263,7 +263,7 @@ class Station(Metadatable, DelegateAttributes):
 
     delegate_attr_dicts = ['components']
 
-    def close_all_instruments(self) -> None:
+    def close_all_registered_instruments(self) -> None:
         for k, v in self.components.items():
             if isinstance(v, Instrument):
                 inst = cast(Instrument, v)

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -275,10 +275,9 @@ class Station(Metadatable, DelegateAttributes):
         The instruments will stay registered as a component to the
         `Station`.
         """
-        for k, v in self.components.items():
-            if isinstance(v, Instrument):
-                inst = v
-                inst.close()
+        for c in self.components.values():
+            if isinstance(c, Instrument):
+                c.close()
 
     def load_config_file(self, filename: Optional[str] = None):
         """

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -273,7 +273,7 @@ class Station(Metadatable, DelegateAttributes):
         """
         for k, v in self.components.items():
             if isinstance(v, Instrument):
-                inst = cast(Instrument, v)
+                inst = v
                 inst.close()
 
     def load_config_file(self, filename: Optional[str] = None):

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -263,6 +263,12 @@ class Station(Metadatable, DelegateAttributes):
 
     delegate_attr_dicts = ['components']
 
+    def close_all_instruments(self) -> None:
+        for k, v in self.components.items():
+            if isinstance(v, Instrument):
+                inst = cast(Instrument, v)
+                inst.close()
+
     def load_config_file(self, filename: Optional[str] = None):
         """
         Loads a configuration from a YAML file. If `filename` is not specified

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -273,7 +273,7 @@ class Station(Metadatable, DelegateAttributes):
         The instruments will stay registered as a component to the
         `Station`.
         """
-        for k, v in self.components.items():
+        for k, v in tuple(self.components.items()):
             if isinstance(v, Instrument):
                 v.close()
                 self.remove_component(k)

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -133,6 +133,17 @@ def test_remove_component():
         _ = station.remove_component('bobby')
 
 
+def test_close_all_instruments():
+    names = [f'some_name_{i}' for i in range(10)]
+    instrs = [Instrument(name=name) for name in names]
+    st = Station(*instrs)
+    for name in names:
+        assert name in Instrument._all_instruments
+    st.close_all_instruments()
+    for name in names:
+        assert name not in Instrument._all_instruments
+
+
 def test_snapshot():
     station = Station()
 

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -133,13 +133,13 @@ def test_remove_component():
         _ = station.remove_component('bobby')
 
 
-def test_close_all_instruments():
+def test_close_all_registered_instruments():
     names = [f'some_name_{i}' for i in range(10)]
     instrs = [Instrument(name=name) for name in names]
     st = Station(*instrs)
     for name in names:
         assert name in Instrument._all_instruments
-    st.close_all_instruments()
+    st.close_all_registered_instruments()
     for name in names:
         assert name not in Instrument._all_instruments
 


### PR DESCRIPTION
Add a method to the Station that closes all instruments that have been registered as a component to the Station.
Open questions:
 - should Instruments also be removed from the station?