### PR TITLE
Use set_cache instead of _save_val and setting raw_value attribute in Keysight B1500 driver

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500.py
@@ -46,8 +46,8 @@ class KeysightB1500(VisaInstrument):
         # Instrument is initialized with this setting having value of
         # `False`, hence let's set the parameter to this value since it is
         # not possible to request this value from the instrument.
-        self.autozero_enabled.raw_value = False
-        self.autozero_enabled._save_val(False)
+        self.measurement_mode.set_cache(False)
+
         self.connect_message()
 
     def add_module(self, name: str, module: B1500Module):

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500.py
@@ -46,7 +46,7 @@ class KeysightB1500(VisaInstrument):
         # Instrument is initialized with this setting having value of
         # `False`, hence let's set the parameter to this value since it is
         # not possible to request this value from the instrument.
-        self.measurement_mode.set_cache(False)
+        self.autozero_enabled.set_cache(False)
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -63,8 +63,7 @@ class B1517A(B1500Module):
         # `1`, spot measurement mode, hence let's set the parameter to this
         # value since it is not possible to request this value from the
         # instrument.
-        self.measurement_mode.raw_value = MM.Mode.SPOT
-        self.measurement_mode._save_val(MM.Mode.SPOT)
+        self.measurement_mode.set_cache(MM.Mode.SPOT)
 
         self.add_parameter(
             name="voltage",


### PR DESCRIPTION
Drivers changed:
- Keysight B1500 and its modules

Requires merge of https://github.com/QCoDeS/Qcodes/pull/1757.