### PR TITLE
h5py tests: silence warnings about changing default by setting mode explicitly

### DIFF
--- a/qcodes/tests/test_hdf5formatter.py
+++ b/qcodes/tests/test_hdf5formatter.py
@@ -222,7 +222,7 @@ class TestHDF5_Format(TestCase):
         fp3 = fp[:-5]+'_3.hdf5'
         copy(fp, fp3)
         # Should not raise an error because the file was properly closed
-        F3 = h5py.File(fp3)
+        F3 = h5py.File(fp3, mode='a')
 
     def test_dataset_flush_after_write(self):
         data = DataSet1D(name='test_flush', location=self.loc_provider)
@@ -231,7 +231,7 @@ class TestHDF5_Format(TestCase):
         fp2 = fp[:-5]+'_2.hdf5'
         copy(fp, fp2)
         # Opening this copy should not raise an error
-        F2 = h5py.File(fp2)
+        F2 = h5py.File(fp2, mode='a')
 
     def test_dataset_finalize_closes_file(self):
         data = DataSet1D(name='test_finalize', location=self.loc_provider)
@@ -245,7 +245,7 @@ class TestHDF5_Format(TestCase):
         fp3 = fp[:-5]+'_4.hdf5'
         copy(fp, fp3)
         # Should now not raise an error because the file was properly closed
-        F3 = h5py.File(fp3)
+        F3 = h5py.File(fp3, mode='a')
 
     def test_double_closing_gives_warning(self):
         data = DataSet1D(name='test_double_close',


### PR DESCRIPTION
Setting it to the current default and not the new one should give the same behaviour as always