### PR TITLE
Add get_cmd for voltage_dc, voltage_ac and frequency in KeysightB1520A

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -76,7 +76,7 @@ _pattern_lrn = re.compile(
 )
 
 
-def parse_dcv_measurement_response(response: str) -> dict:
+def parse_dcv_measurement_response(response: str) -> Dict[str, Union[str, float]]:
     """
     Extract status, channel number, value  and accompanying metadata from
     the string and return them as a dictionary.

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -68,6 +68,32 @@ def parse_module_query_response(response: str) -> Dict[SlotNr, str]:
     }
 
 
+# pattern to match dcv experiment
+_pattern_lrn = re.compile(
+    r"(?P<status_dc>\w{1,3})(?P<chnr_dc>\w),(?P<voltage_dc>\d{1,3}.\d{1,4});"
+    r"(?P<status_ac>\w{1,3})(?P<chnr_ac>\w),(?P<voltage_ac>\d{1,3}.\d{1,4});"
+    r"(?P<status_fc>\w{1,2})(?P<chnr_fc>\w),(?P<frequency>\d{1,6}.\d{1,4})"
+)
+
+
+def parse_dcv_measurement_response(response: str) -> dict:
+    """
+    Extract status, channel number, value  and accompanying metadata from
+    the string and return them as a dictionary.
+
+    Args:
+        response: Response str to *LRN? measurement query For the MFCMU.
+    """
+
+    match = re.match(_pattern_lrn, response)
+    if match is None:
+        raise ValueError(f"{response!r} didn't match {_pattern_lrn!r} pattern")
+
+    dd = match.groupdict()
+    d = cast(Dict[str, Union[str, float]], dd)
+    return d
+
+
 # Pattern to match the spot measurement response against
 _pattern = re.compile(
     r"((?P<status>\w)(?P<chnr>\w)(?P<dtype>\w))?"

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -222,6 +222,6 @@ class B1500Module(InstrumentChannel):
         activated_channels = re.sub(r"[^,\d]", "", response).split(",")
 
         is_enabled = set(self.channels).issubset(
-            int(x) for x in activated_channels
+            int(x) for x in activated_channels if x is not ''
         )
         return is_enabled

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -76,7 +76,8 @@ _pattern_lrn = re.compile(
 )
 
 
-def parse_dcv_measurement_response(response: str) -> Dict[str, Union[str, float]]:
+def parse_dcv_measurement_response(response: str) -> Dict[str, Union[str,
+                                                                     float]]:
     """
     Extract status, channel number, value  and accompanying metadata from
     the string and return them as a dictionary.

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -82,7 +82,7 @@ def parse_dcv_measurement_response(response: str) -> dict:
     the string and return them as a dictionary.
 
     Args:
