### PR TITLE
Parameter set to improvements

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -115,15 +115,16 @@ class _SetParamContext:
     >>> assert abs(dac.voltage() - v) <= tolerance
 
     """
-    def __init__(self, parameter):
+    def __init__(self, parameter: "Parameter", value: Any):
         self._parameter = parameter
+        self._value = value
         self._original_value = self._parameter._latest["value"]
 
         if self._original_value is None:
-            self._original_value = self._parameter.get()
+            self._original_value = self._parameter.get()  # type: ignore
 
     def __enter__(self):
-        pass
+        self._parameter.set(self._value)
 
     def __exit__(self, typ, value, traceback):
         self._parameter.set(self._original_value)
@@ -805,8 +806,7 @@ class _BaseParameter(Metadatable):
         ...    print(f"p value in with block {p.get()}")
         >>> print(f"p value outside with block {p.get()}")
         """
-        context_manager = _SetParamContext(self)
-        self.set(value)
+        context_manager = _SetParamContext(self, value)
         return context_manager
 
     @property

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -120,14 +120,18 @@ class _SetParamContext:
         self._value = value
         self._original_value = self._parameter._latest["value"]
 
-        if self._original_value is None:
+        self._value_is_changing = self._value != self._original_value
+
+        if self._original_value is None and self._value_is_changing:
             self._original_value = self._parameter.get()  # type: ignore
 
     def __enter__(self):
-        self._parameter.set(self._value)
+        if self._value_is_changing:
+            self._parameter.set(self._value)
 
     def __exit__(self, typ, value, traceback):
-        self._parameter.set(self._original_value)
+        if self._value_is_changing:
+            self._parameter.set(self._original_value)
 
 
 def invert_val_mapping(val_mapping: Dict) -> Dict:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -123,7 +123,7 @@ class _SetParamContext:
         self._value_is_changing = self._value != self._original_value
 
         if self._original_value is None and self._value_is_changing:
-            self._original_value = self._parameter.get()  # type: ignore
+            self._original_value = self._parameter.get()  # type: ignore[has-type]
 
     def __enter__(self):
         if self._value_is_changing:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -119,6 +119,9 @@ class _SetParamContext:
         self._parameter = parameter
         self._original_value = self._parameter._latest["value"]
 
+        if self._original_value is None:
+            self._original_value = self._parameter.get()
+
     def __enter__(self):
         pass
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1192,11 +1192,41 @@ class TestSetContextManager(TestCase):
 
     def setUp(self):
         self.instrument = DummyInstrument('dummy_holder')
-        self.instrument.add_parameter(
-            "a",
-            set_cmd=None,
-            get_cmd=None
-        )
+
+        self.instrument.add_parameter("a",
+                                      set_cmd=None,
+                                      get_cmd=None)
+
+        # These two parameters mock actual instrument parameters; when first
+        # connecting to the instrument, they have the _latest["value"] None.
+        # We must call get() on them to get a valid value that we can set
+        # them to in the __exit__ method of the context manager
+        self.instrument.add_parameter("validated_param",
+                                      set_cmd=self._vp_setter,
+                                      get_cmd=self._vp_getter,
+                                      vals=vals.Enum("foo", "bar"))
+
+        self.instrument.add_parameter("parsed_param",
+                                      set_cmd=self._pp_setter,
+                                      get_cmd=self._pp_getter,
+                                      set_parser=int)
+
+        # the mocked instrument state values of validated_param and
+        # parsed_param
+        self._vp_value = "foo"
+        self._pp_value = 42
+
+    def _vp_getter(self):
+        return self._vp_value
+
+    def _vp_setter(self, value):
+        self._vp_value = value
+
+    def _pp_getter(self):
+        return self._pp_value
+
+    def _pp_setter(self, value):
+        self._pp_value = value
 
     def tearDown(self):
         self.instrument.close()
@@ -1213,6 +1243,20 @@ class TestSetContextManager(TestCase):
         with self.instrument.a.set_to(3):
             assert self.instrument.a.get() == 3
         assert self.instrument.a.get() == 2
+
+    def test_validated_param(self):
+        assert self.instrument.validated_param.get_latest() is None
+        with self.instrument.validated_param.set_to("bar"):
+            assert self.instrument.validated_param.get() == "bar"
+        assert self.instrument.validated_param.get_latest() == "foo"
+        assert self.instrument.validated_param.get() == "foo"
+
+    def test_parsed_param(self):
+        assert self.instrument.parsed_param.get_latest() is None
+        with self.instrument.parsed_param.set_to(1):
+            assert self.instrument.parsed_param.get() == 1
+        assert self.instrument.parsed_param.get_latest() == 42
+        assert self.instrument.parsed_param.get() == 42
 
 
 def test_deprecated_param_warns():

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1280,11 +1280,11 @@ class TestSetContextManager(TestCase):
 
         with self.instrument.counting_parameter.set_to(2):
             pass
-        assert self._cp_counter ==3
+        assert self._cp_counter == 3
 
         with self.instrument.counting_parameter.set_to(1):
             pass
-        assert self._cp_counter ==3
+        assert self._cp_counter == 3
 
 
 def test_deprecated_param_warns():


### PR DESCRIPTION
This PR fixes a bug in `parameter.set_to` and reduces the amount of instrument communication (calls to `parameter.set`) that happens in the context manager.

The bugfix: if a parameter has been initialized, but not yet gotten, it will have a `_latest["value"]` of `None`. When exiting the context manager, the value that the parameter is restored to  should not be `None`, but instead the result of `parameter.get`.

The improvement: if `parameter` has value `X`, then `with parameter.set_to(X)` is now a NOOP.

The improvement allows us to write parameter getters that hinge on other parameters without introducing unnecessary communication. An example (simplified) for a DMM that can be in voltage or current mode:
```python
def _voltage_getter(self):
    with self.mode.set_to("voltage"):
        value = self.ask("READ?")
    return value

def _current_getter(self):
    with self.mode.set_to("current"):
        value = self.ask("READ?")
    return value
```
Imagine getting the voltage or current in a tight loop. In that case, we do not want the communication to be
```
MODE:VOLTAGE
READ?
MODE:VOLTAGE
```
for each get call.

@QCoDeS/core 