### PR TITLE
Block ruamel.yaml version with broken type annotations

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -36,4 +36,4 @@ dependencies:
  - conda-forge::requirements-parser
  - pip:
     - broadbean>=0.9.1
-    - ruamel.yaml
+    - ruamel.yaml!=0.16.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ h5py==2.9.0
 PyQt5==5.9.*;python_version<'3.8' # there are currently no pyqt5 packages build for 3.8 on pypi
 QtPy
 jsonschema
-ruamel.yaml
+ruamel.yaml!=0.16.6
 pyzmq>=16.0.2
 broadbean>=0.9.1
 wrapt

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     'h5py>=2.6',
     'websockets>=7.0',
     'jsonschema',
-    'ruamel.yaml',
+    'ruamel.yaml!=0.16.6',
     'pyzmq',
     'wrapt',
     'pandas',


### PR DESCRIPTION
The issue is reported here https://bitbucket.org/ruamel/yaml/issues/331/incorrect-type-annotations-of-taggedscalar 
