### PR TITLE
Remove superflous lines from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,9 +103,3 @@ benchmarking/results/
 
 # Ignore .db files that are generated for some tests
 qcodes/tests/dataset/fixtures/db_files/*
-qdev_wrappers
-export_functions.py
-Config.yaml
-QDAC - trials.py
-doNd.py
-QDAC-driver.code-workspace


### PR DESCRIPTION
PR #1613 accidentally modified the `.gitignore`. This PR undoes that modification.

@Dominik-Vogel 