### PR TITLE
Use pytest fixtures for tmp dir creation in tests

### DIFF
--- a/qcodes/tests/dataset/temporary_databases.py
+++ b/qcodes/tests/dataset/temporary_databases.py
@@ -1,3 +1,4 @@
+import tempfile
 import gc
 import os
 from contextlib import contextmanager
@@ -111,13 +112,14 @@ def temporarily_copied_DB(tmp_path, filepath: str, **kwargs):
     Kwargs:
         kwargs to be passed to connect
     """
-    dbname_new = str(tmp_path / 'temp.db')
-    shutil.copy2(filepath, dbname_new)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dbname_new = os.path.join(tmpdir, 'temp.db')
+        shutil.copy2(filepath, dbname_new)
 
-    conn = connect(dbname_new, **kwargs)
+        conn = connect(dbname_new, **kwargs)
 
-    try:
-        yield conn
+        try:
+            yield conn
 
-    finally:
-        conn.close()
+        finally:
+            conn.close()

--- a/qcodes/tests/dataset/temporary_databases.py
+++ b/qcodes/tests/dataset/temporary_databases.py
@@ -1,4 +1,3 @@
-import tempfile
 import gc
 import os
 from contextlib import contextmanager
@@ -15,71 +14,69 @@ n_experiments = 0
 
 
 @pytest.fixture(scope="function")
-def empty_temp_db():
+def empty_temp_db(tmp_path):
     global n_experiments
     n_experiments = 0
     # create a temp database for testing
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        try:
-            qc.config["core"]["db_location"] = \
-                os.path.join(tmpdirname, 'temp.db')
-            if os.environ.get('QCODES_SQL_DEBUG'):
-                qc.config["core"]["db_debug"] = True
-            else:
-                qc.config["core"]["db_debug"] = False
-            initialise_database()
-            yield
-        finally:
-            # there is a very real chance that the tests will leave open
-            # connections to the database. These will have gone out of scope at
-            # this stage but a gc collection may not have run. The gc
-            # collection ensures that all connections belonging to now out of
-            # scope objects will be closed
-            gc.collect()
+    try:
+        qc.config["core"]["db_location"] = \
+            str(tmp_path / 'temp.db')
+        if os.environ.get('QCODES_SQL_DEBUG'):
+            qc.config["core"]["db_debug"] = True
+        else:
+            qc.config["core"]["db_debug"] = False
+        initialise_database()
+        yield
+    finally:
+        # there is a very real chance that the tests will leave open
+        # connections to the database. These will have gone out of scope at
+        # this stage but a gc collection may not have run. The gc
+        # collection ensures that all connections belonging to now out of
+        # scope objects will be closed
+        gc.collect()
 
 
 @pytest.fixture(scope='function')
-def empty_temp_db_connection():
+def empty_temp_db_connection(tmp_path):
     """
     Yield connection to an empty temporary DB file.
     """
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        path = os.path.join(tmpdirname, 'source.db')
-        conn = connect(path)
-        try:
-            yield conn
-        finally:
-            conn.close()
-            # there is a very real chance that the tests will leave open
-            # connections to the database. These will have gone out of scope at
-            # this stage but a gc collection may not have run. The gc
-            # collection ensures that all connections belonging to now out of
-            # scope objects will be closed
-            gc.collect()
+    path = str(tmp_path / 'source.db')
+    conn = connect(path)
+    try:
+        yield conn
+    finally:
+        conn.close()
+        # there is a very real chance that the tests will leave open
+        # connections to the database. These will have gone out of scope at
+        # this stage but a gc collection may not have run. The gc
+        # collection ensures that all connections belonging to now out of
+        # scope objects will be closed
+        gc.collect()
 
 
 @pytest.fixture(scope='function')
-def two_empty_temp_db_connections():
+def two_empty_temp_db_connections(tmp_path):
     """
     Yield connections to two empty files. Meant for use with the
     test_database_extract_runs
     """
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        source_path = os.path.join(tmpdirname, 'source.db')
-        target_path = os.path.join(tmpdirname, 'target.db')
-        source_conn = connect(source_path)
-        target_conn = connect(target_path)
-        try:
-            yield (source_conn, target_conn)
-        finally:
-            source_conn.close()
-            target_conn.close()
-            # there is a very real chance that the tests will leave open
-            # connections to the database. These will have gone out of scope at
-            # this stage but a gc collection may not have run. The gc
-            # collection ensures that all connections belonging to now out of
-            # scope objects will be closed
-            gc.collect()
+
+    source_path = str(tmp_path / 'source.db')
+    target_path = str(tmp_path / 'target.db')
+    source_conn = connect(source_path)
+    target_conn = connect(target_path)
+    try:
+        yield (source_conn, target_conn)
+    finally:
+        source_conn.close()
+        target_conn.close()
+        # there is a very real chance that the tests will leave open
+        # connections to the database. These will have gone out of scope at
+        # this stage but a gc collection may not have run. The gc
+        # collection ensures that all connections belonging to now out of
+        # scope objects will be closed
+        gc.collect()
 
 
 @pytest.fixture(scope='function')
@@ -102,7 +99,7 @@ def dataset(experiment):
 
 
 @contextmanager
-def temporarily_copied_DB(filepath: str, **kwargs):
+def temporarily_copied_DB(tmp_path, filepath: str, **kwargs):
     """
     Make a temporary copy of a db-file and delete it after use. Meant to be
     used together with the old version database fixtures, lest we change the
