### PR TITLE
AMI430 test: fix flakiness from asserting timestamps of Parameters

### DIFF
--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -1,6 +1,7 @@
 import io
 import numpy as np
 import re
+import time
 import pytest
 from hypothesis import given, settings
 from hypothesis.strategies import floats
@@ -852,6 +853,10 @@ def test_change_ramp_rate_units_parameter(ami430, new_value, unit_string,
     field_unit = ami430.field.unit
     setpoint_unit = ami430.setpoint.unit
     coil_constant_timestamp = ami430.coil_constant.get_latest.get_timestamp()
+    # this prevents possible flakiness of the timestamp comparison
+    # later in the test that may originate from the not-enough resolution
+    # of the time function used in `Parameter` and `GetLatest` classes
+    time.sleep(1)
 
     ami430.ramp_rate_units(new_value)
 
@@ -885,6 +890,10 @@ def test_change_field_units_parameter(ami430, new_value, unit_string):
     current_ramp_limit_unit = ami430.current_ramp_limit.unit
     current_ramp_limit_scale = ami430.current_ramp_limit.scale
     coil_constant_timestamp = ami430.coil_constant.get_latest.get_timestamp()
+    # this prevents possible flakiness of the timestamp comparison
+    # later in the test that may originate from the not-enough resolution
+    # of the time function used in `Parameter` and `GetLatest` classes
+    time.sleep(1)
 
     ami430.field_units(new_value)
 

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -20,6 +20,8 @@ from qcodes.utils.types import numpy_concrete_ints, numpy_concrete_floats, \
     numpy_non_concrete_floats_instantiable
 
 
+_time_resolution = time.get_clock_info('time').resolution
+
 # If any of the field limit functions are satisfied we are in the safe zone.
 # We can have higher field along the z-axis if x and y are zero.
 field_limit = [
@@ -856,7 +858,7 @@ def test_change_ramp_rate_units_parameter(ami430, new_value, unit_string,
     # this prevents possible flakiness of the timestamp comparison
     # later in the test that may originate from the not-enough resolution
     # of the time function used in `Parameter` and `GetLatest` classes
-    time.sleep(1)
+    time.sleep(2 * _time_resolution)
 
     ami430.ramp_rate_units(new_value)
 
@@ -893,7 +895,7 @@ def test_change_field_units_parameter(ami430, new_value, unit_string):
     # this prevents possible flakiness of the timestamp comparison
     # later in the test that may originate from the not-enough resolution
     # of the time function used in `Parameter` and `GetLatest` classes
-    time.sleep(1)
+    time.sleep(2 * _time_resolution)
 
     ami430.field_units(new_value)
 


### PR DESCRIPTION
The `Parameter` uses `datetime.now()` to define a timestamp of when it's value was set. `datetime.now()` may not always provide good resolution, so adding a `time.sleep` to the test code is a quick solution for the flakiness.