### PR TITLE
explicitly install attrs 

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,3 +10,4 @@ codecov
 asv
 gitpython
 pylint
+attrs>=19.2.0 # needed for hypothesis >=4.38.1 but not correctly honored by pip 19.2.3


### PR DESCRIPTION
to workaround  what seems to be a bug in pip (19.2.3)

