### PR TITLE
Remove usage of _save_val in drivers and core qcodes

### DIFF
--- a/docs/examples/writing_drivers/Creating-Instrument-Drivers.ipynb
+++ b/docs/examples/writing_drivers/Creating-Instrument-Drivers.ipynb
@@ -388,7 +388,6 @@
     "            current *= -1\n",
     "\n",
     "        value = (volt, current)\n",
-    "        self._save_val(value)\n",
     "        return value\n",
     "\n",
     "\n",

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -2175,7 +2175,6 @@ class ScaledParameter(Parameter):
             raise RuntimeError(f"ScaledParameter must be either a"
                                f"Multiplier or Divisor; got {self.role}")
 
-        self._save_val(value)
         return value
 
     @property
@@ -2206,7 +2205,6 @@ class ScaledParameter(Parameter):
             raise RuntimeError(f"ScaledParameter must be either a"
                                f"Multiplier or Divisor; got {self.role}")
 
-        self._save_val(value)
         self._wrapped_parameter.set(instrument_value)
 
 

--- a/qcodes/instrument_drivers/AlazarTech/utils.py
+++ b/qcodes/instrument_drivers/AlazarTech/utils.py
@@ -35,4 +35,3 @@ class TraceParameter(Parameter):
     def set_raw(self, value):
         self._instrument._parameters_synced = False
         self._synced_to_card = False
-        self._save_val(value, validate=False)

--- a/qcodes/instrument_drivers/QDev/QDac.py
+++ b/qcodes/instrument_drivers/QDev/QDac.py
@@ -261,7 +261,7 @@ class QDac(VisaInstrument):
             voltageparam = self.parameters['ch{:02}_v'.format(chan)]
             oldvoltage = voltageparam.get_latest()
             newvoltage = {0: 10, 1: 0.1}[switchint]*oldvoltage
-            voltageparam._save_val(newvoltage)
+            voltageparam.set_cache(newvoltage)
 
     def _num_verbose(self, s):
         """
@@ -368,7 +368,7 @@ class QDac(VisaInstrument):
                     attenuation = 0.1*value
                 if param == 'v':
                     value *= attenuation
-                self.parameters[parameter]._save_val(value)
+                self.parameters[parameter].set_cache(value)
             chans_left.remove(chan)
 
         if readcurrents:

--- a/qcodes/instrument_drivers/QDev/QDac.py
+++ b/qcodes/instrument_drivers/QDev/QDac.py
@@ -375,7 +375,7 @@ class QDac(VisaInstrument):
             for chan in range(1, self.num_chans+1):
                 paramname = 'ch{:02}_i'.format(chan)
                 param = self.parameters[paramname]
-                param._save_val(param.get())
+                _ = param.get()
 
         self._status = chans
         self._status_ts = datetime.now()

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -463,7 +463,7 @@ class QDac(VisaInstrument):
         if readcurrents:
             for chan in range(1, self.num_chans+1):
                 param = self.channels[chan-1].i
-                param._save_val(param.get())
+                _ = param.get()
 
         self._status = chans
         self._status_ts = datetime.now()

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -349,7 +349,7 @@ class QDac(VisaInstrument):
             voltageparam = self.channels[chan-1].v
             oldvoltage = voltageparam.get_latest()
             newvoltage = {0: 10, 1: 0.1}[switchint]*oldvoltage
-            voltageparam._save_val(newvoltage)
+            voltageparam.set_cache(newvoltage)
 
     def _num_verbose(self, s):
         """
@@ -457,7 +457,7 @@ class QDac(VisaInstrument):
                     attenuation = 0.1*value
                 if param == 'v':
                     value *= attenuation
-                getattr(self.channels[chan-1], param)._save_val(value)
+                getattr(self.channels[chan-1], param).set_cache(value)
             chans_left.remove(chan)
 
         if readcurrents:

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -2197,7 +2197,7 @@ class ZIUHFLI(Instrument):
             SR_str = self.parameters['scope_samplingrate'].get()
             (number, unit) = SR_str.split(' ')
             SR = float(number)*SRtranslation[unit]
