### PR TITLE
Add schedule for nightly runs at Azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,10 +25,10 @@ pr:
 schedules:
   - cron: "0 0 * * *"
     displayName: Daily midnight build
-      branches:
-        include:
-          - master
-          - release/*
+    branches:
+      include:
+        - master
+        - release/*
 
 jobs:
   - job: "run_the_tests"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,14 @@ pr:
     include:
       - '*' # workaround for missing trigger. Should be same as default
 
+schedules:
+  - cron: "0 0 * * *"
+    displayName: Daily midnight build
+      branches:
+        include:
+          - master
+          - release/*
+
 jobs:
   - job: "run_the_tests"
     strategy:


### PR DESCRIPTION
This PR introduces Nightly runs for CI at Azure pipelines. Currently it is configured to run exactly at midnight and to run for branches `master` and `releases`. Please let me know if you would like to have a different config.

@jenshnielsen 
