### PR TITLE
Improvements to 344xx driver

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -2,7 +2,7 @@
 import time
 import weakref
 import logging
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Sequence, Optional, Dict, Union, Callable, Any, List, \
     TYPE_CHECKING, cast, Type
 
@@ -395,6 +395,7 @@ class AbstractInstrument(ABC):
     """ABC that is useful for defining mixin classes for Instrument class"""
     log: 'InstrumentLoggerAdapter'  # instrument logging
 
+    @abstractmethod
     def ask(self, cmd: str) -> str:
         pass
 

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -303,7 +303,7 @@ class Display(InstrumentChannel):
         self.text.get()  # also update the parameter value
 
 
-class TimeTrace(ParameterWithSetpoints):
+class TimeTrace(ParameterWithSetpoints): # pylint: disable=abstract-method
     """
     A parameter class that holds the data for a time trace type measurement,
     i.e. a measurement of N voltage or current values measured at fixed time
@@ -386,7 +386,7 @@ class TimeTrace(ParameterWithSetpoints):
 
         return data
 
-    def get_raw(self) -> np.ndarray:  # pylint: disable=E0202
+    def get_raw(self) -> np.ndarray:  # pylint: disable=method-hidden
 
         self._validate_dt()
         self._set_units_and_labels()
@@ -395,7 +395,7 @@ class TimeTrace(ParameterWithSetpoints):
         return data
 
 
-class TimeAxis(Parameter):
+class TimeAxis(Parameter): # pylint: disable=abstract-method
     """
     A simple :class:`.Parameter` that holds all the times (relative to the
     measurement start) at which the points of the time trace were acquired.
@@ -869,7 +869,6 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         self.write(f'SENSe:VOLTage:DC:RANGe {value:f}')
 
         # resolution settings change with range
-
         self.resolution.get()
 
     def _set_resolution(self, value: float) -> None:
@@ -888,7 +887,6 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         self.write(f'VOLT:DC:RES {value:.1e}')
 
         # NPLC settings change with resolution
-
         self.NPLC.get()
 
     def autorange_once(self) -> None:
@@ -913,4 +911,4 @@ def _raw_vals_to_array(raw_vals: str) -> np.ndarray:
     Returns:
         numpy 1D array of data
     """
-    return np.array(list(map(float, raw_vals.split(','))))
+    return np.fromstring(raw_vals, dtype=float, sep=",")

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -665,7 +665,10 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         self.add_submodule('sample', Sample(self, 'sample'))
 
         ####################################
-        # Measuring parameter
+        # Measurement Parameters
+        # snapshot_get is disabled for each of these to prevent rapid mode
+        # changes on initialization or snapshot update, however the cached
+        # (last read) value will still be stored in the snapshot.
 
         self.add_parameter('volt',
                            get_cmd=partial(self._get_parameter, "DC Voltage"),

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -1,9 +1,10 @@
 import textwrap
-import numpy as np
 from contextlib import ExitStack
 from functools import partial
 from typing import Sequence, Tuple
 from distutils.version import LooseVersion
+
+import numpy as np
 
 import qcodes.utils.validators as vals
 from qcodes import VisaInstrument, InstrumentChannel
@@ -193,8 +194,8 @@ class Sample(InstrumentChannel):
 
                 Note that the maximum number of pretrigger counts is bounded
                 by the current number of sample counts as specified via the
-                ``sample.count`` parameter. Refer to the doc of the 
-                ``sample.count`` parameter for information on the maximum 
+                ``sample.count`` parameter. Refer to the doc of the
+                ``sample.count`` parameter for information on the maximum
                 number of sample counts."""))
 
         if self.parent.is_34465A_34470A:
@@ -666,34 +667,40 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         self.add_parameter('volt',
                            get_cmd=partial(self._get_parameter, "DC Voltage"),
                            label='Voltage',
-                           unit='V')
+                           unit='V',
+                           snapshot_get=False)
 
         self.add_parameter('curr',
                            get_cmd=partial(self._get_parameter, "DC Current"),
                            label='Current',
-                           unit='A')
+                           unit='A',
+                           snapshot_get=False)
 
         self.add_parameter('ac_volt',
                            get_cmd=partial(self._get_parameter, "AC Voltage"),
                            label='AC Voltage',
-                           unit='V')
+                           unit='V',
+                           snapshot_get=False)
 
         self.add_parameter('ac_curr',
                            get_cmd=partial(self._get_parameter, "AC Current"),
                            label='AC Current',
-                           unit='A')
+                           unit='A',
+                           snapshot_get=False)
 
         self.add_parameter('res',
                            get_cmd=partial(self._get_parameter,
                                            "2 Wire Resistance"),
                            label='Resistance',
-                           unit='Ohms')
+                           unit='Ohms',
+                           snapshot_get=False)
 
         self.add_parameter('four_wire_res',
                            get_cmd=partial(self._get_parameter,
                                            "4 Wire Resistance"),
                            label='Resistance',
-                           unit='Ohms')
+                           unit='Ohms',
+                           snapshot_get=False)
 
         #####################################
         # Time trace parameters
