### PR TITLE
Add types to sqlite queries

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -37,3 +37,5 @@ disallow_untyped_defs = True
 [mypy-qcodes.dataset.descriptions.*]
 disallow_untyped_defs = True
 
+[mypy-qcodes.dataset.sqlite.queries]
+disallow_untyped_defs = True

--- a/qcodes/dataset/database_extract_runs.py
+++ b/qcodes/dataset/database_extract_runs.py
@@ -20,8 +20,8 @@ from qcodes.dataset.linked_datasets.links import links_to_str
 
 def extract_runs_into_db(source_db_path: str,
                          target_db_path: str, *run_ids: int,
-                         upgrade_source_db: bool=False,
-                         upgrade_target_db: bool=False) -> None:
+                         upgrade_source_db: bool = False,
+                         upgrade_target_db: bool = False) -> None:
     """
     Extract a selection of runs into another DB file. All runs must come from
     the same experiment. They will be added to an experiment with the same name
@@ -56,7 +56,7 @@ def extract_runs_into_db(source_db_path: str,
     source_conn = connect(source_db_path)
 
     # Validate that all runs are in the source database
-    do_runs_exist = is_run_id_in_database(source_conn, run_ids)
+    do_runs_exist = is_run_id_in_database(source_conn, *run_ids)
     if False in do_runs_exist.values():
         source_conn.close()
         non_existing_ids = [rid for rid in run_ids if not do_runs_exist[rid]]

--- a/qcodes/dataset/database_extract_runs.py
+++ b/qcodes/dataset/database_extract_runs.py
@@ -35,6 +35,8 @@ def extract_runs_into_db(source_db_path: str,
         run_ids: The ``run_id``'s of the runs to copy into the target DB file
         upgrade_source_db: If the source DB is found to be in a version that is
           not the newest, should it be upgraded?
+        upgrade_target_db: If the target DB is found to be in a version that is
+          not the newest, should it be upgraded?
     """
     # Check for versions
     (s_v, new_v) = get_db_version_and_newest_available_version(source_db_path)
@@ -51,7 +53,6 @@ def extract_runs_into_db(source_db_path: str,
                  f'be in version {new_v}. Run this function again with '
                  'upgrade_target_db=True to auto-upgrade the target DB file.')
             return
-
 
     source_conn = connect(source_db_path)
 

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -46,7 +46,7 @@ RUNS_TABLE_COLUMNS = ["run_id", "exp_id", "name", "result_table_name",
 
 
 def is_run_id_in_database(conn: ConnectionPlus,
-                          *run_ids) -> Dict[int, bool]:
+                          *run_ids: int) -> Dict[int, bool]:
     """
     Look up run_ids and return a dictionary with the answers to the question
     "is this run_id in the database?"
@@ -261,7 +261,7 @@ def get_values(conn: ConnectionPlus,
 def get_parameter_tree_values(conn: ConnectionPlus,
                               result_table_name: str,
                               toplevel_param_name: str,
-                              *other_param_names,
+                              *other_param_names: str,
                               start: Optional[int] = None,
                               end: Optional[int] = None) -> List[List[Any]]:
     """
@@ -523,7 +523,7 @@ def get_guids_from_run_spec(conn: ConnectionPlus,
 
 @deprecate()
 def get_layout(conn: ConnectionPlus,
-               layout_id) -> Dict[str, str]:
+               layout_id: int) -> Dict[str, str]:
     """
     Get the layout of a single parameter for plotting it
 
@@ -729,7 +729,7 @@ def new_experiment(conn: ConnectionPlus,
 
 # TODO(WilliamHPNielsen): we should remove the redundant
 # is_completed
-def mark_run_complete(conn: ConnectionPlus, run_id: int):
+def mark_run_complete(conn: ConnectionPlus, run_id: int) -> None:
     """ Mark run complete
 
     Args:
@@ -748,7 +748,7 @@ def mark_run_complete(conn: ConnectionPlus, run_id: int):
     atomic_transaction(conn, query, time.time(), True, run_id)
 
 
