### PR TITLE
Fix error for writing complex valued standalone parameters

### DIFF
--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -471,7 +471,7 @@ class DataSaver:
         else:
             # We first massage all values into np.arrays of the same
             # shape
-            flat_results: Dict[str, np.ndarray]= {}
+            flat_results: Dict[str, np.ndarray] = {}
 
             toplevel_val = result_dict[toplevel_param]
             flat_results[toplevel_param.name] = toplevel_val.ravel()
@@ -513,6 +513,11 @@ class DataSaver:
                     res_list += [{param.name: number} for number in value]
                 else:
                     res_list += [{param.name: float(value)}]
+            elif param.type == 'complex':
+                if value.shape:
+                    res_list += [{param.name: number} for number in value]
+                else:
+                    res_list += [{param.name: complex(value)}]
             else:
                 res_list += [{param.name: value}]
 

--- a/qcodes/tests/dataset/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/test_measurement_context_manager.py
@@ -1964,6 +1964,27 @@ def test_save_complex_num(complex_num_instrument):
 
 
 @pytest.mark.usefixtures("experiment")
+def test_save_and_reload_complex_standalone(complex_num_instrument):
+    param = complex_num_instrument.complex_num
+    complex_num_instrument.setpoint(1)
+    p = qc.instrument.parameter.Parameter(
+        'test',
+        set_cmd=None,
+        get_cmd=lambda: 1+1j,
+        vals=qc.utils.validators.ComplexNumbers())
+    meas = qc.dataset.measurements.Measurement()
+    meas.register_parameter(param)
+    pval = param.get()
+    with meas.run() as datasaver:
+        datasaver.add_result((param, pval))
+    data = datasaver.dataset.get_parameter_data()
+    data_num = data['dummy_channel_inst_complex_num'][
+        'dummy_channel_inst_complex_num']
+    assert_allclose(data_num, 1 + 1j)
+
+
+
+@pytest.mark.usefixtures("experiment")
 def test_save_complex_num_setpoints(complex_num_instrument):
     """
     Test that we can save a parameter with complex setpoints


### PR DESCRIPTION
Currently writing a complex valued standalone parameter to the db fails when trying to read it back. (See added test). This is e.g. the case for any `do0d`.

It feels that there is a lot of refactoring that can be done in the measurements, while this is only the quick fix.

@WilliamHPNielsen have I interpolated the situation correctly for array valued parameters, i.e. the 'if branch' of the added code?