### PR TITLE
Add new features to keithley 2450

### DIFF
--- a/qcodes/instrument_drivers/tektronix/Keithley_2450.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2450.py
@@ -87,6 +87,20 @@ class Sense2450(InstrumentChannel):
             parameter_class=ParameterWithSetpoints
         )
 
+        self.add_parameter(
+            "nplc",
+            get_cmd=f":SENSe:{self._proper_function}:NPLCycles?",
+            set_cmd=f":SENSe:{self._proper_function}:NPLCycles {{}}",
+            vals=Numbers(0.001, 10)
+        )
+
+        self.add_parameter(
+            "delay",
+            get_cmd=f":SENSe:{self._proper_function}:DELay:USER1?",
+            set_cmd=f":SENSe:{self._proper_function}:DELay:USER1 {{}}",
+            vals=Numbers(0, 1e4)
+        )
+
     def _measure(self) -> str:
         if not self.parent.output_enabled():
             raise RuntimeError("Output needs to be on for a measurement")
@@ -192,6 +206,20 @@ class Source2450(InstrumentChannel):
             get_cmd=self.get_sweep_axis,
             vals=Arrays(shape=(self.parent.npts,)),
             unit=unit
+        )
+
+        self.add_parameter(
+            "delay",
+            get_cmd=f":SOURce:{self._proper_function}:DELay?",
+            set_cmd=f":SOURce:{self._proper_function}:DELay {{}}",
+            vals=Numbers(0, 1e4)
+        )
+
+        self.add_parameter(
+            "auto_delay",
+            get_cmd=f":SOURce:{self._proper_function}:DELay:AUTO?",
+            set_cmd=f":SOURce:{self._proper_function}:DELay:AUTO {{}}",
+            val_mapping=create_on_off_val_mapping(on_val="1", off_val="0")
         )
 
     def get_sweep_axis(self) -> np.ndarray:
@@ -410,3 +438,9 @@ class Keithley2450(VisaInstrument):
         Query if we have the correct language mode
         """
         return self.ask("*LANG?") == "SCPI"
+
+    def reset(self) -> None:
+        """
+        Returns the instrument to default settings, cancels all pending commands.
+        """
+        self.write("*RST")

--- a/qcodes/instrument_drivers/tektronix/Keithley_2450.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2450.py
@@ -44,7 +44,6 @@ class Sense2450(InstrumentChannel):
         self._proper_function = proper_function
         range_vals = self.function_modes[self._proper_function]["range_vals"]
         unit = self.function_modes[self._proper_function]["unit"]
-        self._user_number = 1
 
         self.function = self.parent.sense_function
 
@@ -97,15 +96,15 @@ class Sense2450(InstrumentChannel):
 
         self.add_parameter(
             'user_number',
-            get_cmd=self.get_user_number,
-            set_cmd=self.set_user_number,
+            get_cmd=None,
+            set_cmd=None,
             vals=Ints(1, 5)
         )
 
         self.add_parameter(
             "user_delay",
-            get_cmd=self.get_user_delay,
-            set_cmd=self.set_user_delay,
+            get_cmd=self._get_user_delay,
+            set_cmd=self._set_user_delay,
             vals=Numbers(0, 1e4)
         )
 
@@ -131,18 +130,12 @@ class Sense2450(InstrumentChannel):
         """
         self.write(":TRACe:CLEar")
 
-    def get_user_number(self) -> int:
-        return self._user_number
-
-    def set_user_number(self, value) -> None:
-        self._user_number = value
-
-    def get_user_delay(self) -> str:
+    def _get_user_delay(self) -> str:
         get_cmd = f":SENSe:{self._proper_function}:DELay:USER" \
                   f"{self.user_number()}?"
         return self.ask(get_cmd)
 
-    def set_user_delay(self, value) -> None:
+    def _set_user_delay(self, value) -> None:
         set_cmd = f":SENSe:{self._proper_function}:DELay:USER" \
                   f"{self.user_number()} {value}"
         self.write(set_cmd)
