### PR TITLE
Add _Cache to _BaseParameter, use it in GetLatest, remove set_cache method, remove _latest

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1891,8 +1891,8 @@ class GetLatest(DelegateAttributes):
     ``max_val_age`` for a parameter that does not have a get function.
 
     The functionality of this class is subsumed and improved in
-    :class:`_Cache` that is accessible via ``.cache`` attribute of the
-    class:`.Parameter`. Use of ``parameter.cache`` is recommended over use of
+    :class:`._Cache` that is accessible via ``.cache`` attribute of the
+    :class:`.Parameter`. Use of ``parameter.cache`` is recommended over use of
     ``parameter.get_latest``.
 
     Examples:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -295,7 +295,7 @@ class _BaseParameter(Metadatable):
         self.get: Callable[..., ParamDataType]
         implements_get_raw = (
             hasattr(self, 'get_raw')
-            and getattr(self.get_raw, '__qcodes_is_abstract_method__', False)
+            and not getattr(self.get_raw, '__qcodes_is_abstract_method__', False)
         )
         if implements_get_raw:
             self.get = self._wrap_get(self.get_raw)
@@ -310,7 +310,7 @@ class _BaseParameter(Metadatable):
         self.set: Callable[..., None]
         implements_set_raw = (
             hasattr(self, 'set_raw')
-            and getattr(self.set_raw, '__qcodes_is_abstract_method__', False)
+            and not getattr(self.set_raw, '__qcodes_is_abstract_method__', False)
         )
         if implements_set_raw:
             self.set = self._wrap_set(self.set_raw)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -489,25 +489,6 @@ class _BaseParameter(Metadatable):
 
         return raw_value
 
-    def set_cache(self, value: ParamDataType) -> None:
-        """
-        Set the cached value of the parameter without invoking the
-        ``set_cmd`` of the parameter (if it has one). For example, in case of
-        an instrument parameter, calling :meth:`set_cache` as opposed to
-        calling ``set`` will only change the internally-stored value of
-        the parameter (that is available when calling ``get_latest``),
-        and will pass that value to the instrument.
-
-        Note that this method also respects all the validation, parsing,
-        offsetting, etc that the ``set`` method respects. However,
-        if the parameter has :attr:`step` defined, unlike the ``set`` method,
-        this method does not perform setting the parameter step-by-step.
-
-        Args:
-            value: new value for the parameter
-        """
-        self.cache.set(value)
-
     def _save_val(self, value: ParamDataType, validate: bool = False) -> None:
         """
         Use ``cache.set`` instead of this method. It will be deprecated soon.
@@ -1740,6 +1721,22 @@ class _Cache:
         return self._max_val_age
 
     def set(self, value: ParamDataType) -> None:
+        """
+        Set the cached value of the parameter without invoking the
+        ``set_cmd`` of the parameter (if it has one). For example, in case of
+        an instrument parameter, calling :meth:`cache.set` as opposed to
+        calling ``set`` will only change the internally-stored value of
+        the parameter (that is available when calling ``cache.get`` or
+        ``get_latest``), and will pass that value to the instrument.
+
+        Note that this method also respects all the validation, parsing,
+        offsetting, etc that the parameter's ``set`` method respects. However,
+        if the parameter has :attr:`step` defined, unlike the ``set`` method,
+        this method does not perform setting the parameter step-by-step.
+
+        Args:
+            value: new value for the parameter
+        """
         self._parameter.validate(value)
         raw_value = self._parameter._from_value_to_raw_value(value)
         self._update_with(value=value, raw_value=raw_value)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -293,11 +293,11 @@ class _BaseParameter(Metadatable):
         self.get_latest = GetLatest(self)
 
         self.get: Callable[..., ParamDataType]
-        has_non_abstract_get_raw = (
+        implements_get_raw = (
             hasattr(self, 'get_raw')
             and getattr(self.get_raw, '__qcodes_is_abstract_method__', False)
         )
-        if has_non_abstract_get_raw:
+        if implements_get_raw:
             self.get = self._wrap_get(self.get_raw)
         elif hasattr(self, 'get'):
             warnings.warn(f'Wrapping get method of parameter: '
@@ -308,11 +308,11 @@ class _BaseParameter(Metadatable):
             self.get = self._wrap_get(self.get)
 
         self.set: Callable[..., None]
-        has_non_abstract_set_raw = (
+        implements_set_raw = (
             hasattr(self, 'set_raw')
             and getattr(self.set_raw, '__qcodes_is_abstract_method__', False)
         )
-        if has_non_abstract_set_raw:
+        if implements_set_raw:
             self.set = self._wrap_set(self.set_raw)
         elif hasattr(self, 'set'):
             warnings.warn(f'Wrapping set method of parameter: '

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1734,7 +1734,7 @@ class _Cache:
         an instrument parameter, calling :meth:`cache.set` as opposed to
         calling ``set`` will only change the internally-stored value of
         the parameter (that is available when calling ``cache.get`` or
-        ``get_latest``), and will pass that value to the instrument.
+        ``get_latest``), and will NOT pass that value to the instrument.
 
         Note that this method also respects all the validation, parsing,
         offsetting, etc that the parameter's ``set`` method respects. However,

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -419,8 +419,8 @@ class _BaseParameter(Metadatable):
         Args:
             update: If True, update the state by calling ``parameter.get()``
                 unless ``snapshot_get`` of the parameter is ``False``.
-                If ``update`` is ``False``, just use the value from
-                ``cache`` via ``cache.get()`` method.
+                If ``update`` is ``False``, just use the current value from the
+                ``cache``.
             params_to_skip_update: No effect but may be passed from superclass
 
         Returns:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -295,7 +295,8 @@ class _BaseParameter(Metadatable):
         self.get: Callable[..., ParamDataType]
         implements_get_raw = (
             hasattr(self, 'get_raw')
-            and not getattr(self.get_raw, '__qcodes_is_abstract_method__', False)
+            and not getattr(self.get_raw,
+                            '__qcodes_is_abstract_method__', False)
         )
         if implements_get_raw:
             self.get = self._wrap_get(self.get_raw)
@@ -310,7 +311,8 @@ class _BaseParameter(Metadatable):
         self.set: Callable[..., None]
         implements_set_raw = (
             hasattr(self, 'set_raw')
-            and not getattr(self.set_raw, '__qcodes_is_abstract_method__', False)
+            and not getattr(self.set_raw,
+                            '__qcodes_is_abstract_method__', False)
         )
         if implements_set_raw:
             self.set = self._wrap_set(self.set_raw)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -607,9 +607,6 @@ class _BaseParameter(Metadatable):
 
                     set_function(raw_val_step, **kwargs)
 
-                    self.cache._update_with(value=val_step,
-                                            raw_value=raw_val_step)
-
                     # Update last set time (used for calculating delays)
                     self._t_last_set = time.perf_counter()
 
@@ -618,6 +615,9 @@ class _BaseParameter(Metadatable):
                     if t_elapsed < self.post_delay:
                         # Sleep until total time is larger than self.post_delay
                         time.sleep(self.post_delay - t_elapsed)
+
+                    self.cache._update_with(value=val_step,
+                                            raw_value=raw_val_step)
 
             except Exception as e:
                 e.args = e.args + ('setting {} to {}'.format(self, value),)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1728,12 +1728,12 @@ class MultiParameter(_BaseParameter):
 
 class _Cache:
     """
