### PR TITLE
Disallow missing types for instrument base and visa

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,3 +12,9 @@ ignore_errors = True
 
 [mypy-qcodes._version]
 ignore_errors = True
+
+[mypy-qcodes.instrument.visa]
+disallow_untyped_defs = True
+
+[mypy-qcodes.instrument.base]
+disallow_untyped_defs = True

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -4,7 +4,7 @@ import weakref
 import logging
 from abc import ABC
 from typing import Sequence, Optional, Dict, Union, Callable, Any, List, \
-    TYPE_CHECKING, cast, Type
+    TYPE_CHECKING, cast, Type, TypeVar
 
 import numpy as np
 from qcodes.utils.helpers import DelegateAttributes, strip_attrs, full_class
@@ -45,9 +45,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             such as channel lists or logical groupings of parameters.
             Usually populated via ``add_submodule``.
     """
-
     def __init__(self, name: str,
-                 metadata: Optional[Dict] = None) -> None:
+                 metadata: Optional[dict] = None) -> None:
         self.name = str(name)
         self.short_name = str(name)
 
@@ -63,7 +62,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         self.log = get_instrument_logger(self, __name__)
 
     def add_parameter(self, name: str,
-                      parameter_class: type = Parameter, **kwargs) -> None:
+                      parameter_class: type = Parameter, **kwargs: Any) -> None:
         """
         Bind one Parameter to this instrument.
 
@@ -92,7 +91,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         param = parameter_class(name=name, instrument=self, **kwargs)
         self.parameters[name] = param
 
-    def add_function(self, name: str, **kwargs) -> None:
+    def add_function(self, name: str, **kwargs: Any) -> None:
         """
         Bind one ``Function`` to this instrument.
 
@@ -304,7 +303,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         return name_parts
 
     @property
-    def full_name(self):
+    def full_name(self) -> str:
         return "_".join(self.name_parts)
     #
     # shortcuts to parameters & setters & getters                           #
@@ -345,7 +344,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         """
         return self.parameters[param_name].get()
 
-    def call(self, func_name: str, *args) -> Any:
+    def call(self, func_name: str, *args: Any) -> Any:
         """
         Shortcut for calling a function from its name.
 
@@ -358,7 +357,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         """
         return self.functions[func_name].call(*args)
 
-    def __getstate__(self):
+    def __getstate__(self) -> None:
         """Prevent pickling instruments, and give a nice error message."""
         raise RuntimeError(
             'Pickling {}. qcodes Instruments should not.'.format(self.name) +
@@ -504,11 +503,11 @@ class Instrument(InstrumentBase, AbstractInstrument):
         print(con_msg)
         self.log.info(f"Connected to instrument: {idn}")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Simplified repr giving just the class and name."""
         return '<{}: {}>'.format(type(self).__name__, self.name)
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Close the instrument and remove its instance record."""
         try:
             wr = weakref.ref(self)
@@ -784,9 +783,9 @@ class Instrument(InstrumentBase, AbstractInstrument):
 
 def find_or_create_instrument(instrument_class: Type[Instrument],
                               name: str,
-                              *args,
+                              *args: Any,
                               recreate: bool = False,
-                              **kwargs
+                              **kwargs: Any
                               ) -> Instrument:
     """
     Find an instrument with the given name of a given class, or create one if

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -4,7 +4,7 @@ import weakref
 import logging
 from abc import ABC
 from typing import Sequence, Optional, Dict, Union, Callable, Any, List, \
-    TYPE_CHECKING, cast, Type, TypeVar
+    TYPE_CHECKING, cast, Type
 
 import numpy as np
 from qcodes.utils.helpers import DelegateAttributes, strip_attrs, full_class

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -1,5 +1,5 @@
 """Visa instrument driver based on pyvisa."""
-from typing import Sequence, Optional, Dict, Union
+from typing import Sequence, Optional, Dict, Union, Any
 import warnings
 import logging
 
@@ -47,7 +47,7 @@ class VisaInstrument(Instrument):
 
     def __init__(self, name: str, address: str, timeout: Union[int, float] = 5,
                  terminator: str = '', device_clear: bool = True,
-                 visalib: Optional[str] = None, **kwargs):
+                 visalib: Optional[str] = None, **kwargs: Any):
 
         super().__init__(name, **kwargs)
         self.visa_log = get_instrument_logger(self, VISA_LOGGER)
@@ -92,7 +92,7 @@ class VisaInstrument(Instrument):
         self.set_terminator(terminator)
         self.timeout.set(timeout)
 
-    def set_address(self, address: str):
+    def set_address(self, address: str) -> None:
         """
         Set the address for this instrument.
 
@@ -143,7 +143,7 @@ class VisaInstrument(Instrument):
                 self.visa_log.warning(
                     f"Cleared visa buffer with status code {status_code}")
 
-    def set_terminator(self, terminator: str):
+    def set_terminator(self, terminator: str) -> None:
         r"""
         Change the read terminator to use.
 
@@ -158,7 +158,7 @@ class VisaInstrument(Instrument):
         if self.visabackend == 'sim':
             self.visa_handle.write_termination = terminator
 
-    def _set_visa_timeout(self, timeout: Optional[Union[float, int]]):
+    def _set_visa_timeout(self, timeout: Optional[Union[float, int]]) -> None:
 
         if timeout is None:
             self.visa_handle.timeout = None
@@ -181,7 +181,7 @@ class VisaInstrument(Instrument):
             self.visa_handle.close()
         super().close()
 
-    def check_error(self, ret_code: int):
+    def check_error(self, ret_code: int) -> None:
         """
         Default error checking, raises an error if return code ``!=0``.
 
@@ -200,7 +200,7 @@ class VisaInstrument(Instrument):
         if ret_code != 0:
             raise visa.VisaIOError(ret_code)
 
-    def write_raw(self, cmd: str):
+    def write_raw(self, cmd: str) -> None:
         """
         Low-level interface to ``visa_handle.write``.
 


### PR DESCRIPTION
Since these are core parts of qcodes. 