### PR TITLE
Dont use deprecated matplotlib cbar.get_clim

### DIFF
--- a/qcodes/utils/plotting.py
+++ b/qcodes/utils/plotting.py
@@ -150,7 +150,7 @@ def apply_color_scale_limits(colorbar: matplotlib.pyplot.colorbar,
         else:
             data_lim = cast(Tuple[float, float], tuple(sorted(data_lim)))
     # if `None` is provided in the new limits don't change this limit
-    vlim = [new or old for new, old in zip(new_lim, colorbar.get_clim())]
+    vlim = [new or old for new, old in zip(new_lim, colorbar.mappable.get_clim())]
     # sort limits in case they were given in a wrong order
     vlim = sorted(vlim)
     # detect exceeding colorscale and apply new limits


### PR DESCRIPTION
Use get_clim on the mappable as suggested here https://matplotlib.org/3.1.0/api/api_changes.html#colorbarbase-inheritance

This is already done below in the same function so no breakage with older matplotlib versions needs to be considered. 