-    Cache object for parameter to hold its valud and raw value
+    Cache object for parameter to hold its value and raw value
 
     It also implements ``set`` method for setting parameter's value without
-    invoking its ``get_cmd``, and ``get`` method that allows to retrieve the
-    cached value of the parameter, and if the cache is invalid,
-    ``parameter.get()`` might be called.
+    invoking its ``set_cmd``, and ``get`` method that allows to retrieve the
+    cached value of the parameter without calling ``get_cmd`` might be called
+    unless the cache is invalid.
 
     Args:
          parameter: instance of the parameter that this cache belongs to.
@@ -1741,7 +1741,8 @@ class _Cache:
             If the parameter has not been set or measured more recently than
             this, an additional measurement will be performed in order to
             update the cached value. If it is ``None``, this behavior is
-            disabled.
+            disabled. ``max_val_age`` should not be used for a parameter
+            that does not have a get function.
     """
     def __init__(self,
                  parameter: '_BaseParameter',
@@ -1805,9 +1806,8 @@ class _Cache:
                      timestamp: Optional[datetime] = None
                      ) -> None:
         """
-        Simply overwrites the value and raw value in this cache with new
-        ones. The timestamp, if not ``None``, also gets overwritten, and if not,
-        then timestamp of "now" is used.
+        Simply overwrites the value, raw value, and timestamp in this cache
+        with new ones.
 
         Args:
             value: new value of the parameter
@@ -1824,9 +1824,9 @@ class _Cache:
 
     def get(self, get_if_invalid: bool = True) -> ParamDataType:
         """
-        Return cached value if time since get was less than `max_val_age`,
+        Return cached value if time since get was less than ``max_val_age``,
         otherwise perform ``get()`` on the parameter and return result. A
-        ``get()`` will also be performed if the parameter never has been
+        ``get()`` will also be performed if the parameter has never been
         captured but only if ``get_if_invalid`` argument is ``True``.
 
         Args:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1756,16 +1756,19 @@ class _Cache:
     def get(self, get_if_invalid: bool = True) -> ParamDataType:
         no_get = not hasattr(self._parameter, 'get')
 
-        # the parameter has never been captured so `get` it
-        # unconditionally
+        # the parameter has never been captured so `get` it but only
+        # if `get_if_invalid` is True
         if self._timestamp is None:
-            if no_get:
-                raise RuntimeError(f"Value of parameter "
-                                   f"{(self._parameter.full_name)} "
-                                   f"is unknown and the Parameter does "
-                                   f"not have a get command. Please set "
-                                   f"the value before attempting to get it.")
-            return self._parameter.get()
+            if get_if_invalid:
+                if no_get:
+                    raise RuntimeError(f"Value of parameter "
+                                       f"{(self._parameter.full_name)} "
+                                       f"is unknown and the Parameter does "
+                                       f"not have a get command. Please set "
+                                       f"the value before attempting to get it.")
+                return self._parameter.get()
+            else:
+                return self._value
 
         if self._max_val_age is None:
             # Return last value since max_val_age is not specified

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -336,10 +336,13 @@ class _BaseParameter(Metadatable):
         :setter: Setting the ``raw_value`` is not recommended as it may lead to
             inconsistent state of the parameter.
         """
