### PR TITLE
Warn if unknown kwargs are passed to _BaseParameter

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -243,13 +243,18 @@ class _BaseParameter(Metadatable):
                  snapshot_value: bool = True,
                  snapshot_exclude: bool = False,
                  max_val_age: Optional[float] = None,
-                 vals: Optional[Validator] = None) -> None:
+                 vals: Optional[Validator] = None,
+                 **kwargs: Any) -> None:
         super().__init__(metadata)
         if not str(name).isidentifier():
             raise ValueError(f"Parameter name must be a valid identifier "
                              f"got {name} which is not. Parameter names "
                              f"cannot start with a number and "
                              f"must not contain spaces or special characters")
+        if len(kwargs) > 0:
+            warnings.warn(f"_BaseParameter got unexpected kwargs {kwargs}."
+                          f" These are unused and will be discarded. This"
+                          f" will be an error in the future.")
         self.name = str(name)
         self.short_name = str(name)
         self._instrument = instrument

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -243,8 +243,7 @@ class _BaseParameter(Metadatable):
                  snapshot_value: bool = True,
                  snapshot_exclude: bool = False,
                  max_val_age: Optional[float] = None,
-                 vals: Optional[Validator] = None,
-                 **kwargs: Any) -> None:
+                 vals: Optional[Validator] = None) -> None:
         super().__init__(metadata)
         if not str(name).isidentifier():
             raise ValueError(f"Parameter name must be a valid identifier "

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -252,7 +252,7 @@ class _BaseParameter(Metadatable):
                              f"cannot start with a number and "
                              f"must not contain spaces or special characters")
         if len(kwargs) > 0:
-            warnings.warn(f"_BaseParameter got unexpected kwargs {kwargs}."
+            warnings.warn(f"_BaseParameter got unexpected kwargs: {kwargs}."
                           f" These are unused and will be discarded. This"
                           f" will be an error in the future.")
         self.name = str(name)

--- a/qcodes/instrument_drivers/Keysight/keysight_34934a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_34934a.py
@@ -25,7 +25,7 @@ class Keysight34934A(KeysightSwitchMatrixSubModule):
         self.add_parameter(name='protection_mode',
                            get_cmd=self._get_relay_protection_mode,
                            set_cmd=self._set_relay_protection_mode,
-                           valus=validators.Enum('AUTO100',
+                           vals=validators.Enum('AUTO100',
                                                  'AUTO0',
                                                  'FIX',
                                                  'ISO'),

--- a/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -188,7 +188,7 @@ class BaseOutput(InstrumentChannel):
                                      'range.',
                            vals=vals.Numbers(0, 400),
                            set_cmd=self._set_blocking_t,
-                           snapshotable=False)
+                           snapshot_exclude=True)
 
     def _set_blocking_t(self, temperature):
         self.set_range_from_temperature(temperature)

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1767,3 +1767,13 @@ def test_deprecated_param_warns():
     assert a.set_count == 1+9
     assert a.get() == 20
     assert a.get_count == 3
+
+
+def test_unknown_args_to_baseparameter_warns():
+    """
+    Passing an unknown kwarg to _BaseParameter should trigger a warning
+    """
+    with pytest.warns(Warning):
+        a = _BaseParameter(name='Foo',
+                           instrument=None,
+                           snapshotable=False)

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -380,8 +380,7 @@ class TestParameter(TestCase):
 
         localparameter = LocalParameter('test_param',
                                         None,
-                                        max_val_age=1,
-                                        initial_value=value)
+                                        max_val_age=1)
         with self.assertRaises(RuntimeError):
             localparameter.get_latest()
 


### PR DESCRIPTION
And fix a number of places where this happens. 
In the future this should be an error but it seems safer for now to make it an error. 
