### PR TITLE
Add initial_cache_value kwarg to Parameter

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1049,6 +1049,11 @@ class Parameter(_BaseParameter):
         self.label = name if label is None else label
         self.unit = unit if unit is not None else ''
 
+        if initial_value is not None and initial_cache_value is not None:
+            raise SyntaxError('It is not possible to specify both of the '
+                              '`initial_value` and `initial_cache_value` '
+                              'keyword arguments.')
+
         if initial_value is not None:
             self.set(initial_value)
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1336,11 +1336,12 @@ class DelegateParameter(Parameter):
                 raise KeyError(f'It is not allowed to set "{cmd}" of a '
                                f'DelegateParameter because the one of the '
                                f'source parameter is supposed to be used.')
-        initial_cache_value = kwargs.pop("initial_cache_value")
+        initial_cache_value = kwargs.pop("initial_cache_value", None)
         super().__init__(name, *args, **kwargs)
         delegate_cache = self._DelegateCache(self)
         self.cache = cast(_Cache, delegate_cache)
-        self.cache.set(initial_cache_value)
+        if initial_cache_value is not None:
+            self.cache.set(initial_cache_value)
 
     # Disable the warnings until MultiParameter has been
     # replaced and name/label/unit can live in _BaseParameter

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -973,6 +973,11 @@ class Parameter(_BaseParameter):
             ``get_latest()``. If this parameter has not been set or measured
             more recently than this, perform an additional measurement.
 
+        initial_value: Value to set the parameter to at the end of its
+            initialization (this is equivalent to calling
+            ``parameter.set(initial_value)`` after parameter initialization).
+            Cannot be passed together with ``initial_cache_value`` argument.
+
         docstring: Documentation string for the ``__doc__``
             field of the object. The ``__doc__``  field of the instance is
             used by some help systems, but not all.

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -988,6 +988,7 @@ class Parameter(_BaseParameter):
                  get_cmd: Optional[Union[str, Callable, bool]] = None,
                  set_cmd:  Optional[Union[str, Callable, bool]] = False,
                  initial_value: Optional[Union[float, str]] = None,
+                 initial_cache_value: Optional[Union[float, str]] = None,
                  max_val_age: Optional[float] = None,
                  vals: Optional[Validator] = None,
                  docstring: Optional[str] = None,
@@ -1050,6 +1051,9 @@ class Parameter(_BaseParameter):
 
         if initial_value is not None:
             self.set(initial_value)
+
+        if initial_cache_value is not None:
+            self.cache.set(initial_cache_value)
 
         # generate default docstring
         self.__doc__ = os.linesep.join((

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -978,6 +978,12 @@ class Parameter(_BaseParameter):
             ``parameter.set(initial_value)`` after parameter initialization).
             Cannot be passed together with ``initial_cache_value`` argument.
 
+        initial_cache_value: Value to set the cache of the parameter to
+            at the end of its initialization (this is equivalent to calling
+            ``parameter.cache.set(initial_cache_value)`` after parameter
+            initialization). Cannot be passed together with ``initial_value``
+            argument.
+
         docstring: Documentation string for the ``__doc__``
             field of the object. The ``__doc__``  field of the instance is
             used by some help systems, but not all.

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -988,10 +988,10 @@ class Parameter(_BaseParameter):
                  get_cmd: Optional[Union[str, Callable, bool]] = None,
                  set_cmd:  Optional[Union[str, Callable, bool]] = False,
                  initial_value: Optional[Union[float, str]] = None,
-                 initial_cache_value: Optional[Union[float, str]] = None,
                  max_val_age: Optional[float] = None,
                  vals: Optional[Validator] = None,
                  docstring: Optional[str] = None,
+                 initial_cache_value: Optional[Union[float, str]] = None,
                  **kwargs: Any) -> None:
         super().__init__(name=name, instrument=instrument, vals=vals,
                          max_val_age=max_val_age, **kwargs)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1336,10 +1336,11 @@ class DelegateParameter(Parameter):
                 raise KeyError(f'It is not allowed to set "{cmd}" of a '
                                f'DelegateParameter because the one of the '
                                f'source parameter is supposed to be used.')
