### PR TITLE
Station: fail hard when adding an `Instrument` with a name that is already registered

### DIFF
--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -13,7 +13,7 @@ from typing import Union
 import qcodes
 from qcodes.utils.metadata import Metadatable
 from qcodes.utils.helpers import (
-    make_unique, DelegateAttributes, YAML, checked_getattr)
+    DelegateAttributes, YAML, checked_getattr)
 
 from qcodes.instrument.base import Instrument, InstrumentBase
 from qcodes.instrument.parameter import (
@@ -184,7 +184,11 @@ class Station(Metadatable, DelegateAttributes):
         if name is None:
             name = getattr(component, 'name',
                            'component{}'.format(len(self.components)))
-        namestr = make_unique(str(name), self.components)
+        namestr = str(name)
+        if namestr in self.components.keys():
+            raise RuntimeError(
+                f'Cannot add component "{namestr}", because a '
+                'component of that name is already registered to the station')
         self.components[namestr] = component
         return namestr
 

--- a/qcodes/tests/test_helpers.py
+++ b/qcodes/tests/test_helpers.py
@@ -10,7 +10,7 @@ from unittest import TestCase
 import numpy as np
 
 from qcodes.utils.helpers import (is_sequence, permissive_range, wait_secs,
-                                  make_unique, DelegateAttributes,
+                                  DelegateAttributes,
                                   strip_attrs, full_class,
                                   named_repr, make_sweep, is_sequence_of,
                                   compare_dictionaries, NumpyJSONEncoder,
@@ -255,17 +255,6 @@ class TestWaitSecs(TestCase):
         self.assertEqual(secs_out, 0)
 
         self.assertEqual(logs.value.count('negative delay'), 1, logs.value)
-
-
-class TestMakeUnique(TestCase):
-    def test_no_changes(self):
-        for s, existing in (('a', []), ('a', {}), ('a', ('A', ' a', 'a '))):
-            self.assertEqual(make_unique(s, existing), s)
-
-    def test_changes(self):
-        self.assertEqual(make_unique('a', ('a',)), 'a_2')
-        self.assertEqual(make_unique('a_2', ('a_2',)), 'a_2_2')
-        self.assertEqual(make_unique('a', ('a', 'a_2', 'a_3')), 'a_4')
 
 
 class TestDelegateAttributes(TestCase):

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -352,22 +352,6 @@ class LogCapture():
             self.logger.addHandler(handler)
 
 
-def make_unique(s, existing):
-    """
-    make string s unique, able to be added to a sequence `existing` of
-    existing names without duplication, by appending _<int> to it if needed
-    """
-    n = 1
-    s_out = s
-    existing = set(existing)
-
-    while s_out in existing:
-        n += 1
-        s_out = '{}_{}'.format(s, n)
-
-    return s_out
-
-
 class DelegateAttributes:
     """
     Mixin class to create attributes of this object by


### PR DESCRIPTION
Currently, when adding an instrument to the `Station` with a name that has already been taken, the instrument will be renamed by `make_unique`.

This behavior is, imho, not acceptable, because the instrument name is the best inter process identifier for instruments that we have. Therefore the name may not change silently from the specified name.

This PR removes `make_unique` and raises an error if a name is already taken.

Warning: this might break existing scripts!