### PR TITLE
Avoid getting Keysight B1517A voltage/current parameters upon snapshot

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -68,13 +68,15 @@ class B1517A(B1500Module):
         self.add_parameter(
             name="voltage",
             set_cmd=self._set_voltage,
-            get_cmd=self._get_voltage
+            get_cmd=self._get_voltage,
+            snapshot_get=False
         )
 
         self.add_parameter(
             name="current",
             set_cmd=self._set_current,
-            get_cmd=self._get_current
+            get_cmd=self._get_current,
+            snapshot_get=False
         )
 
         self.add_parameter(


### PR DESCRIPTION
Because they may not be always gettable due to the nature of those parameters and the instrument. Dicovered when working on #1828 