### PR TITLE
A few CI cleanups 

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+junit_family=legacy

--- a/qcodes/tests/dataset/test_plotting.py
+++ b/qcodes/tests/dataset/test_plotting.py
@@ -1,5 +1,5 @@
 import numpy as np
-from hypothesis import given, example, assume
+from hypothesis import given, example, assume, settings, HealthCheck
 from hypothesis.strategies import text, sampled_from, floats, lists, data, \
     one_of, just
 
@@ -34,6 +34,7 @@ from qcodes.tests.dataset.temporary_databases import empty_temp_db, experiment
          unit='V',
          data_strategy=np.random.random((5,))
                        * 10 ** (-3 + min(list(_ENGINEERING_PREFIXES.keys()))))
+@settings(suppress_health_check=[HealthCheck.too_slow])
 def test_rescaled_ticks_and_units(scale, unit,
                                   param_name, param_label, data_strategy):
     if isinstance(data_strategy, np.ndarray):


### PR DESCRIPTION
* Hopefully fix flaky test on azure by disabling health check. This seems to likely be due to an old and buggy version of hypothesis shipped by conda. But work around it here by disabling.
* Remove a deprecation warning from pytest by explicitly setting the output format. We stick to the old version as mypy only supports xunit1/junit output and the test uploader only support one type pr upload 