-        response: Response str to *LRN? measurement query For the MFCMU.
+        response: Response str to lrn_query For the MFCMU.
     """
 
     match = re.match(_pattern_lrn, response)

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -1,6 +1,6 @@
 import re
 import textwrap
-from typing import Optional, TYPE_CHECKING, Tuple, Union
+from typing import Optional, TYPE_CHECKING, Tuple, Union, Dict
 
 from qcodes.instrument.channel import InstrumentChannel
 
@@ -92,12 +92,14 @@ class B1520A(B1500Module):
 
         self.write(msg.message)
 
-    def _get_dcv(self):
-        if self.is_enabled():
-            msg = MessageBuilder().lrn_query(self.channels[0])
-            response = self.ask(msg.message)
-            d = parse_dcv_measurement_response(response)
-        return d or None
+    def _get_dcv(self) -> Dict[str, Union[str, float]]:
+        if not self.is_enabled():
+            raise RuntimeError("The channels are disabled. Cannot get value.")
+
+        msg = MessageBuilder().lrn_query(self.channels[0])
+        response = self.ask(msg.message)
+        d = parse_dcv_measurement_response(response)
+        return d
 
     def _get_voltage_dc(self) -> Optional[float]:
         return float(self._get_dcv()['voltage_dc'])

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -97,7 +97,7 @@ class B1520A(B1500Module):
             msg = MessageBuilder().lrn_query(self.channels[0])
             response = self.ask(msg.message)
             d = parse_dcv_measurement_response(response)
-            return d
+        return d or None
 
     def _get_voltage_dc(self) -> Optional[float]:
         return float(self._get_dcv()['voltage_dc'])

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -101,14 +101,17 @@ class B1520A(B1500Module):
         d = parse_dcv_measurement_response(response)
         return d
 
-    def _get_voltage_dc(self) -> Optional[float]:
-        return float(self._get_dcv()['voltage_dc'])
+    def _get_voltage_dc(self) -> float:
+        dcv = self._get_dcv()
+        return float(dcv['voltage_dc'])
 
-    def _get_voltage_ac(self) -> Optional[float]:
-        return float(self._get_dcv()['voltage_ac'])
+    def _get_voltage_ac(self) -> float:
+        dcv = self._get_dcv()
+        return float(dcv['voltage_ac'])
 
-    def _get_frequency(self) -> Optional[float]:
-        return float(self._get_dcv()['frequency'])
+    def _get_frequency(self) -> float:
+        dcv = self._get_dcv()
+        return float(dcv['frequency'])
 
     def _set_frequency(self, value: float) -> None:
         msg = MessageBuilder().fc(self.channels[0], value)

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -5,7 +5,7 @@ from typing import Optional, TYPE_CHECKING, Tuple, Union
 from qcodes.instrument.channel import InstrumentChannel
 
 from .KeysightB1500_module import B1500Module, parse_dcorr_query_response, \
-    format_dcorr_response, _DCORRResponse
+    format_dcorr_response, _DCORRResponse, parse_dcv_measurement_response
 from .message_builder import MessageBuilder
 from . import constants
 from .constants import ModuleKind, ChNr
@@ -40,17 +40,20 @@ class B1520A(B1500Module):
 
         self.channels = (ChNr(slot_nr),)
 
-        self.add_parameter(
-            name="voltage_dc", set_cmd=self._set_voltage_dc, get_cmd=None
-        )
+        self.add_parameter(name="voltage_dc",
+                           set_cmd=self._set_voltage_dc,
+                           get_cmd=self._get_voltage_dc
+                           )
 
-        self.add_parameter(
-            name="voltage_ac", set_cmd=self._set_voltage_ac, get_cmd=None
-        )
+        self.add_parameter(name="voltage_ac",
+                           set_cmd=self._set_voltage_ac,
+                           get_cmd=self._get_voltage_ac
+                           )
 
-        self.add_parameter(
-            name="frequency", set_cmd=self._set_frequency, get_cmd=None
-        )
+        self.add_parameter(name="frequency",
+                           set_cmd=self._set_frequency,
+                           get_cmd=self._get_frequency
+                           )
 
         self.add_parameter(name="capacitance",
                            get_cmd=self._get_capacitance,
@@ -88,6 +91,22 @@ class B1520A(B1500Module):
         msg = MessageBuilder().acv(self.channels[0], value)
 
         self.write(msg.message)
+
+    def _get_dcv(self):
+        if self.is_enabled():
+            msg = MessageBuilder().lrn_query(self.channels[0])
+            response = self.ask(msg.message)
+            d = parse_dcv_measurement_response(response)
+            return d
+
+    def _get_voltage_dc(self) -> Optional[float]:
+        return float(self._get_dcv()['voltage_dc'])
+
+    def _get_voltage_ac(self) -> Optional[float]:
+        return float(self._get_dcv()['voltage_ac'])
+
+    def _get_frequency(self) -> Optional[float]:
+        return float(self._get_dcv()['frequency'])
 
     def _set_frequency(self, value: float) -> None:
         msg = MessageBuilder().fc(self.channels[0], value)

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
@@ -23,6 +23,11 @@ def test_is_enabled():
     assert not smu.is_enabled()
     mainframe.ask.assert_called_once_with('*LRN? 0')
 
+    mainframe.reset_mock(return_value=True)
+    mainframe.ask.return_value = 'CN'
+    assert not smu.is_enabled()
+    mainframe.ask.assert_called_once_with('*LRN? 0')
+
 
 def test_enable_outputs():
     mainframe = MagicMock()

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
@@ -43,6 +43,57 @@ def test_set_ac_frequency(cmu):
     mainframe.write.assert_called_once_with('FC 3,100000.0')
 
 
+def test_get_dc_voltage(cmu):
+    mainframe = cmu.parent
+    mainframe.ask.return_value = 'DCV3,0.000;ACV3,0.0;FC3,1000.000'
+    response = cmu.voltage_dc()
+    assert response == 0.0
+
+    mainframe.reset_mock()
+    mainframe.ask.return_value = 'DCV3,0.001;ACV3,0.0;FC3,1000.000'
+    response = cmu.voltage_dc()
+    assert response == 0.001
+
+    mainframe.reset_mock()
+    mainframe.ask.return_value = 'DCV3,13.051;ACV3,0.0;FC3,1000.000'
+    response = cmu.voltage_dc()
+    assert response == 13.051
+
+
+def test_get_ac_voltage(cmu):
+    mainframe = cmu.parent
+    mainframe.ask.return_value = 'DCV3,0.000;ACV3,0.000;FC3,1000.000'
+    response = cmu.voltage_ac()
+    assert response == 0.0
+
+    mainframe.reset_mock()
+    mainframe.ask.return_value = 'DCV3,0.001;ACV3,0.01;FC3,1000.000'
+    response = cmu.voltage_ac()
+    assert response == 0.01
+
+    mainframe.reset_mock()
+    mainframe.ask.return_value = 'DCV3,13.051;ACV3,3.045;FC3,1000.000'
+    response = cmu.voltage_ac()
+    assert response == 3.045
+
+
+def test_get_frequency(cmu):
+    mainframe = cmu.parent
+    mainframe.ask.return_value = 'DCV3,0.000;ACV3,0.000;FC3,100000.000'
+    response = cmu.frequency()
+    assert response == 100000.0
+
+    mainframe.reset_mock()
+    mainframe.ask.return_value = 'DCV3,0.001;ACV3,0.01;FC3,1000.033'
+    response = cmu.frequency()
+    assert response == 1000.033
+
+    mainframe.reset_mock()
+    mainframe.ask.return_value = 'DCV3,13.051;ACV3,3.045;FC3,1540.40'
+    response = cmu.frequency()
+    assert response == 1540.40
+
+
 def test_get_capacitance(cmu):
     mainframe = cmu.parent
 

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
@@ -7,6 +7,8 @@ from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1520A import \
     B1520A
 
 
+# pylint: disable=redefined-outer-name
+
 @pytest.fixture
 def mainframe():
     yield MagicMock()


### PR DESCRIPTION
This PR fixes following 2 issues:
1) is_enabled functions was giving error when called before enabling channels. This is fixed by checking if activated_channels is not empty string. 
2) Adds get_cmd to voltage_dc, voltage_ac, frequency

The above two fixes allows user to use the `step` attribute of the parameter to slowly raise/decrease a parameter. Before these fixes the user was getting warning that parameter is jumping to designated value because starting value of the parameter is not found is there was no get_cmd available. 

@astafan8 @jenshnielsen 