### PR TITLE
Feature: measurement progress printer

### DIFF
--- a/docs/api/utils/index.rst
+++ b/docs/api/utils/index.rst
@@ -11,6 +11,7 @@ qcodes.utils
     qcodes.utils.deprecate
     qcodes.utils.helpers
     qcodes.utils.magic
+    qcodes.utils.measurement_subscribers
     qcodes.utils.metadata
     qcodes.utils.plotting
     qcodes.utils.threading

--- a/docs/api/utils/measurement_subscribers.rst
+++ b/docs/api/utils/measurement_subscribers.rst
@@ -1,0 +1,5 @@
+qcodes.utils.measurement_subscribers
+------------------------------------
+
+.. automodule:: qcodes.utils.measurement_subscribers
+   :members:

--- a/qcodes/tests/dataset/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/test_measurement_context_manager.py
@@ -760,7 +760,11 @@ def test_example_subscriber_text_progress(capsys, experiment, DAC, DMM, N):
                     percent = f'{(i + 1) / N * 100 :.1f} %'
                     ptn = rf'{i + 1} / {N} \({percent}\) - elapsed: 0:00:0\d'
                     if i > 0:
-                        ptn += r' - remaining: 0:00:0\d'
+                        ptn += r' - ETA: 0:00:0\d'
+                        if variant == 2:
+                            ptn += r' \(\w+ \w+ \d\d \d\d:\d\d:\d\d\)'
+                        elif variant == 3:
+                            ptn += r' \(\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\)'
 
                 cap = capsys.readouterr()
 

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -1,0 +1,73 @@
+"""
+This module contains example subscriber functions and classes that can be added
+to a ``Measurement`` instance with ``add_subscriber``.
+"""
+
+import time
+import datetime
+from typing import Optional, Tuple, Union, MutableSequence, MutableMapping
+
+class TextProgress:
+    """
+    A textual description of the progress of a measurement, printed in-place so
+    that it doesn't clog up the notebook. Additionally, if the attribute
+    ``total_measurements`` is set, it also prints the progress as a percentage,
+    and attempts to predict how long until the measurement is finished.
+    ``total_measurements`` is an attribute so that it can be added after the
+    measurement has been started, as the number of points might be determined
+    only inside the ``Runner`` context.
+
+    Example::
+
+        meas = qcodes.Measurement()
+
+        meas.register_custom_parameter('x')
+        meas.register_custom_parameter('y', setpoints=('x',))
+
+        pb = TextProgress()
+        meas.add_subscriber(pb)
+
+        with meas.run() as datasaver:
+            xs = np.linspace(-1, 1, 100)
+            ys = np.linspace(0, 10, 20)
+
+            pb.total_measurements = xs.size * ys.size
+
+            for x in xs:
+                for y in ys:
+                    meas.add_result(('x', x), ('y', y))
+                    time.sleep(0.1)
+
+        # Prints something like
+        # 105 / 2000 (5.2%) completed - elapsed: 1.05s - remaining: 19s
+    """
+
+    def __init__(self):
+
+        self.total_measurements: Optional[int] = None
+        self._start_time = None
+
+    def __call__(self, results_list: Tuple, length: int,
+                 state: Union[MutableSequence, MutableMapping]):
+
+        if self._start_time is None:
+            self._start_time = time.monotonic()
+
+        msg = f"\r{length}"
+
+        if self.total_measurements is not None:
+            progress = length / self.total_measurements
+            msg += f" / {self.total_measurements} ({progress * 100:.1f} %)"
+
+        elapsed = time.monotonic() - self._start_time
+
+        msg += f" completed - elapsed: {self._delta_str(elapsed)}"
+
+        if self.total_measurements is not None and progress > 0:
+            remaining = (1 - progress) / progress * elapsed
+            msg += f" - remaining: {self._delta_str(remaining)}"
+
+        print(msg, end='')
+
+    def _delta_str(seconds: float) -> str:
+        return datetime.timedelta(seconds=int(seconds))

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -1,6 +1,6 @@
 """
-This module contains example subscriber functions and classes that can be added
-to a ``Measurement`` instance with ``add_subscriber``.
+This module contains example functions and classes that can subscribe to a
+``Measurement`` instance with ``add_subscriber``.
 """
 
 import time
@@ -40,14 +40,13 @@ class TextProgress:
         meas.add_subscriber(tp, state=None)
 
         with meas.run() as datasaver:
-            xs = np.linspace(-1, 1, 100)
-            ys = np.linspace(0, 10, 20)
+            xs = np.linspace(-1, 1, 2000)
 
             tp.total_measurements = xs.size
 
             for x in xs:
