### PR TITLE
Model325 fix

### DIFF
--- a/qcodes/instrument_drivers/Lakeshore/Model_325.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_325.py
@@ -287,32 +287,28 @@ class Model_325_Sensor(InstrumentChannel):
             sum_of_codes (int)
         """
         components = list(self.sensor_status_codes.keys())
-        codes = self._get_sum_terms(components, int(sum_of_codes))
+        codes = self._get_sum_terms(int(sum_of_codes))
         return ", ".join([self.sensor_status_codes[k] for k in codes])
 
     @staticmethod
-    def _get_sum_terms(components: list, number: int):
+    def _get_sum_terms( n ) :
         """
-        Example:
-        >>> components = [0, 1, 16, 32, 64, 128]
+        Decompose input into powers of 2 for status parsing
         >>> _get_sum_terms(components, 96)
         >>> ...[64, 32]  # This is correct because 96=64+32
         """
-        if number in components:
-            terms = [number]
-        else:
-            terms = []
-            comp = np.sort(components)[::-1]
-            comp = comp[comp <= number]
 
-            while len(comp):
-                c = comp[0]
-                number -= c
-                terms.append(c)
+        if n == 0 :
+            l = [ 0 ]
+        else :
+            l = []
+        
+            for pow, b in enumerate( bin( n )[2:][::-1] ) :
+                intb = int( b )
+                if intb == 1 :
+                    l.append( intb * 2**(pow) )
 
-                comp = comp[comp <= number]
-
-        return terms
+        return l[::-1] # Sort from high to low
 
     @property
     def curve(self) -> Model_325_Curve:

--- a/qcodes/instrument_drivers/Lakeshore/Model_325.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_325.py
@@ -302,13 +302,17 @@ class Model_325_Sensor(InstrumentChannel):
             l = [ 0 ]
         else :
             l = []
-        
-            for pow, b in enumerate( bin( n )[2:][::-1] ) :
-                intb = int( b )
-                if intb == 1 :
-                    l.append( intb * 2**(pow) )
+            while n is not 0 :
+                pow2 = int( 2**( np.floor( np.log2( n ) ) ) )
+                l.append( pow2 )
+                n -= pow2
 
-        return l[::-1] # Sort from high to low
+        return l
+
+def gst( n ) :
+
+
+    return l
 
     @property
     def curve(self) -> Model_325_Curve:


### PR DESCRIPTION
Fixes an endless loop that occurs if Lakeshore Model 325 status != 0.

Changes proposed in this pull request:
- Parse into powers of 2: this uses the fact that model325 error codes are only powers of 2.
- No longer makes use of list(self.sensor_status_codes.keys()). 

@Dominik-Vogel : from earlier email