### PR TITLE
Extend `DelegateParameter` to handle `ParameterWithSetpoints`

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1159,7 +1159,7 @@ class DelegateParameterWithSetpoints(ParameterWithSetpoints):
     def __init__(self, name: str,
                  source: ParameterWithSetpoints,
                   *,
-                 vals: Validator = None,
+                 vals: Optional[Validator] = None,
                  setpoints: Optional[Sequence[_BaseParameter]] = None,
                  **kwargs) -> None:
 
@@ -1187,12 +1187,15 @@ class DelegateParameterWithSetpoints(ParameterWithSetpoints):
             ]
         else:
             delegate_setpoints = setpoints
+
         if vals is None:
-            vals = self.source.vals
+            delegate_vals = self.source.vals
+        else:
+            delegate_vals = vals
 
         super().__init__(
             name=name,
-            vals=vals,
+            vals=delegate_vals,
             setpoints=delegate_setpoints,
             **kwargs)
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1181,17 +1181,19 @@ class DelegateParameterWithSetpoints(ParameterWithSetpoints):
                 f'source parameter is supposed to be used.')
 
         if setpoints is None:
-            setpoints: Sequence[_BaseParameter] = [
+            delegate_setpoints: Sequence[_BaseParameter] = [
                 DelegateParameter('setpoints', source=setpoint)
                 for setpoint in self.source.setpoints
             ]
+        else:
+            delegate_setpoints = setpoints
         if vals is None:
             vals = self.source.vals
 
         super().__init__(
             name=name,
             vals=vals,
-            setpoints=setpoints,
+            setpoints=delegate_setpoints,
             **kwargs)
 
     def get_raw(self):

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -7,7 +7,7 @@ from typing import Optional
 import qcodes
 import qcodes.utils.validators as validators
 from qcodes.utils.helpers import get_qcodes_path
-from qcodes.instrument.parameter import DelegateParameter
+from qcodes.instrument.parameter import DelegateParameter, SimpleDelegateParameter
 from qcodes import Instrument
 from qcodes.station import Station
 from qcodes.instrument.parameter import Parameter
@@ -557,7 +557,7 @@ instruments:
     """)
     mock = st.load_instrument('mock')
     p = getattr(mock, 'gate_a')
-    assert isinstance(p, DelegateParameter)
+    assert isinstance(p, SimpleDelegateParameter)
     assert p.unit == 'mV'
     assert p.label == 'main gate'
     assert p.scale == 2
@@ -629,7 +629,3 @@ def test_monitor_not_loaded_if_specified(example_station_config):
     st = Station(config_file=example_station_config, use_monitor=False)
     st.load_instrument('mock_dac')
     assert Monitor.running is None
-
-
-
-


### PR DESCRIPTION
This PR intends to extend the existing `DelegateParameter` to also cover other parameter types (other than `Parameter`) including the ParameterWithSetpoints.

The current shortcoming is the access of Parameter properties and saving the DelegateParameter correctly to the DB.
