### PR TITLE
Add Keysight 34410A driver

### DIFF
--- a/qcodes/instrument_drivers/Keysight/Keysight_34410A_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_34410A_submodules.py
@@ -1,0 +1,10 @@
+from .private.Keysight_344xxA_submodules import _Keysight_344xxA
+
+
+class Keysight_34410A(_Keysight_344xxA):
+    """
+    This is the qcodes driver for the Keysight 34410A Multimeter
+    """
+    def __init__(self, name, address, silent=False,
+                 **kwargs):
+        super().__init__(name, address, silent, **kwargs)

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -149,6 +149,8 @@ class Sample(InstrumentChannel):
 
         if self.parent.is_34465A_34470A:
             _max_sample_count = 1e9
+        elif self.parent.model == "34410A":
+            _max_sample_count = 50_000
         else:
             _max_sample_count = 1e6
 

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -2,8 +2,7 @@ import textwrap
 import numpy as np
 from contextlib import ExitStack
 from functools import partial
-from typing import Sequence, Optional, Dict, Union, Callable, Any, List, \
-    TYPE_CHECKING, cast, Type
+from typing import Sequence
 
 import qcodes.utils.validators as vals
 from qcodes import VisaInstrument, InstrumentChannel
@@ -417,7 +416,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         ranges: A list of the available voltage ranges
     """
 
-    def __init__(self, name: str, address: str, silent: bool=False,
+    def __init__(self, name: str, address: str, silent: bool = False,
                  **kwargs):
         """
         Create an instance of the instrument.
@@ -459,7 +458,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
                   }
 
         # The resolution factor order matches the order of PLCs