-                meas.add_result(('x', x), ('y', y))
-                time.sleep(0.1)
+                meas.add_result(('x', x), ('y', np.random.randn()))
+                time.sleep(0.01)
 
         # Prints something like
         # 105 / 2000 (5.2%) - elapsed: 0:00:01 - remaining: 0:00:19 (Fri Oct 11 12:34:56)

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -12,8 +12,8 @@ class TextProgress:
     A textual description of the progress of a measurement, printed in-place so
     that it doesn't clog up the notebook. Additionally, if the attribute
     ``total_measurements`` is set, it also prints the progress as a percentage,
-    and attempts to predict how long until the measurement is finished.
-    ``total_measurements`` is an attribute so that it can be added after the
+    and predicts how long the measurement is going to take.
+    ``total_measurements`` is an attribute so that it can be set after the
     measurement has been started, as the number of points might be determined
     only inside the ``Runner`` context.
 
@@ -64,7 +64,7 @@ class TextProgress:
         msg += f" - elapsed: {self._get_delta(elapsed)}"
 
         if self.total_measurements is not None and length > 1:
-            remaining = (1 - progress) / progress * elapsed
+            remaining = elapsed / progress * (1 - progress)
             msg += f" - remaining: {self._get_delta(remaining)}"
 
         print(msg, end='')

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -43,12 +43,11 @@ class TextProgress:
             xs = np.linspace(-1, 1, 100)
             ys = np.linspace(0, 10, 20)
 
-            tp.total_measurements = xs.size * ys.size
+            tp.total_measurements = xs.size
 
             for x in xs:
-                for y in ys:
-                    meas.add_result(('x', x), ('y', y))
-                    time.sleep(0.1)
+                meas.add_result(('x', x), ('y', y))
+                time.sleep(0.1)
 
         # Prints something like
         # 105 / 2000 (5.2%) - elapsed: 0:00:01 - remaining: 0:00:19 (Fri Oct 11 12:34:56)

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -61,13 +61,13 @@ class TextProgress:
 
         elapsed = time.monotonic() - self._start_time
 
-        msg += f" completed - elapsed: {self._delta_str(elapsed)}"
+        msg += f" - elapsed: {self._get_delta(elapsed)}"
 
-        if self.total_measurements is not None and progress > 0:
+        if self.total_measurements is not None and length > 1:
             remaining = (1 - progress) / progress * elapsed
-            msg += f" - remaining: {self._delta_str(remaining)}"
+            msg += f" - remaining: {self._get_delta(remaining)}"
 
         print(msg, end='')
 
-    def _delta_str(seconds: float) -> str:
+    def _get_delta(self, seconds: float) -> str:
         return datetime.timedelta(seconds=int(seconds))

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -8,15 +8,26 @@ import datetime
 from typing import (Optional, List, Tuple, Any, Union, MutableSequence,
                     MutableMapping)
 
+
 class TextProgress:
     """
     A textual description of the progress of a measurement, printed in-place so
-    that it doesn't clog up the notebook. Additionally, if the attribute
+    that it doesn't clog up the notebook. Additionally, if
     ``total_measurements`` is set, it also prints the progress as a percentage,
     and predicts how long the measurement is going to take.
-    ``total_measurements`` is an attribute so that it can be set after the
-    measurement has been started, as the number of points might be determined
-    only inside the ``Runner`` context.
+    ``total_measurements`` can be set after the measurement has been started,
+    as the number of points might be determined only inside the measurement
+    context.
+
+    Args:
+        total_measurements: The total number of data points that will be added
+            to the dataset. Used to show the percentage of completion and
+            extraploate the remaining time. Can also be set as an attribute
+            after instantiating a TextProgress object.
+        time_fmt: The format string used to print the finish time, as accepted
+            by ``strftime``. Defaults to a format like "Fri Oct 11 12:34:56".
+            If None, no date is printed. If total_measurements is not given,
+            this parameter does nothing.
 
     Example::
 
@@ -40,13 +51,15 @@ class TextProgress:
                     time.sleep(0.1)
 
         # Prints something like
-        # 105 / 2000 (5.2%) - elapsed: 0:00:01 - remaining: 0:00:19
+        # 105 / 2000 (5.2%) - elapsed: 0:00:01 - remaining: 0:00:19 (Fri Oct 11 12:34:56)
     """
 
-    def __init__(self, total_measurements: Optional[int] = None):
+    def __init__(self, total_measurements: Optional[int] = None,
+                 time_fmt: Optional[str] = "%a %b %d %H:%M:%S"):
 
         self.total_measurements = total_measurements
         self._start_time = None
+        self._time_fmt = time_fmt
 
     def __call__(self, results_list: List[Tuple[Any, Any]], length: int,
                  state: Union[MutableSequence, MutableMapping]):
@@ -66,9 +79,17 @@ class TextProgress:
 
         if self.total_measurements is not None and length > 1:
             remaining = elapsed / progress * (1 - progress)
