### PR TITLE
_BaseParameter: add _Cache class, use it in GetLatest and in snapshot_base (and IMPROVE IT), remove set_cache method, remove _latest

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -489,25 +489,6 @@ class _BaseParameter(Metadatable):
 
         return raw_value
 
-    def set_cache(self, value: ParamDataType) -> None:
-        """
-        Set the cached value of the parameter without invoking the
-        ``set_cmd`` of the parameter (if it has one). For example, in case of
-        an instrument parameter, calling :meth:`set_cache` as opposed to
-        calling ``set`` will only change the internally-stored value of
-        the parameter (that is available when calling ``get_latest``),
-        and will pass that value to the instrument.
-
-        Note that this method also respects all the validation, parsing,
-        offsetting, etc that the ``set`` method respects. However,
-        if the parameter has :attr:`step` defined, unlike the ``set`` method,
-        this method does not perform setting the parameter step-by-step.
-
-        Args:
-            value: new value for the parameter
-        """
-        self.cache.set(value)
-
     def _save_val(self, value: ParamDataType, validate: bool = False) -> None:
         """
         Use ``cache.set`` instead of this method. It will be deprecated soon.
@@ -1740,6 +1721,22 @@ class _Cache:
         return self._max_val_age
 
     def set(self, value: ParamDataType) -> None:
+        """
+        Set the cached value of the parameter without invoking the
+        ``set_cmd`` of the parameter (if it has one). For example, in case of
+        an instrument parameter, calling :meth:`cache.set` as opposed to
+        calling ``set`` will only change the internally-stored value of
+        the parameter (that is available when calling ``cache.get`` or
+        ``get_latest``), and will pass that value to the instrument.
+
+        Note that this method also respects all the validation, parsing,
+        offsetting, etc that the parameter's ``set`` method respects. However,
+        if the parameter has :attr:`step` defined, unlike the ``set`` method,
+        this method does not perform setting the parameter step-by-step.
+
+        Args:
+            value: new value for the parameter
+        """
         self._parameter.validate(value)
         raw_value = self._parameter._from_value_to_raw_value(value)
         self._update_with(value=value, raw_value=raw_value)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1786,10 +1786,6 @@ class _Cache:
             else:
                 return self._value
 
-    def get_raw(self, get_if_invalid: bool = True) -> ParamRawDataType:
-        self.get(get_if_invalid=get_if_invalid)
-        return self._raw_value
-
     def __call__(self) -> ParamDataType:
         return self.get(get_if_invalid=True)
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1718,6 +1718,22 @@ class MultiParameter(_BaseParameter):
 
 
 class _Cache:
+    """
+    Cache object for parameter to hold its valud and raw value
+
+    It also implements ``set`` method for setting parameter's value without
+    invoking its ``get_cmd``, and ``get`` method that allows to retrieve the
+    cached value of the parameter, and if the cache is invalid,
+    ``parameter.get()`` might be called.
+
+    Args:
+         parameter: instance of the parameter that this cache belongs to.
+         max_val_age: Max time (in seconds) to trust a value stored in cache.
+            If the parameter has not been set or measured more recently than
+            this, an additional measurement will be performed in order to
+            update the cached value. If it is ``None``, this behavior is
+            disabled.
+    """
     def __init__(self,
                  parameter: '_BaseParameter',
                  max_val_age: Optional[float] = None):
@@ -1729,14 +1745,28 @@ class _Cache:
 
     @property
     def raw_value(self) -> ParamRawDataType:
+        """Raw value of the parameter"""
         return self._raw_value
 
     @property
     def timestamp(self) -> Optional[datetime]:
+        """
+        Timestamp of the moment when cache was last updated
+
+        If ``None``, the cache hasn't been updated yet and shall be seen as
+        "invalid".
+        """
         return self._timestamp
 
     @property
     def max_val_age(self) -> Optional[float]:
+        """
+        Max time (in seconds) to trust a value stored in cache. If the
+        parameter has not been set or measured more recently than this,
+        perform an additional measurement.
+
+        If it is ``None``, this behavior is disabled.
+        """
         return self._max_val_age
 
     def set(self, value: ParamDataType) -> None:
@@ -1745,8 +1775,8 @@ class _Cache:
         ``set_cmd`` of the parameter (if it has one). For example, in case of
         an instrument parameter, calling :meth:`cache.set` as opposed to
         calling ``set`` will only change the internally-stored value of
-        the parameter (that is available when calling ``cache.get`` or
-        ``get_latest``), and will NOT pass that value to the instrument.
+        the parameter (that is available when calling ``cache.get()`` or
+        ``get_latest()``), and will NOT pass that value to the instrument.
 
         Note that this method also respects all the validation, parsing,
         offsetting, etc that the parameter's ``set`` method respects. However,
@@ -1765,6 +1795,17 @@ class _Cache:
                      raw_value: ParamRawDataType,
                      timestamp: Optional[datetime] = None
                      ) -> None:
+        """
+        Simply overwrites the value and raw value in this cache with new
+        ones. The timestamp, if not ``None``, also gets overwritten, and if not,
+        then timestamp of "now" is used.
+
+        Args:
+            value: new value of the parameter
+            raw_value: new raw value of the parameter
+            timestamp: new timestamp of the parameter; if ``None``,
+                then timestamp of "now" is used
+        """
         self._value = value
         self._raw_value = raw_value
         if timestamp is None:
@@ -1773,6 +1814,18 @@ class _Cache:
             self._timestamp = timestamp
 
     def get(self, get_if_invalid: bool = True) -> ParamDataType:
+        """
+        Return cached value if time since get was less than `max_val_age`,
+        otherwise perform ``get()`` on the parameter and return result. A
+        ``get()`` will also be performed if the parameter never has been
+        captured but only if ``get_if_invalid`` argument is ``True``.
+
+        Args:
+            get_if_invalid: if set to ``True``, ``get()`` on a parameter
+                will be performed in case the cached value is invalid (for
+                example, due to ``max_val_age``, or because the parameter has
+                never been captured)
+        """
         no_get = not hasattr(self._parameter, 'get')
 
         # the parameter has never been captured so `get` it but only
@@ -1796,8 +1849,8 @@ class _Cache:
         else:
             if no_get:
                 # TODO: this check should really be at the time of setting
-                # max_val_age unfortunately this happens in init before
-                # get wrapping is performed.
+                #  max_val_age unfortunately this happens in init before
+                #  get wrapping is performed.
                 raise RuntimeError("`max_val_age` is not supported for a "
                                    "parameter without get command.")
 
@@ -1811,6 +1864,10 @@ class _Cache:
                 return self._value
 
     def __call__(self) -> ParamDataType:
+        """
+        Same as :meth:`get` but always call ``get`` on parameter if the
+        cache is not valid
+        """
         return self.get(get_if_invalid=True)
 
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -425,8 +425,17 @@ class _BaseParameter(Metadatable):
                                  'full_name': str(self)}
 
         if self._snapshot_value:
-            get_if_invalid = self._snapshot_get and update
-            state['value'] = self.cache.get(get_if_invalid=get_if_invalid)
+            has_get = hasattr(self, 'get')
+            allowed_to_call_get_when_snapshotting = self._snapshot_get
+            can_call_get_when_snapshotting = (
+                    allowed_to_call_get_when_snapshotting and has_get)
+
+            if can_call_get_when_snapshotting and update:
+                state['value'] = self.get()
+            else:
+                state['value'] = self.cache.get(
+                    get_if_invalid=can_call_get_when_snapshotting)
+
             state['raw_value'] = self.cache.raw_value
 
         if isinstance(state['ts'], datetime):

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1727,7 +1727,7 @@ class _Cache:
         an instrument parameter, calling :meth:`cache.set` as opposed to
         calling ``set`` will only change the internally-stored value of
         the parameter (that is available when calling ``cache.get`` or
-        ``get_latest``), and will pass that value to the instrument.
+        ``get_latest``), and will NOT pass that value to the instrument.
 
         Note that this method also respects all the validation, parsing,
         offsetting, etc that the parameter's ``set`` method respects. However,

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -336,10 +336,13 @@ class _BaseParameter(Metadatable):
         :setter: Setting the ``raw_value`` is not recommended as it may lead to
             inconsistent state of the parameter.
         """
-        return self.cache._raw_value
+        return self.cache.raw_value
 
     @raw_value.setter
     def raw_value(self, new_raw_value: ParamRawDataType) -> None:
+        # Setting of the ``raw_value`` property of the parameter will be
+        # deprecated soon anyway, hence, until then, it's ok to refer to
+        # ``cache``s private ``_raw_value`` attribute here
         self.cache._raw_value = new_raw_value
 
     @abstractmethod
