### PR TITLE
fix warning in matplotlib plotting 

### DIFF
--- a/qcodes/plots/qcmatplotlib.py
+++ b/qcodes/plots/qcmatplotlib.py
@@ -420,7 +420,7 @@ class MatPlot(BasePlot):
         # Scale colors if z has elements
         cmin = np.nanmin(args_masked[-1])
         cmax = np.nanmax(args_masked[-1])
-        ax.qcodes_colorbar.set_clim(cmin, cmax)
+        ax.qcodes_colorbar.mappable.set_clim(cmin, cmax)
 
         return pc
 


### PR DESCRIPTION
The warning is issues because `colorbar.set_clim` is deprecated. See https://matplotlib.org/3.1.0/api/api_changes.html#colorbarbase-inheritance

@astafan8 
