### PR TITLE
Close instruments properly in tests

### DIFF
--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -52,12 +52,14 @@ def s46_four():
         driver.close()
 
 
-def test_runtime_error_on_bad_init():
+def test_runtime_error_on_bad_init(request):
     """
     If we initialize the driver from an instrument state with more then one
     channel per relay closed, raise a runtime error. An instrument can come to
     this state if previously, other software was used to control the instrument
     """
+    request.addfinalizer(S46.close_all)
+
     with pytest.raises(
         RuntimeError,
         match="The driver is initialized from an undesirable instrument state"

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -64,9 +64,10 @@ def test_snapshot_exclude_params(request, params, params_to_exclude):
     inst = SnapShotTestInstrument('inst',
                                   params=params,
                                   params_to_skip=[])
+    request.addfinalizer(inst.close)
 
     params.insert(0, "IDN")  # Is added by default to a instrument
-    request.addfinalizer(inst.close)
+
     for param_exl in params_to_exclude:
         inst.parameters[param_exl].snapshot_exclude = True
 
@@ -78,8 +79,5 @@ def test_snapshot_exclude_params(request, params, params_to_exclude):
         f"Parameter(s) is not excluded from the snapshot. expected: " \
         f"{params}, actual: {snap_params}"\
 
-
     assert snap_params == params, f"Snapshot does not contain the expected " \
         f"parameters expected: {params}, actual: {snap_params}"
-
-

--- a/qcodes/tests/test_visa.py
+++ b/qcodes/tests/test_visa.py
@@ -134,35 +134,40 @@ class TestVisaInstrument(TestCase):
 
         rm_mock.return_value = MockRM()
 
-        inst = MockBackendVisaInstrument('name', address='None')
+        inst1 = MockBackendVisaInstrument('name', address='None')
+        self.addCleanup(inst1.close)
         self.assertEqual(rm_mock.call_count, 1)
         self.assertEqual(rm_mock.call_args, ((),))
         self.assertEqual(address_opened[0], 'None')
-        inst.close()
+        inst1.close()
 
-        inst = MockBackendVisaInstrument('name2', address='ASRL2')
+        inst2 = MockBackendVisaInstrument('name2', address='ASRL2')
+        self.addCleanup(inst2.close)
         self.assertEqual(rm_mock.call_count, 2)
         self.assertEqual(rm_mock.call_args, ((),))
         self.assertEqual(address_opened[0], 'ASRL2')
-        inst.close()
+        inst2.close()
 
         # this one raises a warning
         with warnings.catch_warnings(record=True) as w:
-            inst = MockBackendVisaInstrument('name3', address='ASRL3@py')
+            inst3 = MockBackendVisaInstrument('name3', address='ASRL3@py')
+            self.addCleanup(inst3.close)
             self.assertTrue(len(w) == 1)
             self.assertTrue('use the visalib' in str(w[-1].message))
 
         self.assertEqual(rm_mock.call_count, 3)
         self.assertEqual(rm_mock.call_args, (('@py',),))
         self.assertEqual(address_opened[0], 'ASRL3')
-        inst.close()
+        inst3.close()
 
         # this one doesn't
-        inst = MockBackendVisaInstrument('name4', address='ASRL4', visalib='@py')
+        inst4 = MockBackendVisaInstrument('name4',
+                                          address='ASRL4', visalib='@py')
+        self.addCleanup(inst4.close)
         self.assertEqual(rm_mock.call_count, 4)
         self.assertEqual(rm_mock.call_args, (('@py',),))
         self.assertEqual(address_opened[0], 'ASRL4')
-        inst.close()
+        inst4.close()
 
 
 def test_visa_instr_metadata(request):

--- a/qcodes/tests/test_visa.py
+++ b/qcodes/tests/test_visa.py
@@ -93,6 +93,7 @@ class TestVisaInstrument(TestCase):
 
     def test_ask_write_local(self):
         mv = MockVisa('Joe', 'none_address')
+        self.addCleanup(mv.close)
 
         # test normal ask and write behavior
         mv.state.set(2)
@@ -118,8 +119,6 @@ class TestVisaInstrument(TestCase):
             mv.state.get()
         for arg in self.args3:
             self.assertIn(arg, e.exception.args)
-
-        mv.close()
 
     @patch('qcodes.instrument.visa.visa.ResourceManager')
     def test_visa_backend(self, rm_mock):
@@ -166,7 +165,8 @@ class TestVisaInstrument(TestCase):
         inst.close()
 
 
-def test_visa_instr_metadata():
+def test_visa_instr_metadata(request):
     metadatadict = {'foo': 'bar'}
     mv = MockVisa('Joe', 'none_adress', metadata=metadatadict)
+    request.addfinalizer(mv.close)
     assert mv.metadata == metadatadict


### PR DESCRIPTION
### Description

This PR tries to get rid of the following warnings in the CI tests run (tick box when the thing dissapears):
- [ ] Add info on how to close instruments in tests properly to "writing driver notebook" (somewhere else as well?)
- [x] .
```
--- Logging error ---
Traceback (most recent call last):
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 552, in close_all
    inst = cls.find_instrument(inststr)
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 649, in find_instrument
    raise KeyError('Instrument {} has been removed'.format(name))
KeyError: 'Instrument Joe has been removed'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/python/3.7.1/lib/python3.7/logging/__init__.py", line 1036, in emit
    stream.write(msg)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/_pytest/capture.py", line 427, in write
    self.buffer.write(obj)
ValueError: I/O operation on closed file
Call stack:
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 556, in close_all
    log.exception(f"Failed to close {inststr}, ignored")
Message: 'Failed to close Joe, ignored'
Arguments: ()
```
- [x] .
```
--- Logging error ---
Traceback (most recent call last):
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 552, in close_all
    inst = cls.find_instrument(inststr)
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 649, in find_instrument
    raise KeyError('Instrument {} has been removed'.format(name))
KeyError: 'Instrument inst has been removed'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/python/3.7.1/lib/python3.7/logging/__init__.py", line 1036, in emit
    stream.write(msg)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/_pytest/capture.py", line 427, in write
    self.buffer.write(obj)
ValueError: I/O operation on closed file
Call stack:
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 556, in close_all
    log.exception(f"Failed to close {inststr}, ignored")
Message: 'Failed to close inst, ignored'
Arguments: ()
```

- [x] .
```
--- Logging error ---
Traceback (most recent call last):
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 552, in close_all
    inst = cls.find_instrument(inststr)
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 649, in find_instrument
    raise KeyError('Instrument {} has been removed'.format(name))
KeyError: 'Instrument s46_bad_state has been removed'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/python/3.7.1/lib/python3.7/logging/__init__.py", line 1036, in emit
    stream.write(msg)
  File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/_pytest/capture.py", line 427, in write
    self.buffer.write(obj)
ValueError: I/O operation on closed file
Call stack:
  File "/home/travis/build/QCoDeS/Qcodes/qcodes/instrument/base.py", line 556, in close_all
    log.exception(f"Failed to close {inststr}, ignored")
Message: 'Failed to close s46_bad_state, ignored'
Arguments: ()
```

### Reasoning:

The thing is that the instrument instance will be created and will be
added to the registry of instrument instances thanks to the code of the
parent class of the 'S46'. However, in this test the __init__ of 'S46'
will break by intention which means that the instrument instance will
not be returned to the test (an exception will be raised) but that
instrument instance will still remain in the global registry of the
instrument instances which will cause a warning at the end of the test
execution. So, the way to remove that "almost created instance" of the
instrument is to use "close_all" class method (on the 'S46' instrument
class in order to be more specific with what needs to be closed).