@@ -114,14 +111,13 @@ def temporarily_copied_DB(filepath: str, **kwargs):
     Kwargs:
         kwargs to be passed to connect
     """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        dbname_new = os.path.join(tmpdir, 'temp.db')
-        shutil.copy2(filepath, dbname_new)
+    dbname_new = str(tmp_path / 'temp.db')
+    shutil.copy2(filepath, dbname_new)
 
-        conn = connect(dbname_new, **kwargs)
+    conn = connect(dbname_new, **kwargs)
 
-        try:
-            yield conn
+    try:
+        yield conn
 
-        finally:
-            conn.close()
+    finally:
+        conn.close()

--- a/qcodes/tests/dataset/temporary_databases.py
+++ b/qcodes/tests/dataset/temporary_databases.py
@@ -100,7 +100,7 @@ def dataset(experiment):
 
 
 @contextmanager
-def temporarily_copied_DB(tmp_path, filepath: str, **kwargs):
+def temporarily_copied_DB(filepath: str, **kwargs):
     """
     Make a temporary copy of a db-file and delete it after use. Meant to be
     used together with the old version database fixtures, lest we change the

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import tempfile
 from contextlib import contextmanager
 from copy import deepcopy
 
@@ -90,37 +89,35 @@ def test_tables_exist(empty_temp_db, version):
     conn.close()
 
 
-def test_initialise_database_at_for_nonexisting_db():
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        db_location = os.path.join(tmpdirname, 'temp.db')
-        assert not os.path.exists(db_location)
+def test_initialise_database_at_for_nonexisting_db(tmp_path):
+    db_location = str(tmp_path / 'temp.db')
+    assert not os.path.exists(db_location)
 
-        initialise_or_create_database_at(db_location)
+    initialise_or_create_database_at(db_location)
 
-        assert os.path.exists(db_location)
-        assert qc.config["core"]["db_location"] == db_location
+    assert os.path.exists(db_location)
+    assert qc.config["core"]["db_location"] == db_location
 
 
-def test_initialise_database_at_for_existing_db():
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        # Define DB location
-        db_location = os.path.join(tmpdirname, 'temp.db')
-        assert not os.path.exists(db_location)
+def test_initialise_database_at_for_existing_db(tmp_path):
+    # Define DB location
+    db_location = str(tmp_path / 'temp.db')
+    assert not os.path.exists(db_location)
 
-        # Create DB file
-        qc.config["core"]["db_location"] = db_location
-        initialise_database()
+    # Create DB file
+    qc.config["core"]["db_location"] = db_location
+    initialise_database()
 
-        # Check if it has been created correctly
-        assert os.path.exists(db_location)
-        assert qc.config["core"]["db_location"] == db_location
+    # Check if it has been created correctly
+    assert os.path.exists(db_location)
+    assert qc.config["core"]["db_location"] == db_location
 
-        # Call function under test
-        initialise_or_create_database_at(db_location)
+    # Call function under test
+    initialise_or_create_database_at(db_location)
 