-
+        initial_cache_value = kwargs.pop("initial_cache_value")
         super().__init__(name, *args, **kwargs)
         delegate_cache = self._DelegateCache(self)
         self.cache = cast(_Cache, delegate_cache)
+        self.cache.set(initial_cache_value)
 
     # Disable the warnings until MultiParameter has been
     # replaced and name/label/unit can live in _BaseParameter

--- a/qcodes/tests/test_delegate_parameter.py
+++ b/qcodes/tests/test_delegate_parameter.py
@@ -281,7 +281,8 @@ def test_raw_value_scaling(make_observable_parameter):
 def test_setting_initial_value_delegate_parameter():
     value = 10
     p = Parameter('testparam', set_cmd=None, get_cmd=None)
-    d = DelegateParameter('test_delegate_parameter', p, initial_value=value)
+    d = DelegateParameter('test_delegate_parameter', p,
+                          initial_value=value)
     assert p.cache._value == value
     assert d.cache._value == value
 
@@ -289,6 +290,7 @@ def test_setting_initial_value_delegate_parameter():
 def test_setting_initial_cache_delegate_parameter():
     value = 10
     p = Parameter('testparam', set_cmd=None, get_cmd=None)
-    d = DelegateParameter('test_delegate_parameter', p, initial_cache_value=value)
+    d = DelegateParameter('test_delegate_parameter', p,
+                          initial_cache_value=value)
     assert p.cache._value == value
     assert d.cache._value == value

--- a/qcodes/tests/test_delegate_parameter.py
+++ b/qcodes/tests/test_delegate_parameter.py
@@ -259,7 +259,6 @@ def test_delegate_parameter_get_and_snapshot_raises_with_none():
     assert delegate_param.cache._parameter.source.cache is source_param.cache
 
 
