### PR TITLE
Unify default values of arguments for all snapshot_base and snapshot methods in qcodes repo

### DIFF
--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -391,7 +391,7 @@ class ChannelList(Metadatable):
         self._channels = tuple(self._channels)
         self._locked = True
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -406,7 +406,7 @@ class _BaseParameter(Metadatable):
                 raise NotImplementedError('no set cmd found in' +
                                           ' Parameter {}'.format(self.name))
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """
@@ -1333,7 +1333,7 @@ class DelegateParameter(Parameter):
     def set_raw(self, value: Any) -> None:
         self.source(value)
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         snapshot = super().snapshot_base(

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -228,7 +228,7 @@ class VisaInstrument(Instrument):
             self.visa_log.debug(f"Response: {response}")
         return response
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """

--- a/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
+++ b/qcodes/instrument_drivers/ZI/ZIHDAWG8.py
@@ -66,7 +66,7 @@ class ZIHDAWG8(Instrument):
         self.warnings_as_errors: List[str] = []
         self._compiler_sleep_time = 0.01
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """ Override the base method to ignore 'feature_code' by default."""

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1652,7 +1652,7 @@ class ZIUHFLI(Instrument):
                            docstring="Enable jumbo frames on the TCP/IP interface"
                            )
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """ Override the base method to ignore 'sweeper_sweeptime' if no signals selected."""

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -131,7 +131,7 @@ class Station(Metadatable, DelegateAttributes):
 
         self.load_config_file(self.config_file)
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -361,7 +361,7 @@ class Station(Metadatable, DelegateAttributes):
 
         def update_station_configuration_snapshot():
             class StationConfig(UserDict):
-                def snapshot(self, update=True):
+                def snapshot(self, update=False):
                     return self
 
             self.components['config'] = StationConfig(self._config)

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -514,7 +514,7 @@ class SnapShotTestInstrument(Instrument):
         self._get_calls[name] += 1
         return val
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: bool = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         if params_to_skip_update is None:


### PR DESCRIPTION
### Description

To promote "the same" behavior unless needed explicitly. (i think that it's good, but if there are use cases against that i'm happy to hear about those here)

Note that right before merging the commits in this PR will be rebased on the lastest master for a cleaner history :)

### Places in question:
- [ ] https://github.com/QCoDeS/Qcodes/blob/295ad9043ba52d61432b4e73ab1a39714572bb0c/qcodes/instrument_drivers/ZI/ZIHDAWG8.py#L79-L81
  the `ZIHDAWG8` driver - does anyone remember why is this override needed? how is this instrument special to all the other instruments?