### PR TITLE
fix for slack module when a user has not send any messages

### DIFF
--- a/qcodes/tests/test_slack.py
+++ b/qcodes/tests/test_slack.py
@@ -4,51 +4,49 @@ from unittest.mock import patch, MagicMock
 
 class TestSlack(TestCase):
 
-
     def test_Slack(self):
 
-        slack_config = {'bot_name': 'test_bot', 'token': '123123', 'names': ['dummyuser']}    
+        slack_config = {'bot_name': 'test_bot', 'token': '123123', 'names': ['dummyuser']}
 
         mock_slacker_module = MagicMock(name='slacker_module')
         slacker_class_mock = MagicMock(name='SlackerMock')
         slacker_class_mock.users.get_user_id = MagicMock(return_value='bot_id')
         response = MagicMock()
-        response.body = {'members': [{'name':'dummyuser', 'id': '123'}] }
+        response.body = {'members': [{'name': 'dummyuser', 'id': '123'}]}
         slacker_class_mock.users.list = MagicMock(name='mock_users_list', return_value=response)
-        mock_slacker_module.Slacker = slacker_class_mock        
+        mock_slacker_module.Slacker = slacker_class_mock
         mock_slacker_module.Slacker = MagicMock(return_value=slacker_class_mock)
-        
+
         with patch.dict('sys.modules', slacker=mock_slacker_module):
-        
+
             from qcodes.utils.slack import Slack
-        
+
             slack = Slack(config=slack_config, auto_start=False)
-            
-
-            
-config = {'bot_name': 'test_bot', 'token': '123123', 'names': ['dummyuser']}    
 
 
-#%%
+config = {'bot_name': 'test_bot', 'token': '123123', 'names': ['dummyuser']}
+
+
+# %%
 mock_slacker_module = MagicMock(name='slacker_module')
 slacker_class_mock = MagicMock(name='SlackerMock')
 slacker_class_mock.users.get_user_id = MagicMock(return_value='bot_id')
 response = MagicMock()
-response.body = {'members': [{'name':'dummyuser', 'id': '123'}] }
+response.body = {'members': [{'name': 'dummyuser', 'id': '123'}]}
 slacker_class_mock.users.list = MagicMock(name='mock_users_list', return_value=response)
 mock_slacker_module.Slacker = slacker_class_mock
 
-r=slacker_class_mock.users.get_user_id()
+r = slacker_class_mock.users.get_user_id()
 print(r)
-r=slacker_class_mock.users.list()
+r = slacker_class_mock.users.list()
 print(r)
 
 mock_slacker_module.Slacker = MagicMock(return_value=slacker_class_mock)
 
-#%%
+# %%
 with patch.dict('sys.modules', slacker=mock_slacker_module):
 
-#with patch.object(slacker, 'Slacker', return_value=slacker_class_mock ) as slacker_mock:
+    # with patch.object(slacker, 'Slacker', return_value=slacker_class_mock ) as slacker_mock:
     #from slacker import Slacker
 
     from slacker import Slacker
@@ -58,10 +56,9 @@ with patch.dict('sys.modules', slacker=mock_slacker_module):
     slack.users.get_user_id('s')
     slack.users.list()
     #slack.get_users = get_users
-    
+
     print(slack)
-    
+
     slack = Slack(config=config, auto_start=False)
-    users = {'dummyuser':{'id': '123'}}
-    r=slack.get_im_ids(users)
-            
+    users = {'dummyuser': {'id': '123'}}
+    r = slack.get_im_ids(users)

--- a/qcodes/tests/test_slack.py
+++ b/qcodes/tests/test_slack.py
@@ -4,21 +4,21 @@ from unittest.mock import patch, MagicMock
 
 class TestSlack(TestCase):
 
-    def test_Slack(self):
+    def test_slack(self):
 
-        slack_config = {'bot_name': 'test_bot', 'token': '123123', 'names': ['dummyuser']}
+        slack_config = {'bot_name': 'bot', 'token': '123', 'names': ['dummyuser']}
 
         mock_slacker_module = MagicMock(name='slacker_module')
         slacker_class_mock = MagicMock(name='SlackerMock')
         slacker_class_mock.users.get_user_id = MagicMock(return_value='bot_id')
         response = MagicMock()
         response.body = {'members': [{'name': 'dummyuser', 'id': '123'}]}
-        slacker_class_mock.users.list = MagicMock(name='mock_users_list', return_value=response)
+        slacker_class_mock.users.list = MagicMock(name='mock_users_list',
+                                                  return_value=response)
         mock_slacker_module.Slacker = slacker_class_mock
         mock_slacker_module.Slacker = MagicMock(return_value=slacker_class_mock)
 
         with patch.dict('sys.modules', slacker=mock_slacker_module):
-
             from qcodes.utils.slack import Slack
 
             slack = Slack(config=slack_config, auto_start=False)

--- a/qcodes/tests/test_slack.py
+++ b/qcodes/tests/test_slack.py
@@ -22,43 +22,8 @@ class TestSlack(TestCase):
             from qcodes.utils.slack import Slack
 
             slack = Slack(config=slack_config, auto_start=False)
