### PR TITLE
add initialised_database_at contextmanager

### DIFF
--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -259,7 +259,7 @@ def initialise_or_create_database_at(db_file_with_abs_path: str,
 
 
 @contextmanager
-def initialised_database_at(db_file_with_abs_path: str) -> Iterator[Any]:
+def initialised_database_at(db_file_with_abs_path: str) -> Iterator[None]:
     """Initializes or creates a database and restores the 'db_location' afterwards.
 
     Args:

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -8,7 +8,7 @@ import sqlite3
 import sys
 from contextlib import contextmanager
 from os.path import expanduser, normpath
-from typing import Any, Union, Iterator, Tuple, Optional
+from typing import Union, Iterator, Tuple, Optional
 
 import numpy as np
 from numpy import ndarray
@@ -260,7 +260,8 @@ def initialise_or_create_database_at(db_file_with_abs_path: str,
 
 @contextmanager
 def initialised_database_at(db_file_with_abs_path: str) -> Iterator[None]:
-    """Initializes or creates a database and restores the 'db_location' afterwards.
+    """
+    Initializes or creates a database and restores the 'db_location' afterwards.
 
     Args:
         db_file_with_abs_path

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -6,8 +6,9 @@ database version and possibly perform database upgrades.
 import io
 import sqlite3
 import sys
+from contextlib import contextmanager
 from os.path import expanduser, normpath
-from typing import Union, Tuple, Optional
+from typing import Any, Union, Iterator, Tuple, Optional
 
 import numpy as np
 from numpy import ndarray
@@ -255,6 +256,23 @@ def initialise_or_create_database_at(db_file_with_abs_path: str,
     """
     qcodes.config.core.db_location = db_file_with_abs_path
     initialise_database(journal_mode)
+
+
+@contextmanager
+def initialised_database_at(db_file_with_abs_path: str) -> Iterator[Any]:
+    """Initializes or creates a database and restores the 'db_location' afterwards.
+
+    Args:
+        db_file_with_abs_path
+            Database file name with absolute path, for example
+            ``C:\\mydata\\majorana_experiments.db``
+    """
+    db_location = qcodes.config["core"]["db_location"]
+    try:
+        initialise_or_create_database_at(db_file_with_abs_path)
+        yield
+    finally:
+        qcodes.config["core"]["db_location"] = db_location
 
 
 def conn_from_dbpath_or_conn(conn: Optional[ConnectionPlus],


### PR DESCRIPTION
Often one does
```python
db_location = qc.config["core"]["db_location"]
try:
    qc.initialise_or_create_database_at(db_file)
    some_operations_here(...)
finally:
    qc.config["core"]["db_location"] = db_location
```
this can be replaced with:
```python
with initialised_database_at(db_file):
    some_operations_here(...)
```
which is much cleaner!

I am using this in another code, however, @astafan8 recommended me to create a PR 👍 
