### PR TITLE
Fix error created on logging station config validation

### DIFF
--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -396,9 +396,13 @@ class Station(Metadatable, DelegateAttributes):
         try:
             jsonschema.validate(yaml, schema)
         except jsonschema.exceptions.ValidationError as e:
-            warnings.warn(
-                e.message + '\n config:\n' + config,
-                ValidationWarning)
+            message = e.message + '\n config:\n'
+            if isinstance(config, str):
+                message += config
+            else:
+                config.seek(0)
+                message += config.read()
+            warnings.warn(message, ValidationWarning)
 
         self._config = yaml
 


### PR DESCRIPTION
There has been an error appending the station config files to the log messages if the station config validation has not been successful.
This error has not been caught by the tests, because it is specific to handling real station config files, while the tests work with simple strings.
A test has been added for this edge case.
@QCoDeS/core hotfix for v0.8.1