### PR TITLE
Testing on python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache: pip
 addons:
   apt_packages:
     - pandoc
+    - libhdf5-dev # remove once h5py is packaged for 3.8
 
 python:
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ python:
 # we install here, although we uninstall below
 install:
     - pip install --upgrade pip
+    - pip install cython # this can go once we have scipy wheels for 3.8
     - pip install -r requirements.txt
     - pip install -r test_requirements.txt --upgrade --upgrade-strategy only-if-needed
     - pip install -r docs_requirements.txt
-    - pip install cython # this can go once we have scipy wheels for 3.8
     - pip install .
 
 before_script: # fetch full history so we can generate db fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ addons:
   apt_packages:
     - pandoc
     - libhdf5-dev # remove once h5py is packaged for 3.8
+    - gcc # this can go once we have scipy wheels for 3.8
+    - gfortran # this can go once we have scipy wheels for 3.8
+    - python-dev # this can go once we have scipy wheels for 3.8
+    - libopenblas-dev # this can go once we have scipy wheels for 3.8
+    - liblapack-dev # this can go once we have scipy wheels for 3.8
 
 python:
   - "3.6"
@@ -27,6 +32,7 @@ install:
     - pip install -r requirements.txt
     - pip install -r test_requirements.txt --upgrade --upgrade-strategy only-if-needed
     - pip install -r docs_requirements.txt
+    - pip install cython # this can go once we have scipy wheels for 3.8
     - pip install .
 
 before_script: # fetch full history so we can generate db fixtures

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,10 +72,12 @@ script:
       asv machine --machine travis
       asv dev --machine travis
     - cd ..
-    # build docs with warnings as errors
+    # build docs with warnings as errors. We skip the docs for python 3.8 until pyqt5 is available
     - |
-      cd docs
-      make SPHINXOPTS="-W -v" htmlapi
+      if [[ $TRAVIS_PYTHON_VERSION  != "3.8" ]]; then
+        cd docs
+        make SPHINXOPTS="-W -v" htmlapi
+      fi
     # rerun the tests from within a python session to ensure that all fixtures
     # are bundled correctly. To save time we only do this from python 3.6
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ notifications:
 
 cache: pip
 
+# remember to remove 3.8 related workarounds below once
+# 3.8 is released and wheels are available. Also change 3.8-dev to 3.8
+
 addons:
   apt_packages:
     - pandoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
 python:
   - "3.6"
   - "3.7"
+  - "3.8-dev"
   # whitelist
 
 # command to install dependencies and qcodes

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ script:
     - cd ..
     # build docs with warnings as errors. We skip the docs for python 3.8 until pyqt5 is available
     - |
-      if [[ $TRAVIS_PYTHON_VERSION  != "3.8" ]]; then
+      if [[ $TRAVIS_PYTHON_VERSION  != "3.8-dev" ]]; then
         cd docs
         make SPHINXOPTS="-W -v" htmlapi
       fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib==3.1.*
 pyqtgraph==0.10.0
 PyVISA==1.10
 h5py==2.9.0
-PyQt5==5.9.*
+PyQt5==5.9.*;python_version<'3.8' # there are currently no pyqt5 packages build for 3.8 on pypi
 QtPy
 jsonschema
 ruamel.yaml


### PR DESCRIPTION
Since its scheduled for release soon 
There are a few outstanding questions. 

- [ ] Most packages are not available as wheels yet so add a bunch of dependencies to build from source. This does initially take more time but caching should take care of this in the following builds.
- [ ] Pyqt5 is not available from pypi as whl or as source so skip it completely for 3.8
- [ ] Some docs examples require pyqt5 so skip building the docs for 3.8 for now
- [ ] There are a bunch of new deprecation warnings. I am planing on fixing these in a new pr