### PR TITLE
Fix `Station.close_all_registered_instruments` to also remove from Monitor

### DIFF
--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -270,13 +270,13 @@ class Station(Metadatable, DelegateAttributes):
         Closes all instruments that are registered to this `Station`
         object by calling the :meth:`.base.Instrument.close`-method on
         each one.
-        The instruments will stay registered as a component to the
-        `Station`.
+        The instruments will be removed from the station and from the
+        QCoDeS monitor.
         """
-        for k, v in tuple(self.components.items()):
-            if isinstance(v, Instrument):
-                v.close()
-                self.remove_component(k)
+        for c in tuple(self.components.values()):
+            if isinstance(c, Instrument):
+                self.close_and_remove_instrument(c)
+ 
 
     def load_config_file(self, filename: Optional[str] = None):
         """

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -276,7 +276,6 @@ class Station(Metadatable, DelegateAttributes):
         for c in tuple(self.components.values()):
             if isinstance(c, Instrument):
                 self.close_and_remove_instrument(c)
- 
 
     def load_config_file(self, filename: Optional[str] = None):
         """


### PR DESCRIPTION
This fixes the shortcoming of PR #1713, to also remove parameters from the monitor. 
