### PR TITLE
Fix: Keysight_34465A overload value 9.9e37 to be np.inf instead

### DIFF
--- a/qcodes/instrument/sims/Keysight_34465A.yaml
+++ b/qcodes/instrument/sims/Keysight_34465A.yaml
@@ -12,6 +12,8 @@ devices:
         r: "Keysight, 34465A, 1000, A.02.16-02.40-02.16-00.51-03-01"
       - q: "DISPLay:TEXT:CLEar"
         r: null_response
+      - q: "SAMPle:TIMer? MIN"
+        r: 0.1
     properties:
       voltage:
         default: 10
@@ -32,6 +34,41 @@ devices:
           r: "{}"
         setter:
           q: "SAMPle:COUNt {}"
+      trigger_count:
+        default: 1
+        getter:
+          q: "TRIGger:COUNt?"
+          r: "{}"
+        setter:
+          q: "TRIGger:COUNt {}"
+      pretrigger_count:
+        default: 1
+        getter:
+          q: "SAMPle:COUNt:PRETrigger?"
+          r: "{}"
+        setter:
+          q: "SAMPle:COUNt:PRETrigger {}"
+      sample_source:
+        default: "TIM"
+        getter:
+          q: "SAMPle:SOURce?"
+          r: "{}"
+        setter:
+          q: "SAMPle:SOURce {}"
+      trigger_source:
+        default: "BUS"
+        getter:
+          q: "TRIGger:SOURce?"
+          r: "{}"
+        setter:
+          q: "TRIGger:SOURce {}"
+      sample_timer:
+        default: 1.0
+        getter:
+          q: "SAMPle:TIMer?"
+          r: "{}"
+        setter:
+          q: "SAMPle:TIMer {}"
       dc_autorange:
         default: 0
         getter:

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -808,7 +808,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
     def _get_parameter(self, sense_function: str = "DC Voltage") -> float:
         """
         Measure the parameter given by sense_function. In case of overload i.e.
-        instrument throws 9.9e37 as the value it is converted to nan.
+        when instrument throws +/-9.9e37, it is converted to +/-inf.
 
         Args:
             sense_function: The parameter to measure. Valid values are those
@@ -912,8 +912,8 @@ def _raw_vals_to_array(raw_vals: str) -> np.ndarray:
     """
     Helper function that converts comma-delimited string of floating-point
     values to a numpy 1D array of them. Most data retrieval command of these
-    instruments return data in this format. In case of overload i.e.
-    instrument throws 9.9e37 as the value it is converted to nan.
+    instruments return data in this format.In case of overload i.e.
+        when instrument throws +/-9.9e37, it is converted to +/-inf.
 
     Args:
         raw_vals: comma-delimited string of floating-point values

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -821,8 +821,10 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
             with self.sample.count.set_to(1):
                 response = self.ask('READ?')
 
-        if abs(float(response)) >= 9.9e37:
-            return np.nan
+        if float(response) >= 9.9e37:
+            return np.inf
+        elif float(response) <= -9.9e37:
+            return -np.inf
 
         return float(response)
 
@@ -920,5 +922,6 @@ def _raw_vals_to_array(raw_vals: str) -> np.ndarray:
         numpy 1D array of data
     """
     result_array = np.fromstring(raw_vals, dtype=float, sep=",")
-    result_array[abs(result_array) >= 9.9e37] = np.nan
+    result_array[result_array >= 9.9e37] = np.inf
+    result_array[result_array <= -9.9e37] = -np.inf
     return result_array

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -821,7 +821,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
             with self.sample.count.set_to(1):
                 response = self.ask('READ?')
 
-        if float(response) >= 9.9e37:
+        if abs(float(response)) >= 9.9e37:
             return np.nan
 
         return float(response)
@@ -920,5 +920,5 @@ def _raw_vals_to_array(raw_vals: str) -> np.ndarray:
         numpy 1D array of data
     """
     result_array = np.fromstring(raw_vals, dtype=float, sep=",")
-    result_array[result_array >= 9.9e37] = np.nan
+    result_array[abs(result_array) >= 9.9e37] = np.nan
     return result_array

--- a/qcodes/tests/drivers/test_keysight_34465a.py
+++ b/qcodes/tests/drivers/test_keysight_34465a.py
@@ -21,10 +21,10 @@ def driver():
 
 
 @pytest.fixture(scope='function')
-def driver_volt(driver, val_volt):
+def driver_with_read_and_fetch_mocked(driver, val_volt):
     def get_ask_with_read_mock(original_ask, read_value):
         def ask_with_read_mock(cmd: str) -> str:
