### PR TITLE
build docs with sphinx 2.3.1

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.3.0
+sphinx==2.3.1
 sphinx_rtd_theme
 sphinx-jsonschema
 nbsphinx

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.2.2
+sphinx==2.3.0
 sphinx_rtd_theme
 sphinx-jsonschema
 nbsphinx


### PR DESCRIPTION
In the mean time 2.3.1 has been released so go with that 