### PR TITLE
make snapshot base signatures consistent

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1865,7 +1865,8 @@ class CombinedParameter(Metadatable):
         # i.e. how many setpoint
         return numpy.shape(self.setpoints)[0]
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update=False,
+                      params_to_skip_update=None):
         """
         State of the combined parameter as a JSON-compatible dict (everything that
         the custom JSON encoder class :class:`qcodes.utils.helpers.NumpyJSONEncoder`

--- a/qcodes/instrument/sweep_values.py
+++ b/qcodes/instrument/sweep_values.py
@@ -245,12 +245,14 @@ class SweepFixedValues(SweepValues):
             if 'first' in snap and 'last' in snap:
                 snap['last'], snap['first'] = snap['first'], snap['last']
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update=False,
+                      params_to_skip_update=None):
         """
         Snapshot state of SweepValues.
 
         Args:
             update (bool): Place holder for API compatibility.
+            params_to_skip_update: Place holder for API compatibility.
 
         Returns:
             dict: base snapshot

--- a/qcodes/loops.py
+++ b/qcodes/loops.py
@@ -45,7 +45,7 @@ Supported commands to .set_measurement or .each are:
     - Task: any callable that does not generate data
     - Wait: a delay
 """
-
+from typing import Optional, Sequence
 from datetime import datetime
 import logging
 import time
@@ -285,7 +285,8 @@ class Loop(Metadatable):
         """
         return _attach_then_actions(self._copy(), actions, overwrite)
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update: bool = False,
+                      params_to_skip_update: Optional[Sequence[str]] = None):
         """
         State of the loop as a JSON-compatible dict (everything that
         the custom JSON encoder class :class:'qcodes.utils.helpers.NumpyJSONEncoder'
@@ -295,6 +296,7 @@ class Loop(Metadatable):
             update (bool): If True, update the state by querying the underlying
                 sweep_values and actions. If False, just use the latest values
                 in memory.
+            params_to_skip_update: Unused in this implementation.
 
         Returns:
             dict: base snapshot
@@ -424,7 +426,8 @@ class ActiveLoop(Metadatable):
         """
         return _attach_bg_task(self, task, bg_final_task, min_delay)
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update=False,
+                      params_to_skip_update: Optional[Sequence[str]] = None):
         """Snapshot of this ActiveLoop's definition."""
         return {
             '__class__': full_class(self),

--- a/qcodes/measure.py
+++ b/qcodes/measure.py
@@ -1,3 +1,4 @@
+from typing import Optional, Sequence
 from datetime import datetime
 
 from qcodes.instrument.parameter import Parameter
@@ -145,7 +146,8 @@ class Measure(Metadatable):
 
         return data_set
 
-    def snapshot_base(self, update=False):
+    def snapshot_base(self, update: bool = False,
+                      params_to_skip_update: Optional[Sequence[str]] = None):
         return {
             '__class__': full_class(self),
             'actions': _actions_snapshot(self._dummyLoop.actions, update)

--- a/qcodes/tests/test_metadata.py
+++ b/qcodes/tests/test_metadata.py
@@ -20,7 +20,8 @@ class TestMetadatable(TestCase):
         self.assertEqual(m.metadata, {2: 3})
 
     class HasSnapshotBase(Metadatable):
-        def snapshot_base(self, update=False):
+        def snapshot_base(self, update=False,
+                          params_to_skip_update=None):
             return {'cheese': 'gruyere'}
 
     class HasSnapshot(Metadatable):

--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -38,7 +38,7 @@ class Metadatable:
         """
         deep_update(self.metadata, metadata)
 
-    def snapshot(self, update: bool=False):
+    def snapshot(self, update: bool = False):
         """
         Decorate a snapshot dictionary with metadata.
         DO NOT override this method if you want metadata in the snapshot


### PR DESCRIPTION
With the base class in metadatable. This is in all cases a no op 