-        # Check if the DB is still correct
-        assert os.path.exists(db_location)
-        assert qc.config["core"]["db_location"] == db_location
+    # Check if the DB is still correct
+    assert os.path.exists(db_location)
+    assert qc.config["core"]["db_location"] == db_location
 
 
 def test_perform_actual_upgrade_0_to_1():

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -4,7 +4,6 @@ import re
 from unittest.mock import patch
 import random
 from typing import Sequence, Dict, Tuple, Optional
-import tempfile
 import os
 
 import pytest
@@ -1213,7 +1212,7 @@ def limit_data_to_start_end(start, end, input_names, expected_names,
 
 
 @pytest.mark.usefixtures('experiment')
-def test_write_data_to_text_file_save():
+def test_write_data_to_text_file_save(tmp_path_factory):
     dataset = new_data_set("dataset")
     xparam = ParamSpecBase("x", 'numeric')
     yparam = ParamSpecBase("y", 'numeric')
@@ -1225,15 +1224,15 @@ def test_write_data_to_text_file_save():
     dataset.add_results(results)
     dataset.mark_completed()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        dataset.write_data_to_text_file(path=temp_dir)
-        assert os.listdir(temp_dir) == ['y.dat']
-        with open(temp_dir+"//y.dat") as f:
-            assert f.readlines() == ['0\t1\n']
+    path = str(tmp_path_factory.mktemp("write_data_to_text_file_save"))
+    dataset.write_data_to_text_file(path=path)
+    assert os.listdir(path) == ['y.dat']
+    with open(os.path.join(path, "y.dat")) as f:
+        assert f.readlines() == ['0\t1\n']
 
 
 @pytest.mark.usefixtures('experiment')
-def test_write_data_to_text_file_save_multi_keys():
+def test_write_data_to_text_file_save_multi_keys(tmp_path_factory):
     dataset = new_data_set("dataset")
     xparam = ParamSpecBase("x", 'numeric')
     yparam = ParamSpecBase("y", 'numeric')
@@ -1246,17 +1245,17 @@ def test_write_data_to_text_file_save_multi_keys():
     dataset.add_results(results)
     dataset.mark_completed()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        dataset.write_data_to_text_file(path=temp_dir)
-        assert sorted(os.listdir(temp_dir)) == ['y.dat', 'z.dat']
-        with open(temp_dir+"//y.dat") as f:
-            assert f.readlines() == ['0\t1\n']
-        with open(temp_dir+"//z.dat") as f:
-            assert f.readlines() == ['0\t2\n']
+    path = str(tmp_path_factory.mktemp("write_data_to_text_file_save_multi_keys"))
+    dataset.write_data_to_text_file(path=path)
+    assert sorted(os.listdir(path)) == ['y.dat', 'z.dat']
+    with open(path+"//y.dat") as f:
+        assert f.readlines() == ['0\t1\n']
+    with open(path+"//z.dat") as f:
+        assert f.readlines() == ['0\t2\n']
 
 
 @pytest.mark.usefixtures('experiment')
-def test_write_data_to_text_file_save_single_file():
+def test_write_data_to_text_file_save_single_file(tmp_path_factory):
     dataset = new_data_set("dataset")
     xparam = ParamSpecBase("x", 'numeric')
     yparam = ParamSpecBase("y", 'numeric')
@@ -1269,16 +1268,16 @@ def test_write_data_to_text_file_save_single_file():
     dataset.add_results(results)
     dataset.mark_completed()
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        dataset.write_data_to_text_file(path=temp_dir, single_file=True,
-                                           single_file_name='yz')
-        assert os.listdir(temp_dir) == ['yz.dat']
-        with open(temp_dir+"//yz.dat") as f:
-            assert f.readlines() == ['0\t1\t2\n']
+    path = str(tmp_path_factory.mktemp("write_data_to_text_file_save_single_file"))
+    dataset.write_data_to_text_file(path=path, single_file=True,
+                                    single_file_name='yz')
+    assert os.listdir(path) == ['yz.dat']
+    with open(path+"//yz.dat") as f:
+        assert f.readlines() == ['0\t1\t2\n']
 
 
 @pytest.mark.usefixtures('experiment')
-def test_write_data_to_text_file_length_exception():
+def test_write_data_to_text_file_length_exception(tmp_path):
     dataset = new_data_set("dataset")
     xparam = ParamSpecBase("x", 'numeric')
     yparam = ParamSpecBase("y", 'numeric')
@@ -1295,13 +1294,14 @@ def test_write_data_to_text_file_length_exception():
     dataset.add_results(results3)
     dataset.mark_completed()
 
-    with tempfile.TemporaryDirectory() as temp_dir, pytest.raises(Exception, match='different length'):
+    temp_dir = str(tmp_path)
+    with pytest.raises(Exception, match='different length'):
         dataset.write_data_to_text_file(path=temp_dir, single_file=True,
-                                           single_file_name='yz')
+                                        single_file_name='yz')
 
 
 @pytest.mark.usefixtures('experiment')
