### PR TITLE
Keysight B1500: Coerce nplc to integer

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
@@ -138,7 +138,7 @@ class KeysightB1500(VisaInstrument):
     def _setup_integration_time(self,
                                 adc_type: constants.AIT.Type,
                                 mode: Union[constants.AIT.Mode, int],
-                                coeff: Optional[Union[int, float]] = None
+                                coeff: Optional[int] = None
                                 ) -> None:
         """See :meth:`MessageBuilder.ait` for information"""
         self.write(MessageBuilder()
@@ -147,7 +147,7 @@ class KeysightB1500(VisaInstrument):
                    )
 
     def use_nplc_for_high_speed_adc(
-            self, n: Optional[Union[int, float]] = None) -> None:
+            self, n: Optional[int = None) -> None:
         """
         Set the high-speed ADC to NPLC mode, with optionally defining number
         of averaging samples via argument `n`.
@@ -163,16 +163,17 @@ class KeysightB1500(VisaInstrument):
                 The Keysight B1500 gets 128 samples in a power line cycle,
                 repeats this for the times you specify, and performs
                 averaging to get the measurement data. (For more info see
-                Table 4-21.)
+                Table 4-21.).  Note that the integration time will not be
+                updated if a non-integer value is written to the B1500.
         """
         self._setup_integration_time(
             adc_type=constants.AIT.Type.HIGH_SPEED,
             mode=constants.AIT.Mode.NPLC,
-            coeff=n
+            coeff=int(n)
         )
 
     def use_nplc_for_high_resolution_adc(
-            self, n: Optional[Union[int, float]] = None) -> None:
+            self, n: Optional[int] = None) -> None:
         """
         Set the high-resolution ADC to NPLC mode, with optionally defining
         the number of PLCs per sample via argument `n`.
@@ -184,12 +185,14 @@ class KeysightB1500(VisaInstrument):
                 ``Integration time = n / power line frequency``.
 
                 n=1 to 100. Default setting is 1 (if `None` is passed).
-                (For more info see Table 4-21.)
+                (For more info see Table 4-21.).  Note that the integration
+                time will not be updated if a non-integer value is written
+                to the B1500.
         """
         self._setup_integration_time(
             adc_type=constants.AIT.Type.HIGH_RESOLUTION,
             mode=constants.AIT.Mode.NPLC,
-            coeff=n
+            coeff=int(n)
         )
 
     def use_manual_mode_for_high_speed_adc(

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
@@ -198,7 +198,7 @@ class KeysightB1500(VisaInstrument):
         )
 
     def use_manual_mode_for_high_speed_adc(
-            self, n: Optional[Union[int, float]] = None) -> None:
+            self, n: Optional[int] = None) -> None:
         """
         Set the high-speed ADC to manual mode, with optionally defining number
         of averaging samples via argument `n`.
@@ -209,6 +209,8 @@ class KeysightB1500(VisaInstrument):
         Args:
             n: Number of averaging samples, between 1 and 1023. Default
                 setting is 1. (For more info see Table 4-21.)
+                Note that the integration time will not be updated
+                if a non-integer value is written to the B1500.
         """
         self._setup_integration_time(
             adc_type=constants.AIT.Type.HIGH_SPEED,

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
@@ -149,7 +149,7 @@ class KeysightB1500(VisaInstrument):
                    )
 
     def use_nplc_for_high_speed_adc(
-            self, n: Optional[int = None) -> None:
+            self, n: Optional[int] = None) -> None:
         """
         Set the high-speed ADC to NPLC mode, with optionally defining number
         of averaging samples via argument `n`.

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
@@ -141,6 +141,8 @@ class KeysightB1500(VisaInstrument):
                                 coeff: Optional[int] = None
                                 ) -> None:
         """See :meth:`MessageBuilder.ait` for information"""
+        if coeff is not None:
+            coeff = int(coeff)
         self.write(MessageBuilder()
                    .ait(adc_type=adc_type, mode=mode, coeff=coeff)
                    .message
@@ -169,7 +171,7 @@ class KeysightB1500(VisaInstrument):
         self._setup_integration_time(
             adc_type=constants.AIT.Type.HIGH_SPEED,
             mode=constants.AIT.Mode.NPLC,
-            coeff=int(n)
+            coeff=n
         )
 
     def use_nplc_for_high_resolution_adc(
@@ -192,7 +194,7 @@ class KeysightB1500(VisaInstrument):
         self._setup_integration_time(
             adc_type=constants.AIT.Type.HIGH_RESOLUTION,
             mode=constants.AIT.Mode.NPLC,
-            coeff=int(n)
+            coeff=n
         )
 
     def use_manual_mode_for_high_speed_adc(


### PR DESCRIPTION
Coerce coefficient for nplc settings to int.  B1500 does not update integration time if it receives a non-int value.

@astafan8