@@ -781,7 +788,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         Return enabled options of the DMM returned by ``*OPT?`` command.
         The 34410A model does not have options, hence always returns
         an empty tuple.
-        
+
         Note that for firmware version 3.0, output of ```*OPT?`` will contain
         the ``DIG`` option only if it has been purchased before, although
         the option itself is enabled by default in the firmware version 3.0.
@@ -872,10 +879,10 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
                         for v in self._resolution_factors]
         if '{:.1e}'.format(value) not in res_fac_strs:
             raise ValueError(
-                'Resolution setting {:.1e} ({} at range {}) '
+                'Resolution setting {value:.1e} ({value} at range {rang}) '
                 'does not exist. '
-                'Possible values are {}'.format(value, value, rang,
-                                                res_fac_strs))
+                'Possible values are {res_fac_strs}'.format(value=value, rang=rang,
+                                                            res_fac_strs=res_fac_strs))
 
         self.write('VOLT:DC:RES {:.1e}'.format(value))
 

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -401,8 +401,11 @@ class TimeAxis(Parameter):
     measurement start) at which the points of the time trace were acquired.
     """
 
-    def get_raw(self) -> np.ndarray:  # pylint: disable=E0202
-
+    def get_raw(self) -> np.ndarray:  # pylint: disable=method-hidden
+        """
+        Construct a time axis by querying the number of points and step size
+        from the instrument.
+        """
         if self.instrument is None:
            raise RuntimeError("No instrument attached to Parameter.")
 
@@ -847,13 +850,13 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         return _raw_vals_to_array(raw_vals)
 
     def _set_apt_time(self, value: float) -> None:
-        self.write('SENSe:VOLTage:DC:APERture {:f}'.format(value))
+        self.write(f'SENSe:VOLTage:DC:APERture {value:f}')
 
         # setting aperture time switches aperture mode ON
         self.aperture_mode.get()
 
     def _set_NPLC(self, value: float) -> None:
-        self.write('SENSe:VOLTage:DC:NPLC {:f}'.format(value))
+        self.write(f'SENSe:VOLTage:DC:NPLC {value:f}')
 
         # resolution settings change with NPLC
         self.resolution.get()
@@ -863,7 +866,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
             self.aperture_mode.get()
 
     def _set_range(self, value: float):
-        self.write('SENSe:VOLTage:DC:RANGe {:f}'.format(value))
+        self.write(f'SENSe:VOLTage:DC:RANGe {value:f}')
 
         # resolution settings change with range
 
@@ -875,16 +878,14 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         # convert both value*range and the resolution factors
         # to strings with few digits, so we avoid floating point
         # rounding errors.
-        res_fac_strs = ['{:.1e}'.format(v * rang)
-                        for v in self._resolution_factors]
-        if '{:.1e}'.format(value) not in res_fac_strs:
+        res_fac_strs = [f'{(v * rang):.1e}' for v in self._resolution_factors]
+        if f'{value:.1e}' not in res_fac_strs:
             raise ValueError(
-                'Resolution setting {value:.1e} ({value} at range {rang}) '
-                'does not exist. '
-                'Possible values are {res_fac_strs}'.format(value=value, rang=rang,
-                                                            res_fac_strs=res_fac_strs))
+                f'Resolution setting {value:.1e}'
+                f'({value} at range {rang}) does not exist. '
+                f'Possible values are {res_fac_strs}')
 
-        self.write('VOLT:DC:RES {:.1e}'.format(value))
+        self.write(f'VOLT:DC:RES {value:.1e}')
 
         # NPLC settings change with resolution
 


### PR DESCRIPTION
This change implements a fix to the 344xx driver that stops the DMM from cycling through all its measurement modes on a snapshot/initialization.

Changes proposed in this pull request:
- Don't include measurements in a snapshot that would cause the measurement mode to change.
- Make ask abstract in the AbstractInstrument class to fix a bunch of pylint errors.

@jenshnielsen @WilliamHPNielsen 