### PR TITLE
Keysight B1500: Add units to current/voltage parameters to B1571A SMU module

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -67,6 +67,7 @@ class B1517A(B1500Module):
 
         self.add_parameter(
             name="voltage",
+            unit="V",
             set_cmd=self._set_voltage,
             get_cmd=self._get_voltage,
             snapshot_get=False
@@ -74,6 +75,7 @@ class B1517A(B1500Module):
 
         self.add_parameter(
             name="current",
+            unit="A",
             set_cmd=self._set_current,
             get_cmd=self._get_current,
             snapshot_get=False


### PR DESCRIPTION
For some reason they were missing