### PR TITLE
Parameter.set_to: use get_latest, not _latest['value']

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -128,19 +128,9 @@ class _SetParamContext:
     def __init__(self, parameter: "_BaseParameter", value: ParamDataType):
         self._parameter = parameter
         self._value = value
-        self._value_is_changing: bool
-        self._original_value: Optional[ParamDataType]
 
-        parameter_has_been_captured_before = (
-            self._parameter.get_latest.get_timestamp() is not None
-        )
-
-        if parameter_has_been_captured_before or self._value is not None:
-            self._original_value = self._parameter.get_latest()
-            self._value_is_changing = self._value != self._original_value
-        else:
-            self._original_value = None
-            self._value_is_changing = False
+        self._original_value = self._parameter.get_latest()
+        self._value_is_changing = self._value != self._original_value
 
     def __enter__(self) -> None:
         if self._value_is_changing:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -288,6 +288,7 @@ class _BaseParameter(Metadatable):
         # but they all use the same attributes so snapshot is consistent.
         self._latest: Dict[str, Optional[Union[ParamDataType, datetime]]] = \
             {'value': None, 'ts': None, 'raw_value': None}
+        self.get_latest: GetLatest
         self.get_latest = GetLatest(self, max_val_age=max_val_age)
 
         if hasattr(self, 'get_raw') and not getattr(self.get_raw, '__qcodes_is_abstract_method__', False):
@@ -1687,7 +1688,7 @@ class GetLatest(DelegateAttributes):
     delegate_attr_objects = ['parameter']
     omit_delegate_attrs = ['set']
 
-    def get(self) -> Any:
+    def get(self) -> ParamDataType:
         """Return latest value if time since get was less than
         `max_val_age`, otherwise perform `get()` and
         return result. A `get()` will also be performed if the
@@ -1732,7 +1733,7 @@ class GetLatest(DelegateAttributes):
         state = self.parameter._latest
         return state["ts"]
 
-    def __call__(self) -> Any:
+    def __call__(self) -> ParamDataType:
         return self.get()
 
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -134,13 +134,13 @@ class _SetParamContext:
 
     def __enter__(self) -> None:
         if self._value_is_changing:
-            self._parameter.set(self._value)  # type: ignore[has-type]
+            self._parameter.set(self._value)
 
     def __exit__(self, typ,  # type: ignore[no-untyped-def]
                  value,
                  traceback) -> None:
         if self._value_is_changing:
-            self._parameter.set(self._original_value)  # type: ignore[has-type]
+            self._parameter.set(self._original_value)
 
 
 def invert_val_mapping(val_mapping: Dict) -> Dict:
@@ -292,6 +292,7 @@ class _BaseParameter(Metadatable):
         self.get_latest: GetLatest
         self.get_latest = GetLatest(self, max_val_age=max_val_age)
 
+        self.get: Callable[..., ParamDataType]
         if hasattr(self, 'get_raw') and not getattr(self.get_raw, '__qcodes_is_abstract_method__', False):
             self.get = self._wrap_get(self.get_raw)
         elif hasattr(self, 'get'):
@@ -301,6 +302,8 @@ class _BaseParameter(Metadatable):
                           f'define get_raw in your subclass instead. '
                           f'Overwriting get will be an error in the future.')
             self.get = self._wrap_get(self.get)
+
+        self.set: Callable[..., None]
         if hasattr(self, 'set_raw') and not getattr(self.set_raw, '__qcodes_is_abstract_method__', False):
             self.set = self._wrap_set(self.set_raw)
         elif hasattr(self, 'set'):

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1603,7 +1603,7 @@ class TestSetContextManager(TestCase):
         self.instrument.close()
         del self.instrument
 
-    def test_set_to_none_when_current_value_is_none(self):
+    def test_set_to_none_when_parameter_is_not_captured_yet(self):
         counting_parameter = self.instrument.counting_parameter
         # Pre-conditions:
         assert self._cp_counter == 0
@@ -1615,20 +1615,20 @@ class TestSetContextManager(TestCase):
             # The value should not change
             assert counting_parameter._latest["value"] is None
             # The timestamp of the latest value should be still None
-            assert counting_parameter.get_latest.get_timestamp() is None
+            assert counting_parameter.get_latest.get_timestamp() is not None
             # Set method is not called
             assert self._cp_counter == 0
-            # Get method is not called
-            assert self._cp_get_counter == 0
+            # Get method is called once
+            assert self._cp_get_counter == 1
 
         # The value should not change
         assert counting_parameter._latest["value"] is None
         # The timestamp of the latest value should be still None
-        assert counting_parameter.get_latest.get_timestamp() is None
-        # Set method is not called
+        assert counting_parameter.get_latest.get_timestamp() is not None
+        # Set method is still not called
         assert self._cp_counter == 0
-        # Get method is not called
-        assert self._cp_get_counter == 0
+        # Get method is still called once
+        assert self._cp_get_counter == 1
 
     def test_set_to_none_for_not_captured_parameter_but_instrument_has_value(self):
         # representing instrument here

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1375,8 +1375,10 @@ class TestSetContextManager(TestCase):
 
     def test_none_value(self):
         with self.instrument.a.set_to(3):
+            assert self.instrument.a.get_latest.get_timestamp() is not None
             assert self.instrument.a.get() == 3
         assert self.instrument.a.get() is None
+        assert self.instrument.a.get_latest.get_timestamp() is not None
 
     def test_context(self):
         self.instrument.a.set(2)

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1614,7 +1614,7 @@ class TestSetContextManager(TestCase):
         with counting_parameter.set_to(None):
             # The value should not change
             assert counting_parameter._latest["value"] is None
-            # The timestamp of the latest value should be still None
+            # The timestamp of the latest value should not be None anymore
             assert counting_parameter.get_latest.get_timestamp() is not None
             # Set method is not called
             assert self._cp_counter == 0
@@ -1623,7 +1623,7 @@ class TestSetContextManager(TestCase):
 
         # The value should not change
         assert counting_parameter._latest["value"] is None
-        # The timestamp of the latest value should be still None
+        # The timestamp of the latest value should still not be None
         assert counting_parameter.get_latest.get_timestamp() is not None
         # Set method is still not called
         assert self._cp_counter == 0


### PR DESCRIPTION
Refactor `Paramter.set_to` context manager to NOT directly use `._latest` cache. The idea also is that `set_to` defers the parameter-has-not-even-been-captured-hence-we-first-need-to-call-get logic to `get_latest()` as opposed to implementing it itself. Moreover, this PR adds some extra tests for `set_to(None)` edge cases.

@QCoDeS/core when reviewing, please let me know if I missed a test case so that I can add it to the test suite and hence ensure that this refactoring does not break the uncaptured behavior (note that I already added one extra test)