### PR TITLE
Fix deprecation of static methods

### DIFF
--- a/qcodes/tests/test_deprecate.py
+++ b/qcodes/tests/test_deprecate.py
@@ -132,12 +132,22 @@ class TestClassDeprecation:  # pylint: disable=no-self-use
     def test_static_method_uninhibited(self):
         with _ignore_warnings():
             assert C.static_method(1) == 2
+        with _ignore_warnings():
+            c = C('pristine')
+            assert c.static_method(1) == 2
 
-    def test_static_method(self):
+    @pytest.mark.xfail(reason="This is not implemented yet.")
+    def test_static_method_raises(self):
         with assert_deprecated(
                 'The function <static_method> is deprecated, because '
                 'this is a test.'):
             assert C.static_method(1) == 2
+        with _ignore_warnings():
+            c = C('pristine')
+        with assert_deprecated(
+                'The function <static_method> is deprecated, because '
+                'this is a test.'):
+            assert c.static_method(1) == 2
 
     def test_class_method_uninhibited(self):
         with _ignore_warnings():

--- a/qcodes/utils/deprecate.py
+++ b/qcodes/utils/deprecate.py
@@ -69,7 +69,13 @@ def deprecate(
             for m_name in dir(obj):
                 m = getattr(obj, m_name)
                 if isinstance(m, (types.FunctionType, types.MethodType)):
-                     # pylint: disable=no-value-for-parameter
+                    # skip static methods, since they are not wrapped corectly
+                    # by wrapt.
+                    # if anyone reading this knows how the following line
+                    # works please let me know.
+                    if isinstance(obj.__dict__.get(m_name, None), staticmethod):
+                        continue
+                    # pylint: disable=no-value-for-parameter
                     setattr(obj, m_name, decorate_callable(m))
                     # pylint: enable=no-value-for-parameter
             return obj


### PR DESCRIPTION
Turns out that my extensive tests were not extensive enough. Now, laugh and behold v3 of the vicious deprecation decorator, featuring no less then 200 LOC of test.

This time it fixes the issue that static methods could no longer be called uninhibitedly, as in the second part of this test:
```python
    def test_static_method_uninhibited(self):
        with _ignore_warnings():
            assert C.static_method(1) == 2
        with _ignore_warnings():
            c = C('pristine')
            assert c.static_method(1) == 2
``` 

Therefore I found dark magic to refrain from decorating static methods.
Lesson learned: it would have been better to just decorate the `__init__` method....

BTW. This PR does fix all tests of the driver deprecation PR.