### PR TITLE
add types to init functions of concrete keysight drivers

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -33,3 +33,24 @@ disallow_untyped_defs = True
 
 [mypy-qcodes.config.*]
 disallow_untyped_defs = True
+
+[mypy-qcodes.instrument_drivers.Keysight.private.Keysight_344xxA_submodules]
+disallow_untyped_defs = True
+
+[mypy-qcodes.instrument_drivers.Keysight.Keysight_34410A_submodules.*]
+disallow_untyped_defs = True
+
+[mypy-qcodes.instrument_drivers.Keysight.Keysight_34460A_submodules.*]
+disallow_untyped_defs = True
+
+[mypy-qcodes.instrument_drivers.Keysight.Keysight_34461A_submodules.*]
+disallow_untyped_defs = True
+
+[mypy-qcodes.instrument_drivers.Keysight.Keysight_34465A_submodules.*]
+disallow_untyped_defs = True
+
+[mypy-qcodes.instrument_drivers.Keysight.Keysight_34470A_submodules.*]
+disallow_untyped_defs = True
+
+[mypy-qcodes.instrument_drivers.Keysight.Keysight_34480A_submodules.*]
+disallow_untyped_defs = True

--- a/qcodes/instrument_drivers/Keysight/Keysight_34410A_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_34410A_submodules.py
@@ -1,3 +1,4 @@
+from typing import Any
 from .private.Keysight_344xxA_submodules import _Keysight_344xxA
 
 
@@ -5,6 +6,6 @@ class Keysight_34410A(_Keysight_344xxA):
     """
     This is the qcodes driver for the Keysight 34410A Multimeter
     """
-    def __init__(self, name, address, silent=False,
-                 **kwargs):
+    def __init__(self, name: str, address: str, silent: bool = False,
+                 **kwargs: Any):
         super().__init__(name, address, silent, **kwargs)

--- a/qcodes/instrument_drivers/Keysight/Keysight_34460A_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_34460A_submodules.py
@@ -1,3 +1,4 @@
+from typing import Any
 from .private.Keysight_344xxA_submodules import _Keysight_344xxA
 
 
@@ -5,6 +6,6 @@ class Keysight_34460A(_Keysight_344xxA):
     """
     This is the qcodes driver for the Keysight 34460A Multimeter
     """
-    def __init__(self, name, address, silent=False,
-                 **kwargs):
+    def __init__(self, name: str, address: str, silent: bool = False,
+                 **kwargs: Any):
         super().__init__(name, address, silent, **kwargs)

--- a/qcodes/instrument_drivers/Keysight/Keysight_34461A_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_34461A_submodules.py
@@ -1,3 +1,4 @@
+from typing import Any
 from .private.Keysight_344xxA_submodules import _Keysight_344xxA
 
 
@@ -5,6 +6,6 @@ class Keysight_34461A(_Keysight_344xxA):
     """
     This is the qcodes driver for the Keysight 34461A Multimeter
     """
-    def __init__(self, name, address, silent=False,
-                 **kwargs):
+    def __init__(self, name: str, address: str, silent: bool = False,
+                 **kwargs: Any):
         super().__init__(name, address, silent, **kwargs)

--- a/qcodes/instrument_drivers/Keysight/Keysight_34465A_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_34465A_submodules.py
@@ -1,3 +1,4 @@
+from typing import Any
 from .private.Keysight_344xxA_submodules import _Keysight_344xxA
 
 
@@ -5,6 +6,6 @@ class Keysight_34465A(_Keysight_344xxA):
     """
     This is the qcodes driver for the Keysight 34465A Multimeter
     """
-    def __init__(self, name, address, silent=False,
-                 **kwargs):
+    def __init__(self, name: str, address: str, silent: bool = False,
+                 **kwargs: Any):
         super().__init__(name, address, silent, **kwargs)

--- a/qcodes/instrument_drivers/Keysight/Keysight_34470A_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_34470A_submodules.py
@@ -1,3 +1,4 @@
+from typing import Any
 from .private.Keysight_344xxA_submodules import _Keysight_344xxA
 
 
@@ -5,6 +6,6 @@ class Keysight_34470A(_Keysight_344xxA):
     """
     This is the qcodes driver for the Keysight 34470A Multimeter
     """
-    def __init__(self, name, address, silent=False,
-                 **kwargs):
+    def __init__(self, name: str, address: str, silent: bool = False,
+                 **kwargs: Any):
         super().__init__(name, address, silent, **kwargs)

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -1,7 +1,7 @@
 import textwrap
 from contextlib import ExitStack
 from functools import partial
-from typing import Sequence, Tuple
+from typing import Sequence, Tuple, Any
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -17,7 +17,7 @@ from qcodes.instrument.base import Instrument
 class Trigger(InstrumentChannel):
     """Implements triggering parameters and methods of Keysight 344xxA."""
 
-    def __init__(self, parent: '_Keysight_344xxA', name: str, **kwargs):
+    def __init__(self, parent: '_Keysight_344xxA', name: str, **kwargs: Any):
         super(Trigger, self).__init__(parent, name, **kwargs)
 
         if self.parent.is_34465A_34470A:
@@ -147,7 +147,7 @@ class Trigger(InstrumentChannel):
 class Sample(InstrumentChannel):
     """Implements sampling parameters of Keysight 344xxA."""
 
-    def __init__(self, parent: '_Keysight_344xxA', name: str, **kwargs):
+    def __init__(self, parent: '_Keysight_344xxA', name: str, **kwargs: Any):
         super(Sample, self).__init__(parent, name, **kwargs)
 
         if self.parent.is_34465A_34470A:
@@ -262,7 +262,7 @@ class Sample(InstrumentChannel):
 class Display(InstrumentChannel):
     """Implements interaction with the display of Keysight 344xxA."""
 
-    def __init__(self, parent: '_Keysight_344xxA', name: str, **kwargs):
+    def __init__(self, parent: '_Keysight_344xxA', name: str, **kwargs: Any):
         super(Display, self).__init__(parent, name, **kwargs)
 
         self.add_parameter('enabled',
@@ -310,7 +310,7 @@ class TimeTrace(ParameterWithSetpoints): # pylint: disable=abstract-method
     intervals
     """
 
-    def __init__(self, name: str, instrument: Instrument, **kwargs):
+    def __init__(self, name: str, instrument: Instrument, **kwargs: Any):
 
         self.instrument: Instrument  # needed for mypy
         super().__init__(name=name, instrument=instrument, **kwargs)
@@ -433,7 +433,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
     """
 
     def __init__(self, name: str, address: str, silent: bool = False,
-                 **kwargs):
+                 **kwargs: Any):
         """
         Create an instance of the instrument.
 
@@ -874,7 +874,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
         if self.is_34465A_34470A:
             self.aperture_mode.get()
 
-    def _set_range(self, value: float):
+    def _set_range(self, value: float) -> None:
         self.write(f'SENSe:VOLTage:DC:RANGe {value:f}')
 
         # resolution settings change with range


### PR DESCRIPTION
These simply match the types in the base class. So it seems like a good idea to add them to ensure that the end user can get type checking