### PR TITLE
fix warning in b1500 driver

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -249,6 +249,6 @@ class B1500Module(InstrumentChannel):
         activated_channels = re.sub(r"[^,\d]", "", response).split(",")
 
         is_enabled = set(self.channels).issubset(
-            int(x) for x in activated_channels if x is not ''
+            int(x) for x in activated_channels if x != ''
         )
         return is_enabled


### PR DESCRIPTION
Comparing strings with `is` only works due to an implementation detail (small string optimization) 