+            self.assertIn('dummyuser', slack.users)
 
 
-config = {'bot_name': 'test_bot', 'token': '123123', 'names': ['dummyuser']}
 
 
-# %%
-mock_slacker_module = MagicMock(name='slacker_module')
-slacker_class_mock = MagicMock(name='SlackerMock')
-slacker_class_mock.users.get_user_id = MagicMock(return_value='bot_id')
-response = MagicMock()
-response.body = {'members': [{'name': 'dummyuser', 'id': '123'}]}
-slacker_class_mock.users.list = MagicMock(name='mock_users_list', return_value=response)
-mock_slacker_module.Slacker = slacker_class_mock
-
-r = slacker_class_mock.users.get_user_id()
-print(r)
-r = slacker_class_mock.users.list()
-print(r)
-
-mock_slacker_module.Slacker = MagicMock(return_value=slacker_class_mock)
-
-# %%
-with patch.dict('sys.modules', slacker=mock_slacker_module):
-
-    # with patch.object(slacker, 'Slacker', return_value=slacker_class_mock ) as slacker_mock:
-    #from slacker import Slacker
-
-    from slacker import Slacker
-    from qcodes.utils.slack import Slack
-
-    slack = Slacker(config['token'])
-    slack.users.get_user_id('s')
-    slack.users.list()
-    #slack.get_users = get_users
-
-    print(slack)
-
-    slack = Slack(config=config, auto_start=False)
-    users = {'dummyuser': {'id': '123'}}
-    r = slack.get_im_ids(users)

--- a/qcodes/tests/test_slack.py
+++ b/qcodes/tests/test_slack.py
@@ -1,0 +1,67 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+
+class TestSlack(TestCase):
+
+
+    def test_Slack(self):
+
+        slack_config = {'bot_name': 'test_bot', 'token': '123123', 'names': ['dummyuser']}    
+
+        mock_slacker_module = MagicMock(name='slacker_module')
+        slacker_class_mock = MagicMock(name='SlackerMock')
+        slacker_class_mock.users.get_user_id = MagicMock(return_value='bot_id')
+        response = MagicMock()
+        response.body = {'members': [{'name':'dummyuser', 'id': '123'}] }
+        slacker_class_mock.users.list = MagicMock(name='mock_users_list', return_value=response)
+        mock_slacker_module.Slacker = slacker_class_mock        
+        mock_slacker_module.Slacker = MagicMock(return_value=slacker_class_mock)
+        
+        with patch.dict('sys.modules', slacker=mock_slacker_module):
+        
+            from qcodes.utils.slack import Slack
+        
+            slack = Slack(config=slack_config, auto_start=False)
+            
+
+            
+config = {'bot_name': 'test_bot', 'token': '123123', 'names': ['dummyuser']}    
+
+
+#%%
+mock_slacker_module = MagicMock(name='slacker_module')
+slacker_class_mock = MagicMock(name='SlackerMock')
+slacker_class_mock.users.get_user_id = MagicMock(return_value='bot_id')
+response = MagicMock()
+response.body = {'members': [{'name':'dummyuser', 'id': '123'}] }
+slacker_class_mock.users.list = MagicMock(name='mock_users_list', return_value=response)
+mock_slacker_module.Slacker = slacker_class_mock
+
+r=slacker_class_mock.users.get_user_id()
+print(r)
+r=slacker_class_mock.users.list()
+print(r)
+
+mock_slacker_module.Slacker = MagicMock(return_value=slacker_class_mock)
+
+#%%
+with patch.dict('sys.modules', slacker=mock_slacker_module):
+
+#with patch.object(slacker, 'Slacker', return_value=slacker_class_mock ) as slacker_mock:
+    #from slacker import Slacker
+
+    from slacker import Slacker
+    from qcodes.utils.slack import Slack
+
+    slack = Slacker(config['token'])
+    slack.users.get_user_id('s')
+    slack.users.list()
+    #slack.get_users = get_users
+    
+    print(slack)
+    
+    slack = Slack(config=config, auto_start=False)
+    users = {'dummyuser':{'id': '123'}}
+    r=slack.get_im_ids(users)
+            

--- a/qcodes/utils/slack.py
+++ b/qcodes/utils/slack.py
@@ -239,8 +239,11 @@ class Slack(threading.Thread):
             if user_id in im_ids:
                 users[username]['im_id'] = im_ids[user_id]
                 # update last ts
-                users[username]['last_ts'] = float(
-                    self.get_im_messages(username=username, count=1)[0]['ts'])
+                messages = self.get_im_messages(username=username, count=1)
+                if messages:
+                    users[username]['last_ts'] = float(messages[0]['ts'])
+                else:
+                    users[username]['last_ts'] = None
 
     def get_im_messages(self, username, **kwargs):
         """


### PR DESCRIPTION
The slack module generates an error when retreiving the latest timestamp if a user has not posted any messages. This PR assigns a None value in that case.

@astafan8 
