### PR TITLE
[DRAFT]: Add binder for notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -441,3 +441,15 @@ numfig = True
 nbsphinx_kernel_name = 'python3'
 # always execute notebooks.
 nbsphinx_execute = 'always'
+
+# Binder configuration (WRITE MORE DETAILS ONCE FIXED)
+sphinx_gallery_conf = {
+  'binder': {
+     'org': 'qcodes',
+     'repo': 'https://github.com/qcodes/qcodes',
+     'branch': 'master',
+     'binderhub_url': 'https://mybinder.org',
+     'notebooks_dir': 'notebooks',
+     'use_jupyter_lab': True,
+     }
+}


### PR DESCRIPTION
Add binder (mybinder.org) for the qcodes notebooks so that they can easily executed. Helps users to quickly interact with new features, APIs, and tutorials. 

DRAFT because I am still playing around with the binder to look for the best settings