@@ -183,7 +176,6 @@ class Source2450(InstrumentChannel):
 
         self.function = self.parent.source_function
         self._sweep_arguments: Dict[str, Union[float, int, str]] = {}
-        self._user_number = 1
 
         self.add_parameter(
             "range",
@@ -242,15 +234,15 @@ class Source2450(InstrumentChannel):
 
         self.add_parameter(
             'user_number',
-            get_cmd=self.get_user_number,
-            set_cmd=self.set_user_number,
+            get_cmd=None,
+            set_cmd=None,
             vals=Ints(1, 5)
         )
 
         self.add_parameter(
             "user_delay",
-            get_cmd=self.get_user_delay,
-            set_cmd=self.set_user_delay,
+            get_cmd=self._get_user_delay,
+            set_cmd=self._set_user_delay,
             vals=Numbers(0, 1e4)
         )
 
@@ -310,18 +302,12 @@ class Source2450(InstrumentChannel):
     def sweep_reset(self) -> None:
         self._sweep_arguments = {}
 
-    def get_user_number(self) -> int:
-        return self._user_number
-
-    def set_user_number(self, value) -> None:
-        self._user_number = value
-
-    def get_user_delay(self) -> str:
+    def _get_user_delay(self) -> str:
         get_cmd = f":SOURce:{self._proper_function}:DELay:USER" \
                   f"{self.user_number()}?"
         return self.ask(get_cmd)
 
-    def set_user_delay(self, value) -> None:
+    def _set_user_delay(self, value) -> None:
         set_cmd = f":SOURce:{self._proper_function}:DELay:USER" \
                   f"{self.user_number()} {value}"
         self.write(set_cmd)

--- a/qcodes/instrument_drivers/tektronix/Keithley_2450.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2450.py
@@ -138,11 +138,13 @@ class Sense2450(InstrumentChannel):
         self._user_number = value
 
     def get_user_delay(self) -> str:
-        get_cmd = f":SENSe:{self._proper_function}:DELay:USER{self.user_number()}?"
+        get_cmd = f":SENSe:{self._proper_function}:DELay:USER" \
+                  f"{self.user_number()}?"
         return self.ask(get_cmd)
 
     def set_user_delay(self, value) -> None:
-        set_cmd = f":SENSe:{self._proper_function}:DELay:USER{self.user_number()} {value}"
+        set_cmd = f":SENSe:{self._proper_function}:DELay:USER" \
+                  f"{self.user_number()} {value}"
         self.write(set_cmd)
 
 
@@ -315,11 +317,13 @@ class Source2450(InstrumentChannel):
         self._user_number = value
 
     def get_user_delay(self) -> str:
-        get_cmd = f":SOURce:{self._proper_function}:DELay:USER{self.user_number()}?"
+        get_cmd = f":SOURce:{self._proper_function}:DELay:USER" \
+                  f"{self.user_number()}?"
         return self.ask(get_cmd)
 
     def set_user_delay(self, value) -> None:
-        set_cmd = f":SOURce:{self._proper_function}:DELay:USER{self.user_number()} {value}"
+        set_cmd = f":SOURce:{self._proper_function}:DELay:USER" \
+                  f"{self.user_number()} {value}"
         self.write(set_cmd)
 
 
@@ -492,6 +496,6 @@ class Keithley2450(VisaInstrument):
 
     def reset(self) -> None:
         """
-        Returns the instrument to default settings, cancels all pending commands.
+        Returns instrument to default settings, cancels all pending commands.
         """
         self.write("*RST")


### PR DESCRIPTION
Changes proposed in this pull request:
- add reset() method to the main module,
- add nplc parameter to the sense module,
- add user delay to the sense module,
- add delay, user delay, and auto delay setting to the source module.

The newly added user delay to both sense and source module can be used in the trigger model. However, the trigger model does not exist in the qcodes driver yet. So my next step is to write the trigger module for the driver, and a new example notebook for how to perform triggering.

Speaking of example notebook, the new features added in the PR do not really fit in the existing example notebook (methods like the reset() are well self-explained). I'll try to include as many as I can in the upcoming example notebook for trigger module.

@sohailc 
