### PR TITLE
Add minimal steps to automatically publish qcodes to PyPI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -153,7 +153,7 @@ jobs:
       - script: |
           source activate qcodes &&
           python setup.py bdist_wheel &&
-          python setup.py sdist &&
+          python setup.py sdist
         condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
         displayName: "Build dist artifacts"
       - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,7 @@ jobs:
           source activate qcodes &&
           pip install -r test_requirements.txt &&
           pip install -r docs_requirements.txt &&
+          pip install twine &&
           pip install -e .
         displayName: "Install environment, qcodes"
       - bash: |
@@ -144,3 +145,19 @@ jobs:
           git push
         displayName: "Publish docs to gh-pages"
         condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['Build.Reason'], 'IndividualCI'))
+
+      - task: TwineAuthenticate@1
+        inputs:
+          pythonUploadServiceConnection: qcodes_upload_to_pypi
+        condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ), contains(variables['Build.SourceBranch'], 'refs/tags/'))
+      - script: |
+          source activate qcodes &&
+          python setup.py bdist_wheel &&
+          python setup.py sdist &&
+        condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ))
+        displayName: "Build dist artifacts"
+      - script: |
+          source activate qcodes &&
+          twine upload -r "pypi" --config-file $(PYPIRC_PATH) dist/*
+        condition: and(succeeded(), eq( variables['Agent.OS'], 'Linux' ), contains(variables['Build.SourceBranch'], 'refs/tags/'))
+        displayName: "Upload tagged release to PyPi"


### PR DESCRIPTION
This is a simple PR that makes ~two last steps of "qcodes release process" (from wiki) automatic.

all sorts of improvements to pipelines is out of scope of this PR. Also getting rid of the need for having that "how to release" wiki is also out of scope.