-
 def test_raw_value_scaling(make_observable_parameter):
     """
     The :attr:`raw_value` will be deprecated soon,
@@ -277,3 +276,19 @@ def test_raw_value_scaling(make_observable_parameter):
     d(val)
     assert d.raw_value == val * 5 + 3
     assert d.raw_value == p()
+
+
+def test_setting_initial_value_delegate_parameter():
+    value = 10
+    p = Parameter('testparam', set_cmd=None, get_cmd=None)
+    d = DelegateParameter('test_delegate_parameter', p, initial_value=value)
+    assert p.cache._value == value
+    assert d.cache._value == value
+
+
+def test_setting_initial_cache_delegate_parameter():
+    value = 10
+    p = Parameter('testparam', set_cmd=None, get_cmd=None)
+    d = DelegateParameter('test_delegate_parameter', p, initial_cache_value=value)
+    assert p.cache._value == value
+    assert d.cache._value == value

--- a/qcodes/tests/test_delegate_parameter.py
+++ b/qcodes/tests/test_delegate_parameter.py
@@ -283,8 +283,8 @@ def test_setting_initial_value_delegate_parameter():
     p = Parameter('testparam', set_cmd=None, get_cmd=None)
     d = DelegateParameter('test_delegate_parameter', p,
                           initial_value=value)
-    assert p.cache._value == value
-    assert d.cache._value == value
+    assert p.cache.get(get_if_invalid=False) == value
+    assert d.cache.get(get_if_invalid=False) == value
 
 
 def test_setting_initial_cache_delegate_parameter():
@@ -292,5 +292,5 @@ def test_setting_initial_cache_delegate_parameter():
     p = Parameter('testparam', set_cmd=None, get_cmd=None)
     d = DelegateParameter('test_delegate_parameter', p,
                           initial_cache_value=value)
-    assert p.cache._value == value
-    assert d.cache._value == value
+    assert p.cache.get(get_if_invalid=False) == value
+    assert d.cache.get(get_if_invalid=False) == value

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1873,11 +1873,11 @@ def test_initial_set_with_without_cache():
     # setting the initial value triggers a set
     param1 = SettableParam(name="param", initial_value=value)
     assert param1._set_count == 1
-    assert param1.cache.get() == value
+    assert param1.cache.get(get_if_invalid=False) == value
     # setting the cache does not trigger a set
     param2 = SettableParam(name="param", initial_cache_value=value)
     assert param2._set_count == 0
-    assert param2.cache.get() == value
+    assert param2.cache.get(get_if_invalid=False) == value
 
 
 def test_set_initial_and_initial_cache_raises():

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -4,11 +4,9 @@ Test suite for parameter
 from collections import namedtuple
 from collections.abc import Iterable
 from unittest import TestCase
-from typing import Tuple
 import pytest
 from datetime import datetime, timedelta
 import time
-from functools import partial
 
 import numpy as np
 from hypothesis import given, event, settings
@@ -16,7 +14,7 @@ import hypothesis.strategies as hst
 from qcodes import Function
 from qcodes.instrument.parameter import (
     Parameter, ArrayParameter, MultiParameter, ManualParameter,
-    InstrumentRefParameter, ScaledParameter, DelegateParameter,
+    InstrumentRefParameter, ScaledParameter,
     _BaseParameter)
 import qcodes.utils.validators as vals
 from qcodes.tests.instrument_mocks import DummyInstrument
@@ -2096,4 +2094,3 @@ def test_no_get_timestamp_none_runtime_error():
     with pytest.raises(RuntimeError, match="Value of parameter test_param"):
         local_parameter.cache.get()
 
-    local_parameter.cache.get()

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1883,3 +1883,217 @@ def test_initial_set_with_without_cache():
 def test_set_initial_and_initial_cache_raises():
     with pytest.raises(SyntaxError, match="`initial_value` and `initial_cache_value`"):
         Parameter(name="param", initial_value=1, initial_cache_value=2)
+
+
+def test_get_from_cache_does_not_trigger_real_get_if_get_if_invalid_false():
+    """
+    assert that calling get on the cache with get_if_invalid=False does
+    not trigger a get of the parameter when parameter has expired due to max_val_age
+    """
+    param = BetterGettableParam(name="param", max_val_age=1)
+    param.get()
+    assert param._get_count == 1
+    # let the cache expire
+    time.sleep(2)
+    param.cache.get(get_if_invalid=False)
+    assert param._get_count == 1
+
+
+def test_get_from_cache_does_not_trigger_real_get_if_get_if_invalid_false():
+    """
+    assert that calling get on the cache with get_if_invalid=False does
+    not trigger a get of the parameter when parameter has expired due to max_val_age
+    """
+    param = BetterGettableParam(name="param", max_val_age=1)
+    param.get()
+    assert param._get_count == 1
+    # let the cache expire
+    time.sleep(2)
+    param.cache.get(get_if_invalid=False)
+    assert param._get_count == 1
+
+
+def test_get_cache():
+    time_resolution = time.get_clock_info('time').resolution
+    sleep_delta = 2 * time_resolution
+
+    # Create a gettable parameter
+    local_parameter = Parameter('test_param', set_cmd=None, get_cmd=None)
+    before_set = datetime.now()
+    time.sleep(sleep_delta)
+    local_parameter.set(1)
+    time.sleep(sleep_delta)
+    after_set = datetime.now()
+
+    # Check we return last set value, with the correct timestamp
+    assert local_parameter.cache.get() == 1
+    assert before_set < local_parameter.cache.timestamp < after_set
+
+    # Check that updating the value updates the timestamp
+    time.sleep(sleep_delta)
+    local_parameter.set(2)
+    assert local_parameter.cache.get() == 2
+    assert local_parameter.cache.timestamp > after_set
+
+
+def test_get_cache_raw_value():
+    # To have a simple distinction between raw value and value of the
+    # parameter lets create a parameter with an offset
+    p = Parameter('p', set_cmd=None, get_cmd=None, offset=42)
+    assert p.cache.timestamp is None
+
+    # Initially, the parameter's raw value is None
+    assert p.cache.raw_value is None
+
+    # After setting the parameter to some value, the
+    # raw_value attribute of the cache should return the raw_value
+    p(3)
+    assert p.cache.timestamp is not None
+    assert p.cache.get() == 3
+    assert p.cache.raw_value == 3 + 42
+
+
+def test_get_cache_unknown():
+    """
+    Test that cache get on a parameter that has not been acquired will
+    trigger a get
+    """
+    value = 1
+    local_parameter = BetterGettableParam('test_param', set_cmd=None,
+                                          get_cmd=None)
+    # fake a parameter that has a value but never been get/set to mock
+    # an instrument.
+    local_parameter.cache._value = value
+    local_parameter.cache._raw_value = value
+    assert local_parameter.cache.timestamp is None
+    before_get = datetime.now()
+    assert local_parameter._get_count == 0
+    assert local_parameter.cache.get() == value
+    assert local_parameter._get_count == 1
+    # calling get above will call get since TS is None
+    # and the TS will therefore no longer be None
+    assert local_parameter.cache.timestamp is not None
+    assert local_parameter.cache.timestamp >= before_get
+    # calling cache.get now will not trigger get
+    assert local_parameter.cache.get() == value
+    assert local_parameter._get_count == 1
+
+
+def test_get_cache_known():
+    """
+    Test that cache.get on a parameter that has a known value will not
+    trigger a get
+    """
+    value = 1
+    local_parameter = BetterGettableParam('test_param', set_cmd=None,
+                                          get_cmd=None)
+    # fake a parameter that has a value acquired 10 sec ago
+    start = datetime.now()
+    set_time = start - timedelta(seconds=10)
+    local_parameter.cache._update_with(
+        value=value, raw_value=value, timestamp=set_time)
+    assert local_parameter._get_count == 0
+    assert local_parameter.cache.timestamp == set_time
+    assert local_parameter.cache.get() == value
+    # calling cache.get above will not call get since TS is set and
+    # max_val_age is not
+    assert local_parameter._get_count == 0
+    assert local_parameter.cache.timestamp == set_time
+
+
+def test_get_cache_no_get():
+    """
+    Test that cache.get on a parameter that does not have get is handled
+    correctly.
+    """
+    local_parameter = Parameter('test_param', set_cmd=None, get_cmd=False)
+    # The parameter does not have a get method.
+    with pytest.raises(AttributeError):
+        local_parameter.get()
+    # get_latest will fail as get cannot be called and no cache
+    # is available
+    with pytest.raises(RuntimeError):
+        local_parameter.cache.get()
+    value = 1
+    local_parameter.set(value)
+    assert local_parameter.cache.get() == value
+
+    local_parameter2 = Parameter('test_param2', set_cmd=None,
+                                 get_cmd=False, initial_value=value)
+    with pytest.raises(AttributeError):
+        local_parameter2.get()
+    assert local_parameter2.cache.get() == value
+
+
+def test_max_val_age():
+    value = 1
+    start = datetime.now()
+    local_parameter = BetterGettableParam('test_param',
+                                          set_cmd=None,
+                                          max_val_age=1,
+                                          initial_value=value)
+    assert local_parameter.cache.max_val_age == 1
+    assert local_parameter._get_count == 0
+    assert local_parameter.cache.get() == value
+    assert local_parameter._get_count == 0
+    # now fake the time stamp so get should be triggered
+    set_time = start - timedelta(seconds=10)
+    local_parameter.cache._update_with(
+        value=value, raw_value=value, timestamp=set_time)
+    # now that ts < max_val_age calling get_latest should update the time
+    assert local_parameter.cache.timestamp == set_time
+    assert local_parameter.cache.get() == value
+    assert local_parameter._get_count == 1
+    assert local_parameter.cache.timestamp >= start
+
+
+def test_no_get_max_val_age():
+    """
+    Test that cache.get on a parameter with max_val_age set and
+    no get cmd raises correctly.
+    """
+    value = 1
+    with pytest.raises(SyntaxError):
+        _ = Parameter('test_param', set_cmd=None,
+                      get_cmd=False,
+                      max_val_age=1, initial_value=value)
+
+
+def test_no_get_max_val_age_runtime_error():
+    """
+    _BaseParameter does not have a check on creation time that
+    no get_cmd is mixed with max_val_age since get_cmd could be added
+    in a subclass. Here we create a subclass that does not add a get
+    command and also does not implement the check for max_val_age
+    """
+    value = 1
+    class LocalParameter(_BaseParameter):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.set_raw = lambda x: x
+            self.set = self._wrap_set(self.set_raw)
+
+    local_parameter = LocalParameter('test_param',
+                                     None,
+                                     max_val_age=1)
+    start = datetime.now()
+    set_time = start - timedelta(seconds=10)
+    local_parameter.cache._update_with(
+        value=value, raw_value=value, timestamp=set_time)
+
+    with pytest.raises(RuntimeError, match="max_val_age` is not supported"):
+        local_parameter.cache.get()
+
+
+def test_no_get_timestamp_none_runtime_error():
+    """
+    Test that a parameter that has never been
+    set, cannot be get and does not support
+    getting raises a RuntimeError.
+    """
+    local_parameter = Parameter('test_param', get_cmd=False)
+
+    with pytest.raises(RuntimeError, match="Value of parameter test_param"):
+        local_parameter.cache.get()
+
+    local_parameter.cache.get()

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1897,20 +1897,6 @@ def test_get_from_cache_does_not_trigger_real_get_if_get_if_invalid_false():
     assert param._get_count == 1
 
 
-def test_get_from_cache_does_not_trigger_real_get_if_get_if_invalid_false():
-    """
-    assert that calling get on the cache with get_if_invalid=False does
-    not trigger a get of the parameter when parameter has expired due to max_val_age
-    """
-    param = BetterGettableParam(name="param", max_val_age=1)
-    param.get()
-    assert param._get_count == 1
-    # let the cache expire
-    time.sleep(2)
-    param.cache.get(get_if_invalid=False)
-    assert param._get_count == 1
-
-
 def test_get_cache():
     time_resolution = time.get_clock_info('time').resolution
     sleep_delta = 2 * time_resolution

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -2063,6 +2063,7 @@ def test_no_get_max_val_age_runtime_error():
     no get_cmd is mixed with max_val_age since get_cmd could be added
     in a subclass. Here we create a subclass that does not add a get
     command and also does not implement the check for max_val_age
+    and test that it raises correctly when calling get on the cache
     """
     value = 1
     class LocalParameter(_BaseParameter):
