### PR TITLE
Use default delay for test subscriber from config

### DIFF
--- a/qcodes/tests/dataset/test_subscribing.py
+++ b/qcodes/tests/dataset/test_subscribing.py
@@ -174,7 +174,7 @@ def test_subscription_from_config(dataset, basic_subscriber):
             expected_state[x+1] = [(x, y)]
 
             @retry_until_does_not_throw(
-                exception_class_to_expect=AssertionError, delay=0, tries=10)
+                exception_class_to_expect=AssertionError, tries=10)
             def assert_expected_state():
                 assert dataset.subscribers[sub_id].state == expected_state
                 assert dataset.subscribers[sub_id_c].state == expected_state


### PR DESCRIPTION
otherwise, it would sometimes fail because the CI infra is slow, which forces to restart the CI job completely and waste time.