### PR TITLE
Deprecate default measurement

### DIFF
--- a/docs/changes/0.12.0.rst
+++ b/docs/changes/0.12.0.rst
@@ -36,7 +36,8 @@ No documentation updates in this release.
 Deprecations:
 _____________
 
-Nothing deprecated :)
+The methods `set_measurement` and `measure` on the Station object have been deprecated.
+They relied on the QCoDeS legacy dataset and were not frequently used. (#1937)
 
 
 Under the hood:

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -35,7 +35,7 @@ from qcodes.instrument.parameter import (
     DelegateParameter, _BaseParameter)
 import qcodes.utils.validators as validators
 from qcodes.monitor.monitor import Monitor
-
+from qcodes.utils.deprecate import deprecate
 from qcodes.actions import _actions_snapshot
 
 
@@ -237,6 +237,7 @@ class Station(Metadatable, DelegateAttributes):
             else:
                 raise e
 
+    @deprecate()
     def set_measurement(self, *actions):
         """
         Save a set ``*actions``` as the default measurement for this Station.
@@ -257,6 +258,7 @@ class Station(Metadatable, DelegateAttributes):
 
         self.default_measurement = actions
 
+    @deprecate()
     def measure(self, *actions):
         """
         Measure the default measurement, or parameters in actions.

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -237,7 +237,8 @@ class Station(Metadatable, DelegateAttributes):
             else:
                 raise e
 
-    @deprecate("Default measurements on a station will be removed in a future release")
+    @deprecate("Default measurements on a station will "
+               "be removed in a future release")
     def set_measurement(self, *actions):
         """
         Save a set ``*actions``` as the default measurement for this Station.
@@ -258,7 +259,8 @@ class Station(Metadatable, DelegateAttributes):
 
         self.default_measurement = actions
 
-    @deprecate("Default measurements on a station will be removed in a future release")
+    @deprecate("Default measurements on a station will "
+               "be removed in a future release")
     def measure(self, *actions):
         """
         Measure the default measurement, or parameters in actions.

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -237,7 +237,7 @@ class Station(Metadatable, DelegateAttributes):
             else:
                 raise e
 
-    @deprecate()
+    @deprecate("Default measurements on a station will be removed in a future release")
     def set_measurement(self, *actions):
         """
         Save a set ``*actions``` as the default measurement for this Station.
@@ -258,7 +258,7 @@ class Station(Metadatable, DelegateAttributes):
 
         self.default_measurement = actions
 
-    @deprecate()
+    @deprecate("Default measurements on a station will be removed in a future release")
     def measure(self, *actions):
         """
         Measure the default measurement, or parameters in actions.


### PR DESCRIPTION
These see little use and are using the old dataset 
