### PR TITLE
limit hypothesis version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
  - QtPy
  - jsonschema
  - jupyter=1.0.0
- - hypothesis
+ - hypothesis<5.6.0 # large number of warnings due to change in 5.6.0 https://hypothesis.readthedocs.io/en/latest/changes.html#v5-6-0
  - pytest
  - pytest-runner
  - spyder

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,7 +3,7 @@ pytest-cov
 pytest
 pytest-rerunfailures
 codacy-coverage
-hypothesis!=3.69.11 # due to bug in log capture
+hypothesis<5.6.0 # large number of warnings due to change in 5.6.0 https://hypothesis.readthedocs.io/en/latest/changes.html#v5-6-0
 mypy==0.770
 git+https://github.com/QCoDeS/pyvisa-sim.git
 lxml


### PR DESCRIPTION
To prevent a large number of warnings about using function scope fixtures. 
Its not clear at the moment how to best avoid these
and open issues may result in changes https://github.com/HypothesisWorks/hypothesis/issues/2370

So lets limit this for now 