-            if (cmd == "READ?") or (cmd == "FETCH?"):
+            if cmd in ("READ?", "FETCH?"):
                 return read_value
             else:
                 return original_ask(cmd)
@@ -56,20 +56,20 @@ def test_NPLC(driver):
 
 
 @pytest.mark.parametrize("val_volt", ['100.0'])
-def test_get_voltage(driver_volt):
-    voltage = driver_volt.volt.get()
+def test_get_voltage(driver_with_read_and_fetch_mocked):
+    voltage = driver_with_read_and_fetch_mocked.volt.get()
     assert voltage == 100.0
 
 
 @pytest.mark.parametrize("val_volt", ['9.9e37'])
-def test_get_voltage_plus_inf(driver_volt):
-    voltage = driver_volt.volt.get()
+def test_get_voltage_plus_inf(driver_with_read_and_fetch_mocked):
+    voltage = driver_with_read_and_fetch_mocked.volt.get()
     assert voltage == np.inf
 
 
 @pytest.mark.parametrize("val_volt", ['-9.9e37'])
-def test_get_voltage_minus_inf(driver_volt):
-    voltage = driver_volt.volt.get()
+def test_get_voltage_minus_inf(driver_with_read_and_fetch_mocked):
+    voltage = driver_with_read_and_fetch_mocked.volt.get()
     assert voltage == -np.inf
 
 
@@ -78,10 +78,10 @@ def test_get_voltage_minus_inf(driver_volt):
                                      "fail. The problem is coming from "
                                      "timetrace().")
 @pytest.mark.parametrize("val_volt", ['10, 9.9e37, -9.9e37'])
-def test_get_timetrace(driver_volt):
-    driver_volt.timetrace_npts(3)
-    assert driver_volt.timetrace_npts() == 3
-    voltage = driver_volt.timetrace()
+def test_get_timetrace(driver_with_read_and_fetch_mocked):
+    driver_with_read_and_fetch_mocked.timetrace_npts(3)
+    assert driver_with_read_and_fetch_mocked.timetrace_npts() == 3
+    voltage = driver_with_read_and_fetch_mocked.timetrace()
     assert (voltage == np.array([10.0, np.inf, -np.inf])).all()
 
 

--- a/qcodes/tests/drivers/test_keysight_34465a.py
+++ b/qcodes/tests/drivers/test_keysight_34465a.py
@@ -21,7 +21,11 @@ def driver():
 
 
 @pytest.fixture(scope='function')
-def driver_with_read_and_fetch_mocked(driver, val_volt):
+def driver_with_read_and_fetch_mocked(val_volt):
+    keysight_sim = Keysight_34465A('keysight_34465A_sim',
+                                   address='GPIB::1::INSTR',
+                                   visalib=visalib)
+
     def get_ask_with_read_mock(original_ask, read_value):
         def ask_with_read_mock(cmd: str) -> str:
             if cmd in ("READ?", "FETCH?"):
@@ -30,8 +34,11 @@ def driver_with_read_and_fetch_mocked(driver, val_volt):
                 return original_ask(cmd)
         return ask_with_read_mock
 
-    driver.ask = get_ask_with_read_mock(driver.ask, val_volt)
-    yield driver
+    keysight_sim.ask = get_ask_with_read_mock(keysight_sim.ask, val_volt)
+    try:
+        yield keysight_sim
+    finally:
+        Keysight_34465A.close_all()
 
 
 def test_init(driver):

--- a/qcodes/tests/drivers/test_keysight_34465a.py
+++ b/qcodes/tests/drivers/test_keysight_34465a.py
@@ -37,6 +37,7 @@ def driver_volt(driver, val_volt):
 def test_init(driver):
     idn = driver.IDN()
     assert idn['vendor'] == 'Keysight'
+    assert idn['model'] == '34465A'
 
 
 def test_has_dig_option(driver):


### PR DESCRIPTION
In case the DMM tries to measure the voltage value outside the its range, it overloads and throws 9.9e37 instead of throwing an error. Here we substitute this number with np.nan. 

Side note: The error query does not throw any error even though the instrument display shows in bold that instrument is overloaded. 

 - [x] Test on the instrument  

To reproduce the error: 
![20200224_165145](https://user-images.githubusercontent.com/18750964/75253306-8a210f00-57de-11ea-8375-bfd4475f7fb4.jpg)





@jenshnielsen @astafan8 