### PR TITLE
AlazarATS9870: Set default external_trigger_coupling to DC 

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS9870.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9870.py
@@ -158,7 +158,7 @@ class AlazarTech_ATS9870(AlazarTech_ATS):
                            parameter_class=TraceParameter,
                            label='External Trigger Coupling',
                            unit=None,
-                           initial_value='AC',
+                           initial_value='DC',
                            val_mapping={'AC': 1,
                                         'DC': 2})
         self.add_parameter(name='external_trigger_range',

--- a/qcodes/instrument_drivers/AlazarTech/ATS9870.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9870.py
@@ -159,8 +159,8 @@ class AlazarTech_ATS9870(AlazarTech_ATS):
                            label='External Trigger Coupling',
                            unit=None,
                            initial_value='DC',
-                           val_mapping={'AC': 1,
-                                        'DC': 2})
+                           val_mapping={'DC': 2})
+
         self.add_parameter(name='external_trigger_range',
                            parameter_class=TraceParameter,
                            label='External Trigger Range',


### PR DESCRIPTION
Fixes [#1829](https://github.com/QCoDeS/Qcodes/issues/1829).

The user manual and SDK manual of the driver suggest that both AC and DC coupling on CHA, CHB, and EXT channels are supported by this card. However, the card in Delft does not support AC coupling.

I have contacted the Alazar tech support for this discrepancy. Indeed for external_trigger_coupling only DC mode is supported. This is captured in page 9 of the datasheet and specification page.

The driver is updated so that it does not allow AC coupling anymore.

~~In the meantime, as a solution, the `initial_value` of `external_trigger_coupling` is changed to DC. This also makes more sense till now the user has only used DC coupling.~~

@astafan8 

 - [x] Confirm if the initial_value of coupling for CHA and CHB should also be changed to DC. The issue specifically mentioned external_trigger_coupling but did not comment about the above two. 
        -  Only the `external_trigger_coupling` is the problematic case, rest is fine. 

