### PR TITLE
Fix/group parameter initial value

### DIFF
--- a/qcodes/instrument/group_parameter.py
+++ b/qcodes/instrument/group_parameter.py
@@ -185,14 +185,15 @@ class Group:
                                for p in parameters]
         if any(have_initial_values):
             if not all(have_initial_values):
-                have_initial_values = [p.name for p in parameters
-                                       if p._initial_value is not None]
-                have_no_initial_values = [p.name for p in parameters
-                                          if p._initial_value is None]
+                params_with_initial_values = [p.name for p in parameters
+                                              if p._initial_value is not None]
+                params_without_initial_values = [p.name for p in parameters
+                                                 if p._initial_value is None]
                 error_msg = (f'Either none or all of the parameters in a '
                              f'group should have an initial value. Found '
-                             f'initial values for {have_initial_values} but '
-                             f'not for {have_no_initial_values}.')
+                             f'initial values for '
+                             f'{params_with_initial_values} but not for '
+                             f'{params_without_initial_values}.')
                 raise ValueError(error_msg)
 
             calling_dict = {name: p._initial_value

--- a/qcodes/instrument/group_parameter.py
+++ b/qcodes/instrument/group_parameter.py
@@ -200,6 +200,14 @@ class Group:
         calling_dict = {name: p.raw_value
                         for name, p in self.parameters.items()}
         calling_dict[set_parameter.name] = value
+
+        self._set_from_dict(calling_dict)
+
+    def _set_from_dict(self, calling_dict: Dict[str, Any]):
+        """
+        Use ``set_cmd`` to parse a dict that maps parameter names to parameter
+        values, and actually perform setting the values.
+        """
         if self.set_cmd is None:
             raise RuntimeError("Calling set but no `set_cmd` defined")
         command_str = self.set_cmd.format(**calling_dict)

--- a/qcodes/tests/test_group_parameter.py
+++ b/qcodes/tests/test_group_parameter.py
@@ -102,15 +102,15 @@ def test_raises_on_get_set_without_group():
 def test_initial_values():
     initial_a = 42
     initial_b = 43
-    dummy = Dummy("dummy2", initial_a=initial_a, initial_b=initial_b)
+    dummy = Dummy("dummy", initial_a=initial_a, initial_b=initial_b)
 
     assert dummy.a() == initial_a
     assert dummy.b() == initial_b
 
 def test_raise_on_not_all_initial_values():
 
-    expected_err_msg = (r'Either none or all of the group parameters should '
-                        r'have an initial value. Found initial values for '
-                        r'\[.*\] but not for \[.*\].')
+    expected_err_msg = (r'Either none or all of the parameters in a group '
+                        r'should have an initial value. Found initial values '
+                        r'for \[.*\] but not for \[.*\].')
     with pytest.raises(ValueError, match=expected_err_msg):
-        dummy = Dummy("dummy3", initial_a=42)
+        dummy = Dummy("dummy", initial_a=42)

--- a/qcodes/tests/test_group_parameter.py
+++ b/qcodes/tests/test_group_parameter.py
@@ -5,12 +5,14 @@ from typing import Optional
 from qcodes.instrument.group_parameter import GroupParameter, Group
 from qcodes import Instrument
 
+
 @pytest.fixture(autouse=True)
 def close_all_instruments():
     """Makes sure that after startup and teardown all instruments are closed"""
     Instrument.close_all()
     yield
     Instrument.close_all()
+
 
 class Dummy(Instrument):
     def __init__(self, name: str,
@@ -77,6 +79,7 @@ def test_sanity():
     assert dummy.a() == 3
     assert dummy.b() == 10
 
+
 def test_raise_on_get_set_cmd():
 
     for arg in ["set_cmd", "get_cmd"]:
@@ -87,6 +90,7 @@ def test_raise_on_get_set_cmd():
 
         assert str(e.value) == "A GroupParameter does not use 'set_cmd' or " \
                                "'get_cmd' kwarg"
+
 
 def test_raises_on_get_set_without_group():
     param = GroupParameter(name='b')
@@ -99,6 +103,7 @@ def test_raises_on_get_set_without_group():
         param.set(1)
     assert str(e.value) == "('Trying to set Group value but no group defined', 'setting b to 1')"
 
+
 def test_initial_values():
     initial_a = 42
     initial_b = 43
@@ -107,8 +112,8 @@ def test_initial_values():
     assert dummy.a() == initial_a
     assert dummy.b() == initial_b
 
-def test_raise_on_not_all_initial_values():
 
+def test_raise_on_not_all_initial_values():
     expected_err_msg = (r'Either none or all of the parameters in a group '
                         r'should have an initial value. Found initial values '
                         r'for \[.*\] but not for \[.*\].')

--- a/qcodes/tests/test_group_parameter.py
+++ b/qcodes/tests/test_group_parameter.py
@@ -5,6 +5,12 @@ from typing import Optional
 from qcodes.instrument.group_parameter import GroupParameter, Group
 from qcodes import Instrument
 
+@pytest.fixture(autouse=True)
+def close_all_instruments():
+    """Makes sure that after startup and teardown all instruments are closed"""
+    Instrument.close_all()
+    yield
+    Instrument.close_all()
 
 class Dummy(Instrument):
     def __init__(self, name: str,


### PR DESCRIPTION
Fixes #1730 .

Changes proposed in this pull request:
- Add initial_value kwarg to GroupParameter and appropriate logic for setting initial values for all parameters in a group, after the group has been created.

@astafan8 