### PR TITLE
Better snapshot of station.config (and other UserDicts)

### DIFF
--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -365,6 +365,7 @@ class Station(Metadatable, DelegateAttributes):
     def load_config(self, config: Union[str, IO[AnyStr]]) -> None:
         """
         Loads a configuration from a supplied string or file/stream handle.
+        The string or file/stream is expected to be YAML formatted
 
         Loading of a configuration will update the snapshot of the station and
         make the instruments described in the config file available for

--- a/qcodes/tests/test_json.py
+++ b/qcodes/tests/test_json.py
@@ -1,8 +1,12 @@
 from unittest import TestCase
 import numpy as np
 import json
+from collections import UserDict
 
 from qcodes.utils.helpers import NumpyJSONEncoder
+
+class SomeUserDict(UserDict):
+    pass
 
 
 class TestNumpyJson(TestCase):
@@ -19,7 +23,8 @@ class TestNumpyJson(TestCase):
             'length': 45.23,
             'points': [12, 24, 48],
             'RapunzelNumber': np.float64(4.89) + np.float64(0.11) * 1j,
-            'verisimilitude': 1j
+            'verisimilitude': 1j,
+            'myuserdict': SomeUserDict({'a': 1})
         }
 
     def test_numpy_fail(self):
@@ -42,7 +47,8 @@ class TestNumpyJson(TestCase):
             'length': 45.23,
             'points': [12, 24, 48],
             'RapunzelNumber': {'__dtype__': 'complex', 're': 4.89, 'im': 0.11},
-            'verisimilitude': {'__dtype__': 'complex', 're': 0, 'im': 1}
+            'verisimilitude': {'__dtype__': 'complex', 're': 0, 'im': 1},
+            'myuserdict': {'a': 1}
         }
 
         self.assertEqual(metadata, data_dict)

--- a/qcodes/tests/test_json.py
+++ b/qcodes/tests/test_json.py
@@ -5,6 +5,7 @@ from collections import UserDict
 
 from qcodes.utils.helpers import NumpyJSONEncoder
 
+
 class SomeUserDict(UserDict):
     pass
 

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -6,6 +6,7 @@ import numbers
 import time
 import os
 from pathlib import Path
+import collections
 
 from collections.abc import Iterator, Sequence, Mapping
 from copy import deepcopy
@@ -80,6 +81,11 @@ class NumpyJSONEncoder(json.JSONEncoder):
             try:
                 s = super(NumpyJSONEncoder, self).default(obj)
             except TypeError:
+                # json does not support dumping UserDict but
+                # we can dump the dict stored internally in the
+                # UserDict
+                if isinstance(obj, collections.UserDict):
+                    return obj.data
                 # See if the object supports the pickle protocol.
                 # If so, we should be able to use that to serialize.
                 if hasattr(obj, '__getnewargs__'):


### PR DESCRIPTION
This was falling back to `str() repr` which is not great for reloading. This fixes that by serializing the data member of the userdict which is a regural dict
