### PR TITLE
Snapshot_base introduce new update=None, and use cache in parameter's snapshot_base

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -174,7 +174,9 @@ class InstrumentBase(Metadatable, DelegateAttributes):
 
         Args:
             update: If ``True``, update the state by querying the
-                instrument. If ``False``, just use the latest values in memory.
+                instrument. If None update the state if known to be invalid.
+                If ``False``, just use the latest values in memory and never update
+                state.
             params_to_skip_update: List of parameter names that will be skipped
                 in update even if update is True. This is useful if you have
                 parameters that are slow to update but can be updated in a

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -175,8 +175,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         Args:
             update: If ``True``, update the state by querying the
                 instrument. If None update the state if known to be invalid.
-                If ``False``, just use the latest values in memory and never update
-                state.
+                If ``False``, just use the latest values in memory and never
+                update state.
             params_to_skip_update: List of parameter names that will be skipped
                 in update even if update is True. This is useful if you have
                 parameters that are slow to update but can be updated in a

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -163,7 +163,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             raise TypeError('Submodules must be metadatable.')
         self.submodules[name] = submodule
 
-    def snapshot_base(self, update: bool = False,
+    def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """
@@ -202,7 +202,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             if param.snapshot_exclude:
                 continue
             if params_to_skip_update and name in params_to_skip_update:
-                update_par = False
+                update_par: Optional[bool] = False
             else:
                 update_par = update
 

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -400,8 +400,9 @@ class ChannelList(Metadatable):
 
         Args:
             update: If True, update the state by querying the
-                instrument. If None only update if the state is known to be invalid.
-                If False, just use the latest values in memory and never update.
+                instrument. If None only update if the state is known to be
+                invalid. If False, just use the latest values in memory
+                and never update.
             params_to_skip_update: List of parameter names that will be skipped
                 in update even if update is True. This is useful if you have
                 parameters that are slow to update but can be updated in a

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -390,7 +390,7 @@ class ChannelList(Metadatable):
         self._channels = tuple(self._channels)
         self._locked = True
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """
@@ -400,7 +400,14 @@ class ChannelList(Metadatable):
 
         Args:
             update: If True, update the state by querying the
-                instrument. If False, just use the latest values in memory..
+                instrument. If None only update if the state is known to be invalid.
+                If False, just use the latest values in memory and never update.
+            params_to_skip_update: List of parameter names that will be skipped
+                in update even if update is True. This is useful if you have
+                parameters that are slow to update but can be updated in a
+                different way (as in the qdac). If you want to skip the
+                update of certain parameters in all snapshots, use the
+                ``snapshot_get``  attribute of those parameters instead.
 
         Returns:
             dict: base snapshot

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -215,14 +215,16 @@ class IPInstrument(Instrument):
 
         Args:
             update: If True, update the state by querying the
-                instrument. If None only update if the state is known to be invalid.
-                If False, just use the latest values in memory and never update.
-            params_to_skip_update: List of parameter names that will be skipped
-                in update even if update is True. This is useful if you have
-                parameters that are slow to update but can be updated in a
-                different way (as in the qdac). If you want to skip the
-                update of certain parameters in all snapshots, use the
-                `snapshot_get`  attribute of those parameters: instead.
+                instrument. If None only update if the state is known to be
+                invalid. If False, just use the latest values in memory and
+                never update.
+            params_to_skip_update: List of parameter names that will be
+                skipped in update even if update is True. This is useful
+                if you have parameters that are slow to update but can
+                be updated in a different way (as in the qdac). If you
+                want to skip the update of certain parameters in all
+                snapshots, use the `snapshot_get`  attribute of those
+                parameters: instead.
 
         Returns:
             dict: base snapshot

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -204,7 +204,7 @@ class IPInstrument(Instrument):
     def __del__(self) -> None:
         self.close()
 
-    def snapshot_base(self, update: bool = False,
+    def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """
@@ -214,8 +214,9 @@ class IPInstrument(Instrument):
         supports).
 
         Args:
-            update (bool): If True, update the state by querying the
-                instrument. If False, just use the latest values in memory.
+            update: If True, update the state by querying the
+                instrument. If None only update if the state is known to be invalid.
+                If False, just use the latest values in memory and never update.
             params_to_skip_update: List of parameter names that will be skipped
                 in update even if update is True. This is useful if you have
                 parameters that are slow to update but can be updated in a

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -433,7 +433,8 @@ class _BaseParameter(Metadatable):
 
         if self._snapshot_value:
             has_get = self.gettable
-            allowed_to_call_get_when_snapshotting = self._snapshot_get and update is not False
+            allowed_to_call_get_when_snapshotting = (self._snapshot_get
+                                                     and update is not False)
             can_call_get_when_snapshotting = (
                     allowed_to_call_get_when_snapshotting and has_get)
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -416,7 +416,7 @@ class _BaseParameter(Metadatable):
             update: If True, update the state by calling ``parameter.get()``
                 unless ``snapshot_get`` of the parameter is ``False``.
                 If ``update`` is ``None``, use the current value from the
-                ``cache`` unless the cache is invalid. If False never call
+                ``cache`` unless the cache is invalid. If ``False``, never call
                 ``parameter.get()``.
             params_to_skip_update: No effect but may be passed from superclass
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -400,7 +400,7 @@ class _BaseParameter(Metadatable):
                 raise NotImplementedError('no set cmd found in' +
                                           ' Parameter {}'.format(self.name))
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """
@@ -415,8 +415,9 @@ class _BaseParameter(Metadatable):
         Args:
             update: If True, update the state by calling ``parameter.get()``
                 unless ``snapshot_get`` of the parameter is ``False``.
-                If ``update`` is ``False``, just use the current value from the
-                ``cache``.
+                If ``update`` is ``None``, use the current value from the
+                ``cache`` unless the cache is invalid. If False never call
+                ``parameter.get()``.
             params_to_skip_update: No effect but may be passed from superclass
 
         Returns:
@@ -432,7 +433,7 @@ class _BaseParameter(Metadatable):
 
         if self._snapshot_value:
             has_get = self.gettable
-            allowed_to_call_get_when_snapshotting = self._snapshot_get
+            allowed_to_call_get_when_snapshotting = self._snapshot_get and update is not False
             can_call_get_when_snapshotting = (
                     allowed_to_call_get_when_snapshotting and has_get)
 
@@ -1357,7 +1358,7 @@ class DelegateParameter(Parameter):
     def set_raw(self, value: Any) -> None:
         self.source(value)
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         snapshot = super().snapshot_base(
@@ -2182,7 +2183,7 @@ class CombinedParameter(Metadatable):
         # i.e. how many setpoint
         return numpy.shape(self.setpoints)[0]
 
-    def snapshot_base(self, update: bool = False,
+    def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> dict:
         """

--- a/qcodes/instrument/sweep_values.py
+++ b/qcodes/instrument/sweep_values.py
@@ -257,7 +257,7 @@ class SweepFixedValues(SweepValues):
             if 'first' in snap and 'last' in snap:
                 snap['last'], snap['first'] = snap['first'], snap['last']
 
-    def snapshot_base(self, update: bool = False,
+    def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """
@@ -270,7 +270,7 @@ class SweepFixedValues(SweepValues):
         Returns:
             dict: base snapshot
         """
-        self._snapshot['parameter'] = self.parameter.snapshot()
+        self._snapshot['parameter'] = self.parameter.snapshot(update=update)
         self._snapshot['values'] = self._value_snapshot
         return self._snapshot
 

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -228,7 +228,7 @@ class VisaInstrument(Instrument):
             self.visa_log.debug(f"Response: {response}")
         return response
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """
@@ -238,7 +238,8 @@ class VisaInstrument(Instrument):
 
         Args:
             update: If True, update the state by querying the
-                instrument. If False, just use the latest values in memory.
+                instrument. If None only update if the state is known to be invalid.
+                If False, just use the latest values in memory and never update.
             params_to_skip_update: List of parameter names that will be skipped
                 in update even if update is True. This is useful if you have
                 parameters that are slow to update but can be updated in a

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -238,8 +238,9 @@ class VisaInstrument(Instrument):
 
         Args:
             update: If True, update the state by querying the
-                instrument. If None only update if the state is known to be invalid.
-                If False, just use the latest values in memory and never update.
+                instrument. If None only update if the state is known to be
+                invalid. If False, just use the latest values in memory and
+                never update.
             params_to_skip_update: List of parameter names that will be skipped
                 in update even if update is True. This is useful if you have
                 parameters that are slow to update but can be updated in a

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1652,7 +1652,7 @@ class ZIUHFLI(Instrument):
                            docstring="Enable jumbo frames on the TCP/IP interface"
                            )
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """ Override the base method to ignore 'sweeper_sweeptime' if no signals selected."""

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -156,7 +156,7 @@ class SR86xBuffer(InstrumentChannel):
                 parameter_class=SR86xBufferReadout
             )
 
-    def snapshot_base(self, update: bool = False,
+    def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         if params_to_skip_update is None:

--- a/qcodes/loops.py
+++ b/qcodes/loops.py
@@ -293,7 +293,7 @@ class Loop(Metadatable):
         supports).
 
         Args:
-            update : If True, update the state by querying the underlying
+            update: If True, update the state by querying the underlying
                 sweep_values and actions. If None only update state if known
                 to be invalid. If False, just use the latest values
                 in memory.

--- a/qcodes/loops.py
+++ b/qcodes/loops.py
@@ -285,7 +285,7 @@ class Loop(Metadatable):
         """
         return _attach_then_actions(self._copy(), actions, overwrite)
 
-    def snapshot_base(self, update: bool = False,
+    def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None):
         """
         State of the loop as a JSON-compatible dict (everything that
@@ -293,8 +293,9 @@ class Loop(Metadatable):
         supports).
 
         Args:
-            update (bool): If True, update the state by querying the underlying
-                sweep_values and actions. If False, just use the latest values
+            update : If True, update the state by querying the underlying
+                sweep_values and actions. If None only update state if known
+                to be invalid. If False, just use the latest values
                 in memory.
             params_to_skip_update: Unused in this implementation.
 

--- a/qcodes/measure.py
+++ b/qcodes/measure.py
@@ -146,7 +146,7 @@ class Measure(Metadatable):
 
         return data_set
 
-    def snapshot_base(self, update: bool = False,
+    def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None):
         return {
             '__class__': full_class(self),

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -143,7 +143,7 @@ class Station(Metadatable, DelegateAttributes):
 
         self.load_config_file(self.config_file)
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         """
@@ -158,8 +158,10 @@ class Station(Metadatable, DelegateAttributes):
         Args:
             update: If ``True``, update the state by querying the
                 all the children: f.ex. instruments, parameters,
-                components, etc. If ``False``, just use the latest
-                values in memory.
+                components, etc. If None only update if the state
+                is known to be invalid.
+                If ``False``, just use the latest
+                values in memory and never update the state.
             params_to_skip_update: Not used.
 
         Returns:

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -514,7 +514,7 @@ class SnapShotTestInstrument(Instrument):
         self._get_calls[name] += 1
         return val
 
-    def snapshot_base(self, update: bool = True,
+    def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:
         if params_to_skip_update is None:

--- a/qcodes/tests/test_loop.py
+++ b/qcodes/tests/test_loop.py
@@ -491,9 +491,9 @@ class AbortingGetter(Parameter):
         super().__init__(*args, **kwargs)
 
     def get_raw(self):
+        self._count -= 1
         if self._count <= 0:
             raise _QcodesBreak
-        self._count -= 1
         return self.cache.raw_value
 
     def reset(self):

--- a/qcodes/tests/test_loop.py
+++ b/qcodes/tests/test_loop.py
@@ -491,10 +491,10 @@ class AbortingGetter(Parameter):
         super().__init__(*args, **kwargs)
 
     def get_raw(self):
-        self._count -= 1
         if self._count <= 0:
             raise _QcodesBreak
-        return self.get_latest()
+        self._count -= 1
+        return self.cache.raw_value
 
     def reset(self):
         self._count = self._initial_count

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -2150,8 +2150,8 @@ def create_parameter(snapshot_get, snapshot_value, cache_is_valid, get_cmd,
 
     return p
 
-# extend with None
-@pytest.fixture(params=(True, False, NOT_PASSED))
+
+@pytest.fixture(params=(True, False, None, NOT_PASSED))
 def update(request):
     return request.param
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -2067,3 +2067,292 @@ def test_no_get_timestamp_none_runtime_error():
     with pytest.raises(RuntimeError, match="Value of parameter test_param"):
         local_parameter.cache.get()
 
+
+NOT_PASSED = 'NOT_PASSED'
+
+
+@pytest.fixture(params=(True, False, NOT_PASSED))
+def snapshot_get(request):
+    return request.param
+
+
+@pytest.fixture(params=(True, False, NOT_PASSED))
+def snapshot_value(request):
+    return request.param
+
+
+@pytest.fixture(params=(None, False, NOT_PASSED))
+def get_cmd(request):
+    return request.param
+
+
+def create_parameter(snapshot_get, snapshot_value, cache_is_valid, get_cmd,
+                     offset=NOT_PASSED):
+    kwargs = dict(set_cmd=None,
+                  label='Parameter',
+                  unit='a.u.',
+                  docstring='some docs')
+
+    if offset != NOT_PASSED:
+        kwargs.update(offset=offset)
+
+    if snapshot_get != NOT_PASSED:
+        kwargs.update(snapshot_get=snapshot_get)
+
+    if snapshot_value != NOT_PASSED:
+        kwargs.update(snapshot_value=snapshot_value)
+
+    if get_cmd != NOT_PASSED:
+        kwargs.update(get_cmd=get_cmd)
+
+    p = Parameter('p', **kwargs)
+
+    if get_cmd is not False:
+        def wrap_in_call_counter(get_func):
+            call_count = 0
+
+            def wrapped_func(*args, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                return get_func(*args, **kwargs)
+
+            wrapped_func.call_count = lambda: call_count
+
+            return wrapped_func
+
+        p.get = wrap_in_call_counter(p.get)
+        assert p.get.call_count() == 0  # pre-condition
+    else:
+        assert not hasattr(p, 'get')  # pre-condition
+
+    if cache_is_valid:
+        p.set(42)
+
+    return p
+
+
+@pytest.fixture(params=(True, False, NOT_PASSED))
+def update(request):
+    return request.param
+
+
+@pytest.fixture(params=(True, False))
+def cache_is_valid(request):
+    return request.param
+
+
+def test_snapshot_contains_parameter_attributes(
+        snapshot_get, snapshot_value, get_cmd, cache_is_valid, update):
+    p = create_parameter(snapshot_get, snapshot_value, cache_is_valid, get_cmd)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    assert isinstance(s, dict)
+
+    # Not metadata key in the snapshot because we didn't pass any metadata
+    # for the parameter
+    # TODO: test for parameter with metadata
+    assert 'metadata' not in s
+
+    assert s['__class__'] == 'qcodes.instrument.parameter.Parameter'
+    assert s['full_name'] == 'p'
+
+    # The following is because the parameter does not belong to an instrument
+    # TODO: test for a parameter that is attached to instrument
+    assert 'instrument' not in s
+    assert 'instrument_name' not in s
+
+    # These attributes have value of ``None`` hence not included in the snapshot
+    # TODO: test snapshot when some of these are not None
+    none_attrs = ('step', 'scale', 'offset', 'val_mapping', 'vals')
+    for attr in none_attrs:
+        assert getattr(p, attr) is None  # pre-condition
+        assert attr not in s
+
+    # TODO: test snapshot when some of these are None
+    not_none_attrs = {'name': p.name, 'label': p.label, 'unit': p.unit,
+                      'inter_delay': p.inter_delay, 'post_delay': p.post_delay}
+    for attr, value in not_none_attrs.items():
+        assert s[attr] == value
+
+
+def test_snapshot_timestamp_of_non_gettable_depends_only_on_cache_validity(
+        snapshot_get, snapshot_value, update, cache_is_valid):
+    p = create_parameter(snapshot_get, snapshot_value, cache_is_valid,
+                         get_cmd=False)
+
+    t0 = p.cache.timestamp
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if cache_is_valid:
+        ts = datetime.strptime(s['ts'], '%Y-%m-%d %H:%M:%S')
+        t0_up_to_seconds = t0.replace(microsecond=0)
+        assert ts >= t0_up_to_seconds
+    else:
+        assert s['ts'] is None
+
+
+def test_snapshot_timestamp_for_valid_cache_depends_on_cache_update(
+        snapshot_get, snapshot_value, update):
+
+    p = create_parameter(snapshot_get, snapshot_value,
+                         get_cmd=lambda: 69, cache_is_valid=True)
+
+    # Hack cache's timestamp to simplify this test
+    p.cache._timestamp = p.cache.timestamp - timedelta(days=31)
+
+    tu = datetime.now()
+    assert p.cache.timestamp < tu  # pre-condition
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    ts = datetime.strptime(s['ts'], '%Y-%m-%d %H:%M:%S')
+    tu_up_to_seconds = tu.replace(microsecond=0)
+
+    cache_gets_updated_on_snapshot_call = (
+            snapshot_value is not False
+            and snapshot_get is not False
+            and update is True
+    )
+
+    if cache_gets_updated_on_snapshot_call:
+        assert ts >= tu_up_to_seconds
+    else:
+        assert ts < tu_up_to_seconds
+
+
+def test_snapshot_timestamp_for_invalid_cache_depends_only_on_snapshot_flags(
+        snapshot_get, snapshot_value, update):
+
+    p = create_parameter(snapshot_get, snapshot_value,
+                         get_cmd=lambda: 69, cache_is_valid=False)
+
+    cache_gets_updated_on_snapshot_call = (
+            snapshot_value is not False
+            and snapshot_get is not False
+    )
+
+    if cache_gets_updated_on_snapshot_call:
+        tu = datetime.now()
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if cache_gets_updated_on_snapshot_call:
+        ts = datetime.strptime(s['ts'], '%Y-%m-%d %H:%M:%S')
+        tu_up_to_seconds = tu.replace(microsecond=0)
+        assert ts >= tu_up_to_seconds
+    else:
+        assert s['ts'] is None
+
+
+def test_snapshot_when_snapshot_value_is_false(
+        snapshot_get, get_cmd, cache_is_valid, update):
+
+    p = create_parameter(
+        snapshot_get=snapshot_get, snapshot_value=False, get_cmd=get_cmd, cache_is_valid=cache_is_valid)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    assert 'value' not in s
+    assert 'raw_value' not in s
+
+    if get_cmd is not False:
+        assert p.get.call_count() == 0
+
+
+def test_snapshot_value_is_true_by_default(snapshot_get, get_cmd):
+    p = create_parameter(
+        snapshot_value=NOT_PASSED,
+        snapshot_get=snapshot_get,
+        get_cmd=get_cmd,
+        cache_is_valid=True
+    )
+    assert p._snapshot_value is True
+
+
+def test_snapshot_get_is_true_by_default(snapshot_value, get_cmd):
+    p = create_parameter(
+        snapshot_get=NOT_PASSED,
+        snapshot_value=snapshot_value,
+        get_cmd=get_cmd,
+        cache_is_valid=True
+    )
+    assert p._snapshot_get is True
+
+
+def test_snapshot_when_snapshot_get_is_false(get_cmd, update, cache_is_valid):
+    p = create_parameter(
+        snapshot_get=False,
+        snapshot_value=True,
+        get_cmd=get_cmd,
+        cache_is_valid=cache_is_valid,
+        offset=4)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if cache_is_valid:
+        assert s['value'] == 42
+        assert s['raw_value'] == 46
+    else:
+        assert s['value'] is None
+        assert s['raw_value'] is None
+
+    if get_cmd is not False:
+        assert p.get.call_count() == 0
+
+
+def test_snapshot_of_non_gettable_parameter_mirrors_cache(
+        update, cache_is_valid):
+    p = create_parameter(
+        snapshot_get=True, snapshot_value=True, get_cmd=False,
+        cache_is_valid=cache_is_valid, offset=4)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if cache_is_valid:
+        assert s['value'] == 42
+        assert s['raw_value'] == 46
+    else:
+        assert s['value'] is None
+        assert s['raw_value'] is None
+
+
+def test_snapshot_of_gettable_parameter_depends_on_update(update, cache_is_valid):
+    p = create_parameter(
+        snapshot_get=True, snapshot_value=True, get_cmd=lambda: 69,
+        cache_is_valid=cache_is_valid, offset=4)
+
+    if update != NOT_PASSED:
+        s = p.snapshot(update=update)
+    else:
+        s = p.snapshot()
+
+    if update is not True and cache_is_valid:
+        assert s['value'] == 42
+        assert s['raw_value'] == 46
+        assert p.get.call_count() == 0
+    else:
+        assert s['value'] == 65
+        assert s['raw_value'] == 69
+        assert p.get.call_count() == 1

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -2150,7 +2150,7 @@ def create_parameter(snapshot_get, snapshot_value, cache_is_valid, get_cmd,
 
     return p
 
-
+# extend with None
 @pytest.fixture(params=(True, False, NOT_PASSED))
 def update(request):
     return request.param
@@ -2259,6 +2259,8 @@ def test_snapshot_timestamp_for_invalid_cache_depends_only_on_snapshot_flags(
     cache_gets_updated_on_snapshot_call = (
             snapshot_value is not False
             and snapshot_get is not False
+            and update is not False
+            and update != NOT_PASSED
     )
 
     if cache_gets_updated_on_snapshot_call:
@@ -2371,6 +2373,10 @@ def test_snapshot_of_gettable_parameter_depends_on_update(update, cache_is_valid
     if update is not True and cache_is_valid:
         assert s['value'] == 42
         assert s['raw_value'] == 46
+        assert p.get.call_count() == 0
+    elif update is False or update == NOT_PASSED:
+        assert s['value'] is None
+        assert s['raw_value'] is None
         assert p.get.call_count() == 0
     else:
         assert s['value'] == 65

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -157,6 +157,7 @@ class TestParameter(TestCase):
         self.assertIn(name, p.__doc__)
 
         # test snapshot_get by looking at _get_count
+        # by default, snapshot_get is True, hence we expect ``get`` to be called
         self.assertEqual(p._get_count, 0)
         snap = p.snapshot(update=True)
         self.assertEqual(p._get_count, 1)
@@ -165,10 +166,12 @@ class TestParameter(TestCase):
             'label': name,
             'unit': '',
             'value': 42,
+            'raw_value': 42,
             'vals': repr(vals.Numbers())
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertNotEqual(snap['ts'], None)
 
     def test_explicit_attributes(self):
         # Test the explicit attributes, providing everything we can
@@ -205,6 +208,9 @@ class TestParameter(TestCase):
             'label': label,
             'unit': unit,
             'vals': repr(vals.Numbers(5, 10)),
+            'value': None,
+            'raw_value': None,
+            'ts': None,
             'metadata': metadata
         }
         for k, v in snap_expected.items():
@@ -251,11 +257,15 @@ class TestParameter(TestCase):
         p_snapshot(42)
         snap = p_snapshot.snapshot()
         self.assertIn('value', snap)
+        self.assertIn('raw_value', snap)
+        self.assertIn('ts', snap)
         p_no_snapshot = Parameter('no_snapshot', set_cmd=None, get_cmd=None,
                                   snapshot_value=False)
         p_no_snapshot(42)
         snap = p_no_snapshot.snapshot()
         self.assertNotIn('value', snap)
+        self.assertNotIn('raw_value', snap)
+        self.assertIn('ts', snap)
 
     def test_get_latest(self):
         time_resolution = time.get_clock_info('time').resolution
@@ -941,6 +951,9 @@ class TestArrayParameter(TestCase):
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertNotIn('value', snap)
+        self.assertNotIn('raw_value', snap)
+        self.assertIsNone(snap['ts'])
 
         self.assertIn(name, p.__doc__)
 
@@ -980,10 +993,12 @@ class TestArrayParameter(TestCase):
             'setpoint_names': setpoint_names,
             'setpoint_labels': setpoint_labels,
             'metadata': metadata,
-            'value': [6, 7]
+            'value': [6, 7],
+            'raw_value': [6, 7]
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertIsNotNone(snap['ts'])
 
         self.assertIn(name, p.__doc__)
         self.assertIn(docstring, p.__doc__)
@@ -1094,10 +1109,13 @@ class TestMultiParameter(TestCase):
             'name': name,
             'names': names,
             'labels': names,
-            'units': [''] * 3
+            'units': [''] * 3,
+            'ts': None
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertNotIn('value', snap)
+        self.assertNotIn('raw_value', snap)
 
         self.assertIn(name, p.__doc__)
 
@@ -1148,10 +1166,12 @@ class TestMultiParameter(TestCase):
             'setpoint_names': setpoint_names,
             'setpoint_labels': setpoint_labels,
             'metadata': metadata,
-            'value': [0, [1, 2, 3], [[4, 5], [6, 7]]]
+            'value': [0, [1, 2, 3], [[4, 5], [6, 7]]],
+            'raw_value': [0, [1, 2, 3], [[4, 5], [6, 7]]]
         }
         for k, v in snap_expected.items():
             self.assertEqual(snap[k], v)
+        self.assertIsNotNone(snap['ts'])
 
         self.assertIn(name, p.__doc__)
         self.assertIn(docstring, p.__doc__)

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -864,6 +864,7 @@ def test_set_latest_works_for_plain_memory_parameter(p, value, raw_value):
 
     if not p.gettable:
         assert not hasattr(p, 'get')
+        assert p.gettable is False
         return  # finish the test here for non-gettable parameters
 
     gotten_value = p.get()
@@ -2161,6 +2162,7 @@ def create_parameter(snapshot_get, snapshot_value, cache_is_valid, get_cmd,
         assert p.get.call_count() == 0  # pre-condition
     else:
         assert not hasattr(p, 'get')  # pre-condition
+        assert not p.gettable
 
     if cache_is_valid:
         p.set(42)

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -28,6 +28,13 @@ def test_snapshot_skip_params_update(request, params, params_to_skip):
                                   params_to_skip=params_to_skip)
     request.addfinalizer(inst.close)
 
+    # Set parameters to some values so their ``get`` is NOT called when the
+    # ``snapshot`` is called with ``update=False``; in other words,
+    # this will ensure that the parameters have their caches filled with
+    # actual values
+    for ind, p in enumerate(params):
+        inst.parameters[p].set(ind)
+
     assert list(inst._get_calls.values()) == [0, 0, 0, 0]
 
     inst.snapshot(update=False)

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -28,13 +28,6 @@ def test_snapshot_skip_params_update(request, params, params_to_skip):
                                   params_to_skip=params_to_skip)
     request.addfinalizer(inst.close)
 
-    # Set parameters to some values so their ``get`` is NOT called when the
-    # ``snapshot`` is called with ``update=False``; in other words,
-    # this will ensure that the parameters have their caches filled with
-    # actual values
-    for ind, p in enumerate(params):
-        inst.parameters[p].set(ind)
-
     assert list(inst._get_calls.values()) == [0, 0, 0, 0]
 
     inst.snapshot(update=False)

--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -38,7 +38,7 @@ class Metadatable:
         """
         deep_update(self.metadata, metadata)
 
-    def snapshot(self, update: bool = False) -> Dict:
+    def snapshot(self, update: Optional[bool] = False) -> Dict:
         """
         Decorate a snapshot dictionary with metadata.
         DO NOT override this method if you want metadata in the snapshot
@@ -59,7 +59,7 @@ class Metadatable:
         return snap
 
     def snapshot_base(
-            self, update: bool = False,
+            self, update: Optional[bool] = False,
             params_to_skip_update: Optional[Sequence[str]] = None) -> Dict:
         """
         Override this with the primary information for a subclass.


### PR DESCRIPTION
### Main thing

`_BaseParameter.snapshot_base` has been refactored to use `cache` and rely on `cache.get`.
It has gaied a third value for update such that `update=True` means unconditionally update the cache. `update=None` means update if known to be out of date and `update=False` meas do not ever try to update the underlying value. It is the intention that `update=None` should become the default in many places but that will happen in a diffrent pr.

### Other notes
- Note that `_BaseParameter._snapshot_get` is passed to `cache.get` via this new `get_if_invalid` flag.
- `_BaseParameter.snapshot_base` got it's own set of parametrized set of tests so that its current behavior is captured (to the best of my abilities)

### ToDo
- [x] **IMPORTANT** add tests for `get_if_invalid` on `_Cache.get(...)` (also for the whole `_Cache`) **EDIT** done in a different pr
- [x] remove `_value` from `DelegateCache` because it should not be needed ever, thanks to this PR **EDIT** done in a different pr
- [x] due to fixes to tests that have to be done... is the suggested behavior really correct? **EDIT** not needed any more since the change to update=False was reverted