@@ -422,7 +425,7 @@ class _BaseParameter(Metadatable):
         if self._snapshot_value:
             get_if_invalid = self._snapshot_get and update
             state['value'] = self.cache.get(get_if_invalid=get_if_invalid)
-            state['raw_value'] = self.cache._raw_value
+            state['raw_value'] = self.cache.raw_value
 
         if isinstance(state['ts'], datetime):
             dttime: datetime = state['ts']
@@ -497,7 +500,7 @@ class _BaseParameter(Metadatable):
                 self.offset is None):
             raw_value = value
         else:
-            raw_value = self.cache._raw_value
+            raw_value = self.cache.raw_value
         self.cache._update_with(value=value, raw_value=raw_value)
 
     def _from_raw_value_to_value(self, raw_value: ParamRawDataType
@@ -1025,7 +1028,7 @@ class Parameter(_BaseParameter):
         # get/set methods)
         if not hasattr(self, 'get') and get_cmd is not False:
             if get_cmd is None:
-                self.get_raw = lambda: self.cache._raw_value   # type: ignore[assignment]
+                self.get_raw = lambda: self.cache.raw_value   # type: ignore[assignment]
             else:
                 exec_str_ask = getattr(instrument, "ask", None) \
                     if instrument else None
@@ -1704,6 +1707,10 @@ class _Cache:
         self._raw_value: ParamRawDataType = None
         self._timestamp: Optional[datetime] = None
         self._max_val_age = max_val_age
+
+    @property
+    def raw_value(self) -> ParamRawDataType:
+        return self._raw_value
 
     @property
     def timestamp(self) -> Optional[datetime]:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -600,9 +600,6 @@ class _BaseParameter(Metadatable):
 
                     set_function(raw_val_step, **kwargs)
 
-                    self.cache._update_with(value=val_step,
-                                            raw_value=raw_val_step)
-
                     # Update last set time (used for calculating delays)
                     self._t_last_set = time.perf_counter()
 
@@ -611,6 +608,9 @@ class _BaseParameter(Metadatable):
                     if t_elapsed < self.post_delay:
                         # Sleep until total time is larger than self.post_delay
                         time.sleep(self.post_delay - t_elapsed)
+
+                    self.cache._update_with(value=val_step,
+                                            raw_value=raw_val_step)
 
             except Exception as e:
                 e.args = e.args + ('setting {} to {}'.format(self, value),)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -420,8 +420,7 @@ class _BaseParameter(Metadatable):
                 f"Parameter ({self.name}) is used in the snapshot while it "
                 f"should be excluded from the snapshot")
 
-        state: Dict[str, Any] = {'ts': self.cache.timestamp,
-                                 '__class__': full_class(self),
+        state: Dict[str, Any] = {'__class__': full_class(self),
                                  'full_name': str(self)}
 
         if self._snapshot_value:
@@ -437,6 +436,8 @@ class _BaseParameter(Metadatable):
                     get_if_invalid=can_call_get_when_snapshotting)
 
             state['raw_value'] = self.cache.raw_value
+
+        state['ts'] = self.cache.timestamp
 
         if isinstance(state['ts'], datetime):
             dttime: datetime = state['ts']

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -35,8 +35,8 @@ more specialized ones:
     using :class:`.ParameterWithSetpoints`.
 
     :class:`.ParameterWithSetpoints` is supported in a
-    :class:`qcodes.dataset.measurements.Measurement` but is not supported by the
-    legacy :class:`qcodes.loops.Loop` and :class:`qcodes.measure.Measure`
+    :class:`qcodes.dataset.measurements.Measurement` but is not supported by
+    the legacy :class:`qcodes.loops.Loop` and :class:`qcodes.measure.Measure`
     measurement types.
 
 - :class:`.DelegateParameter` is intended proxy-ing other parameters.
@@ -295,15 +295,17 @@ class _BaseParameter(Metadatable):
         if hasattr(self, 'get_raw') and not get_raw_is_abstract:
             self.get = self._wrap_get(self.get_raw)
         elif hasattr(self, 'get'):
