### PR TITLE
Type annotate qcodes.math.*, make FieldVector's attributes always computed

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -21,3 +21,6 @@ disallow_untyped_defs = False
 
 [mypy-qcodes.dataset.*]
 disallow_untyped_defs = True
+
+[mypy-qcodes.math.*]
+disallow_untyped_defs = True

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -355,7 +355,7 @@ class MercuryiPS(VisaInstrument):
         if len(coordinates) == 1:
             return meas_field.get_components(*coordinates)[0]
         else:
-            return meas_field.get_components(*coordinates)
+            return list(meas_field.get_components(*coordinates))
 
     def _get_field(self) -> FieldVector:
         return FieldVector(


### PR DESCRIPTION
todo until completion:
- [ ] rework the logic regarding `_compute_unknowns` method so that a `FieldVector` instance ALWAYS has ALL of its coordinates calculated (currently it is possible to end up with a `FieldVector` that has some of its attributes equal to `None`)
- [ ] remove `T` `TypeVar` completely becuase `mypy` complained when it was used to annotate dunder methods :( or use `T` such that `mypy` understands the typing of dunders