### PR TITLE
add electrical delay parameter and function set_electrical_delay_auto for ZNB driver

### DIFF
--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -241,13 +241,14 @@ class ZNBChannel(InstrumentChannel):
                            channel=n,
                            parameter_class=FrequencySweep)
         self.add_parameter(name='electrical_delay',
+                           label='Electrical delay',
                            get_cmd='SENS{}:CORR:EDEL2:TIME?'.format(n),
                            set_cmd='SENS{}:CORR:EDEL2:TIME {{}}'.format(n),
                            get_parser=float,
                            unit='s')
 
         self.add_function('set_electrical_delay_auto',
-                            call_cmd='SENS{}:CORR:EDEL:AUTO ONCE'.format(n))
+                          call_cmd='SENS{}:CORR:EDEL:AUTO ONCE'.format(n))
 
         self.add_function('autoscale',
                           call_cmd='DISPlay:TRACe1:Y:SCALe:AUTO ONCE, "{}"'.format(self._tracename))

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -240,6 +240,14 @@ class ZNBChannel(InstrumentChannel):
                            npts=self.npts(),
                            channel=n,
                            parameter_class=FrequencySweep)
+        self.add_parameter(name='electrical_delay',
+                           get_cmd='SENS{}:CORR:EDEL2:TIME?'.format(n),
+                           set_cmd='SENS{}:CORR:EDEL2:TIME {{}}'.format(n),
+                           get_parser=float,
+                           unit='s')
+
+        self.add_function('set_electrical_delay_auto',
+                            call_cmd='SENS{}:CORR:EDEL:AUTO ONCE'.format(n))
 
         self.add_function('autoscale',
                           call_cmd='DISPlay:TRACe1:Y:SCALe:AUTO ONCE, "{}"'.format(self._tracename))


### PR DESCRIPTION
Added parameter 'electrical_delay' to rohde_schwarz/ZNB driver. 
Allows to get and set the electrical delay to de-embed the cabel length from the phase signal.
The electrical delay will be added to port2, this is currently hardcoded. When autosetting on the softbuttons on the physical instrument, this seems to be the default option. Also, it does not make a difference (as far as we can see) for the signal.

Added function 'set_electrical_delay_auto'. This function automatically sets the electrical delay to the active port. A wide frequency span during execution of the function leads to more accurate results.

Changes proposed in this pull request:
- add parameter electrical_delay in rohde_schwarz/ZNB.py
- add function set_electrical_delay_auto in rohde_schwarz/ZNB.py

@astafan8 @lakhotiaharshit 