-def test_write_data_to_text_file_name_exception():
+def test_write_data_to_text_file_name_exception(tmp_path):
     dataset = new_data_set("dataset")
     xparam = ParamSpecBase("x", 'numeric')
     yparam = ParamSpecBase("y", 'numeric')
@@ -1314,6 +1314,7 @@ def test_write_data_to_text_file_name_exception():
     dataset.add_results(results)
     dataset.mark_completed()
 
-    with tempfile.TemporaryDirectory() as temp_dir, pytest.raises(Exception, match='desired file name'):
+    temp_dir = str(tmp_path)
+    with pytest.raises(Exception, match='desired file name'):
         dataset.write_data_to_text_file(path=temp_dir, single_file=True,
-                                           single_file_name=None)
+                                        single_file_name=None)

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1248,9 +1248,9 @@ def test_write_data_to_text_file_save_multi_keys(tmp_path_factory):
     path = str(tmp_path_factory.mktemp("write_data_to_text_file_save_multi_keys"))
     dataset.write_data_to_text_file(path=path)
     assert sorted(os.listdir(path)) == ['y.dat', 'z.dat']
-    with open(path+"//y.dat") as f:
+    with open(os.path.join(path, "y.dat")) as f:
         assert f.readlines() == ['0\t1\n']
-    with open(path+"//z.dat") as f:
+    with open(os.path.join(path, "z.dat")) as f:
         assert f.readlines() == ['0\t2\n']
 
 
@@ -1272,7 +1272,7 @@ def test_write_data_to_text_file_save_single_file(tmp_path_factory):
     dataset.write_data_to_text_file(path=path, single_file=True,
                                     single_file_name='yz')
     assert os.listdir(path) == ['yz.dat']
-    with open(path+"//yz.dat") as f:
+    with open(os.path.join(path, "yz.dat")) as f:
         assert f.readlines() == ['0\t1\t2\n']
 
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1243,8 +1243,8 @@ def test_write_data_to_text_file_save_multi_keys(tmp_path_factory):
     results = [{'x': 0, 'y': 1, 'z': 2}]
     dataset.add_results(results)
     dataset.mark_completed()
-
-    path = str(tmp_path_factory.mktemp("write_data_to_text_file_save_multi_keys"))
+    tmp_path = tmp_path_factory.mktemp("write_data_to_text_file_save_multi_keys")
+    path = str(tmp_path)
     dataset.write_data_to_text_file(path=path)
     assert sorted(os.listdir(path)) == ['y.dat', 'z.dat']
     with open(os.path.join(path, "y.dat")) as f:
@@ -1266,8 +1266,8 @@ def test_write_data_to_text_file_save_single_file(tmp_path_factory):
     results = [{'x': 0, 'y': 1, 'z': 2}]
     dataset.add_results(results)
     dataset.mark_completed()
-
-    path = str(tmp_path_factory.mktemp("write_data_to_text_file_save_single_file"))
+    tmp_path = tmp_path_factory.mktemp("to_text_file_save_single_file")
+    path = str(tmp_path)
     dataset.write_data_to_text_file(path=path, single_file=True,
                                     single_file_name='yz')
     assert os.listdir(path) == ['yz.dat']

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1243,7 +1243,7 @@ def test_write_data_to_text_file_save_multi_keys(tmp_path_factory):
     results = [{'x': 0, 'y': 1, 'z': 2}]
     dataset.add_results(results)
     dataset.mark_completed()
-    tmp_path = tmp_path_factory.mktemp("write_data_to_text_file_save_multi_keys")
+    tmp_path = tmp_path_factory.mktemp("data_to_text_file_save_multi_keys")
     path = str(tmp_path)
     dataset.write_data_to_text_file(path=path)
     assert sorted(os.listdir(path)) == ['y.dat', 'z.dat']

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -2,8 +2,6 @@
 # test the sqlite module, we mainly test exceptions and small helper
 # functions here
 from sqlite3 import OperationalError
