### PR TITLE
Refactor parameter cache.get

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1898,33 +1898,33 @@ class _Cache:
         if cache_valid:
             return self._value
         else:
-            if gettable:
-                if get_if_invalid:
+            if get_if_invalid:
+                if gettable:
                     return self._parameter.get()
-                else:  # invalid cache but not allowed to update
-                    # TODO this will silently return a not up to date value
-                    # is that really what we want? It seems like this should
-                    # at least be a warning.
-                    return self._value
-            else:  # invalid cache but cannot update
-                if self._timestamp is None:
-                    raise RuntimeError(f"Value of parameter "
-                                       f"{(self._parameter.full_name)} "
-                                       f"is unknown and the Parameter does "
-                                       f"not have a get command. "
-                                       f"Please set the value before "
-                                       f"attempting to get it.")
-                elif self._max_val_age is not None:
-                    # TODO: this check should really be at the time of setting
-                    #  max_val_age unfortunately this happens in init before
-                    #  get wrapping is performed.
-                    raise RuntimeError("`max_val_age` is not supported for a "
-                                       "parameter without get command.")
                 else:
-                    # max_val_age is None and TS is not None but cache is invalid
-                    # with the current logic that should never happen
-                    raise RuntimeError("Cannot return cache of a parameter that does not"
-                                       "have a get command and has an invalid cache")
+                    if self._timestamp is None:
+                        raise RuntimeError(f"Value of parameter "
+                                           f"{(self._parameter.full_name)} "
+                                           f"is unknown and the Parameter does "
+                                           f"not have a get command. "
+                                           f"Please set the value before "
+                                           f"attempting to get it.")
+                    elif self._max_val_age is not None:
+                        # TODO: this check should really be at the time of setting
+                        #  max_val_age unfortunately this happens in init before
+                        #  get wrapping is performed.
+                        raise RuntimeError("`max_val_age` is not supported for a "
+                                           "parameter without get command.")
+                    else:
+                        # max_val_age is None and TS is not None but cache is invalid
+                        # with the current logic that should never happen
+                        raise RuntimeError("Cannot return cache of a parameter that does not"
+                                           "have a get command and has an invalid cache")
+            else:
+                # todo should this trigger a warning or even raise?
+                # todo this used to call get if get_if_invalid=False and TS is not None and max_val_age expired.
+                # that seemed like a bug
+                return self._value
 
     def __call__(self) -> ParamDataType:
         """

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1903,27 +1903,32 @@ class _Cache:
                     return self._parameter.get()
                 else:
                     if self._timestamp is None:
-                        raise RuntimeError(f"Value of parameter "
-                                           f"{(self._parameter.full_name)} "
-                                           f"is unknown and the Parameter does "
-                                           f"not have a get command. "
-                                           f"Please set the value before "
-                                           f"attempting to get it.")
+                        error_msg = (f"Value of parameter "
+                                     f"{(self._parameter.full_name)} "
+                                     f"is unknown and the Parameter "
+                                     f"does not have a get command. "
+                                     f"Please set the value before "
+                                     f"attempting to get it.")
                     elif self._max_val_age is not None:
-                        # TODO: this check should really be at the time of setting
-                        #  max_val_age unfortunately this happens in init before
-                        #  get wrapping is performed.
-                        raise RuntimeError("`max_val_age` is not supported for a "
-                                           "parameter without get command.")
+                        # TODO: this check should really be at the time
+                        #  of setting max_val_age unfortunately this
+                        #  happens in init before get wrapping is performed.
+                        error_msg = ("`max_val_age` is not supported "
+                                     "for a parameter without get "
+                                     "command.")
                     else:
-                        # max_val_age is None and TS is not None but cache is invalid
-                        # with the current logic that should never happen
-                        raise RuntimeError("Cannot return cache of a parameter that does not"
-                                           "have a get command and has an invalid cache")
+                        # max_val_age is None and TS is not None but cache is
+                        # invalid with the current logic that should never
+                        # happen
+                        error_msg = ("Cannot return cache of a parameter "
+                                     "that does not have a get command "
+                                     "and has an invalid cache")
+                    raise RuntimeError(error_msg)
             else:
                 # todo should this trigger a warning or even raise?
-                # todo this used to call get if get_if_invalid=False and TS is not None and max_val_age expired.
-                # that seemed like a bug
+                # todo this used to call get if get_if_invalid=False
+                #  and TS is not None and max_val_age expired.
+                #  that seemed like a bug
                 return self._value
 
     def __call__(self) -> ParamDataType:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1902,30 +1902,34 @@ class _Cache:
                 if gettable:
                     return self._parameter.get()
                 else:
-                    if self._timestamp is None:
-                        error_msg = (f"Value of parameter "
-                                     f"{(self._parameter.full_name)} "
-                                     f"is unknown and the Parameter "
-                                     f"does not have a get command. "
-                                     f"Please set the value before "
-                                     f"attempting to get it.")
-                    elif self._max_val_age is not None:
-                        # TODO: this check should really be at the time
-                        #  of setting max_val_age unfortunately this
-                        #  happens in init before get wrapping is performed.
-                        error_msg = ("`max_val_age` is not supported "
-                                     "for a parameter without get "
-                                     "command.")
-                    else:
-                        # max_val_age is None and TS is not None but cache is
-                        # invalid with the current logic that should never
-                        # happen
-                        error_msg = ("Cannot return cache of a parameter "
-                                     "that does not have a get command "
-                                     "and has an invalid cache")
+                    error_msg = self._construct_error_msg()
                     raise RuntimeError(error_msg)
             else:
                 return self._value
+
+    def _construct_error_msg(self) -> str:
+        if self._timestamp is None:
+            error_msg = (f"Value of parameter "
+                         f"{self._parameter.full_name} "
+                         f"is unknown and the Parameter "
+                         f"does not have a get command. "
+                         f"Please set the value before "
+                         f"attempting to get it.")
+        elif self._max_val_age is not None:
+            # TODO: this check should really be at the time
+            #  of setting max_val_age unfortunately this
+            #  happens in init before get wrapping is performed.
+            error_msg = ("`max_val_age` is not supported "
+                         "for a parameter without get "
+                         "command.")
+        else:
+            # max_val_age is None and TS is not None but cache is
+            # invalid with the current logic that should never
+            # happen
+            error_msg = ("Cannot return cache of a parameter "
+                         "that does not have a get command "
+                         "and has an invalid cache")
+        return error_msg
 
     def __call__(self) -> ParamDataType:
         """

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1925,10 +1925,6 @@ class _Cache:
                                      "and has an invalid cache")
                     raise RuntimeError(error_msg)
             else:
