### PR TITLE
keysight 34934a: Don't use is to compare strings

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysight_34934a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_34934a.py
@@ -162,7 +162,7 @@ class Keysight34934A(KeysightSwitchMatrixSubModule):
         }
 
         offset = 0
-        if wiring_config is not '':
+        if wiring_config != '':
             offset = offsets[wiring_config] * columns
 
         channels_per_row = 800 / rows


### PR DESCRIPTION
This only works due to small string optimization which is an implementation detail that should not be relied on. Fixes a warning under python 3.8 