-            warnings.warn(f'Wrapping get method of parameter: {self.full_name},'
-                          f' original get method will not '
+            warnings.warn(f'Wrapping get method of parameter: '
+                          f'{self.full_name}, original get method will not '
                           f'be directly accessible. It is recommended to '
                           f'define get_raw in your subclass instead. '
                           f'Overwriting get will be an error in the future.')
             self.get = self._wrap_get(self.get)
 
         self.set: Callable[..., None]
-        if hasattr(self, 'set_raw') and not getattr(self.set_raw, '__qcodes_is_abstract_method__', False):
+        set_raw_is_abstract = getattr(self.set_raw,
+                                      '__qcodes_is_abstract_method__', False)
+        if hasattr(self, 'set_raw') and not set_raw_is_abstract:
             self.set = self._wrap_set(self.set_raw)
         elif hasattr(self, 'set'):
             warnings.warn(f'Wrapping set method of parameter: '
@@ -660,9 +662,9 @@ class _BaseParameter(Metadatable):
             if not (isinstance(start_value, (int, float)) and
                     isinstance(value, (int, float))):
                 # something weird... parameter is numeric but one of the ends
-                # isn't, even though it's valid.
-                # probably MultiType with a mix of numeric and non-numeric types
-                # just set the endpoint and move on
+                # isn't, even though it's valid. probably MultiType with a
+                # mix of numeric and non-numeric types... So just set the
+                # endpoint and move on.
                 log.warning(f'cannot sweep {self.name} from {start_value!r} '
                             f'to {value!r} - jumping.')
                 return []
@@ -766,9 +768,9 @@ class _BaseParameter(Metadatable):
         the command for setting the parameter returns quickly.
 
         Args:
-            post_delay: the target time after the *start*
-                of a set operation. The actual time will not be shorter than
-                this, but may be longer if the underlying set call takes longer.
+            post_delay: the target time after the *start* of a set
+                operation. The actual time will not be shorter than this,
+                but may be longer if the underlying set call takes longer.
 
         Raises:
             TypeError: If delay is not int nor float
@@ -797,9 +799,9 @@ class _BaseParameter(Metadatable):
         *between* sets.
 
         Args:
-            inter_delay: the minimum time between set calls.
-                The actual time will not be shorter than this, but may be longer
-                if the underlying set call takes longer.
+            inter_delay: the minimum time between set calls. The actual time
+                will not be shorter than this, but may be longer if the
+                underlying set call takes longer.
 
         Raises:
             TypeError: If delay is not int nor float
@@ -1036,8 +1038,8 @@ class Parameter(_BaseParameter):
         # Enable set/get methods from get_cmd/set_cmd if given and
         # no `get`/`set` or `get_raw`/`set_raw` methods have been defined
         # in the scope of this class.
-        # (previous call to `super().__init__` wraps existing get_raw/set_raw to
-        # get/set methods)
+        # (previous call to `super().__init__` wraps existing
+        # get_raw/set_raw into get/set methods)
         if not hasattr(self, 'get') and get_cmd is not False:
             if get_cmd is None:
                 self.get_raw = (  # type: ignore[assignment]
@@ -1680,7 +1682,7 @@ class MultiParameter(_BaseParameter):
         """
         Names of the parameter components including the name of the instrument
         and submodule that the parameter may be bound to. The name parts are
-        separated by underscores, like this: ``instrument_submodule_parameter``.
+        separated by underscores, like this: ``instrument_submodule_parameter``
         """
         inst_name = "_".join(self.name_parts[:-1])
         if inst_name != '':
@@ -1704,7 +1706,8 @@ class MultiParameter(_BaseParameter):
                 full_sp_names_subgroupd = []
                 for spname in sp_group:
                     if spname is not None:
-                        full_sp_names_subgroupd.append(inst_name + '_' + spname)
+                        full_sp_names_subgroupd.append(
+                            inst_name + '_' + spname)
                     else:
                         full_sp_names_subgroupd.append(None)
                 full_sp_names.append(tuple(full_sp_names_subgroupd))
@@ -1780,8 +1783,9 @@ class _Cache:
                     raise RuntimeError(f"Value of parameter "
                                        f"{(self._parameter.full_name)} "
                                        f"is unknown and the Parameter does "
-                                       f"not have a get command. Please set "
-                                       f"the value before attempting to get it.")
+                                       f"not have a get command. "
+                                       f"Please set the value before "
+                                       f"attempting to get it.")
                 return self._parameter.get()
             else:
                 return self._value

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -290,7 +290,9 @@ class _BaseParameter(Metadatable):
         self.get_latest = GetLatest(self)
 
         self.get: Callable[..., ParamDataType]
-        if hasattr(self, 'get_raw') and not getattr(self.get_raw, '__qcodes_is_abstract_method__', False):
+        get_raw_is_abstract = getattr(self.get_raw,
+                                      '__qcodes_is_abstract_method__', False)
+        if hasattr(self, 'get_raw') and not get_raw_is_abstract:
             self.get = self._wrap_get(self.get_raw)
         elif hasattr(self, 'get'):
             warnings.warn(f'Wrapping get method of parameter: {self.full_name},'
@@ -1028,11 +1030,13 @@ class Parameter(_BaseParameter):
         # get/set methods)
         if not hasattr(self, 'get') and get_cmd is not False:
             if get_cmd is None:
-                self.get_raw = lambda: self.cache.raw_value   # type: ignore[assignment]
+                self.get_raw = (  # type: ignore[assignment]
+                    lambda: self.cache.raw_value)
             else:
                 exec_str_ask = getattr(instrument, "ask", None) \
                     if instrument else None
-                self.get_raw = Command(arg_count=0, cmd=get_cmd,   # type: ignore[assignment]
+                self.get_raw = Command(arg_count=0,  # type: ignore[assignment]
+                                       cmd=get_cmd,
                                        exec_str=exec_str_ask)
             self.get = self._wrap_get(self.get_raw)
 
@@ -1467,9 +1471,11 @@ class ArrayParameter(_BaseParameter):
 
 
 def _is_nested_sequence_or_none(obj: Any,
-                                types: Optional[Union[Type[object],
-                                                      Tuple[Type[object], ...]]],
-                                shapes: Sequence[Sequence[Optional[int]]]) -> bool:
+                                types: Optional[Union[
+                                    Type[object],
+                                    Tuple[Type[object], ...]]],
+                                shapes: Sequence[Sequence[Optional[int]]]
+                                ) -> bool:
     """Validator for MultiParameter setpoints/names/labels"""
     if obj is None:
         return True
@@ -1781,7 +1787,8 @@ class _Cache:
                 raise RuntimeError("`max_val_age` is not supported for a "
                                    "parameter without get command.")
 
-            oldest_ok_val = datetime.now() - timedelta(seconds=self._max_val_age)
+            oldest_ok_val = (datetime.now()
+                             - timedelta(seconds=self._max_val_age))
             if self._timestamp < oldest_ok_val:
                 # Time of last get exceeds max_val_age seconds, need to
                 # perform new .get()
@@ -1848,7 +1855,8 @@ def combine(*parameters: 'Parameter',
             label: Optional[str] = None,
             unit: Optional[str] = None,
             units: Optional[str] = None,
-            aggregator: Optional[Callable[[Sequence[Any]], Any]] = None) -> 'CombinedParameter':
+            aggregator: Optional[Callable[[Sequence[Any]], Any]] = None
+            ) -> 'CombinedParameter':
     """
     Combine parameters into one sweepable parameter
 
@@ -1998,11 +2006,12 @@ class CombinedParameter(Metadatable):
         return numpy.shape(self.setpoints)[0]
 
     def snapshot_base(self, update: bool = False,
-                      params_to_skip_update: Optional[Sequence[str]] = None) -> dict:
+                      params_to_skip_update: Optional[Sequence[str]] = None
+                      ) -> dict:
         """
-        State of the combined parameter as a JSON-compatible dict (everything that
-        the custom JSON encoder class :class:`qcodes.utils.helpers.NumpyJSONEncoder`
-        supports).
+        State of the combined parameter as a JSON-compatible dict (everything
+        that the custom JSON encoder class
+        :class:`qcodes.utils.helpers.NumpyJSONEncoder` supports).
 
         Args:
             update: ``True`` or ``False``.
@@ -2013,9 +2022,10 @@ class CombinedParameter(Metadatable):
         """
         meta_data: Dict[str, Any] = collections.OrderedDict()
         meta_data['__class__'] = full_class(self)
-        meta_data['unit'] = self.parameter.unit  # type: ignore[attr-defined]
-        meta_data['label'] = self.parameter.label  # type: ignore[attr-defined]
-        meta_data['full_name'] = self.parameter.full_name  # type: ignore[attr-defined]
+        param = self.parameter
+        meta_data['unit'] = param.unit  # type: ignore[attr-defined]
+        meta_data['label'] = param.label  # type: ignore[attr-defined]
+        meta_data['full_name'] = param.full_name  # type: ignore[attr-defined]
         meta_data['aggregator'] = repr(getattr(self, 'f', None))
         for param in self.parameters:
             meta_data[str(param)] = param.snapshot()
@@ -2142,7 +2152,8 @@ class ScaledParameter(Parameter):
         >>> vb = ScaledParameter(dac.chan0, gain = 30, name = 'Vb')
 
         Transimpedance amplifier
-        >>> Id = ScaledParameter(multimeter.amplitude, division = 1e6, name = 'Id', unit = 'A')
+        >>> Id = ScaledParameter(multimeter.amplitude,
+        ...                      division = 1e6, name = 'Id', unit = 'A')
 
     Args:
         output: Physical Parameter that need conversion.
@@ -2223,7 +2234,8 @@ class ScaledParameter(Parameter):
         self._meta_attrs.extend(["role"])
         self.metadata['wrapped_parameter'] = self._wrapped_parameter.name
         if self._wrapped_instrument:
-            self.metadata['wrapped_instrument'] = getattr(self._wrapped_instrument, "name", None)
+            wrapped_instr_name = getattr(self._wrapped_instrument, "name", None)
+            self.metadata['wrapped_instrument'] = wrapped_instr_name
 
     # Internal handling of the multiplier
     # can be either a Parameter or a scalar
@@ -2238,7 +2250,8 @@ class ScaledParameter(Parameter):
     def _multiplier(self, multiplier: Union[Number, Parameter]) -> None:
         if isinstance(multiplier, Parameter):
             self._multiplier_parameter = multiplier
-            self.metadata['variable_multiplier'] = self._multiplier_parameter.name
+            multiplier_name = self._multiplier_parameter.name
+            self.metadata['variable_multiplier'] = multiplier_name
         else:
             self._multiplier_parameter = ManualParameter(
                 'multiplier', initial_value=multiplier)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -39,7 +39,7 @@ more specialized ones:
     the legacy :class:`qcodes.loops.Loop` and :class:`qcodes.measure.Measure`
     measurement types.
 
-- :class:`.DelegateParameter` is intended proxy-ing other parameters.
+- :class:`.DelegateParameter` is intended for proxy-ing other parameters.
     It forwards its ``get`` and ``set`` to the underlying source parameter,
     while allowing to specify label/unit/etc that is different from the
     source parameter.
@@ -114,7 +114,7 @@ log = logging.getLogger(__name__)
 
 class _SetParamContext:
     """
-    This class is returned by the ``set_to`` method of parameters
+    This class is returned by the ``set_to`` method of parameter
 
     Example usage:
 
@@ -184,7 +184,7 @@ class _BaseParameter(Metadatable):
 
         scale: Scale to multiply value with before
             performing set. the internally multiplied value is stored in
-            `raw_value`. Can account for a voltage divider.
+            ``cache.raw_value``. Can account for a voltage divider.
 
         offset: Compensate for a parameter specific offset. (just as scale)
             get value = raw value - offset.
@@ -222,7 +222,7 @@ class _BaseParameter(Metadatable):
         vals: a Validator object for this parameter
 
         max_val_age: The max time (in seconds) to trust a saved value obtained
-            from get_latest(). If this parameter has not
+            from ``cache.get`` (or ``get_latest``). If this parameter has not
             been set or measured more recently than this, perform an
             additional measurement.
 
@@ -282,10 +282,13 @@ class _BaseParameter(Metadatable):
         self.get_parser = get_parser
         self.set_parser = set_parser
 
-        # record of latest value and when it was set or measured
-        # what exactly this means is different for different subclasses
-        # but they all use the same attributes so snapshot is consistent.
+        # ``_Cache`` stores "latest" value (and raw value) and timestamp
+        # when it was set or measured
         self.cache = _Cache(self, max_val_age=max_val_age)
+        # ``GetLatest`` is left from previous versions where it would
+        # implement a subset of features which ``_Cache`` has.
+        # It is left for now for backwards compatibility reasons and shall
+        # be deprecated and removed in the future versions.
         self.get_latest: GetLatest
         self.get_latest = GetLatest(self)
 
@@ -332,9 +335,10 @@ class _BaseParameter(Metadatable):
     @property
     def raw_value(self) -> ParamRawDataType:
         """
-        Represents the cached raw value of the parameter.
+        Note that this property will be deprecated soon. Use
+        ``cache.raw_value`` instead.
 
-        Note that this property will be deprecated soon.
+        Represents the cached raw value of the parameter.
 
         :getter: Returns the cached raw value of the parameter.
         :setter: Setting the ``raw_value`` is not recommended as it may lead to
@@ -408,11 +412,16 @@ class _BaseParameter(Metadatable):
         the custom JSON encoder class
         :class:`qcodes.utils.helpers.NumpyJSONEncoder` supports).
 
+        If the parameter has been initiated with ``snapshot_value=False``,
+        the snapshot will NOT include the ``value`` and ``raw_value`` of the
+        parameter.
+
         Args:
-            update (bool): If True, update the state by calling
-                parameter.get().
-                If False, just use the latest values in memory.
-            params_to_skip_update: No effect but may be passed from super Class:
+            update: If True, update the state by calling ``parameter.get()``
+                unless ``snapshot_get`` of the parameter is ``False``.
+                If ``update`` is ``False``, just use the value from
+                ``cache`` via ``cache.get()`` method.
+            params_to_skip_update: No effect but may be passed from superclass
 
         Returns:
             dict: base snapshot
@@ -501,9 +510,7 @@ class _BaseParameter(Metadatable):
 
     def _save_val(self, value: ParamDataType, validate: bool = False) -> None:
         """
-        Use ``cache.set`` instead of this method. It will be deprecated soon.
-
-        Update latest
+        Use ``cache.set`` instead of this method. This will be deprecated soon.
         """
         if validate:
             self.validate(value)
@@ -924,10 +931,14 @@ class Parameter(_BaseParameter):
        :meth:`set_raw` methods are automatically wrapped to provide ``get`` and
        ``set``.
 
-    Parameters have a ``.get_latest`` method that simply returns the most
-    recent set or measured value. This can be called ( ``param.get_latest()`` )
+    Parameters have a ``cache`` object that stores internally the current
+    ``value`` and ``raw_value`` of the parameter. Calling ``cache.get()``
+    (or ``cache()``) simply returns the most recent set or measured value of
+    the parameter.
 
-
+    Parameter also has a ``.get_latest`` method that duplicates the behavior
+    of ``cache()`` call, as in, it also simply returns the most recent set
+    or measured value.
 
     Args:
         name: The local name of the parameter. Should be a valid
@@ -946,8 +957,9 @@ class Parameter(_BaseParameter):
 
         snapshot_get: ``False`` prevents any update to the
             parameter during a snapshot, even if the snapshot was called with
-            ``update=True``, for example, if it takes too long to update.
-            Default True.
+            ``update=True``, for example, if it takes too long to update,
+            or if the parameter is only meant for measurements hence its value
+            in the snapshot may not always make sense. Default True.
 
         snapshot_value: ``False`` prevents parameter value to be
             stored in the snapshot. Useful if the value is large.
@@ -963,7 +975,7 @@ class Parameter(_BaseParameter):
 
         scale: Scale to multiply value with before
             performing set. the internally multiplied value is stored in
-            `raw_value`. Can account for a voltage divider.
+            ``cache.raw_value``. Can account for a voltage divider.
 
         inter_delay: Minimum time (in seconds)
             between successive sets. If the previous set was less than this,
@@ -998,9 +1010,9 @@ class Parameter(_BaseParameter):
             Only relevant if settable. Defaults to ``Numbers()``.
 
         max_val_age: The max time (in seconds) to trust a
-            saved value obtained from ``get_latest()``. If this  parameter
-            has not been set or measured more recently than this, perform an
-            additional measurement.
+            saved value obtained from ``cache()`` (or ``cache.get()``, or
+            ``get_latest()``. If this parameter has not been set or measured
+            more recently than this, perform an additional measurement.
 
         docstring: Documentation string for the ``__doc__``
             field of the object. The ``__doc__``  field of the instance is
@@ -1008,7 +1020,6 @@ class Parameter(_BaseParameter):
 
         metadata: Extra information to include with the
             JSON snapshot of the parameter.
-
     """
 
     def __init__(self, name: str,
@@ -1028,9 +1039,10 @@ class Parameter(_BaseParameter):
         no_get = not hasattr(self, 'get') and (get_cmd is None
                                                or get_cmd is False)
         # TODO: a matching check should be in _BaseParameter but
-        # due to the current limited design the _BaseParameter cannot
-        # know if this subclass will supply a get_cmd
-        # To work around this a RunTime check is put into get of GetLatest
+        #   due to the current limited design the _BaseParameter cannot
+        #   know if this subclass will supply a get_cmd
+        #   To work around this a RunTime check is put into get of GetLatest
+        #   and into get of _Cache
         if max_val_age is not None and no_get:
             raise SyntaxError('Must have get method or specify get_cmd '
                               'when max_val_age is set')
@@ -1878,8 +1890,13 @@ class GetLatest(DelegateAttributes):
     on the parameter or the time since get was called is larger than
     ``max_val_age``, get will be called on the parameter. If the parameter
     does not implement get, set should be called (or the initial_value set)
-    before calling get on this wrapper. It is an error
-    to set ``max_val_age`` for a parameter that does not have a get function.
+    before calling get on this wrapper. It is an error to set
+    ``max_val_age`` for a parameter that does not have a get function.
+
+    The functionality of this class is subsumed and improved in
+    :class:`_Cache` that is accessible via ``.cache`` attribute of the
+    class:`.Parameter`. Use of ``parameter.cache`` is recommended over use of
+    ``parameter.get_latest``.
 
     Examples:
         >>> # Can be called:
@@ -1902,22 +1919,33 @@ class GetLatest(DelegateAttributes):
         `max_val_age`, otherwise perform `get()` and
         return result. A `get()` will also be performed if the
         parameter never has been captured.
+
+        It is recommended to use ``parameter.cache.get()`` instead.
         """
         return self.parameter.cache.get()
 
     def get_timestamp(self) -> Optional[datetime]:
         """
         Return the age of the latest parameter value.
+
+        It is recommended to use ``parameter.cache.timestamp`` instead.
         """
         return self.cache.timestamp
 
     def get_raw_value(self) -> Optional[ParamRawDataType]:
         """
         Return latest raw value of the parameter.
+
+        It is recommended to use ``parameter.cache.raw_value`` instead.
         """
         return self.cache._raw_value
 
     def __call__(self) -> ParamDataType:
+        """
+        Same as ``get()``
+
+        It is recommended to use ``parameter.cache()`` instead.
+        """
         return self.cache()
 
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500.py
@@ -46,7 +46,7 @@ class KeysightB1500(VisaInstrument):
         # Instrument is initialized with this setting having value of
         # `False`, hence let's set the parameter to this value since it is
         # not possible to request this value from the instrument.
-        self.autozero_enabled.set_cache(False)
+        self.autozero_enabled.cache.set(False)
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -68,13 +68,15 @@ class B1517A(B1500Module):
         self.add_parameter(
             name="voltage",
             set_cmd=self._set_voltage,
-            get_cmd=self._get_voltage
+            get_cmd=self._get_voltage,
+            snapshot_get=False
         )
 
         self.add_parameter(
             name="current",
             set_cmd=self._set_current,
-            get_cmd=self._get_current
+            get_cmd=self._get_current,
+            snapshot_get=False
         )
 
         self.add_parameter(

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -63,7 +63,7 @@ class B1517A(B1500Module):
         # `1`, spot measurement mode, hence let's set the parameter to this
         # value since it is not possible to request this value from the
         # instrument.
-        self.measurement_mode.set_cache(MM.Mode.SPOT)
+        self.measurement_mode.cache.set(MM.Mode.SPOT)
 
         self.add_parameter(
             name="voltage",

--- a/qcodes/instrument_drivers/QDev/QDac.py
+++ b/qcodes/instrument_drivers/QDev/QDac.py
@@ -261,7 +261,7 @@ class QDac(VisaInstrument):
             voltageparam = self.parameters['ch{:02}_v'.format(chan)]
             oldvoltage = voltageparam.get_latest()
             newvoltage = {0: 10, 1: 0.1}[switchint]*oldvoltage
-            voltageparam.set_cache(newvoltage)
+            voltageparam.cache.set(newvoltage)
 
     def _num_verbose(self, s):
         """
@@ -368,7 +368,7 @@ class QDac(VisaInstrument):
                     attenuation = 0.1*value
                 if param == 'v':
                     value *= attenuation
-                self.parameters[parameter].set_cache(value)
+                self.parameters[parameter].cache.set(value)
             chans_left.remove(chan)
 
         if readcurrents:

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -349,7 +349,7 @@ class QDac(VisaInstrument):
             voltageparam = self.channels[chan-1].v
             oldvoltage = voltageparam.get_latest()
             newvoltage = {0: 10, 1: 0.1}[switchint]*oldvoltage
-            voltageparam.set_cache(newvoltage)
+            voltageparam.cache.set(newvoltage)
 
     def _num_verbose(self, s):
         """
@@ -457,7 +457,7 @@ class QDac(VisaInstrument):
                     attenuation = 0.1*value
                 if param == 'v':
                     value *= attenuation
-                getattr(self.channels[chan-1], param).set_cache(value)
+                getattr(self.channels[chan-1], param).cache.set(value)
             chans_left.remove(chan)
 
         if readcurrents:

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -2197,7 +2197,7 @@ class ZIUHFLI(Instrument):
             SR_str = self.parameters['scope_samplingrate'].get()
             (number, unit) = SR_str.split(' ')
             SR = float(number)*SRtranslation[unit]
-            self.parameters['scope_duration'].set_cache(value/SR)
+            self.parameters['scope_duration'].cache.set(value/SR)
             self.daq.setInt('/{}/scopes/0/length'.format(self.device), value)
 
         def setduration(value):
@@ -2206,8 +2206,8 @@ class ZIUHFLI(Instrument):
             (number, unit) = SR_str.split(' ')
             SR = float(number)*SRtranslation[unit]
             N = int(np.round(value*SR))
-            self.parameters['scope_length'].set_cache(N)
-            self.parameters['scope_duration'].set_cache(value)
+            self.parameters['scope_length'].cache.set(N)
+            self.parameters['scope_duration'].cache.set(value)
             self.daq.setInt('/{}/scopes/0/length'.format(self.device), N)
 
         def setholdoffseconds(value):
@@ -2227,7 +2227,7 @@ class ZIUHFLI(Instrument):
             oldSR = float(number)*SRtranslation[unit]
             oldduration = self.parameters['scope_duration'].get()
             newduration = oldduration*oldSR/newSR
-            self.parameters['scope_duration'].set_cache(newduration)
+            self.parameters['scope_duration'].cache.set(newduration)
             self.daq.setInt('/{}/scopes/0/time'.format(self.device), value)
 
         specialcases = {'length': setlength,

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -407,13 +407,13 @@ class ScopeChannel(InstrumentChannel):
     #########################
     # Specialised/interlinked set/getters
     def _set_range(self, value):
-        self.scale.set_cache(value/10)
+        self.scale.cache.set(value/10)
 
         self._parent.write('CHANnel{}:RANGe {}'.format(self.channum,
                                                        value))
 
     def _set_scale(self, value):
-        self.range.set_cache(value*10)
+        self.range.cache.set(value*10)
 
         self._parent.write('CHANnel{}:SCALe {}'.format(self.channum,
                                                        value))
@@ -727,7 +727,7 @@ class RTO1000(VisaInstrument):
         Set the full range of the timebase
         """
         self._make_traces_not_ready()
-        self.timebase_scale.set_cache(value/self._horisontal_divs)
+        self.timebase_scale.cache.set(value/self._horisontal_divs)
 
         self.write('TIMebase:RANGe {}'.format(value))
 
@@ -736,7 +736,7 @@ class RTO1000(VisaInstrument):
         Set the length of one horizontal division
         """
         self._make_traces_not_ready()
-        self.timebase_range.set_cache(value*self._horisontal_divs)
+        self.timebase_range.cache.set(value*self._horisontal_divs)
 
         self.write('TIMebase:SCALe {}'.format(value))
 

--- a/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
@@ -402,7 +402,7 @@ class SignalHound_USB_SA124B(Instrument):
         of power and trace.
         """
         sweep_info = self.QuerySweep()
-        self.npts.set_cache(sweep_info[0])
+        self.npts.cache.set(sweep_info[0])
         self.trace.set_sweep(*sweep_info)
 
     def sync_parameters(self) -> None:

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -510,7 +510,7 @@ class SnapShotTestInstrument(Instrument):
                                get_cmd=partial(self._getter, p_name))
 
     def _getter(self, name: str):
-        val = self.parameters[name]._latest['value']
+        val = self.parameters[name].cache._value
         self._get_calls[name] += 1
         return val
 

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -35,8 +35,8 @@ class TestInstrument(TestCase):
         instrument = self.instrument
         instrument.validate_status()  # test the instrument has valid values
 
-        instrument.dac1._latest['value'] = 1000  # overrule the validator
-        instrument.dac1._latest['raw_value'] = 1000  # overrule the validator
+        instrument.dac1.cache._value = 1000  # overrule the validator
+        instrument.dac1.cache._raw_value = 1000  # overrule the validator
         with self.assertRaises(Exception):
             instrument.validate_status()
 

--- a/qcodes/tests/test_loop.py
+++ b/qcodes/tests/test_loop.py
@@ -490,10 +490,10 @@ class AbortingGetter(Parameter):
         super().__init__(*args, **kwargs)
 
     def get_raw(self):
-        self._count -= 1
         if self._count <= 0:
             raise _QcodesBreak
-        return self.get_latest()
+        self._count -= 1
+        return self.cache.raw_value
 
     def reset(self):
         self._count = self._initial_count

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -201,19 +201,19 @@ class TestParameter(TestCase):
         self.assertEqual(p.vals.values_validated,
                          [0, 0, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
-    def test_number_of_validations_for_set_cached(self):
+    def test_number_of_validations_for_set_cache(self):
         p = Parameter('p', set_cmd=None,
                       vals=BookkeepingValidator())
         self.assertEqual(p.vals.values_validated, [])
 
-        p.set_cache(1)
+        p.cache.set(1)
         self.assertEqual(p.vals.values_validated, [1])
 
-        p.set_cache(4)
+        p.cache.set(4)
         self.assertEqual(p.vals.values_validated, [1, 4])
 
         p.step = 1
-        p.set_cache(10)
+        p.cache.set(10)
         self.assertEqual(p.vals.values_validated, [1, 4, 10])
 
     def test_snapshot_value(self):
@@ -406,8 +406,8 @@ class TestParameter(TestCase):
             gettable_parameter(1)
         # Initial value is None if not explicitly set
         self.assertIsNone(gettable_parameter())
-        # Assert the set_cache still works for non-settable parameter
-        gettable_parameter.set_cache(1)
+        # Assert the ``cache.set`` still works for non-settable parameter
+        gettable_parameter.cache.set(1)
         self.assertEqual(gettable_parameter(), 1)
 
         # Create parameter that saves value during set, and has no get_cmd
@@ -461,10 +461,10 @@ class TestParameter(TestCase):
         p(44.5)
         self.assertListEqual(p.set_values, [42, 43, 44, 44.5])
 
-        # Assert that stepping does not impact ``set_cache`` call, and that
-        # the value that is passed to ``set_cache`` call does not get
+        # Assert that stepping does not impact ``cache.set`` call, and that
+        # the value that is passed to ``cache.set`` call does not get
         # propagated to parameter's ``set_cmd``
-        p.set_cache(40)
+        p.cache.set(40)
         self.assertEqual(p.get_latest(), 40)
         self.assertListEqual(p.set_values, [42, 43, 44, 44.5])
 
@@ -575,12 +575,12 @@ class TestParameter(TestCase):
             TestFloats, SharedSize, ValuesScalar, False),
         scales=iterable_or_number(
             TestFloats, SharedSize, ValuesScalar, False))
-    def test_scale_and_offset_raw_value_iterable_for_set_cached(
+    def test_scale_and_offset_raw_value_iterable_for_set_cache(
             self, values, offsets, scales):
         p = Parameter(name='test_scale_and_offset_raw_value', set_cmd=None)
 
         # test that scale and offset does not change the default behaviour
-        p.set_cache(values)
+        p.cache.set(values)
         self.assertEqual(p.raw_value, values)
 
         # test setting scale and offset does not change anything
@@ -606,15 +606,15 @@ class TestParameter(TestCase):
         np.testing.assert_allclose(np_get_latest_values_after_get,
                                    (np_values - np_offsets) / np_scales)
 
-        # test set_cache for scalar values
+        # test ``cache.set`` for scalar values
         if not isinstance(values, Iterable):
-            p.set_cache(values)
+            p.cache.set(values)
             np.testing.assert_allclose(np.array(p.raw_value),
                                        np_values * np_scales + np_offsets)
             # No set/get cmd performed
 
             # testing conversion back and forth
-            p.set_cache(values)
+            p.cache.set(values)
             np_get_latest_values = np.array(p.get_latest())
             # No set/get cmd performed
             np.testing.assert_allclose(np_get_latest_values, np_values)
@@ -804,7 +804,7 @@ _P = Parameter
 )
 def test_set_latest_works_for_plain_memory_parameter(p, value, raw_value):
     # Set latest value of the parameter
-    p.set_cache(value)
+    p.cache.set(value)
 
     # Assert the latest value and raw_value
     assert p.get_latest() == value
@@ -965,7 +965,7 @@ class TestArrayParameter(TestCase):
         self.assertFalse(hasattr(p, 'set'))
 
         # Yet, it's possible to set the cached value
-        p.set_cache([6, 7, 8])
+        p.cache.set([6, 7, 8])
         self.assertListEqual(p.get_latest(), [6, 7, 8])
         # However, due to the implementation of this ``SimpleArrayParam``
         # test parameter it's ``get`` call will return the originally passed
@@ -1131,9 +1131,9 @@ class TestMultiParameter(TestCase):
 
         self.assertTrue(hasattr(p, 'get'))
         self.assertFalse(hasattr(p, 'set'))
-        # Ensure that ``set_cache`` works
+        # Ensure that ``cache.set`` works
         new_cache = [10, [10, 20, 30], [[40, 50], [60, 70]]]
-        p.set_cache(new_cache)
+        p.cache.set(new_cache)
         self.assertListEqual(p.get_latest(), new_cache)
         # However, due to the implementation of this ``SimpleMultiParam``
         # test parameter it's ``get`` call will return the originally passed
@@ -1149,8 +1149,8 @@ class TestMultiParameter(TestCase):
         value_to_set = [2, [1, 5, 2], [[8, 2], [4, 9]]]
         p.set(value_to_set)
         assert p.get() == value_to_set
-        # Also, ``set_cache`` works as expected
-        p.set_cache(new_cache)
+        # Also, ``cache.set`` works as expected
+        p.cache.set(new_cache)
         assert p.get_latest() == new_cache
         assert p.get() == value_to_set
 
@@ -1243,9 +1243,9 @@ class TestStandardParam(TestCase):
         self.assertEqual(self._p, '5')
         self.assertEqual(p(), 5)
 
-        p.set_cache(7)
+        p.cache.set(7)
         self.assertEqual(p.get_latest(), 7)
-        # Nothing has been passed to the "instrument" at ``set_cache``
+        # Nothing has been passed to the "instrument" at ``cache.set``
         # call, hence the following assertions should hold
         self.assertEqual(self._p, '5')
         self.assertEqual(p(), 5)
@@ -1262,9 +1262,9 @@ class TestStandardParam(TestCase):
         self.assertTrue(hasattr(p, 'set'))
         self.assertFalse(hasattr(p, 'get'))
 
-        # For settable-only parameters, using ``set_cache`` may not make
-        # sense, neertheless, it works
-        p.set_cache(7)
+        # For settable-only parameters, using ``cache.set`` may not make
+        # sense, nevertheless, it works
+        p.cache.set(7)
         self.assertEqual(p.get_latest(), 7)
 
     def test_gettable(self):
@@ -1280,9 +1280,9 @@ class TestStandardParam(TestCase):
         self.assertTrue(hasattr(p, 'get'))
         self.assertFalse(hasattr(p, 'set'))
 
-        p.set_cache(7)
+        p.cache.set(7)
         self.assertEqual(p.get_latest(), 7)
-        # Nothing has been passed to the "instrument" at ``set_cache``
+        # Nothing has been passed to the "instrument" at ``cache.set``
         # call, hence the following assertions should hold
         self.assertEqual(self._p, 21)
         self.assertEqual(p(), 21)
@@ -1311,9 +1311,9 @@ class TestStandardParam(TestCase):
 
         self._p = 1  # for further testing
 
-        p.set_cache('off')
+        p.cache.set('off')
         self.assertEqual(p.get_latest(), 'off')
-        # Nothing has been passed to the "instrument" at ``set_cache``
+        # Nothing has been passed to the "instrument" at ``cache.set``
         # call, hence the following assertions should hold
         self.assertEqual(self._p, 1)
         self.assertEqual(p(), 'on')
@@ -1338,9 +1338,9 @@ class TestStandardParam(TestCase):
         self._p = 'PVAL: 1'
         self.assertEqual(p(), 'on')
 
-        p.set_cache('off')
+        p.cache.set('off')
         self.assertEqual(p.get_latest(), 'off')
-        # Nothing has been passed to the "instrument" at ``set_cache``
+        # Nothing has been passed to the "instrument" at ``cache.set``
         # call, hence the following assertions should hold
         self.assertEqual(self._p, 'PVAL: 1')
         self.assertEqual(p(), 'on')
@@ -1824,7 +1824,7 @@ def test_delegate_parameter_snapshot():
     assert source_snapshot['value'] == 13
 
 
-def test_delegate_parameter_set_cached_for_memory_source_parameter():
+def test_delegate_parameter_set_cache_for_memory_source_parameter():
     initial_value = 1
     source = Parameter('p', set_cmd=None, get_cmd=None,
                        initial_value=initial_value, offset=1, scale=2)
@@ -1834,7 +1834,7 @@ def test_delegate_parameter_set_cached_for_memory_source_parameter():
     # delegate parameter
 
     new_source_value = 3
-    source.set_cache(new_source_value)
+    source.cache.set(new_source_value)
 
     assert source.raw_value == new_source_value * 2 + 1
     assert source.get_latest() == new_source_value
@@ -1853,7 +1853,7 @@ def test_delegate_parameter_set_cached_for_memory_source_parameter():
     # the source parameter
 
     new_delegate_value = 2
-    delegate.set_cache(new_delegate_value)
+    delegate.cache.set(new_delegate_value)
 
     assert delegate.raw_value == new_delegate_value * 5 + 4
     assert delegate.get_latest() == new_delegate_value
@@ -1861,12 +1861,12 @@ def test_delegate_parameter_set_cached_for_memory_source_parameter():
     assert source.raw_value == new_source_value * 2 + 1
     assert source.get_latest() == new_source_value
 
-    pytest.xfail(reason="DelegateParameter's get_latest and set_cache should "
+    pytest.xfail(reason="DelegateParameter's get_latest and cache.set should "
                         "reflect the state of the source parameter as "
                         "opposed to the behavior that this test exposes.")
 
 
-def test_delegate_parameter_set_cached_for_instrument_source_parameter():
+def test_delegate_parameter_set_cache_for_instrument_source_parameter():
     instrument_value = -689
 
     def get_instrument_value():
@@ -1888,7 +1888,7 @@ def test_delegate_parameter_set_cached_for_instrument_source_parameter():
     # delegate parameter. It also has no impact on the instrument value.
 
     new_source_value = 3
-    source.set_cache(new_source_value)
+    source.cache.set(new_source_value)
 
     assert source.raw_value == new_source_value * 2 + 1
     assert source.get_latest() == new_source_value
@@ -1913,7 +1913,7 @@ def test_delegate_parameter_set_cached_for_instrument_source_parameter():
     # the source parameter, and on the instrument value
 
     new_delegate_value = 2
-    delegate.set_cache(new_delegate_value)
+    delegate.cache.set(new_delegate_value)
 
     assert delegate.raw_value == new_delegate_value * 5 + 4
     assert delegate.get_latest() == new_delegate_value
@@ -1923,6 +1923,6 @@ def test_delegate_parameter_set_cached_for_instrument_source_parameter():
 
     assert instrument_value == initial_value * 2 + 1
 
-    pytest.xfail(reason="DelegateParameter's get_latest and set_cache should "
+    pytest.xfail(reason="DelegateParameter's get_latest and cache.set should "
                         "reflect the state of the source parameter as "
                         "opposed to the behavior that this test exposes.")

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1855,8 +1855,16 @@ def parameterized_parameter(snapshot_get, snapshot_value, get_cmd):
     return p
 
 
-@pytest.mark.parametrize('cache_is_valid', (True, False))
-@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
+@pytest.fixture(params=(True, False, NOT_PASSED))
+def update(request):
+    return request.param
+
+
+@pytest.fixture(params=(True, False))
+def cache_is_valid(request):
+    return request.param
+
+
 def test_snapshot_contains_parameter_attributes(
         parameterized_parameter, cache_is_valid, update):
     p = parameterized_parameter
@@ -1898,8 +1906,6 @@ def test_snapshot_contains_parameter_attributes(
         assert s[attr] == value
 
 
-@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
-@pytest.mark.parametrize('cache_is_valid', (True, False))
 def test_snapshot_timestamp_depends_only_on_cache_validity(
         parameterized_parameter, update, cache_is_valid):
     p = parameterized_parameter
@@ -1921,8 +1927,6 @@ def test_snapshot_timestamp_depends_only_on_cache_validity(
         assert s['ts'] is None
 
 
-@pytest.mark.parametrize('cache_is_valid', (True, False))
-@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
 def test_snapshot_when_snapshot_value_is_false(
         snapshot_get, get_cmd, cache_is_valid, update):
 
@@ -1958,8 +1962,6 @@ def test_snapshot_get_is_true_by_default(snapshot_value, get_cmd):
     assert p._snapshot_get is True
 
 
-@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
-@pytest.mark.parametrize('cache_is_valid', (True, False))
 def test_snapshot_when_snapshot_get_is_false(get_cmd, update, cache_is_valid):
     p = create_parameter(
         snapshot_get=False,
@@ -1984,8 +1986,6 @@ def test_snapshot_when_snapshot_get_is_false(get_cmd, update, cache_is_valid):
         assert p.get.call_count() == 0
 
 
-@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
-@pytest.mark.parametrize('cache_is_valid', (True, False))
 def test_snapshot_of_non_gettable_parameter_mirrors_cache(
         update, cache_is_valid):
     p = create_parameter(
@@ -2007,8 +2007,6 @@ def test_snapshot_of_non_gettable_parameter_mirrors_cache(
         assert s['raw_value'] is None
 
 
-@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
-@pytest.mark.parametrize('cache_is_valid', (True, False))
 def test_snapshot_of_gettable_parameter_depends_on_update(update, cache_is_valid):
     p = create_parameter(
         snapshot_get=True, snapshot_value=True, get_cmd=lambda: 69, offset=4)

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -128,6 +128,7 @@ class TestParameter(TestCase):
         self.assertIn(name, p.__doc__)
 
         # test snapshot_get by looking at _get_count
+        # by default, snapshot_get is True, hence we expect ``get`` to be called
         self.assertEqual(p._get_count, 0)
         snap = p.snapshot(update=True)
         self.assertEqual(p._get_count, 1)
@@ -136,10 +137,12 @@ class TestParameter(TestCase):
             'label': name,
             'unit': '',
             'value': 42,
+            'raw_value': 42,
             'vals': repr(vals.Numbers())
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertNotEqual(snap['ts'], None)
 
     def test_explicit_attributes(self):
         # Test the explicit attributes, providing everything we can
@@ -176,6 +179,9 @@ class TestParameter(TestCase):
             'label': label,
             'unit': unit,
             'vals': repr(vals.Numbers(5, 10)),
+            'value': None,
+            'raw_value': None,
+            'ts': None,
             'metadata': metadata
         }
         for k, v in snap_expected.items():
@@ -222,11 +228,15 @@ class TestParameter(TestCase):
         p_snapshot(42)
         snap = p_snapshot.snapshot()
         self.assertIn('value', snap)
+        self.assertIn('raw_value', snap)
+        self.assertIn('ts', snap)
         p_no_snapshot = Parameter('no_snapshot', set_cmd=None, get_cmd=None,
                                   snapshot_value=False)
         p_no_snapshot(42)
         snap = p_no_snapshot.snapshot()
         self.assertNotIn('value', snap)
+        self.assertNotIn('raw_value', snap)
+        self.assertIn('ts', snap)
 
     def test_get_latest(self):
         time_resolution = time.get_clock_info('time').resolution
@@ -906,6 +916,9 @@ class TestArrayParameter(TestCase):
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertNotIn('value', snap)
+        self.assertNotIn('raw_value', snap)
+        self.assertIsNone(snap['ts'])
 
         self.assertIn(name, p.__doc__)
 
@@ -945,10 +958,12 @@ class TestArrayParameter(TestCase):
             'setpoint_names': setpoint_names,
             'setpoint_labels': setpoint_labels,
             'metadata': metadata,
-            'value': [6, 7]
+            'value': [6, 7],
+            'raw_value': [6, 7]
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertIsNotNone(snap['ts'])
 
         self.assertIn(name, p.__doc__)
         self.assertIn(docstring, p.__doc__)
@@ -1057,10 +1072,13 @@ class TestMultiParameter(TestCase):
             'name': name,
             'names': names,
             'labels': names,
-            'units': [''] * 3
+            'units': [''] * 3,
+            'ts': None
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertNotIn('value', snap)
+        self.assertNotIn('raw_value', snap)
 
         self.assertIn(name, p.__doc__)
 
@@ -1111,10 +1129,12 @@ class TestMultiParameter(TestCase):
             'setpoint_names': setpoint_names,
             'setpoint_labels': setpoint_labels,
             'metadata': metadata,
-            'value': [0, [1, 2, 3], [[4, 5], [6, 7]]]
+            'value': [0, [1, 2, 3], [[4, 5], [6, 7]]],
+            'raw_value': [0, [1, 2, 3], [[4, 5], [6, 7]]]
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertIsNotNone(snap['ts'])
 
         self.assertIn(name, p.__doc__)
         self.assertIn(docstring, p.__doc__)
@@ -2062,7 +2082,9 @@ def test_delegate_parameter_snapshot():
     source_snapshot = snapshot.pop('source_parameter')
     assert source_snapshot == p.snapshot()
     assert snapshot['value'] == 2
+    assert snapshot['raw_value'] == 13
     assert source_snapshot['value'] == 13
+    assert source_snapshot['raw_value'] == 27
 
 
 def test_delegate_parameter_set_cache_for_memory_source_parameter():

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1770,6 +1770,247 @@ def test_deprecated_param_warns():
     assert a.get_count == 3
 
 
+NOT_PASSED = 'NOT_PASSED'
+
+
+@pytest.fixture(params=(True, False, NOT_PASSED))
+def snapshot_get(request):
+    return request.param
+
+
+@pytest.fixture(params=(True, False, NOT_PASSED))
+def snapshot_value(request):
+    return request.param
+
+
+@pytest.fixture(params=(None, False, NOT_PASSED))
+def get_cmd(request):
+    return request.param
+
+
+def create_parameter(snapshot_get, snapshot_value, get_cmd, offset=NOT_PASSED):
+    kwargs = dict(set_cmd=None,
+                  label='Parameter',
+                  unit='a.u.',
+                  docstring='some docs')
+
+    if offset != NOT_PASSED:
+        kwargs.update(offset=offset)
+
+    if snapshot_get != NOT_PASSED:
+        kwargs.update(snapshot_get=snapshot_get)
+
+    if snapshot_value != NOT_PASSED:
+        kwargs.update(snapshot_value=snapshot_value)
+
+    if get_cmd != NOT_PASSED:
+        kwargs.update(get_cmd=get_cmd)
+
+    p = Parameter('p', **kwargs)
+
+    if get_cmd is not False:
+        def wrap_in_call_counter(get_func):
+            call_count = 0
+
+            def wrapped_func(*args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                return get_func(*args, **kwargs)
+
+            wrapped_func.call_count = lambda: call_count
+
+            return wrapped_func
+
+        p.get = wrap_in_call_counter(p.get)
+        assert p.get.call_count() == 0  # pre-condition
+    else:
+        assert not hasattr(p, 'get')  # pre-condition
+
+    return p
+
+
+@pytest.fixture
+def parameterized_parameter(snapshot_get, snapshot_value, get_cmd):
+    p = create_parameter(snapshot_get, snapshot_value, get_cmd)
+    return p
+
+
+@pytest.mark.parametrize('cache_is_valid', (True, False))
+@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
+def test_snapshot_contains_parameter_attributes(
+        parameterized_parameter, cache_is_valid, update):
+    p = parameterized_parameter
+
+    if cache_is_valid:
+        p.set(42)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    assert isinstance(s, dict)
+
+    # Not metadata key in the snapshot because we didn't pass any metadata
+    # for the parameter
+    # TODO: test for parameter with metadata
+    assert 'metadata' not in s
+
+    assert s['__class__'] == 'qcodes.instrument.parameter.Parameter'
+    assert s['full_name'] == 'p'
+
+    # The following is because the parameter does not belong to an instrument
+    # TODO: test for a parameter that is attached to instrument
+    assert 'instrument' not in s
+    assert 'instrument_name' not in s
+
+    # These attributes have value of ``None`` hence not included in the snapshot
+    # TODO: test snapshot when some of these are not None
+    none_attrs = ('step', 'scale', 'offset', 'val_mapping', 'vals')
+    for attr in none_attrs:
+        assert getattr(p, attr) is None  # pre-condition
+        assert attr not in s
+
+    # TODO: test snapshot when some of these are None
+    not_none_attrs = {'name': p.name, 'label': p.label, 'unit': p.unit,
+                      'inter_delay': p.inter_delay, 'post_delay': p.post_delay}
+    for attr, value in not_none_attrs.items():
+        assert s[attr] == value
+
+
+@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
+@pytest.mark.parametrize('cache_is_valid', (True, False))
+def test_snapshot_timestamp_depends_only_on_cache_validity(
+        parameterized_parameter, update, cache_is_valid):
+    p = parameterized_parameter
+
+    if cache_is_valid:
+        t0 = datetime.now()
+        p.set(42)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if cache_is_valid:
+        ts = datetime.strptime(s['ts'], '%Y-%m-%d %H:%M:%S')
+        t0_up_to_seconds = t0.replace(microsecond=0)
+        assert ts >= t0_up_to_seconds
+    else:
+        assert s['ts'] is None
+
+
+@pytest.mark.parametrize('cache_is_valid', (True, False))
+@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
+def test_snapshot_when_snapshot_value_is_false(
+        snapshot_get, get_cmd, cache_is_valid, update):
+
+    p = create_parameter(
+        snapshot_get=snapshot_get, snapshot_value=False, get_cmd=get_cmd)
+
+    if cache_is_valid:
+        p.set(42)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    assert 'value' not in s
+    assert 'raw_value' not in s
+
+    if get_cmd is not False:
+        assert p.get.call_count() == 0
+
+
+def test_snapshot_value_is_true_by_default(snapshot_get, get_cmd):
+    p = create_parameter(
+        snapshot_value=NOT_PASSED,
+        snapshot_get=snapshot_get, get_cmd=get_cmd)
+    assert p._snapshot_value is True
+
+
+def test_snapshot_get_is_true_by_default(snapshot_value, get_cmd):
+    p = create_parameter(
+        snapshot_get=NOT_PASSED,
+        snapshot_value=snapshot_value, get_cmd=get_cmd)
+    assert p._snapshot_get is True
+
+
+@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
+@pytest.mark.parametrize('cache_is_valid', (True, False))
+def test_snapshot_when_snapshot_get_is_false(get_cmd, update, cache_is_valid):
+    p = create_parameter(
+        snapshot_get=False,
+        snapshot_value=True, get_cmd=get_cmd, offset=4)
+
+    if cache_is_valid:
+        p.set(42)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if cache_is_valid:
+        assert s['value'] == 42
+        assert s['raw_value'] == 46
+    else:
+        assert s['value'] is None
+        assert s['raw_value'] is None
+
+    if get_cmd is not False:
+        assert p.get.call_count() == 0
+
+
+@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
+@pytest.mark.parametrize('cache_is_valid', (True, False))
+def test_snapshot_of_non_gettable_parameter_mirrors_cache(
+        update, cache_is_valid):
+    p = create_parameter(
+        snapshot_get=True, snapshot_value=True, get_cmd=False, offset=4)
+
+    if cache_is_valid:
+        p.set(42)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if cache_is_valid:
+        assert s['value'] == 42
+        assert s['raw_value'] == 46
+    else:
+        assert s['value'] is None
+        assert s['raw_value'] is None
+
+
+@pytest.mark.parametrize('update', (True, False, NOT_PASSED))
+@pytest.mark.parametrize('cache_is_valid', (True, False))
+def test_snapshot_of_gettable_parameter_depends_on_update(update, cache_is_valid):
+    p = create_parameter(
+        snapshot_get=True, snapshot_value=True, get_cmd=lambda: 69, offset=4)
+
+    if cache_is_valid:
+        p.set(42)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if update is not True and cache_is_valid:
+        assert s['value'] == 42
+        assert s['raw_value'] == 46
+        assert p.get.call_count() == 0
+    else:
+        assert s['value'] == 65
+        assert s['raw_value'] == 69
+        assert p.get.call_count() == 1
+
+
 def test_delegate_parameter_init():
     """
     Test that the lable and unit get used from source parameter if not

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1849,12 +1849,6 @@ def create_parameter(snapshot_get, snapshot_value, get_cmd, offset=NOT_PASSED):
     return p
 
 
-@pytest.fixture
-def parameterized_parameter(snapshot_get, snapshot_value, get_cmd):
-    p = create_parameter(snapshot_get, snapshot_value, get_cmd)
-    return p
-
-
 @pytest.fixture(params=(True, False, NOT_PASSED))
 def update(request):
     return request.param
@@ -1866,8 +1860,8 @@ def cache_is_valid(request):
 
 
 def test_snapshot_contains_parameter_attributes(
-        parameterized_parameter, cache_is_valid, update):
-    p = parameterized_parameter
+        snapshot_get, snapshot_value, get_cmd, cache_is_valid, update):
+    p = create_parameter(snapshot_get, snapshot_value, get_cmd)
 
     if cache_is_valid:
         p.set(42)
@@ -1907,8 +1901,8 @@ def test_snapshot_contains_parameter_attributes(
 
 
 def test_snapshot_timestamp_depends_only_on_cache_validity(
-        parameterized_parameter, update, cache_is_valid):
-    p = parameterized_parameter
+        snapshot_get, snapshot_value, get_cmd, update, cache_is_valid):
+    p = create_parameter(snapshot_get, snapshot_value, get_cmd)
 
     if cache_is_valid:
         t0 = datetime.now()

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1905,8 +1905,9 @@ def test_snapshot_timestamp_of_non_gettable_depends_only_on_cache_validity(
     p = create_parameter(snapshot_get, snapshot_value, get_cmd=False)
 
     if cache_is_valid:
-        t0 = datetime.now()
         p.set(42)
+
+    t0 = p.cache.timestamp
 
     if update != NOT_PASSED:
         s = p.snapshot(update=update)

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -28,6 +28,13 @@ def test_snapshot_skip_params_update(request, params, params_to_skip):
                                   params_to_skip=params_to_skip)
     request.addfinalizer(inst.close)
 
+    # Set parameters to some values so their ``get`` is NOT called when the
+    # ``snapshot`` is called with ``update=False``; in other words,
+    # this will ensure that the parameters have their caches filled with
+    # actual values
+    for ind, p in enumerate(params):
+        inst.parameters[p].set(ind)
+
     assert list(inst._get_calls.values()) == [0, 0, 0, 0]
 
     inst.snapshot(update=False)
@@ -78,8 +85,5 @@ def test_snapshot_exclude_params(request, params, params_to_exclude):
         f"Parameter(s) is not excluded from the snapshot. expected: " \
         f"{params}, actual: {snap_params}"\
 
-
     assert snap_params == params, f"Snapshot does not contain the expected " \
         f"parameters expected: {params}, actual: {snap_params}"
-
-


### PR DESCRIPTION
### Main thing

This PR takes another approach to #1791 - introducing `_Cache` class which:
- incorporates the `_latest` dictionary with `value`, `raw_value`, and `timestamp` (also `max_val_age`), and 
- `get` method that behaves as `get_latest` and 
- `set` method that behaves as `set_cache` that was introduced in #1757.

### Some details of this PR

- `GetLatest` and `get_latest` remain as is for backwards compatibility, but under the hood they reuse `_Cache` and its methods "as-is". In the near future we will be able to deprecate `GetLatest` altogether 
and move our users to use `.cache` only.
- Note that `_Cache.get` as opposed to `get_latest.get` has an additional `get_if_invalid` flag that is useful to set to `False` when you don't want to call `get` of the parameter if the cached value is invalid (for example, because the parameter has never been captured).
- All docstrings in `parameter.py` were rewritten to reflect the existence of the `_Cache`
- Drivers which used `set_cache` were changed to use `cache.set`.
- Closes  #1791 because it subsumes it.
- refactoring `test_parameter.py` into a package is out of scope for this PR

### Also, `snapshot_base` improvement (SHOULD WE DO IT NOW?)
- Moreover, `_BaseParameter.snapshot_base` has been refactored to use `cache` and rely on `cache.get`. Note that `_BaseParameter._snapshot_get` is passed to `cache.get` via this new `get_if_invalid` flag.
- `_BaseParameter.snapshot_base` got it's own set of parametrized set of tests so that its current behavior is captured (to the best of my abilities)
- Note that due to the new behavior of `_BaseParameter.snapshot_base`, some parameters had to receive `snapshot_get=False` kwarg, also some weird bug in tests for `Loop` was discovered and fixed

### ToDo:
- [ ] rewrite `test_parameter.py` to test `cache.*` instead of `get_latest.*` but also add minor tests for get_latest to ensure that it does the same as cache
