### PR TITLE
QuickFix: Add connect message at init to Keithley 2400 and HP 83650

### DIFF
--- a/qcodes/instrument_drivers/HP/HP_83650A.py
+++ b/qcodes/instrument_drivers/HP/HP_83650A.py
@@ -101,6 +101,7 @@ class HP_83650A(VisaInstrument):
                            vals=vals.Strings(),
                            get_parser=parsestr,
                            docstring='Pulse source, ....')
+        self.connect_message()
 
     def reset(self):
         log.debug('Resetting instrument')

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -97,6 +97,8 @@ class Keithley_2400(VisaInstrument):
                            docstring="Measure resistance from current and voltage "
                                      "Note that it is an error to read current "
                                      "and voltage with output off")
+        self.connect_message()
+
 
     def _get_read_output_protected(self) -> str:
         """

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -99,7 +99,6 @@ class Keithley_2400(VisaInstrument):
                                      "and voltage with output off")
         self.connect_message()
 
-
     def _get_read_output_protected(self) -> str:
         """
         This wrapper function around ":READ?" exists because calling


### PR DESCRIPTION
@WilliamHPNielsen A Few months back we had decided to check for all the drivers which do not have the `connect-message` at init. Today, I went through all the drivers in (qcodes - qcodes_contrib_repo) repository and found that Keithley 2400 and HP 83650 needs connect message at init.


@astafan8 @GateBuilder 