-def completed(conn: ConnectionPlus, run_id) -> bool:
+def completed(conn: ConnectionPlus, run_id: int) -> bool:
     """ Check if the run scomplete
 
     Args:
@@ -789,12 +789,12 @@ def get_guid_from_run_id(conn: ConnectionPlus, run_id: int) -> str:
     return select_one_where(conn, "runs", "guid", "run_id", run_id)
 
 
-def finish_experiment(conn: ConnectionPlus, exp_id: int):
+def finish_experiment(conn: ConnectionPlus, exp_id: int) -> None:
     """ Finish experiment
 
     Args:
         conn: database connection
-        name: the name of the experiment
+        exp_id: the id of the experiment
     """
     query = """
     UPDATE experiments SET end_time=? WHERE exp_id=?;
@@ -834,7 +834,8 @@ def get_experiments(conn: ConnectionPlus) -> List[sqlite3.Row]:
     return c.fetchall()
 
 
-def get_matching_exp_ids(conn: ConnectionPlus, **match_conditions) -> List[int]:
+def get_matching_exp_ids(conn: ConnectionPlus,
+                         **match_conditions: Any) -> List[int]:
     """
     Get exp_ids for experiments matching the match_conditions
 
@@ -1013,7 +1014,7 @@ def _insert_run(conn: ConnectionPlus, exp_id: int, name: str,
                 captured_run_id: Optional[int] = None,
                 captured_counter: Optional[int] = None,
                 parent_dataset_links: str = "[]"
-                ):
+                ) -> Tuple[int, str, int]:
 
     # get run counter and formatter from experiments
     run_counter, format_string = select_many_where(conn,
@@ -1331,7 +1332,7 @@ def set_run_timestamp(conn: ConnectionPlus, run_id: int) -> None:
 
 def add_parameter(conn: ConnectionPlus,
                   formatted_name: str,
-                  *parameter: ParamSpec):
+                  *parameter: ParamSpec) -> None:
     """
     Add parameters to the dataset
 
@@ -1564,7 +1565,7 @@ def get_parent_dataset_links(conn: ConnectionPlus, run_id: int) -> str:
     return link_str
 
 
-def get_metadata(conn: ConnectionPlus, tag: str, table_name: str):
+def get_metadata(conn: ConnectionPlus, tag: str, table_name: str) -> str:
     """ Get metadata under the tag from table
     """
     return select_one_where(conn, "runs", tag,
@@ -1712,20 +1713,22 @@ def update_GUIDs(conn: ConnectionPlus) -> None:
 
     # now, there are four actions we can take
 
-    def _both_nonzero(run_id: int, *args) -> None:
+    def _both_nonzero(run_id: int, *args: Any) -> None:
         log.info(f'Run number {run_id} already has a valid GUID, skipping.')
 
-    def _location_only_zero(run_id: int, *args) -> None:
+    def _location_only_zero(run_id: int, *args: Any) -> None:
         log.warning(f'Run number {run_id} has a zero (default) location '
                     'code, but a non-zero work station code. Please manually '
                     'resolve this, skipping the run now.')
 
-    def _workstation_only_zero(run_id: int, *args) -> None:
+    def _workstation_only_zero(run_id: int, *args: Any) -> None:
         log.warning(f'Run number {run_id} has a zero (default) work station'
                     ' code, but a non-zero location code. Please manually '
                     'resolve this, skipping the run now.')
 
-    def _both_zero(run_id: int, conn, guid_comps) -> None:
+    def _both_zero(run_id: int,
+                   conn: ConnectionPlus,
+                   guid_comps: Dict[str, Any]) -> None:
         guid_str = generate_guid(timeint=guid_comps['time'],
                                  sampleint=guid_comps['sample'])
         with atomic(conn) as conn:

--- a/qcodes/dataset/sqlite/query_helpers.py
+++ b/qcodes/dataset/sqlite/query_helpers.py
@@ -113,7 +113,7 @@ def _massage_dict(metadata: Dict[str, Any]) -> Tuple[str, List[Any]]:
 
 
 def update_where(conn: ConnectionPlus, table: str,
-                 where_column: str, where_value: Any, **updates) -> None:
+                 where_column: str, where_value: Any, **updates: Any) -> None:
     _updates, values = _massage_dict(updates)
     query = f"""
     UPDATE


### PR DESCRIPTION
This uncovers an actual bug in in database extract runs that was not correctly unpacking the run_ids. 
This bug happened to not matter since numpy.unique flattens nested arrays such that `[[1,2,3,3]] -> np.ndarray([1,2,3])` and was therefore not caught by tests
