### PR TITLE
Bugfix/parameter set to

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -119,6 +119,9 @@ class _SetParamContext:
         self._parameter = parameter
         self._original_value = self._parameter._latest["value"]
 
+        if self._original_value is None:
+            self._original_value = self._parameter.get()
+
     def __enter__(self):
         pass
 


### PR DESCRIPTION
There is a small bug in `parameter.set_to` that this PR fixes. 

The bug:

Have an instrument driver. 
Have a parameter, `p`, of that driver with a validator that does not accept `None`. 
Connect to instrument (now all parameters have `_latest["value"] == None`). 
Use `with p.set_to(some_valid_value):`. 
Get `ValueError` from the setter of `p` that `None` is invalid.

This PR fixes the bug by querying `p` in case `_latest["value"] == None`.

@QCoDeS/core 
