### PR TITLE
refactor m4i to have a wait_ready method

### DIFF
--- a/qcodes/instrument_drivers/Spectrum/M4i.py
+++ b/qcodes/instrument_drivers/Spectrum/M4i.py
@@ -752,6 +752,15 @@ class M4i(Instrument):
 
         self.general_command(pyspcm.M2CMD_CARD_STOP)
 
+    def wait_ready(self) -> int:
+        """  Wait for the M4i card to be ready using M2CMD_CARD_WAITREADY
+
+        Returns:
+               Return code of the M4i general command used to wait for the card to be ready
+        """
+        command_result = pyspcm.spcm_dwSetParam_i32(self.hCard, pyspcm.SPC_M2CMD, int(pyspcm.M2CMD_CARD_WAITREADY))
+        return command_result
+
     # TODO: if multiple channels are used at the same time, the voltage conversion needs to be updated
     # TODO: the data also needs to be organized nicely (currently it
     # interleaves the data)
@@ -776,8 +785,8 @@ class M4i(Instrument):
         self.posttrigger_memory_size(posttrigger_size)
         numch = self._num_channels()
 
-        self.general_command(pyspcm.M2CMD_CARD_START |
-                             pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
+        self.general_command(pyspcm.M2CMD_CARD_START | pyspcm.M2CMD_CARD_ENABLETRIGGER)
+        self.wait_ready()
 
         # convert transfer data to numpy array
         output = self._transfer_buffer_numpy(
@@ -867,7 +876,7 @@ class M4i(Instrument):
         numch = trace['numch']
         mV_range = trace['mV_range']
 
-        self.general_command(pyspcm.M2CMD_CARD_WAITREADY)
+        self.wait_ready()
         output = self._transfer_buffer_numpy(memsize, numch)
         self._stop_acquisition()
 
@@ -894,8 +903,8 @@ class M4i(Instrument):
         self.posttrigger_memory_size(posttrigger_size)
         numch = self._num_channels()
 
-        self.general_command(pyspcm.M2CMD_CARD_START |
-                             pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
+        self.general_command(pyspcm.M2CMD_CARD_START | pyspcm.M2CMD_CARD_ENABLETRIGGER)
+        self.wait_ready()
 
         output = self._transfer_buffer_numpy(memsize, numch)
         self._stop_acquisition()
@@ -918,8 +927,8 @@ class M4i(Instrument):
         self.posttrigger_memory_size(posttrigger_size)
         numch = self._num_channels()
 
-        self.general_command(pyspcm.M2CMD_CARD_START |
-                             pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
+        self.general_command(pyspcm.M2CMD_CARD_START | pyspcm.M2CMD_CARD_ENABLETRIGGER)
+        self.wait_ready()
 
         output = self._transfer_buffer_numpy(memsize, numch)
 
@@ -947,8 +956,8 @@ class M4i(Instrument):
         numch = self._num_channels()
 
         self.trigger_or_mask(pyspcm.SPC_TMASK_SOFTWARE)
-        self.general_command(pyspcm.M2CMD_CARD_START |
-                             pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
+        self.general_command(pyspcm.M2CMD_CARD_START | pyspcm.M2CMD_CARD_ENABLETRIGGER)
+        self.wait_ready()
 
         output = self._transfer_buffer_numpy(
             memsize, numch, bytes_per_sample=4)
@@ -977,8 +986,8 @@ class M4i(Instrument):
 
         # start/enable trigger/wait ready
         self.trigger_or_mask(pyspcm.SPC_TMASK_SOFTWARE)  # software trigger
-        self.general_command(pyspcm.M2CMD_CARD_START |
-                             pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
+        self.general_command(pyspcm.M2CMD_CARD_START | pyspcm.M2CMD_CARD_ENABLETRIGGER)
+        self.wait_ready()
 
         output = self._transfer_buffer_numpy(memsize, numch)
         self._stop_acquisition()
@@ -1049,8 +1058,8 @@ class M4i(Instrument):
 
         self.external_trigger_mode(pyspcm.SPC_TM_POS)
         self.trigger_or_mask(pyspcm.SPC_TMASK_EXT0)
-        self.general_command(pyspcm.M2CMD_CARD_START |
-                             pyspcm.M2CMD_CARD_ENABLETRIGGER | pyspcm.M2CMD_CARD_WAITREADY)
+        self.general_command(pyspcm.M2CMD_CARD_START | pyspcm.M2CMD_CARD_ENABLETRIGGER)
+        self.wait_ready()
 
         output = self._transfer_buffer_numpy(memsize, numch, bytes_per_sample=4) / nr_averages
 


### PR DESCRIPTION
The previous implementation would block the python session for the entire duration of the acquisition of the M4i. This new implementation allows the user to override the `wait_ready` command (either in a subclass or by dynamic update of the class method), so that the python session is not blocked.

@astafan8 

For example to make plots interactive during data acquisition we use the following method
```
def m4i_wait_ready(self, timeout_step: Optional[float] = None) -> int:
        """  Wait for the M4i card to be ready 

        Args:
            timeout_step (None or float): If None then wait in blocking mode. Otherwise wait for the result in steps of specified duration (in miliseconds)

        If the timeout_step is None, then wait for the card to be ready in blocking mode. Otherwise
        wait steps of the specified duration untill the card is ready
        
        Returns:
               Return code of general command used to set M2CMD_CARD_WAITREADY
        """
        if timeout_step is None:
            card_result = pyspcm.spcm_dwSetParam_i32(self.hCard, pyspcm.SPC_M2CMD, int(pyspcm.M2CMD_CARD_WAITREADY))
            return card_result

        original_timeout = self.timeout()
        card_result = None
        qtapp=pyqtgraph.mkQApp()
        with parameter_context(self.timeout, 1):
            import time
            t0 = time.time()
            dt = -1
            while dt < original_timeout/1000:
                timeout_remaining = (original_timeout - 1000*dt)
                self.log.debug(f'multiple_trigger_acquisition: dt {dt:.4f}: timeout_remaining {timeout_remaining}')
                time.sleep(min(timeout_step, timeout_remaining)*1e-3)
                card_result = pyspcm.spcm_dwSetParam_i32(self.hCard, pyspcm.SPC_M2CMD, int(pyspcm.M2CMD_CARD_WAITREADY))
                qtapp.processEvents()
                dt = time.time()-t0
                if card_result != pyspcm.ERR_TIMEOUT:
                    break
        
        card_result = pyspcm.spcm_dwSetParam_i32(self.hCard, pyspcm.SPC_M2CMD, int(pyspcm.M2CMD_CARD_WAITREADY))
        return card_result 

import types
m4i.wait_ready=types.MethodType(partial(m4i_wait_ready, timeout_step=2000), m4i) 
```
(this method is specific for Qt, so should not be put into the general M4i driver)
