### PR TITLE
Upgrade pyqt5 to 5.12 which has support for python 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib==3.1.*
 pyqtgraph==0.10.0
 PyVISA==1.10.1
 h5py==2.9.0
-PyQt5==5.9.*;python_version<'3.8' # there are currently no pyqt5 packages build for 3.8 on pypi
+PyQt5==5.12.*
 QtPy
 jsonschema
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib==3.1.*
 pyqtgraph==0.10.0
 PyVISA==1.10.1
 h5py==2.9.0
-PyQt5==5.12.*
+PyQt5==5.13.*
 QtPy
 jsonschema
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib==3.1.*
 pyqtgraph==0.10.0
 PyVISA==1.10.1
 h5py==2.9.0
-PyQt5==5.13.*
+PyQt5==5.14.*
 QtPy
 jsonschema
 ruamel.yaml


### PR DESCRIPTION
This will hopefully enable us to run qt related tests on python 3.8 and eventually build the docs too. 

Pyqt 5.13 and 5.14 have been released but are not yet supported by spyder