-import tempfile
-import os
 from contextlib import contextmanager
 import time
 
@@ -54,15 +52,15 @@ def shadow_conn(path_to_db: str):
     conn.close()
 
 
-def test_path_to_dbfile():
-    with tempfile.TemporaryDirectory() as tempdir:
-        tempdb = os.path.join(tempdir, 'database.db')
-        conn = mut_db.connect(tempdb)
-        try:
-            assert path_to_dbfile(conn) == tempdb
-            assert conn.path_to_dbfile == tempdb
-        finally:
-            conn.close()
+def test_path_to_dbfile(tmp_path):
+
+    tempdb = str(tmp_path / 'database.db')
+    conn = mut_db.connect(tempdb)
+    try:
+        assert path_to_dbfile(conn) == tempdb
+        assert conn.path_to_dbfile == tempdb
+    finally:
+        conn.close()
 
 
 def test_one_raises(experiment):

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -194,7 +194,7 @@ def side_effect(map, name):
 
 
 @pytest.fixture(scope="function")
-def path_to_config_file_on_disk():
+def path_to_config_file_on_disk(tmp_path):
 
     contents = {
         "core": {
@@ -211,13 +211,12 @@ def path_to_config_file_on_disk():
         }  # we omit a non-required section (stationconfigurator)
     }
 
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        with open(os.path.join(tmpdirname, 'qcodesrc.json'), 'w') as f:
-            f.write(json.dumps(contents))
-        with open(os.path.join(tmpdirname, 'qcodesrc_schema.json'), 'w') as f:
-            f.write(json.dumps(SCHEMA))
+    with open(str(tmp_path / 'qcodesrc.json'), 'w') as f:
+        f.write(json.dumps(contents))
+    with open(str(tmp_path / 'qcodesrc_schema.json'), 'w') as f:
+        f.write(json.dumps(SCHEMA))
 
-        yield tmpdirname
+    yield str(tmp_path)
 
 
 class TestConfig(TestCase):

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -32,6 +32,7 @@ def use_default_config():
     with default_config():
         yield
 
+
 @pytest.fixture(autouse=True)
 def set_default_station_to_none():
     """Makes sure that after startup and teardown there is no default station"""
@@ -256,7 +257,6 @@ def test_update_config_schema():
     assert len(schema['definitions']['instruments']['enum']) > 1
 
 
-
 @contextmanager
 def config_file_context(file_content):
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -412,6 +412,7 @@ instruments:
     type: qcodes.tests.instrument_mocks.DummyInstrument
         """)
 
+
 def test_simple_mock_config(simple_mock_station):
     st = simple_mock_station
     assert station_config_has_been_loaded(st)
@@ -527,7 +528,6 @@ instruments:
     assert "TestGate" in mock.parameters.keys()
     assert len(mock.parameters) == 2  # there is also IDN
 
-
     # test address
     sims_path = get_qcodes_path('instrument', 'sims')
     st = station_from_config_str(f"""
@@ -585,6 +585,7 @@ instruments:
     assert mock.ch1() == 3
     assert p.raw_value == 7
     assert mock.ch1.raw_value == 7
+
 
 def test_setup_delegate_parameters():
     st = station_from_config_str("""
@@ -717,6 +718,7 @@ instruments:
                         ' to it')):
         st.load_instrument('mock')
 
+
 def test_deprecated_limits_keyword_as_string():
     st = station_from_config_str("""
 instruments:
@@ -758,6 +760,7 @@ invalid_keyword:
     """
         with config_file_context(test_config) as filename:
             Station(config_file=filename)
+
 
 def test_config_validation_comprehensive_config():
     Station(config_file=os.path.join(


### PR DESCRIPTION
This should prevent the unable to unlink tmpdir because pytest has a reference to it failures that we see from time to time. https://docs.pytest.org/en/latest/tmpdir.html#temporary-directories-and-files

There are 3 context managers that I have still not changed. These should probably eventually be rewritten as pytest fixtures. 

The pytest fixtures will only create one tmp_path pr test so in tests that requires 2 distinct directories I have used the factory functions to generate another one