-            self.parameters['scope_duration']._save_val(value/SR)
+            self.parameters['scope_duration'].set_cache(value/SR)
             self.daq.setInt('/{}/scopes/0/length'.format(self.device), value)
 
         def setduration(value):
@@ -2206,8 +2206,8 @@ class ZIUHFLI(Instrument):
             (number, unit) = SR_str.split(' ')
             SR = float(number)*SRtranslation[unit]
             N = int(np.round(value*SR))
-            self.parameters['scope_length']._save_val(N)
-            self.parameters['scope_duration']._save_val(value)
+            self.parameters['scope_length'].set_cache(N)
+            self.parameters['scope_duration'].set_cache(value)
             self.daq.setInt('/{}/scopes/0/length'.format(self.device), N)
 
         def setholdoffseconds(value):
@@ -2227,7 +2227,7 @@ class ZIUHFLI(Instrument):
             oldSR = float(number)*SRtranslation[unit]
             oldduration = self.parameters['scope_duration'].get()
             newduration = oldduration*oldSR/newSR
-            self.parameters['scope_duration']._save_val(newduration)
+            self.parameters['scope_duration'].set_cache(newduration)
             self.daq.setInt('/{}/scopes/0/time'.format(self.device), value)
 
         specialcases = {'length': setlength,

--- a/qcodes/instrument_drivers/devices.py
+++ b/qcodes/instrument_drivers/devices.py
@@ -74,8 +74,6 @@ class VoltageDivider(Parameter):
 
     def set_raw(self, value: Union[int, float]) -> None:
         instrument_value = value * self.division_value
-
-        self._save_val(value)
         self.v1.set(instrument_value)
 
     def get_raw(self) -> Union[int, float]:
@@ -84,7 +82,6 @@ class VoltageDivider(Parameter):
             value at which was set at the sample
         """
         value = self.v1.get() / self.division_value
-        self._save_val(value)
         return value
 
     def get_instrument_value(self) -> Union[int, float]:

--- a/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
+++ b/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
@@ -51,7 +51,6 @@ class CurrentParameter(MultiParameter):
             current *= -1
 
         value = (volt, current)
-        self._save_val(value)
         return value
 
 

--- a/qcodes/instrument_drivers/oxford/mercuryiPS.py
+++ b/qcodes/instrument_drivers/oxford/mercuryiPS.py
@@ -26,7 +26,6 @@ class MercuryiPSArray(MultiParameter):
     def get_raw(self):
         try:
             value = self._get()
-            self._save_val(value)
             return value
         except Exception as e:
             e.args = e.args + ('getting {}'.format(self.full_name),)

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -407,13 +407,13 @@ class ScopeChannel(InstrumentChannel):
     #########################
     # Specialised/interlinked set/getters
     def _set_range(self, value):
-        self.scale._save_val(value/10)
+        self.scale.set_cache(value/10)
 
         self._parent.write('CHANnel{}:RANGe {}'.format(self.channum,
                                                        value))
 
     def _set_scale(self, value):
-        self.range._save_val(value*10)
+        self.range.set_cache(value*10)
 
         self._parent.write('CHANnel{}:SCALe {}'.format(self.channum,
                                                        value))
@@ -727,7 +727,7 @@ class RTO1000(VisaInstrument):
         Set the full range of the timebase
         """
         self._make_traces_not_ready()
-        self.timebase_scale._save_val(value/self._horisontal_divs)
+        self.timebase_scale.set_cache(value/self._horisontal_divs)
 
         self.write('TIMebase:RANGe {}'.format(value))
 
@@ -736,7 +736,7 @@ class RTO1000(VisaInstrument):
         Set the length of one horizontal division
         """
         self._make_traces_not_ready()
-        self.timebase_range._save_val(value*self._horisontal_divs)
+        self.timebase_range.set_cache(value*self._horisontal_divs)
 
         self.write('TIMebase:SCALe {}'.format(value))
 

--- a/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
@@ -402,7 +402,7 @@ class SignalHound_USB_SA124B(Instrument):
         of power and trace.
         """
         sweep_info = self.QuerySweep()
-        self.npts._save_val(sweep_info[0])
+        self.npts.set_cache(sweep_info[0])
         self.trace.set_sweep(*sweep_info)
 
     def sync_parameters(self) -> None:

--- a/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
@@ -31,7 +31,6 @@ class TraceParameter(Parameter):
             raise RuntimeError("TraceParameter only works with "
                                "'SignalHound_USB_SA124B'")
         self.instrument._parameters_synced = False
-        self._save_val(value, validate=False)
 
 
 class ExternalRefParameter(TraceParameter):

--- a/qcodes/instrument_drivers/stanford_research/SR560.py
+++ b/qcodes/instrument_drivers/stanford_research/SR560.py
@@ -52,7 +52,6 @@ class VoltageParameter(MultiParameter):
             volt_amp *= -1
 
         value = (volt, volt_amp)
-        self._save_val(value)
         return value
 
 

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -292,7 +292,6 @@ class MultiSetPointParam(MultiParameter):
 
     def get_raw(self):
         items = (np.zeros(5), np.ones(5))
-        self._save_val(items)
         return items
 
 
@@ -330,7 +329,6 @@ class Multi2DSetPointParam(MultiParameter):
 
     def get_raw(self):
         items = (np.zeros((5, 3)), np.ones((5, 3)))
-        self._save_val(items)
         return items
 
 
@@ -353,7 +351,6 @@ class MultiScalarParam(MultiParameter):
 
     def get_raw(self):
         items = (0, 1)
-        self._save_val(items)
         return items
 
 

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -381,7 +381,6 @@ class ArraySetPointParam(ArrayParameter):
 
     def get_raw(self):
         item = np.ones(5) + 1
-        self._save_val(item)
         return item
 
 
@@ -412,7 +411,6 @@ class ComplexArraySetPointParam(ArrayParameter):
 
     def get_raw(self):
         item = np.arange(5) - 1j*np.arange(5)
-        self._save_val(item)
         return item
 
 

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -35,7 +35,8 @@ class TestInstrument(TestCase):
         instrument = self.instrument
         instrument.validate_status()  # test the instrument has valid values
 
-        instrument.dac1._save_val(1000)  # overrule the validator
+        instrument.dac1._latest['value'] = 1000  # overrule the validator
+        instrument.dac1._latest['raw_value'] = 1000  # overrule the validator
         with self.assertRaises(Exception):
             instrument.validate_status()
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -689,7 +689,6 @@ class SimpleArrayParam(ArrayParameter):
 
     def get_raw(self):
         self._get_count += 1
-        self._save_val(self._return_val)
         return self._return_val
 
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -830,7 +830,6 @@ class SimpleMultiParam(MultiParameter):
 
     def get_raw(self):
         self._get_count += 1
-        self._save_val(self._return_val)
         return self._return_val
 
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -340,10 +340,9 @@ class TestParameter(TestCase):
         # in a subclass. Here we create a subclass that does add a get command and alsoo does 
         # not implement the check for max_val_age
         class LocalParameter(_BaseParameter):
-
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, **kwargs)
-                self.set_raw = partial(self._save_val, validate=False)
+                self.set_raw = lambda x: x
                 self.set = self._wrap_set(self.set_raw)
 
         localparameter = LocalParameter('test_param',


### PR DESCRIPTION
... via `set_cache` or other fixes.

Requires merge of https://github.com/QCoDeS/Qcodes/pull/1757.

Note: Keysight B1500 use of `_save_val` is fixed in https://github.com/QCoDeS/Qcodes/pull/1789.