### PR TITLE
Ensure that get_latest will call get on a parameter

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1642,8 +1642,8 @@ class GetLatest(DelegateAttributes):
     Wrapper for a class:`.Parameter` that just returns the last set or measured
     value stored in the class:`.Parameter` itself. If get has never been called
     on the parameter or the time since get was called is larger than
-    ``max_val_age`` get will be called on the parameter. If the parameter
-    does not implement get set should be called (or the initial_value set)
+    ``max_val_age``, get will be called on the parameter. If the parameter
+    does not implement get, set should be called (or the initial_value set)
     before calling get on this wrapper. It is an error
     to set ``max_val_age`` for a parameter that does not have a get function.
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1666,15 +1666,15 @@ class GetLatest(DelegateAttributes):
 
         # the parameter has never been captured so do this
         # unconditionally
-        if state['value'] is None and state['ts'] is None and state['raw_value'] is None:
-            self.parameter.get()
+        if state['ts'] is None:
+            return self.parameter.get()
 
         if self.max_val_age is None:
             # Return last value since max_val_age is not specified
             return state['value']
         else:
             oldest_ok_val = datetime.now() - timedelta(seconds=self.max_val_age)
-            if state['ts'] is None or state['ts'] < oldest_ok_val:
+            if state['ts'] < oldest_ok_val:
                 # Time of last get exceeds max_val_age seconds, need to
                 # perform new .get()
                 return self.parameter.get()

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1650,7 +1650,7 @@ class GetLatest(DelegateAttributes):
             additional measurement.
     """
     def __init__(self, parameter: _BaseParameter,
-                 max_val_age: Number = None):
+                 max_val_age: Optional[Number] = None):
         self.parameter = parameter
         self.max_val_age = max_val_age
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -946,17 +946,25 @@ class Parameter(_BaseParameter):
     """
 
     def __init__(self, name: str,
-                 instrument: Optional['InstrumentBase']=None,
-                 label: Optional[str]=None,
-                 unit: Optional[str]=None,
-                 get_cmd: Optional[Union[str, Callable, bool]]=None,
-                 set_cmd:  Optional[Union[str, Callable, bool]]=False,
-                 initial_value: Optional[Union[float, int, str]]=None,
-                 max_val_age: Optional[float]=None,
-                 vals: Optional[Validator]=None,
-                 docstring: Optional[str]=None,
+                 instrument: Optional['InstrumentBase'] = None,
+                 label: Optional[str] = None,
+                 unit: Optional[str] = None,
+                 get_cmd: Optional[Union[str, Callable, bool]] = None,
+                 set_cmd:  Optional[Union[str, Callable, bool]] = False,
+                 initial_value: Optional[Union[float, int, str]] = None,
+                 max_val_age: Optional[float] = None,
+                 vals: Optional[Validator] = None,
+                 docstring: Optional[str] = None,
                  **kwargs) -> None:
-        super().__init__(name=name, instrument=instrument, vals=vals, **kwargs)
+        super().__init__(name=name, instrument=instrument, vals=vals,
+                         max_val_age=max_val_age, **kwargs)
+
+        no_get = not hasattr(self, 'get') and (get_cmd is None
+                                               or get_cmd is False)
+
+        if max_val_age is not None and no_get:
+            raise SyntaxError('Must have get method or specify get_cmd '
+                              'when max_val_age is set')
 
         # Enable set/get methods from get_cmd/set_cmd if given and
         # no `get`/`set` or `get_raw`/`set_raw` methods have been defined
@@ -965,9 +973,6 @@ class Parameter(_BaseParameter):
         # get/set methods)
         if not hasattr(self, 'get') and get_cmd is not False:
             if get_cmd is None:
