### PR TITLE
Add get_raw_value to GetLatest of Parameter

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1725,6 +1725,13 @@ class GetLatest(DelegateAttributes):
         state = self.parameter._latest
         return state["ts"]
 
+    def get_raw_value(self) -> Optional[ParamRawDataType]:
+        """
+        Return latest raw value of the parameter.
+        """
+        state = self.parameter._latest
+        return state["raw_value"]
+
     def __call__(self) -> Any:
         return self.get()
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -235,6 +235,24 @@ class TestParameter(TestCase):
         self.assertEqual(local_parameter.get_latest(), 2)
         self.assertGreater(local_parameter.get_latest.get_timestamp(), after_set)
 
+    def test_get_latest_raw_value(self):
+        # To have a simple distinction between raw value and value of the
+        # parameter lets create a parameter with an offset
+        p = Parameter('p', set_cmd=None, get_cmd=None, offset=42)
+        assert p.get_latest.get_timestamp() is None
+
+        # Initially, the parameter's raw value is None
+        assert p.get_latest.get_raw_value() is None
+
+        # After setting the parameter to some value, the
+        # ``.get_latest.get_raw_value()`` call should return the new raw value
+        # of the parameter
+        p(3)
+        assert p.get_latest.get_timestamp() is not None
+        assert p.get_latest.get() == 3
+        assert p.get_latest() == 3
+        assert p.get_latest.get_raw_value() == 3 + 42
+
     def test_get_latest_unknown(self):
         """
         Test that get latest on a parameter that has not been acquired will


### PR DESCRIPTION
... that returns `._latest['raw_value']`. Reason - API consistency with `GetLatest.get` and `GetLatest.get_timestamp`.

In a later PR, this one https://github.com/QCoDeS/Qcodes/pull/1791, `_BaseParameter` will get all the three of these methods as well but named with a word `cache`.