### PR TITLE
Delegateparam ensure that cache matches source parameter

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1235,9 +1235,7 @@ class DelegateParameter(Parameter):
 
     class _DelegateCache:
         def __init__(self,
-                     source: _BaseParameter,
-                     parameter: _BaseParameter):
-            self._source = source
+                     parameter: 'DelegateParameter'):
             self._parameter = parameter
 
         @property
@@ -1253,7 +1251,7 @@ class DelegateParameter(Parameter):
             This bug will not be fixed since the `raw_value` property will be
             removed soon.
             """
-            return self._source.cache._value
+            return self._parameter.source.cache._value
 
         @property
         def _value(self) -> ParamDataType:
@@ -1261,19 +1259,19 @@ class DelegateParameter(Parameter):
 
         @property
         def max_val_age(self) -> Optional[float]:
-            return self._source.cache.max_val_age
+            return self._parameter.source.cache.max_val_age
 
         @property
         def timestamp(self) -> Optional[datetime]:
-            return self._source.cache.timestamp
+            return self._parameter.source.cache.timestamp
 
         def get(self, get_if_invalid: bool = True) -> ParamDataType:
             return self._parameter._from_raw_value_to_value(
-                self._source.cache.get(get_if_invalid=get_if_invalid))
+                self._parameter.source.cache.get(get_if_invalid=get_if_invalid))
 
         def set(self, value: ParamDataType) -> None:
             self._parameter.validate(value)
-            self._source.cache.set(
+            self._parameter.source.cache.set(
                 self._parameter._from_value_to_raw_value(value))
 
         def _update_with(self, *,
@@ -1309,7 +1307,7 @@ class DelegateParameter(Parameter):
                                f'source parameter is supposed to be used.')
 
         super().__init__(name, *args, **kwargs)
-        delegate_cache = self._DelegateCache(source, self)
+        delegate_cache = self._DelegateCache(self)
         self.cache = cast(_Cache, delegate_cache)
 
     # Disable the warnings until MultiParameter has been

--- a/qcodes/tests/test_delegate_parameter.py
+++ b/qcodes/tests/test_delegate_parameter.py
@@ -252,6 +252,7 @@ def test_delegate_parameter_get_and_snapshot_raises_with_none():
         delegate_param.get()
     with pytest.raises(TypeError):
         delegate_param.snapshot()
+    assert delegate_param.cache._parameter.source.cache is none_param.cache
     delegate_param.source = source_param
     assert delegate_param.get() == 1
     assert delegate_param.snapshot()['value'] == 1

--- a/qcodes/tests/test_delegate_parameter.py
+++ b/qcodes/tests/test_delegate_parameter.py
@@ -237,6 +237,27 @@ def test_delegate_get_updates_cache(make_observable_parameter, numeric_val):
     assert t.get_instr_val() == initial_value
 
 
+def test_delegate_parameter_get_and_snapshot_raises_with_none():
+    """
+    Test that a delegate parameter raises on get and snapshot if
+    the source has a value of None and a scale is used.
+    But works correctly if the source is remapped to a real parameter.
+
+    """
+    none_param = Parameter("None")
+    source_param = Parameter('source', get_cmd=None, set_cmd=None, initial_value=2)
+    delegate_param = DelegateParameter(name='delegate', source=none_param)
+    delegate_param.scale = 2
+    with pytest.raises(TypeError):
+        delegate_param.get()
+    with pytest.raises(TypeError):
+        delegate_param.snapshot()
+    delegate_param.source = source_param
+    assert delegate_param.get() == 1
+    assert delegate_param.snapshot()['value'] == 1
+    assert delegate_param.cache._parameter.source.cache is source_param.cache
+
+
 class RawValueTests:  # pylint: disable=no-self-use
     """
     The :attr:`raw_value` will be deprecated soon,


### PR DESCRIPTION
Otherwise issues may arise if the source is remapped