-        return self.cache._raw_value
+        return self.cache.raw_value
 
     @raw_value.setter
     def raw_value(self, new_raw_value: ParamRawDataType) -> None:
+        # Setting of the ``raw_value`` property of the parameter will be
+        # deprecated soon anyway, hence, until then, it's ok to refer to
+        # ``cache``s private ``_raw_value`` attribute here
         self.cache._raw_value = new_raw_value
 
     @abstractmethod
@@ -421,7 +424,7 @@ class _BaseParameter(Metadatable):
 
         state: Dict[str, Any] = {
             'value': self.cache._value,
-            'raw_value': self.cache._raw_value,
+            'raw_value': self.cache.raw_value,
             'ts': self.cache.timestamp
         }
         state['__class__'] = full_class(self)
@@ -504,7 +507,7 @@ class _BaseParameter(Metadatable):
                 self.offset is None):
             raw_value = value
         else:
-            raw_value = self.cache._raw_value
+            raw_value = self.cache.raw_value
         self.cache._update_with(value=value, raw_value=raw_value)
 
     def _from_raw_value_to_value(self, raw_value: ParamRawDataType
@@ -1032,7 +1035,7 @@ class Parameter(_BaseParameter):
         # get/set methods)
         if not hasattr(self, 'get') and get_cmd is not False:
             if get_cmd is None:
-                self.get_raw = lambda: self.cache._raw_value   # type: ignore[assignment]
+                self.get_raw = lambda: self.cache.raw_value   # type: ignore[assignment]
             else:
                 exec_str_ask = getattr(instrument, "ask", None) \
                     if instrument else None
@@ -1711,6 +1714,10 @@ class _Cache:
         self._raw_value: ParamRawDataType = None
         self._timestamp: Optional[datetime] = None
         self._max_val_age = max_val_age
+
+    @property
+    def raw_value(self) -> ParamRawDataType:
+        return self._raw_value
 
     @property
     def timestamp(self) -> Optional[datetime]:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1891,7 +1891,7 @@ class GetLatest(DelegateAttributes):
     ``max_val_age`` for a parameter that does not have a get function.
 
     The functionality of this class is subsumed and improved in
-    :class:`._Cache` that is accessible via ``.cache`` attribute of the
+    parameter's cache that is accessible via ``.cache`` attribute of the
     :class:`.Parameter`. Use of ``parameter.cache`` is recommended over use of
     ``parameter.get_latest``.
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1786,10 +1786,6 @@ class _Cache:
             else:
                 return self._value
 
-    def get_raw(self, get_if_invalid: bool = True) -> ParamRawDataType:
-        self.get(get_if_invalid=get_if_invalid)
-        return self._raw_value
-
     def __call__(self) -> ParamDataType:
         return self.get(get_if_invalid=True)
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -293,9 +293,11 @@ class _BaseParameter(Metadatable):
         self.get_latest = GetLatest(self)
 
         self.get: Callable[..., ParamDataType]
-        get_raw_is_abstract = getattr(self.get_raw,
-                                      '__qcodes_is_abstract_method__', False)
-        if hasattr(self, 'get_raw') and not get_raw_is_abstract:
+        has_non_abstract_get_raw = (
+            hasattr(self, 'get_raw')
+            and getattr(self.get_raw, '__qcodes_is_abstract_method__', False)
+        )
+        if has_non_abstract_get_raw:
             self.get = self._wrap_get(self.get_raw)
         elif hasattr(self, 'get'):
             warnings.warn(f'Wrapping get method of parameter: '
@@ -306,9 +308,11 @@ class _BaseParameter(Metadatable):
             self.get = self._wrap_get(self.get)
 
         self.set: Callable[..., None]
-        set_raw_is_abstract = getattr(self.set_raw,
-                                      '__qcodes_is_abstract_method__', False)
-        if hasattr(self, 'set_raw') and not set_raw_is_abstract:
+        has_non_abstract_set_raw = (
+            hasattr(self, 'set_raw')
+            and getattr(self.set_raw, '__qcodes_is_abstract_method__', False)
+        )
+        if has_non_abstract_set_raw:
             self.set = self._wrap_set(self.set_raw)
         elif hasattr(self, 'set'):
             warnings.warn(f'Wrapping set method of parameter: '

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -35,8 +35,8 @@ more specialized ones:
     using :class:`.ParameterWithSetpoints`.
 
     :class:`.ParameterWithSetpoints` is supported in a
-    :class:`qcodes.dataset.measurements.Measurement` but is not supported by the
-    legacy :class:`qcodes.loops.Loop` and :class:`qcodes.measure.Measure`
+    :class:`qcodes.dataset.measurements.Measurement` but is not supported by
+    the legacy :class:`qcodes.loops.Loop` and :class:`qcodes.measure.Measure`
     measurement types.
 
 - :class:`.DelegateParameter` is intended proxy-ing other parameters.
@@ -295,15 +295,17 @@ class _BaseParameter(Metadatable):
         if hasattr(self, 'get_raw') and not get_raw_is_abstract:
             self.get = self._wrap_get(self.get_raw)
         elif hasattr(self, 'get'):
-            warnings.warn(f'Wrapping get method of parameter: {self.full_name},'
-                          f' original get method will not '
+            warnings.warn(f'Wrapping get method of parameter: '
+                          f'{self.full_name}, original get method will not '
                           f'be directly accessible. It is recommended to '
                           f'define get_raw in your subclass instead. '
                           f'Overwriting get will be an error in the future.')
             self.get = self._wrap_get(self.get)
 
         self.set: Callable[..., None]
-        if hasattr(self, 'set_raw') and not getattr(self.set_raw, '__qcodes_is_abstract_method__', False):
+        set_raw_is_abstract = getattr(self.set_raw,
+                                      '__qcodes_is_abstract_method__', False)
+        if hasattr(self, 'set_raw') and not set_raw_is_abstract:
             self.set = self._wrap_set(self.set_raw)
         elif hasattr(self, 'set'):
             warnings.warn(f'Wrapping set method of parameter: '
@@ -657,9 +659,9 @@ class _BaseParameter(Metadatable):
             if not (isinstance(start_value, (int, float)) and
                     isinstance(value, (int, float))):
                 # something weird... parameter is numeric but one of the ends
-                # isn't, even though it's valid.
-                # probably MultiType with a mix of numeric and non-numeric types
-                # just set the endpoint and move on
+                # isn't, even though it's valid. probably MultiType with a
+                # mix of numeric and non-numeric types... So just set the
+                # endpoint and move on.
                 log.warning(f'cannot sweep {self.name} from {start_value!r} '
                             f'to {value!r} - jumping.')
                 return []
@@ -763,9 +765,9 @@ class _BaseParameter(Metadatable):
         the command for setting the parameter returns quickly.
 
         Args:
-            post_delay: the target time after the *start*
-                of a set operation. The actual time will not be shorter than
-                this, but may be longer if the underlying set call takes longer.
+            post_delay: the target time after the *start* of a set
+                operation. The actual time will not be shorter than this,
+                but may be longer if the underlying set call takes longer.
 
         Raises:
             TypeError: If delay is not int nor float
@@ -794,9 +796,9 @@ class _BaseParameter(Metadatable):
         *between* sets.
 
         Args:
-            inter_delay: the minimum time between set calls.
-                The actual time will not be shorter than this, but may be longer
-                if the underlying set call takes longer.
+            inter_delay: the minimum time between set calls. The actual time
+                will not be shorter than this, but may be longer if the
+                underlying set call takes longer.
 
         Raises:
             TypeError: If delay is not int nor float
@@ -1033,8 +1035,8 @@ class Parameter(_BaseParameter):
         # Enable set/get methods from get_cmd/set_cmd if given and
         # no `get`/`set` or `get_raw`/`set_raw` methods have been defined
         # in the scope of this class.
-        # (previous call to `super().__init__` wraps existing get_raw/set_raw to
-        # get/set methods)
+        # (previous call to `super().__init__` wraps existing
+        # get_raw/set_raw into get/set methods)
         if not hasattr(self, 'get') and get_cmd is not False:
             if get_cmd is None:
                 self.get_raw = (  # type: ignore[assignment]
@@ -1677,7 +1679,7 @@ class MultiParameter(_BaseParameter):
         """
         Names of the parameter components including the name of the instrument
         and submodule that the parameter may be bound to. The name parts are
-        separated by underscores, like this: ``instrument_submodule_parameter``.
+        separated by underscores, like this: ``instrument_submodule_parameter``
         """
         inst_name = "_".join(self.name_parts[:-1])
         if inst_name != '':
@@ -1701,7 +1703,8 @@ class MultiParameter(_BaseParameter):
                 full_sp_names_subgroupd = []
                 for spname in sp_group:
                     if spname is not None:
-                        full_sp_names_subgroupd.append(inst_name + '_' + spname)
+                        full_sp_names_subgroupd.append(
+                            inst_name + '_' + spname)
                     else:
                         full_sp_names_subgroupd.append(None)
                 full_sp_names.append(tuple(full_sp_names_subgroupd))
@@ -1777,8 +1780,9 @@ class _Cache:
                     raise RuntimeError(f"Value of parameter "
                                        f"{(self._parameter.full_name)} "
                                        f"is unknown and the Parameter does "
-                                       f"not have a get command. Please set "
-                                       f"the value before attempting to get it.")
+                                       f"not have a get command. "
+                                       f"Please set the value before "
+                                       f"attempting to get it.")
                 return self._parameter.get()
             else:
                 return self._value

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1867,9 +1867,9 @@ class _Cache:
                 raise RuntimeError("`max_val_age` is not supported for a "
                                    "parameter without get command.")
 
-            oldest_ok_val = (datetime.now()
-                             - timedelta(seconds=self._max_val_age))
-            if self._timestamp < oldest_ok_val:
+            oldest_accepted_timestamp = (
+                    datetime.now() - timedelta(seconds=self._max_val_age))
+            if self._timestamp < oldest_accepted_timestamp:
                 # Time of last get exceeds max_val_age seconds, need to
                 # perform new .get()
                 return self._parameter.get()

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500.py
@@ -46,7 +46,7 @@ class KeysightB1500(VisaInstrument):
         # Instrument is initialized with this setting having value of
         # `False`, hence let's set the parameter to this value since it is
         # not possible to request this value from the instrument.
-        self.autozero_enabled.set_cache(False)
+        self.autozero_enabled.cache.set(False)
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -63,7 +63,7 @@ class B1517A(B1500Module):
         # `1`, spot measurement mode, hence let's set the parameter to this
         # value since it is not possible to request this value from the
         # instrument.
-        self.measurement_mode.set_cache(MM.Mode.SPOT)
+        self.measurement_mode.cache.set(MM.Mode.SPOT)
 
         self.add_parameter(
             name="voltage",

--- a/qcodes/instrument_drivers/QDev/QDac.py
+++ b/qcodes/instrument_drivers/QDev/QDac.py
@@ -261,7 +261,7 @@ class QDac(VisaInstrument):
             voltageparam = self.parameters['ch{:02}_v'.format(chan)]
             oldvoltage = voltageparam.get_latest()
             newvoltage = {0: 10, 1: 0.1}[switchint]*oldvoltage
-            voltageparam.set_cache(newvoltage)
+            voltageparam.cache.set(newvoltage)
 
     def _num_verbose(self, s):
         """
@@ -368,7 +368,7 @@ class QDac(VisaInstrument):
                     attenuation = 0.1*value
                 if param == 'v':
                     value *= attenuation
-                self.parameters[parameter].set_cache(value)
+                self.parameters[parameter].cache.set(value)
             chans_left.remove(chan)
 
         if readcurrents:

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -349,7 +349,7 @@ class QDac(VisaInstrument):
             voltageparam = self.channels[chan-1].v
             oldvoltage = voltageparam.get_latest()
             newvoltage = {0: 10, 1: 0.1}[switchint]*oldvoltage
-            voltageparam.set_cache(newvoltage)
+            voltageparam.cache.set(newvoltage)
 
     def _num_verbose(self, s):
         """
@@ -457,7 +457,7 @@ class QDac(VisaInstrument):
                     attenuation = 0.1*value
                 if param == 'v':
                     value *= attenuation
-                getattr(self.channels[chan-1], param).set_cache(value)
+                getattr(self.channels[chan-1], param).cache.set(value)
             chans_left.remove(chan)
 
         if readcurrents:

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -2197,7 +2197,7 @@ class ZIUHFLI(Instrument):
             SR_str = self.parameters['scope_samplingrate'].get()
             (number, unit) = SR_str.split(' ')
             SR = float(number)*SRtranslation[unit]
-            self.parameters['scope_duration'].set_cache(value/SR)
+            self.parameters['scope_duration'].cache.set(value/SR)
             self.daq.setInt('/{}/scopes/0/length'.format(self.device), value)
 
         def setduration(value):
@@ -2206,8 +2206,8 @@ class ZIUHFLI(Instrument):
             (number, unit) = SR_str.split(' ')
             SR = float(number)*SRtranslation[unit]
             N = int(np.round(value*SR))
-            self.parameters['scope_length'].set_cache(N)
-            self.parameters['scope_duration'].set_cache(value)
+            self.parameters['scope_length'].cache.set(N)
+            self.parameters['scope_duration'].cache.set(value)
             self.daq.setInt('/{}/scopes/0/length'.format(self.device), N)
 
         def setholdoffseconds(value):
@@ -2227,7 +2227,7 @@ class ZIUHFLI(Instrument):
             oldSR = float(number)*SRtranslation[unit]
             oldduration = self.parameters['scope_duration'].get()
             newduration = oldduration*oldSR/newSR
-            self.parameters['scope_duration'].set_cache(newduration)
+            self.parameters['scope_duration'].cache.set(newduration)
             self.daq.setInt('/{}/scopes/0/time'.format(self.device), value)
 
         specialcases = {'length': setlength,

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -407,13 +407,13 @@ class ScopeChannel(InstrumentChannel):
     #########################
     # Specialised/interlinked set/getters
     def _set_range(self, value):
-        self.scale.set_cache(value/10)
+        self.scale.cache.set(value/10)
 
         self._parent.write('CHANnel{}:RANGe {}'.format(self.channum,
                                                        value))
 
     def _set_scale(self, value):
-        self.range.set_cache(value*10)
+        self.range.cache.set(value*10)
 
         self._parent.write('CHANnel{}:SCALe {}'.format(self.channum,
                                                        value))
@@ -727,7 +727,7 @@ class RTO1000(VisaInstrument):
         Set the full range of the timebase
         """
         self._make_traces_not_ready()
-        self.timebase_scale.set_cache(value/self._horisontal_divs)
+        self.timebase_scale.cache.set(value/self._horisontal_divs)
 
         self.write('TIMebase:RANGe {}'.format(value))
 
@@ -736,7 +736,7 @@ class RTO1000(VisaInstrument):
         Set the length of one horizontal division
         """
         self._make_traces_not_ready()
-        self.timebase_range.set_cache(value*self._horisontal_divs)
+        self.timebase_range.cache.set(value*self._horisontal_divs)
 
         self.write('TIMebase:SCALe {}'.format(value))
 

--- a/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
@@ -402,7 +402,7 @@ class SignalHound_USB_SA124B(Instrument):
         of power and trace.
         """
         sweep_info = self.QuerySweep()
-        self.npts.set_cache(sweep_info[0])
+        self.npts.cache.set(sweep_info[0])
         self.trace.set_sweep(*sweep_info)
 
     def sync_parameters(self) -> None:

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -510,7 +510,7 @@ class SnapShotTestInstrument(Instrument):
                                get_cmd=partial(self._getter, p_name))
 
     def _getter(self, name: str):
-        val = self.parameters[name]._latest['value']
+        val = self.parameters[name].cache._value
         self._get_calls[name] += 1
         return val
 

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -35,8 +35,8 @@ class TestInstrument(TestCase):
         instrument = self.instrument
         instrument.validate_status()  # test the instrument has valid values
 
-        instrument.dac1._latest['value'] = 1000  # overrule the validator
-        instrument.dac1._latest['raw_value'] = 1000  # overrule the validator
+        instrument.dac1.cache._value = 1000  # overrule the validator
+        instrument.dac1.cache._raw_value = 1000  # overrule the validator
         with self.assertRaises(Exception):
             instrument.validate_status()
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -201,19 +201,19 @@ class TestParameter(TestCase):
         self.assertEqual(p.vals.values_validated,
                          [0, 0, 10, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
-    def test_number_of_validations_for_set_cached(self):
+    def test_number_of_validations_for_set_cache(self):
         p = Parameter('p', set_cmd=None,
                       vals=BookkeepingValidator())
         self.assertEqual(p.vals.values_validated, [])
 
-        p.set_cache(1)
+        p.cache.set(1)
         self.assertEqual(p.vals.values_validated, [1])
 
-        p.set_cache(4)
+        p.cache.set(4)
         self.assertEqual(p.vals.values_validated, [1, 4])
 
         p.step = 1
-        p.set_cache(10)
+        p.cache.set(10)
         self.assertEqual(p.vals.values_validated, [1, 4, 10])
 
     def test_snapshot_value(self):
@@ -406,8 +406,8 @@ class TestParameter(TestCase):
             gettable_parameter(1)
         # Initial value is None if not explicitly set
         self.assertIsNone(gettable_parameter())
-        # Assert the set_cache still works for non-settable parameter
-        gettable_parameter.set_cache(1)
+        # Assert the ``cache.set`` still works for non-settable parameter
+        gettable_parameter.cache.set(1)
         self.assertEqual(gettable_parameter(), 1)
 
         # Create parameter that saves value during set, and has no get_cmd
@@ -461,10 +461,10 @@ class TestParameter(TestCase):
         p(44.5)
         self.assertListEqual(p.set_values, [42, 43, 44, 44.5])
 
-        # Assert that stepping does not impact ``set_cache`` call, and that
-        # the value that is passed to ``set_cache`` call does not get
+        # Assert that stepping does not impact ``cache.set`` call, and that
+        # the value that is passed to ``cache.set`` call does not get
         # propagated to parameter's ``set_cmd``
-        p.set_cache(40)
+        p.cache.set(40)
         self.assertEqual(p.get_latest(), 40)
         self.assertListEqual(p.set_values, [42, 43, 44, 44.5])
 
@@ -575,12 +575,12 @@ class TestParameter(TestCase):
             TestFloats, SharedSize, ValuesScalar, False),
         scales=iterable_or_number(
             TestFloats, SharedSize, ValuesScalar, False))
-    def test_scale_and_offset_raw_value_iterable_for_set_cached(
+    def test_scale_and_offset_raw_value_iterable_for_set_cache(
             self, values, offsets, scales):
         p = Parameter(name='test_scale_and_offset_raw_value', set_cmd=None)
 
         # test that scale and offset does not change the default behaviour
-        p.set_cache(values)
+        p.cache.set(values)
         self.assertEqual(p.raw_value, values)
 
         # test setting scale and offset does not change anything
@@ -606,15 +606,15 @@ class TestParameter(TestCase):
         np.testing.assert_allclose(np_get_latest_values_after_get,
                                    (np_values - np_offsets) / np_scales)
 
-        # test set_cache for scalar values
+        # test ``cache.set`` for scalar values
         if not isinstance(values, Iterable):
-            p.set_cache(values)
+            p.cache.set(values)
             np.testing.assert_allclose(np.array(p.raw_value),
                                        np_values * np_scales + np_offsets)
             # No set/get cmd performed
 
             # testing conversion back and forth
-            p.set_cache(values)
+            p.cache.set(values)
             np_get_latest_values = np.array(p.get_latest())
             # No set/get cmd performed
             np.testing.assert_allclose(np_get_latest_values, np_values)
@@ -804,7 +804,7 @@ _P = Parameter
 )
 def test_set_latest_works_for_plain_memory_parameter(p, value, raw_value):
     # Set latest value of the parameter
-    p.set_cache(value)
+    p.cache.set(value)
 
     # Assert the latest value and raw_value
     assert p.get_latest() == value
@@ -965,7 +965,7 @@ class TestArrayParameter(TestCase):
         self.assertFalse(hasattr(p, 'set'))
 
         # Yet, it's possible to set the cached value
-        p.set_cache([6, 7, 8])
+        p.cache.set([6, 7, 8])
         self.assertListEqual(p.get_latest(), [6, 7, 8])
         # However, due to the implementation of this ``SimpleArrayParam``
         # test parameter it's ``get`` call will return the originally passed
@@ -1131,9 +1131,9 @@ class TestMultiParameter(TestCase):
 
         self.assertTrue(hasattr(p, 'get'))
         self.assertFalse(hasattr(p, 'set'))
-        # Ensure that ``set_cache`` works
+        # Ensure that ``cache.set`` works
         new_cache = [10, [10, 20, 30], [[40, 50], [60, 70]]]
-        p.set_cache(new_cache)
+        p.cache.set(new_cache)
         self.assertListEqual(p.get_latest(), new_cache)
         # However, due to the implementation of this ``SimpleMultiParam``
         # test parameter it's ``get`` call will return the originally passed
@@ -1149,8 +1149,8 @@ class TestMultiParameter(TestCase):
         value_to_set = [2, [1, 5, 2], [[8, 2], [4, 9]]]
         p.set(value_to_set)
         assert p.get() == value_to_set
-        # Also, ``set_cache`` works as expected
-        p.set_cache(new_cache)
+        # Also, ``cache.set`` works as expected
+        p.cache.set(new_cache)
         assert p.get_latest() == new_cache
         assert p.get() == value_to_set
 
@@ -1243,9 +1243,9 @@ class TestStandardParam(TestCase):
         self.assertEqual(self._p, '5')
         self.assertEqual(p(), 5)
 
-        p.set_cache(7)
+        p.cache.set(7)
         self.assertEqual(p.get_latest(), 7)
-        # Nothing has been passed to the "instrument" at ``set_cache``
+        # Nothing has been passed to the "instrument" at ``cache.set``
         # call, hence the following assertions should hold
         self.assertEqual(self._p, '5')
         self.assertEqual(p(), 5)
@@ -1262,9 +1262,9 @@ class TestStandardParam(TestCase):
         self.assertTrue(hasattr(p, 'set'))
         self.assertFalse(hasattr(p, 'get'))
 
-        # For settable-only parameters, using ``set_cache`` may not make
-        # sense, neertheless, it works
-        p.set_cache(7)
+        # For settable-only parameters, using ``cache.set`` may not make
+        # sense, nevertheless, it works
+        p.cache.set(7)
         self.assertEqual(p.get_latest(), 7)
 
     def test_gettable(self):
@@ -1280,9 +1280,9 @@ class TestStandardParam(TestCase):
         self.assertTrue(hasattr(p, 'get'))
         self.assertFalse(hasattr(p, 'set'))
 
-        p.set_cache(7)
+        p.cache.set(7)
         self.assertEqual(p.get_latest(), 7)
-        # Nothing has been passed to the "instrument" at ``set_cache``
+        # Nothing has been passed to the "instrument" at ``cache.set``
         # call, hence the following assertions should hold
         self.assertEqual(self._p, 21)
         self.assertEqual(p(), 21)
@@ -1311,9 +1311,9 @@ class TestStandardParam(TestCase):
 
         self._p = 1  # for further testing
 
-        p.set_cache('off')
+        p.cache.set('off')
         self.assertEqual(p.get_latest(), 'off')
-        # Nothing has been passed to the "instrument" at ``set_cache``
+        # Nothing has been passed to the "instrument" at ``cache.set``
         # call, hence the following assertions should hold
         self.assertEqual(self._p, 1)
         self.assertEqual(p(), 'on')
@@ -1338,9 +1338,9 @@ class TestStandardParam(TestCase):
         self._p = 'PVAL: 1'
         self.assertEqual(p(), 'on')
 
-        p.set_cache('off')
+        p.cache.set('off')
         self.assertEqual(p.get_latest(), 'off')
-        # Nothing has been passed to the "instrument" at ``set_cache``
+        # Nothing has been passed to the "instrument" at ``cache.set``
         # call, hence the following assertions should hold
         self.assertEqual(self._p, 'PVAL: 1')
         self.assertEqual(p(), 'on')
@@ -1824,7 +1824,7 @@ def test_delegate_parameter_snapshot():
     assert source_snapshot['value'] == 13
 
 
-def test_delegate_parameter_set_cached_for_memory_source_parameter():
+def test_delegate_parameter_set_cache_for_memory_source_parameter():
     initial_value = 1
     source = Parameter('p', set_cmd=None, get_cmd=None,
                        initial_value=initial_value, offset=1, scale=2)
@@ -1834,7 +1834,7 @@ def test_delegate_parameter_set_cached_for_memory_source_parameter():
     # delegate parameter
 
     new_source_value = 3
-    source.set_cache(new_source_value)
+    source.cache.set(new_source_value)
 
     assert source.raw_value == new_source_value * 2 + 1
     assert source.get_latest() == new_source_value
@@ -1853,7 +1853,7 @@ def test_delegate_parameter_set_cached_for_memory_source_parameter():
     # the source parameter
 
     new_delegate_value = 2
-    delegate.set_cache(new_delegate_value)
+    delegate.cache.set(new_delegate_value)
 
     assert delegate.raw_value == new_delegate_value * 5 + 4
     assert delegate.get_latest() == new_delegate_value
@@ -1861,12 +1861,12 @@ def test_delegate_parameter_set_cached_for_memory_source_parameter():
     assert source.raw_value == new_source_value * 2 + 1
     assert source.get_latest() == new_source_value
 
-    pytest.xfail(reason="DelegateParameter's get_latest and set_cache should "
+    pytest.xfail(reason="DelegateParameter's get_latest and cache.set should "
                         "reflect the state of the source parameter as "
                         "opposed to the behavior that this test exposes.")
 
 
-def test_delegate_parameter_set_cached_for_instrument_source_parameter():
+def test_delegate_parameter_set_cache_for_instrument_source_parameter():
     instrument_value = -689
 
     def get_instrument_value():
@@ -1888,7 +1888,7 @@ def test_delegate_parameter_set_cached_for_instrument_source_parameter():
     # delegate parameter. It also has no impact on the instrument value.
 
     new_source_value = 3
-    source.set_cache(new_source_value)
+    source.cache.set(new_source_value)
 
     assert source.raw_value == new_source_value * 2 + 1
     assert source.get_latest() == new_source_value
@@ -1913,7 +1913,7 @@ def test_delegate_parameter_set_cached_for_instrument_source_parameter():
     # the source parameter, and on the instrument value
 
     new_delegate_value = 2
-    delegate.set_cache(new_delegate_value)
+    delegate.cache.set(new_delegate_value)
 
     assert delegate.raw_value == new_delegate_value * 5 + 4
     assert delegate.get_latest() == new_delegate_value
@@ -1923,6 +1923,6 @@ def test_delegate_parameter_set_cached_for_instrument_source_parameter():
 
     assert instrument_value == initial_value * 2 + 1
 
-    pytest.xfail(reason="DelegateParameter's get_latest and set_cache should "
+    pytest.xfail(reason="DelegateParameter's get_latest and cache.set should "
                         "reflect the state of the source parameter as "
                         "opposed to the behavior that this test exposes.")


### PR DESCRIPTION
### Main thing

This PR takes another approach to #1791 - introducing `_Cache` class which:
- incorporates the `_latest` dictionary with `value`, `raw_value`, and `timestamp` (also `max_val_age`), and 
- `get` method that behaves as `get_latest` and 
- `set` method that behaves as `set_cache` that was introduced in #1757.

This PR subsumes significant part of https://github.com/QCoDeS/Qcodes/pull/1828 but not the improvements to `snapshot_base`.

### Some details of this PR

- `GetLatest` and `get_latest` remain as is for backwards compatibility, but under the hood they reuse `_Cache` and its methods "as-is". In the near future we will be able to deprecate `GetLatest` altogether 
and move our users to use `.cache` only.
- Note that `_Cache.get` as opposed to `get_latest.get` has an additional `get_if_invalid` flag that is useful to set to `False` when you don't want to call `get` of the parameter if the cached value is invalid (for example, because the parameter has never been captured).
- All docstrings in `parameter.py` were rewritten to reflect the existence of the `_Cache`
- Drivers which used `set_cache` were changed to use `cache.set`.
- Closes #1791 because it subsumes it.
- refactoring `test_parameter.py` into a package is out of scope for this PR

### To be done in another PR:
- rewrite `test_parameter.py` to test `cache.*` instead of `get_latest.*` but also add minor tests for `get_latest` to ensure that it does the same as `cache`