-            msg += f" - remaining: {self._get_delta(remaining)}"
+            remaining_delta = self._get_delta(remaining)
+            msg += f" - remaining: {remaining_delta}"
+
+            if self._time_fmt is not None:
+                finish_time = datetime.datetime.strftime(
+                                  datetime.datetime.now() + remaining_delta,
+                                  format=self._time_fmt)
+
+                msg += f" ({finish_time})"
 
         print(msg, end='')
 
-    def _get_delta(self, seconds: float) -> str:
+    def _get_delta(self, seconds: float) -> datetime.timedelta:
         return datetime.timedelta(seconds=int(seconds))

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -5,7 +5,8 @@ to a ``Measurement`` instance with ``add_subscriber``.
 
 import time
 import datetime
-from typing import Optional, Tuple, Union, MutableSequence, MutableMapping
+from typing import (Optional, List, Tuple, Any, Union, MutableSequence,
+                    MutableMapping)
 
 class TextProgress:
     """
@@ -42,12 +43,12 @@ class TextProgress:
         # 105 / 2000 (5.2%) - elapsed: 0:00:01 - remaining: 0:00:19
     """
 
-    def __init__(self):
+    def __init__(self, total_measurements: Optional[int] = None):
 
-        self.total_measurements: Optional[int] = None
+        self.total_measurements = total_measurements
         self._start_time = None
 
-    def __call__(self, results_list: Tuple, length: int,
+    def __call__(self, results_list: List[Tuple[Any, Any]], length: int,
                  state: Union[MutableSequence, MutableMapping]):
 
         if self._start_time is None:

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -49,7 +49,7 @@ class TextProgress:
                 time.sleep(0.01)
 
         # Prints something like
-        # 105 / 2000 (5.2%) - elapsed: 0:00:01 - remaining: 0:00:19 (Fri Oct 11 12:34:56)
+        # 105 / 2000 (5.2%) - elapsed: 0:00:01 - ETA: 0:00:19 (Fri Oct 11 12:34:56)
     """
 
     def __init__(self, total_measurements: Optional[int] = None,
@@ -78,7 +78,7 @@ class TextProgress:
         if self.total_measurements is not None and length > 1:
             remaining = elapsed / progress * (1 - progress)
             remaining_delta = self._get_delta(remaining)
-            msg += f" - remaining: {remaining_delta}"
+            msg += f" - ETA: {remaining_delta}"
 
             if self._time_fmt is not None:
                 finish_time = datetime.datetime.strftime(

--- a/qcodes/utils/measurement_subscribers.py
+++ b/qcodes/utils/measurement_subscribers.py
@@ -24,14 +24,14 @@ class TextProgress:
         meas.register_custom_parameter('x')
         meas.register_custom_parameter('y', setpoints=('x',))
 
-        pb = TextProgress()
-        meas.add_subscriber(pb)
+        tp = TextProgress()
+        meas.add_subscriber(tp, state=None)
 
         with meas.run() as datasaver:
             xs = np.linspace(-1, 1, 100)
             ys = np.linspace(0, 10, 20)
 
-            pb.total_measurements = xs.size * ys.size
+            tp.total_measurements = xs.size * ys.size
 
             for x in xs:
                 for y in ys:
@@ -39,7 +39,7 @@ class TextProgress:
                     time.sleep(0.1)
 
         # Prints something like
-        # 105 / 2000 (5.2%) completed - elapsed: 1.05s - remaining: 19s
+        # 105 / 2000 (5.2%) - elapsed: 0:00:01 - remaining: 0:00:19
     """
 
     def __init__(self):


### PR DESCRIPTION
This contains a small class to monitor the progress of a measurement by adding a subscriber, like so:
```py
from qcodes.utils.measurement_subscribers import TextProgress

meas = qcodes.Measurement()

meas.register_custom_parameter("x")
meas.register_custom_parameter("y", setpoints=("y",))

xs = np.linspace(-1, 1, 2000)

meas.add_subscriber(TextProgress(total_measurements=xs.size), state=None)

with meas.run() as datasaver:
    for x in xs:
        meas.add_result(("x", x), ("y", np.random.randn())) 
        time.sleep(0.01)
```
This prints something like
```
105 / 2000 (5.2%) - elapsed: 0:00:01 - ETA: 0:00:19 (Fri Oct 11 12:34:56)
```
It's nothing fancy, but I think something like this should be built-in.

Some things to consider:
- Is it a good idea to have a full module for this? Or should it just go to `helpers`?
- This should be mentioned in some of the example notebooks. I think it could be added to the `Dataset context manager` notebook as a third example, to the `Example measurements with real instruments`, and maybe to the `15 Minutes to Qcodes` notebook. Do you have other suggestions?
- The start and end times are a bit fudgy, since the subscriber function has no real way of knowing if it is being called on the first or last insertion (maybe the subscriber API could be extended)
- With an `ArrayParameter`/`MultiParameter`, the array sizes need to be taken into account in `total_measurements`, this should be probably mentioned somewhere


@astafan8
