### PR TITLE
Binder: Point to master instead of latest release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,9 +74,10 @@ nbsphinx_prolog = r"""
     <div class="admonition note">
       <p>This page was generated from
         <a class="reference external" 
-        href="https://github.com/qcodes/qcodes/blob/v""" + str(release) + r"""/{{docname|e }}">{{ docname|replace("\\","/") }}</a>.
+        href="https://github.com/qcodes/qcodes/blob/master/{{docname|e}}">{{ docname|replace("\\","/") }}</a>.
         Interactive online version:
-        <a href="https://mybinder.org/v2/gh/qcodes/qcodes/v""" + str(release) + r"""?filepath={{ docname|replace("\\","/") }}"><img 
+        <a href="https://mybinder.org/v2/gh/qcodes/qcodes/master?filepath={{ 
+        docname|replace("\\","/") }}"><img 
     alt="Binder badge" 
         src="https://mybinder.org/badge_logo.svg" 
         style="vertical-align:text-bottom"></a>.


### PR DESCRIPTION
Current release does not include .binder folder that contains requirements to run the notebooks through binder. Until next release we point the binder to create the environment for notebooks from master instead of the latest release. We do not want to keep this is as a permanent solution because pointing to master would lead to creation of docker image each time a new commit is made which is a very slow process. After next release we will revert back to creating docker image from latest release. 