### PR TITLE
Bump installed versions of numpy and pyvisa

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,10 +4,10 @@ channels:
 dependencies:
  - python=3.7.4
  - pip
- - numpy=1.16.4 # numpy 1.16.0 .. 1.16.2 may fail our tests due to https://github.com/numpy/numpy/issues/13089
+ - numpy=1.16.5 # numpy 1.16.0 .. 1.16.2 may fail our tests due to https://github.com/numpy/numpy/issues/13089
  - matplotlib=3.1
  - pyqtgraph=0.10.0
- - conda-forge::pyvisa=1.10
+ - conda-forge::pyvisa=1.10.1
  - h5py=2.9.0
  - pyqt=5.9
  - QtPy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-numpy==1.16.4 # numpy 1.16.0 .. 1.16.2 may fail our tests due to https://github.com/numpy/numpy/issues/13089
+numpy==1.16.5 # numpy 1.16.0 .. 1.16.2 may fail our tests due to https://github.com/numpy/numpy/issues/13089
 matplotlib==3.1.*
 pyqtgraph==0.10.0
-PyVISA==1.10
+PyVISA==1.10.1
 h5py==2.9.0
 PyQt5==5.9.*;python_version<'3.8' # there are currently no pyqt5 packages build for 3.8 on pypi
 QtPy


### PR DESCRIPTION
Install the latest patch release of numpy on the 1.16 branch and the latest version of pyvisa.


Note that h5py 2.10 and numpy 1.17 have been released. However they are not packaged in the default channel for conda so I have left them off for now. 
