### PR TITLE
CI: Travis don't apt-get install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,8 @@ addons:
   apt_packages:
     - pandoc
     - libhdf5-dev # remove once h5py is packaged for 3.8
-    - gcc # this can go once we have scipy wheels for 3.8
-    - gfortran # this can go once we have scipy wheels for 3.8
-    - python-dev # this can go once we have scipy wheels for 3.8
-    - libopenblas-dev # this can go once we have scipy wheels for 3.8
-    - liblapack-dev # this can go once we have scipy wheels for 3.8
+    - gcc # remove once h5py is packaged for 3.8
+    - python-dev # remove once h5py is packaged for 3.8
 
 python:
   - "3.6"


### PR DESCRIPTION
packages needed for scipy as there are now wheels for scipy.
The last few packages need to remain until we have 3.8 wheels for h5py