### PR TITLE
Convert hypothesis args to kwarg

### DIFF
--- a/qcodes/tests/drivers/test_lakeshore_325.py
+++ b/qcodes/tests/drivers/test_lakeshore_325.py
@@ -6,7 +6,8 @@ STATUS = Model_325.Status
 
 
 @given(
-    st.lists(st.sampled_from(list(STATUS)), 1, 5, unique=True).map(sorted)
+    st.lists(st.sampled_from(list(STATUS)),
+             min_size=1, max_size=5, unique=True).map(sorted)
 )
 def test_decode_sensor_status(list_of_codes):
     """


### PR DESCRIPTION
This is needed for compatibility with hypothesis 550 and currently causes mypy to fail with hypothesis >= 0.550 

