### PR TITLE
fix: Keithley_2400 READ? format may be inconsistent

### DIFF
--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -1,5 +1,6 @@
 from qcodes import VisaInstrument
 from qcodes.utils.validators import Strings, Enum
+from qcodes.utils.helpers import create_on_off_val_mapping
 
 
 class Keithley_2400(VisaInstrument):
@@ -73,9 +74,9 @@ class Keithley_2400(VisaInstrument):
                            label='Sense mode')
 
         self.add_parameter('output',
-                           get_parser=int,
-                           set_cmd=':OUTP:STAT {:d}',
-                           get_cmd=':OUTP:STAT?')
+                           set_cmd=':OUTP:STAT {}',
+                           get_cmd=':OUTP:STAT?',
+                           val_mapping=create_on_off_val_mapping(on_val="1", off_val="0"))
 
         self.add_parameter('nplcv',
                            get_cmd='SENS:VOLT:NPLC?',
@@ -97,6 +98,7 @@ class Keithley_2400(VisaInstrument):
                            docstring="Measure resistance from current and voltage "
                                      "Note that it is an error to read current "
                                      "and voltage with output off")
+        self.write(':TRIG:COUN 1;:FORM:ELEM VOLT,CURR')
         self.connect_message()
 
     def _get_read_output_protected(self) -> str:

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -74,9 +74,9 @@ class Keithley_2400(VisaInstrument):
                            label='Sense mode')
 
         self.add_parameter('output',
-                           set_cmd=':OUTP:STAT {}',
-                           get_cmd=':OUTP:STAT?',
-                           val_mapping=create_on_off_val_mapping(on_val="1", off_val="0"))
+            set_cmd=':OUTP:STAT {}',
+            get_cmd=':OUTP:STAT?',
+            val_mapping=create_on_off_val_mapping(on_val="1", off_val="0"))
 
         self.add_parameter('nplcv',
                            get_cmd='SENS:VOLT:NPLC?',

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -98,19 +98,19 @@ class Keithley_2400(VisaInstrument):
                            docstring="Measure resistance from current and voltage "
                                      "Note that it is an error to read current "
                                      "and voltage with output off")
-        
+
         self.write(':TRIG:COUN 1;:FORM:ELEM VOLT,CURR')
         # This line sends 2 commands to the instrument:
         # ":TRIG:COUN 1" sets the trigger count to 1 so that each READ? returns
         # only 1 measurement result.
-        # ":FORM:ELEM VOLT,CURR" sets the output string formatting of the the 
+        # ":FORM:ELEM VOLT,CURR" sets the output string formatting of the the
         # Keithley 2400 to return "{voltage}, {current}".
-        # Default value upon instrument reset is "VOLT, CURR, RES, TIME, STATUS";
+        # Default value on instrument reset is "VOLT, CURR, RES, TIME, STATUS";
         # however, resistance, status, and time are unused in this driver and
         # so are omitted.
         # These commands do not reset the instrument but do the minimal amount
         # to ensure that voltage and current parameters can be read from the
-        # instrument, in the event that output formatting of the instrument was 
+        # instrument, in the event that output formatting of the instrument was
         # previously changed to some other unknown state.
         self.connect_message()
 

--- a/qcodes/instrument_drivers/tektronix/Keithley_2400.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2400.py
@@ -98,7 +98,20 @@ class Keithley_2400(VisaInstrument):
                            docstring="Measure resistance from current and voltage "
                                      "Note that it is an error to read current "
                                      "and voltage with output off")
+        
         self.write(':TRIG:COUN 1;:FORM:ELEM VOLT,CURR')
+        # This line sends 2 commands to the instrument:
+        # ":TRIG:COUN 1" sets the trigger count to 1 so that each READ? returns
+        # only 1 measurement result.
+        # ":FORM:ELEM VOLT,CURR" sets the output string formatting of the the 
+        # Keithley 2400 to return "{voltage}, {current}".
+        # Default value upon instrument reset is "VOLT, CURR, RES, TIME, STATUS";
+        # however, resistance, status, and time are unused in this driver and
+        # so are omitted.
+        # These commands do not reset the instrument but do the minimal amount
+        # to ensure that voltage and current parameters can be read from the
+        # instrument, in the event that output formatting of the instrument was 
+        # previously changed to some other unknown state.
         self.connect_message()
 
     def _get_read_output_protected(self) -> str:


### PR DESCRIPTION
Fixes 'bugginess' mentioned in #488 

Changes proposed in this pull request:
- Added code to ensure Keithley 2400 instrument sends responses to READ? in correct format in the driver __init__ method.
- Modify 'output' parameter to use create_on_off_val_mapping instead of int.

Breaking changes: 'output' parameter type change could possibly break existing code that depends on 'output' being an int.

@WilliamHPNielsen 