@@ -2086,8 +2087,8 @@ def test_no_get_max_val_age_runtime_error():
 def test_no_get_timestamp_none_runtime_error():
     """
     Test that a parameter that has never been
-    set, cannot be get and does not support
-    getting raises a RuntimeError.
+    set and does not support getting raises a RuntimeError
+    when trying to get the cache.
     """
     local_parameter = Parameter('test_param', get_cmd=False)
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1883,20 +1883,6 @@ def test_set_initial_and_initial_cache_raises():
         Parameter(name="param", initial_value=1, initial_cache_value=2)
 
 
-def test_get_from_cache_does_not_trigger_real_get_if_get_if_invalid_false():
-    """
-    assert that calling get on the cache with get_if_invalid=False does
-    not trigger a get of the parameter when parameter has expired due to max_val_age
-    """
-    param = BetterGettableParam(name="param", max_val_age=1)
-    param.get()
-    assert param._get_count == 1
-    # let the cache expire
-    time.sleep(2)
-    param.cache.get(get_if_invalid=False)
-    assert param._get_count == 1
-
-
 def test_get_cache():
     time_resolution = time.get_clock_info('time').resolution
     sleep_delta = 2 * time_resolution


### PR DESCRIPTION
Similar to `initial_value` kwarg, but `initial_cache_value` will call `self.cache.set`.

ToDo:
- [x] mutually exclude use of `initial_value` and `initial_cache_value`
- [x] add tests: "`initial_cache_value` works", "mutual exclusion with `initial_value`", "`initial_cache_value` works for `DelegateParameter`"
- [x] add docstring explaining `initial_cache_value`
- [x] add docstring explaining `initial_value` (i was surprised to find out that it's not there)