-        res_factors = {'34410A': [30e-6, 15e-5, 6e-6, 3e-6, 1.5e-6, 0.7e-6, 
+        res_factors = {'34410A': [30e-6, 15e-5, 6e-6, 3e-6, 1.5e-6, 0.7e-6,
                                   0.3e-6, 0.2e-6, 0.1e-6, 0.03e-6],
                        '34460A': [300e-6, 100e-6, 30e-6, 10e-6, 3e-6],
                        '34461A': [100e-6, 10e-6, 3e-6, 1e-6, 0.3e-6],
@@ -665,12 +664,14 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
                            unit='A')
 
         self.add_parameter('res',
-                           get_cmd=partial(self._get_parameter, "2 Wire Resistance"),
+                           get_cmd=partial(self._get_parameter,
+                                           "2 Wire Resistance"),
                            label='Resistance',
                            unit='Ohms')
 
         self.add_parameter('four_wire_res',
-                           get_cmd=partial(self._get_parameter, "4 Wire Resistance"),
+                           get_cmd=partial(self._get_parameter,
+                                           "4 Wire Resistance"),
                            label='Resistance',
                            unit='Ohms')
 
@@ -755,13 +756,13 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
             return licenses_list
         return tuple()
 
-    def _get_parameter(self, sense_function: str="DC Voltage") -> float:
+    def _get_parameter(self, sense_function: str = "DC Voltage") -> float:
         """
         Measure the parameter given by sense_function
 
         Args:
-            sense_function: The parameter to measure. Valid values are those accepted by
-                the sense_function parameter.
+            sense_function: The parameter to measure. Valid values are those
+                accepted by the sense_function parameter.
 
         Returns:
             The float value of the parameter.

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -1,6 +1,7 @@
 import textwrap
 import numpy as np
 from contextlib import ExitStack
+from functools import partial
 
 import qcodes.utils.validators as vals
 from qcodes import VisaInstrument, InstrumentChannel
@@ -640,9 +641,34 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         # Measuring parameter
 
         self.add_parameter('volt',
-                           get_cmd=self._get_voltage,
+                           get_cmd=partial(self._get_parameter, "DC Voltage"),
                            label='Voltage',
                            unit='V')
+
+        self.add_parameter('curr',
+                           get_cmd=partial(self._get_parameter, "DC Current"),
+                           label='Current',
+                           unit='A')
+
+        self.add_parameter('ac_volt',
+                           get_cmd=partial(self._get_parameter, "AC Voltage"),
+                           label='AC Voltage',
+                           unit='V')
+
+        self.add_parameter('ac_curr',
+                           get_cmd=partial(self._get_parameter, "AC Current"),
+                           label='AC Current',
+                           unit='A')
+
+        self.add_parameter('res',
+                           get_cmd=partial(self._get_parameter, "2 Wire Resistance"),
+                           label='Resistance',
+                           unit='Ohms')
+
+        self.add_parameter('four_wire_res',
+                           get_cmd=partial(self._get_parameter, "4 Wire Resistance"),
+                           label='Resistance',
+                           unit='Ohms')
 
         #####################################
         # Time trace parameters
@@ -725,10 +751,18 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         return licenses_list
         return tuple()
 
-    def _get_voltage(self):
-        # TODO: do we need to set any other parameters here?
+    def _get_parameter(self, sense_function: str="DC Voltage") -> float:
+        """
+        Measure the parameter given by sense_function
 
-        with self.sense_function.set_to('DC Voltage'):
+        Args:
+            sense_function: The parameter to measure. Valid values are those accepted by
+                the sense_function parameter.
+
+        Returns:
+            The float value of the parameter.
+        """
+        with self.sense_function.set_to(sense_function):
             with self.sample.count.set_to(1):
                 response = self.ask('READ?')
 

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -436,7 +436,8 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
 
         self.has_DIG = 'DIG' in self._licenses()
 
-        PLCs = {'34460A': [0.02, 0.2, 1, 10, 100],
+        PLCs = {'34410A': [0.006, 0.02, 0.06, 0.2, 1, 2, 10, 100],
+                '34460A': [0.02, 0.2, 1, 10, 100],
                 '34461A': [0.02, 0.2, 1, 10, 100],
                 '34465A': [0.02, 0.06, 0.2, 1, 10, 100],
                 '34470A': [0.02, 0.06, 0.2, 1, 10, 100]
@@ -445,14 +446,17 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
             PLCs['34465A'] = [0.001, 0.002, 0.006] + PLCs['34465A']
             PLCs['34470A'] = [0.001, 0.002, 0.006] + PLCs['34470A']
 
-        ranges = {'34460A': [10**n for n in range(-3, 9)],  # 1 m to 100 M
+        ranges = {'34410A': [10**n for n in range(3, 10)],  # 100 to 1 G
+                  '34460A': [10**n for n in range(-3, 9)],  # 1 m to 100 M
                   '34461A': [10**n for n in range(-3, 9)],  # 1 m to 100 M
                   '34465A': [10**n for n in range(-3, 10)],  # 1 m to 1 G
                   '34470A': [10**n for n in range(-3, 10)],  # 1 m to 1 G
                   }
 
         # The resolution factor order matches the order of PLCs
-        res_factors = {'34460A': [300e-6, 100e-6, 30e-6, 10e-6, 3e-6],
+        res_factors = {'34410A': [30e-6, 15e-5, 6e-6, 3e-6, 1.5e-6, 0.7e-6, 
+                                  0.3e-6, 0.2e-6, 0.1e-6, 0.03e-6],
+                       '34460A': [300e-6, 100e-6, 30e-6, 10e-6, 3e-6],
                        '34461A': [100e-6, 10e-6, 3e-6, 1e-6, 0.3e-6],
                        '34465A': [3e-6, 1.5e-6, 0.7e-6, 0.3e-6, 0.1e-6,
                                   0.03e-6],
@@ -710,10 +714,16 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         """
         self.write('ABORt')
 
-    def _licenses(self):
+    def _licenses(self) -> Sequence[str]:
+        """
+        Return extra licenses purchased with the DMM. The 34410A does not have
+        optional modules, hence always returns an empty tuple.
+        """
+        if self.model != '34410A':
         licenses_raw = self.ask('SYST:LIC:CAT?')
         licenses_list = [x.strip('"') for x in licenses_raw.split(',')]
         return licenses_list
+        return tuple()
 
     def _get_voltage(self):
         # TODO: do we need to set any other parameters here?

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -2,6 +2,8 @@ import textwrap
 import numpy as np
 from contextlib import ExitStack
 from functools import partial
+from typing import Sequence, Optional, Dict, Union, Callable, Any, List, \
+    TYPE_CHECKING, cast, Type
 
 import qcodes.utils.validators as vals
 from qcodes import VisaInstrument, InstrumentChannel
@@ -748,9 +750,9 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         optional modules, hence always returns an empty tuple.
         """
         if self.model != '34410A':
-        licenses_raw = self.ask('SYST:LIC:CAT?')
-        licenses_list = [x.strip('"') for x in licenses_raw.split(',')]
-        return licenses_list
+            licenses_raw = self.ask('SYST:LIC:CAT?')
+            licenses_list = [x.strip('"') for x in licenses_raw.split(',')]
+            return licenses_list
         return tuple()
 
     def _get_parameter(self, sense_function: str="DC Voltage") -> float:
@@ -800,13 +802,13 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         raw_vals: str = self.ask('READ?')
         return _raw_vals_to_array(raw_vals)
 
-    def _set_apt_time(self, value):
+    def _set_apt_time(self, value: float) -> None:
         self.write('SENSe:VOLTage:DC:APERture {:f}'.format(value))
 
         # setting aperture time switches aperture mode ON
         self.aperture_mode.get()
 
-    def _set_NPLC(self, value):
+    def _set_NPLC(self, value: float) -> None:
         self.write('SENSe:VOLTage:DC:NPLC {:f}'.format(value))
 
         # resolution settings change with NPLC
@@ -816,14 +818,14 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         if self.is_34465A_34470A:
             self.aperture_mode.get()
 
-    def _set_range(self, value):
+    def _set_range(self, value: float):
         self.write('SENSe:VOLTage:DC:RANGe {:f}'.format(value))
 
         # resolution settings change with range
 
         self.resolution.get()
 
-    def _set_resolution(self, value):
+    def _set_resolution(self, value: float) -> None:
         rang = self.range.get()
 
         # convert both value*range and the resolution factors


### PR DESCRIPTION
Add support for the Keysight 34410A DMM into qcodes, and add support for pulling other types of parameter (current and resistance) into the driver.

Changes proposed in this pull request:
- Keysight 34410A support
- Support for current, resistance measurements
- Add some missing mypy annotations

@WilliamHPNielsen 