### PR TITLE
Remove no longer needed apt deps from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,6 @@ notifications:
 
 cache: pip
 
-# remember to remove 3.8 related workarounds below once
-# 3.8 is released and wheels are available.
-
 addons:
   apt_packages:
     - pandoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ cache: pip
 addons:
   apt_packages:
     - pandoc
-    - libhdf5-dev # remove once h5py is packaged for 3.8
-    - gcc # remove once h5py is packaged for 3.8
-    - python-dev # remove once h5py is packaged for 3.8
     - libxkbcommon-x11-0 # needed for pyqt > 5.11 to work correctly with xvfb
 
 python:


### PR DESCRIPTION
used to build h5py which now has wheels for python 3.8