### PR TITLE
Run pip with --no-index in installation_info

### DIFF
--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -32,6 +32,7 @@ def is_qcodes_installed_editably() -> Optional[bool]:
     try:
         pipproc = subprocess.run(['pip', 'list', '-e','--no-index',
                                   '--format=json'],
+                                 check=True,
                                  stdout=subprocess.PIPE)
         e_pkgs = json.loads(pipproc.stdout.decode('utf-8'))
         answer = any([d["name"] == 'qcodes' for d in e_pkgs])

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -30,8 +30,9 @@ def is_qcodes_installed_editably() -> Optional[bool]:
     answer: Optional[bool]
 
     try:
-        pipproc = subprocess.run(['pip', 'list', '-e', '--format=json'],
-                                  stdout=subprocess.PIPE)
+        pipproc = subprocess.run(['pip', 'list', '-e','--no-index',
+                                  '--format=json'],
+                                 stdout=subprocess.PIPE)
         e_pkgs = json.loads(pipproc.stdout.decode('utf-8'))
         answer = any([d["name"] == 'qcodes' for d in e_pkgs])
     except Exception as e:  # we actually do want a catch-all here

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -30,7 +30,7 @@ def is_qcodes_installed_editably() -> Optional[bool]:
     answer: Optional[bool]
 
     try:
-        pipproc = subprocess.run(['pip', 'list', '-e','--no-index',
+        pipproc = subprocess.run(['pip', 'list', '-e', '--no-index',
                                   '--format=json'],
                                  check=True,
                                  stdout=subprocess.PIPE)


### PR DESCRIPTION
We're running Qcodes on a lab computer with no internet access. Running `pip list` looks online for the package index. This takes 20 seconds to time out, which makes `start_all_logging()` annoyingly slow. This fixes that.