### PR TITLE
Use Mypy 0.730

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -87,7 +87,8 @@ from qcodes.dataset.sqlite.database import initialise_database, \
     initialise_or_create_database_at
 
 try:
-    get_ipython() # type: ignore # Check if we are in iPython
+    # Check if we are in iPython
+    get_ipython()  # type: ignore[name-defined]
     from qcodes.utils.magic import register_magic_class
     _register_magic = config.core.get('register_magic', False)
     if _register_magic is not False:
@@ -121,4 +122,4 @@ def test(**kwargs):
     return retcode
 
 
-test.__test__ = False  # type: ignore # Don't try to run this method as a test
+test.__test__ = False  # type: ignore[attr-defined] # Don't try to run this method as a test

--- a/qcodes/data/gnuplot_format.py
+++ b/qcodes/data/gnuplot_format.py
@@ -253,7 +253,7 @@ class GNUPlotFormat(Formatter):
 
     # this signature is unfortunatly incompatible with the super class
     # so we have to ignore type errors
-    def write(self,  # type: ignore
+    def write(self,  # type: ignore[override]
               data_set: 'DataSet',
               io_manager, location, force_write=False,
               write_metadata=True, only_complete=True,

--- a/qcodes/data/location.py
+++ b/qcodes/data/location.py
@@ -84,7 +84,7 @@ class FormatLocation:
         as '{date:%Y-%m-%d}' or '{counter:03}'
     """
 
-    default_fmt = qcodes.config['core']['default_fmt'] # type: ignore
+    default_fmt = qcodes.config['core']['default_fmt']  # type: ignore[index]
     # qcodes.__init__.py imports the Config class from the qcodes.config
     # module and overwrites qcodes.config with an instance of this class.
     # That confuses mypy so ignore the type above.

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -439,7 +439,7 @@ def _convert_complex_to_real(
     # out how to get mypy to correctly infer the type of iterated values
     # (the name, label, unit, and data above)
 
-    return new_parameters  # type: ignore
+    return new_parameters  # type: ignore[return-value]
 
 
 def _get_label_of_data(data_dict: Dict[str, Any]) -> str:

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -127,7 +127,7 @@ def connect(name: str, debug: bool = False,
     # register numpy->binary(TEXT) adapter
     # the typing here is ignored due to what we think is a flaw in typeshed
     # see https://github.com/python/typeshed/issues/2429
-    sqlite3.register_adapter(np.ndarray, _adapt_array)  # type: ignore
+    sqlite3.register_adapter(np.ndarray, _adapt_array)  # type: ignore[arg-type]
     # register binary(TEXT) -> numpy converter
     # for some reasons mypy complains about this
     sqlite3.register_converter("array", _convert_array)
@@ -159,7 +159,7 @@ def connect(name: str, debug: bool = False,
         sqlite3.register_adapter(numpy_float, _adapt_float)
 
     for complex_type in complex_types:
-        sqlite3.register_adapter(complex_type, _adapt_complex)  # type: ignore
+        sqlite3.register_adapter(complex_type, _adapt_complex)  # type: ignore[arg-type]
     sqlite3.register_converter("complex", _convert_complex)
 
     if debug:

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -816,7 +816,7 @@ class AutoLoadableChannelList(ChannelList):
             parent, name, chan_type, chan_list, snapshotable,
             multichan_paramclass
         )
-        new_channels = self._chan_type.load_from_instrument(  # type: ignore
+        new_channels = self._chan_type.load_from_instrument(  # type: ignore[attr-defined]
             self._parent, channel_list=self, **kwargs)
 
         self.extend(new_channels)
@@ -832,7 +832,7 @@ class AutoLoadableChannelList(ChannelList):
         Returns:
             Newly created instance of the channel class
         """
-        new_channel = self._chan_type.new_instance(  # type: ignore
+        new_channel = self._chan_type.new_instance(  # type: ignore[attr-defined]
             self._parent,
             create_on_instrument=True,
             channel_list=self,

--- a/qcodes/instrument/ip_to_visa.py
+++ b/qcodes/instrument/ip_to_visa.py
@@ -19,7 +19,7 @@ import qcodes.utils.validators as vals
 # Such a driver is just a two-line class definition.
 
 
-class IPToVisa(VisaInstrument, IPInstrument):  # type: ignore
+class IPToVisa(VisaInstrument, IPInstrument):  # type: ignore[misc]
     """
     Class to inject an VisaInstrument like behaviour in an
     IPInstrument that we'd like to use as a VISAInstrument with the
@@ -85,5 +85,5 @@ class IPToVisa(VisaInstrument, IPInstrument):  # type: ignore
 
 
 
-class AMI430_VISA(AMI430, IPToVisa): # type: ignore
+class AMI430_VISA(AMI430, IPToVisa): # type: ignore[misc]
     pass

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1735,15 +1735,15 @@ class CombinedParameter(Metadatable):
         self.parameter = lambda: None
         # mypy will complain that a callable does not have these attributes
         # but you can still create them here.
-        self.parameter.full_name = name  # type: ignore
-        self.parameter.name = name  # type: ignore
-        self.parameter.label = label  # type: ignore
+        self.parameter.full_name = name  # type: ignore[attr-defined]
+        self.parameter.name = name  # type: ignore[attr-defined]
+        self.parameter.label = label  # type: ignore[attr-defined]
 
         if units is not None:
             warn_units('CombinedParameter', self)
             if unit is None:
                 unit = units
-        self.parameter.unit = unit  # type: ignore
+        self.parameter.unit = unit  # type: ignore[attr-defined]
         self.setpoints: List[Any] = []
         # endhack
         self.parameters = parameters

--- a/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
+++ b/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
@@ -100,7 +100,7 @@ class DllWrapperMeta(type):
     # should not change the method signatures, but we need it here in order to
     # use the ``dll_path`` argument which the ``type`` superclass obviously
     # does not have in its ``__call__`` method.
-    def __call__(  # type: ignore
+    def __call__(  # type: ignore[override]
             cls,
             dll_path: str,
             *args,

--- a/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -111,10 +111,10 @@ class DacReader:
         for i in range(count):
             # Set DAC to point to address
             ret = int(self._dac_parse(
-                self.ask_raw(f"A{addr};")))  # type: ignore
+                self.ask_raw(f"A{addr};")))  # type: ignore[attr-defined]
             if ret != addr:
                 raise DACException(f"Failed to set EEPROM address {addr}.")
-            val += int(self._dac_parse(self.ask_raw(  # type: ignore
+            val += int(self._dac_parse(self.ask_raw(  # type: ignore[attr-defined]
                 query_command))) << (32*(count-i-1))
             addr += 1
 
@@ -157,13 +157,13 @@ class DacReader:
 
         # Write the value to the DAC
         # Set DAC to point to address
-        ret = int(self._dac_parse(self.ask_raw(f"A{addr};")))  # type: ignore
+        ret = int(self._dac_parse(self.ask_raw(f"A{addr};")))   # type: ignore[attr-defined]
         if ret != addr:
             raise DACException("Failed to set EEPROM address {}.".format(addr))
-        self.ask_raw("{}{};".format(write_command, val))  # type: ignore
+        self.ask_raw("{}{};".format(write_command, val))   # type: ignore[attr-defined]
         # Check the write was successful
         if int(self._dac_parse(
-                self.ask_raw(query_command))) != val:  # type: ignore
+                self.ask_raw(query_command))) != val:   # type: ignore[attr-defined]
             raise DACException(f"Failed to write value ({val}) to "
                                f"address {addr}.")
 

--- a/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -23,8 +23,8 @@ class PNASweep(ArrayParameter):
                          setpoints=((0,),),
                          **kwargs)
 
-    @property # type: ignore
-    def shape(self) -> Sequence[int]: # type: ignore
+    @property  # type: ignore[override]
+    def shape(self) -> Sequence[int]:  # type: ignore[override]
         if self._instrument is None:
             return (0,)
         return (self._instrument.root_instrument.points(),)
@@ -32,8 +32,8 @@ class PNASweep(ArrayParameter):
     def shape(self, val: Sequence[int]) -> None:
         pass
 
-    @property # type: ignore
-    def setpoints(self) -> Sequence: # type: ignore
+    @property  # type: ignore[override]
+    def setpoints(self) -> Sequence:  # type: ignore[override]
         if self._instrument is None:
             raise RuntimeError("Cannot return setpoints if not attached "
                                "to instrument")

--- a/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
+++ b/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
@@ -1,6 +1,6 @@
 import socket
 import select
-from msvcrt import kbhit, getch  # type: ignore
+from msvcrt import kbhit, getch  # type: ignore[attr-defined]
 import logging
 
 from qcodes.instrument_drivers.QuantumDesign.\

--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -62,7 +62,7 @@ class QtPlot(BasePlot):
     # close event on win but this is difficult with remote proxy process
     # as the list of plots lives in the main process and the plot locally
     # in a remote process
-    max_len = qcodes.config['gui']['pyqtmaxplots'] # type: ignore
+    max_len = qcodes.config['gui']['pyqtmaxplots']  # type: ignore[index]
     # qcodes.__init__.py imports the Config class from the qcodes.config
     # module and overwrites qcodes.config with an instance of this class.
     # That confuses mypy so ignore the type above.

--- a/qcodes/tests/drivers/test_lakeshore.py
+++ b/qcodes/tests/drivers/test_lakeshore.py
@@ -25,7 +25,7 @@ class MockVisaInstrument:
         # ignore this line in mypy: Mypy does not support mixins yet
         # and seen by itself with this class definition it does not make sense
         # to call __init__ on the super()
-        super().__init__(*args, **kwargs)  # type: ignore
+        super().__init__(*args, **kwargs)  # type: ignore[call-arg]
         self.visa_log = get_instrument_logger(self, VISA_LOGGER)
 
         # This base class mixin holds two dictionaries associated with the

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ pytest-cov
 pytest
 codacy-coverage
 hypothesis!=3.69.11 # due to bug in log capture
-mypy==0.720
+mypy==0.730
 git+https://github.com/QCoDeS/pyvisa-sim.git
 lxml
 codecov


### PR DESCRIPTION
This allows us to restrict ignore comments to only specific error codes. 

This has 2 benefits imho:

* We don't ignore any other errors than we should 
* This self documents why we need the ignore statements. 

For earlier versions of mypy this is simply ignored.
