### PR TITLE
make it an error to supply get/set_cmd if get/set_raw is not abstract

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -883,6 +883,10 @@ class Parameter(_BaseParameter):
        :meth:`set_raw` methods are automatically wrapped to provide ``get`` and
        ``set``.
 
+    It is an error to do both 1 and 2. E.g supply a ``get_cmd``/``set_cmd``
+     and implement ``get_raw``/``set_raw``
+
+
     To detect if a parameter is gettable or settable check the attributes
     ``gettable`` and ``settable`` on the parameter.
 

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1007,7 +1007,11 @@ class Parameter(_BaseParameter):
         # in the scope of this class.
         # (previous call to `super().__init__` wraps existing
         # get_raw/set_raw into get/set methods)
-        if not hasattr(self, 'get') and get_cmd is not False:
+        if self.gettable and get_cmd is not None:
+            raise TypeError("Supplying a not None `get_cmd` to a Parameter"
+                            " that already implements"
+                            " get_raw is an error.")
+        elif not self.gettable and get_cmd is not False:
             if get_cmd is None:
                 self.get_raw = (  # type: ignore[assignment]
                     lambda: self.cache.raw_value)
@@ -1020,8 +1024,11 @@ class Parameter(_BaseParameter):
             self.gettable = True
             self.get = self._wrap_get(self.get_raw)
 
-
-        if not hasattr(self, 'set') and set_cmd is not False:
+        if self.settable and set_cmd is not None:
+            raise TypeError("Supplying a not None `set_cmd` to a Parameter"
+                            " that already implements"
+                            " set_raw is an error.")
+        elif not self.settable and set_cmd is not False:
             if set_cmd is None:
                 self.set_raw: Callable = lambda x: x
             else:

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1015,7 +1015,7 @@ class Parameter(_BaseParameter):
             raise TypeError("Supplying a not None or False `get_cmd` to a Parameter"
                             " that already implements"
                             " get_raw is an error.")
-        elif not self.gettable and get_cmd not in (None, False):
+        elif not self.gettable and get_cmd is not False:
             if get_cmd is None:
                 self.get_raw = (  # type: ignore[assignment]
                     lambda: self.cache.raw_value)

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1007,11 +1007,11 @@ class Parameter(_BaseParameter):
         # in the scope of this class.
         # (previous call to `super().__init__` wraps existing
         # get_raw/set_raw into get/set methods)
-        if self.gettable and get_cmd is not None:
-            raise TypeError("Supplying a not None `get_cmd` to a Parameter"
+        if self.gettable and get_cmd not in (None, False):
+            raise TypeError("Supplying a not None or False `get_cmd` to a Parameter"
                             " that already implements"
                             " get_raw is an error.")
-        elif not self.gettable and get_cmd is not False:
+        elif not self.gettable and get_cmd not in (None, False):
             if get_cmd is None:
                 self.get_raw = (  # type: ignore[assignment]
                     lambda: self.cache.raw_value)
@@ -1024,8 +1024,8 @@ class Parameter(_BaseParameter):
             self.gettable = True
             self.get = self._wrap_get(self.get_raw)
 
-        if self.settable and set_cmd is not None:
-            raise TypeError("Supplying a not None `set_cmd` to a Parameter"
+        if self.settable and set_cmd not in (None, False):
+            raise TypeError("Supplying a not None or False `set_cmd` to a Parameter"
                             " that already implements"
                             " set_raw is an error.")
         elif not self.settable and set_cmd is not False:

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -81,8 +81,7 @@ class GetSetRawParameter(Parameter):
         return self.cache._raw_value
 
     def set_raw(self, raw_value):
-        value = self._from_raw_value_to_value(raw_value)
-        self.cache.set(value)
+        pass
 
 
 class BookkeepingValidator(vals.Validator):

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -72,6 +72,19 @@ class OverwriteSetParam(Parameter):
         self._value = value
 
 
+class GetSetRawParameter(Parameter):
+    """ Parameter that implements get and set raw"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_raw(self):
+        return self.cache._raw_value
+
+    def set_raw(self, raw_value):
+        value = self._from_raw_value_to_value(raw_value)
+        self.cache.set(value)
+
+
 class BookkeepingValidator(vals.Validator):
     """
     Validator that keeps track of what it validates
@@ -1820,3 +1833,13 @@ def test_gettable_settable_attributes_with_get_set_raw(baseclass):
 
     assert b.gettable is False
     assert b.settable is False
+
+
+@pytest.mark.parametrize("working_get_cmd", (False, None))
+@pytest.mark.parametrize("working_set_cmd", (False, None))
+def test_get_raw_and_get_cmd_raises(working_get_cmd, working_set_cmd):
+    with pytest.raises(TypeError, match="get_raw"):
+        GetSetRawParameter(name="param1", get_cmd="GiveMeTheValue", set_cmd=working_set_cmd)
+    with pytest.raises(TypeError, match="set_raw"):
+        GetSetRawParameter(name="param2", set_cmd="HereIsTheValue {}", get_cmd=working_get_cmd)
+    GetSetRawParameter("param3", get_cmd=working_get_cmd, set_cmd=working_set_cmd)


### PR DESCRIPTION
It makes no sense to both implement get_raw and supply a get_cmd. Which one should be used. So lets make this an error. There are already 2 subclasses that does the same. DelegateParameter and GroupParameter