-                if max_val_age is not None:
-                    raise SyntaxError('Must have get method or specify get_cmd '
-                                      'when max_val_age is set')
                 self.get_raw = lambda: self._latest['raw_value']
             else:
                 exec_str_ask = getattr(instrument, "ask", None) if instrument else None

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1676,7 +1676,7 @@ class GetLatest(DelegateAttributes):
         """
         state = self.parameter._latest
 
-        # the parameter has never been captured so do this
+        # the parameter has never been captured so `get` it
         # unconditionally
         if state['ts'] is None:
             if not hasattr(self.parameter, 'get'):

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -223,6 +223,29 @@ class TestParameter(TestCase):
         self.assertEqual(local_parameter.get_latest(), 2)
         self.assertGreater(local_parameter.get_latest.get_timestamp(), after_set)
 
+    def test_get_latest_no_get(self):
+        """
+        Test that get_latest on a parameter that does not have get is handled
+        correctly.
+        """
+        local_parameter = Parameter('test_param', set_cmd=None, get_cmd=False)
+        # The parameter does not have a get method.
+        with self.assertRaises(AttributeError):
+            local_parameter.get()
+        # get_latest will fail as get cannot be called and no cache
+        # is available
+        with self.assertRaises(RuntimeError):
+            local_parameter.get_latest()
+        value = 1
+        local_parameter.set(value)
+        assert local_parameter.get_latest() == value
+
+        local_parameter2 = Parameter('test_param2', set_cmd=None,
+                                     get_cmd=False, initial_value=value)
+        with self.assertRaises(AttributeError):
+            local_parameter2.get()
+        assert local_parameter2.get_latest() == value
+
     def test_has_set_get(self):
         # Create parameter that has no set_cmd, and get_cmd returns last value
         gettable_parameter = Parameter('one', set_cmd=False, get_cmd=None)

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1345,14 +1345,16 @@ class TestSetContextManager(TestCase):
         assert self.instrument.a.get() == 2
 
     def test_validated_param(self):
-        assert self.instrument.validated_param.get_latest() is None
+        assert self.instrument.parsed_param._latest['value'] is None
+        assert self.instrument.validated_param.get_latest() == "foo"
         with self.instrument.validated_param.set_to("bar"):
             assert self.instrument.validated_param.get() == "bar"
         assert self.instrument.validated_param.get_latest() == "foo"
         assert self.instrument.validated_param.get() == "foo"
 
     def test_parsed_param(self):
-        assert self.instrument.parsed_param.get_latest() is None
+        assert self.instrument.parsed_param._latest['value'] is None
+        assert self.instrument.parsed_param.get_latest() == 42
         with self.instrument.parsed_param.set_to(1):
             assert self.instrument.parsed_param.get() == 1
         assert self.instrument.parsed_param.get_latest() == 42

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -336,9 +336,9 @@ class TestParameter(TestCase):
                           get_cmd=False,
                           max_val_age=1, initial_value=value)
 
-        # _BaseParameter does not have this check since get_cmd could be added
-        # in a subclass. Here we create a subclass that does not and
-        # also does not check that max_val_age is None
+        # _BaseParameter does not have this check on creation time since get_cmd could be added
+        # in a subclass. Here we create a subclass that does add a get command and alsoo does 
+        # not implement the check for max_val_age
         class LocalParameter(_BaseParameter):
 
             def __init__(self, *args, **kwargs):

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -285,6 +285,33 @@ class TestParameter(TestCase):
             local_parameter2.get()
         assert local_parameter2.get_latest() == value
 
+    def test_no_get_max_val_age(self):
+        """
+        Test that get_latest on a parameter with max_val_age set and
+        no get cmd raises correctly.
+        """
+        value = 1
+        with self.assertRaises(SyntaxError):
+            _ = Parameter('test_param', set_cmd=None,
+                          get_cmd=False,
+                          max_val_age=1, initial_value=value)
+        # _BaseParameter does not have this check since get_cmd could be added
+        # in a subclass. Here we create a subclass that does not and
+        # also does not check that max_val_age is None
+        class LocalParameter(_BaseParameter):
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.set_raw = partial(self._save_val, validate=False)
+                self.set = self._wrap_set(self.set_raw)
+
+        localparameter = LocalParameter('test_param',
+                                        None,
+                                        max_val_age=1,
+                                        initial_value=value)
+        with self.assertRaises(RuntimeError):
+            localparameter.get_latest()
+
     def test_has_set_get(self):
         # Create parameter that has no set_cmd, and get_cmd returns last value
         gettable_parameter = Parameter('one', set_cmd=False, get_cmd=None)


### PR DESCRIPTION
If the parameter has never been captured it seems like `get_latest` should also call `get`

This is draft due to the missing tests
