### PR TITLE
[wip] Group parameter snapshot

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -17,6 +17,7 @@ from .function import Function
 if TYPE_CHECKING:
     from qcodes.instrument.channel import ChannelList
     from qcodes.logger.instrument_logger import InstrumentLoggerAdapter
+    from qcodes.instrument.group_parameter import Group
 
 log = logging.getLogger(__name__)
 
@@ -54,6 +55,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         self.functions: Dict[str, Function] = {}
         self.submodules: Dict[str, Union['InstrumentBase',
                                          'ChannelList']] = {}
+        self.groups: Dict[str, 'Group'] = {}
         super().__init__(metadata)
 
         # This is needed for snapshot method to work
@@ -178,6 +180,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
 
         if params_to_skip_update is None:
             params_to_skip_update = []
+        for group in self.groups.values():
+            group.refresh_snapshot(update=update)
 
         snap = {
             "functions": {name: func.snapshot(update=update)

--- a/qcodes/instrument/group_parameter.py
+++ b/qcodes/instrument/group_parameter.py
@@ -6,7 +6,7 @@ should be of type :class:`GroupParameter`
 
 
 from collections import OrderedDict
-from typing import List, Union, Callable, Dict, Any, Optional
+from typing import List, Union, Callable, Dict, Any, Optional, Sequence
 
 from qcodes.instrument.parameter import Parameter
 from qcodes import Instrument
@@ -74,6 +74,23 @@ class GroupParameter(Parameter):
             raise RuntimeError("Trying to set Group value but no "
                                "group defined")
         self.group.set(self, value)
+
+    def snapshot_base(self, update: bool = True,
+                      params_to_skip_update: Optional[Sequence[str]] = None
+                      ) -> Dict:
+        """
+        Hack to avoid updating the snapshot of the parameter even if update
+        is true if and only if this is called from snapshot above
+        """
+
+        import inspect
+        curframe = inspect.currentframe()
+        calframe = inspect.getouterframes(curframe)
+
+        if len(calframe) > 2 and calframe[2].function == 'snapshot_base':
+            update = False
+        return super().snapshot_base(update=update,
+                                     params_to_skip_update=params_to_skip_update)
 
 
 class Group:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -388,11 +388,16 @@ class _BaseParameter(Metadatable):
                 f"Parameter ({self.name}) is used in the snapshot while it "
                 f"should be excluded from the snapshot")
 
-        if hasattr(self, 'get') and self._snapshot_get \
-                and self._snapshot_value and update:
+        if (hasattr(self, 'get') and self._snapshot_get
+                and self._snapshot_value and update):
             self.get()
+        elif (hasattr(self, 'get') and self._snapshot_get
+                and self._snapshot_value):
+            # trigger a refresh of the parameter even if update
+            # is false in the case that the parameter cache is invalid
+            self.get_latest()
 
-        state = copy(self._latest) # type: Dict[str, Any]
+        state: Dict[str, Any] = copy(self._latest)
         state['__class__'] = full_class(self)
         state['full_name'] = str(self)
 
@@ -401,7 +406,7 @@ class _BaseParameter(Metadatable):
             state.pop('raw_value', None)
 
         if isinstance(state['ts'], datetime):
-            dttime = state['ts'] # type: datetime
+            dttime: datetime = state['ts']
             state['ts'] = dttime.strftime('%Y-%m-%d %H:%M:%S')
 
         for attr in set(self._meta_attrs):


### PR DESCRIPTION
This is a proposal for discussion as there at least one unsettled design issue.

The idea is to ensure that snapshot(update=True) is only triggered once pr parameter group. This has the potential of significant time savings on instruments that make use of multiparam getters when calling snapshot(update=True) i.e. when adding an instrument to a station. 

It also bring in a fix where snapshot will update parameters that have unknown values even if update=False. We may want to move that to its own pr. 

Open questions:

* The implementation that relies on stack inspection is not nice. But on the other hand I do not want to change the signature of snapshot_base as that would require fixing all drivers that overwrite snapshot_base. Potentially breaking drivers outside qcodes. Can we find a better way to determine if the snapshot is part of a larger snapshot that includes the group?
* 

Todo: 
- [ ] Documentation that groups needs to be added to the Groups dict. Should there be a add_group thing. Should this be enforced somehow. 
- [ ] Revise the above in all drivers that uses groups.
- [ ] More tests naturally