-                # todo should this trigger a warning or even raise?
-                # todo this used to call get if get_if_invalid=False
-                #  and TS is not None and max_val_age expired.
-                #  that seemed like a bug
                 return self._value
 
     def __call__(self) -> ParamDataType:

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -1842,3 +1842,17 @@ def test_get_raw_and_get_cmd_raises(working_get_cmd, working_set_cmd):
     with pytest.raises(TypeError, match="set_raw"):
         GetSetRawParameter(name="param2", set_cmd="HereIsTheValue {}", get_cmd=working_get_cmd)
     GetSetRawParameter("param3", get_cmd=working_get_cmd, set_cmd=working_set_cmd)
+
+
+def test_get_from_cache_does_not_trigger_real_get_if_get_if_invalid_false():
+    """
+    assert that calling get on the cache with get_if_invalid=False does
+    not trigger a get of the parameter when parameter has expired due to max_val_age
+    """
+    param = BetterGettableParam(name="param", max_val_age=1)
+    param.get()
+    assert param._get_count == 1
+    # let the cache expire
+    time.sleep(2)
+    param.cache.get(get_if_invalid=False)
+    assert param._get_count == 1


### PR DESCRIPTION
This IMHO makes the logic a bit more clear. Functinality it should be the same. 
I have changed a case in the if/else statments that should never happen to an error from silently returning a not up to date value. 

- [x] Should there be a warning if get_if_invalid=False and the cache is invalid? (mayby but not in this pr)
