### PR TITLE
B1500: Fix spot measurement of capacitance checking for wrong impedance model, and working with ac_dc_volt_monitor=True

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -526,9 +526,7 @@ class B1520A(B1500Module):
         parsed = [item for item in re.finditer(_pattern, response)]
 
         if (
-                len(parsed) != 2
-                or parsed[0]["dtype"] != "C"
-                or parsed[1]["dtype"] != "Y"
+                len(parsed) not in (2, 4)
         ):
             raise ValueError("Result format not supported.")
 

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
@@ -116,7 +116,7 @@ def test_get_capacitance(cmu):
 def test_raise_error_on_unsupported_result_format(cmu):
     mainframe = cmu.parent
 
-    mainframe.ask.return_value = "NCR-1.1234E-03,NCX-4.5677E-03"
+    mainframe.ask.return_value = "NCR-1.1234E-03,NCX-4.5677E-03,NCV+0.14235E-03"
 
     with pytest.raises(ValueError):
         cmu.capacitance()

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
@@ -103,9 +103,14 @@ def test_get_frequency(cmu):
 def test_get_capacitance(cmu):
     mainframe = cmu.parent
 
-    mainframe.ask.return_value = "NCC-1.45713E-06,NCY-3.05845E-03"
+    mainframe.ask.return_value = "NCC-1.45713E-06,NCD-3.05845E-03"
 
     assert pytest.approx((-1.45713E-06, -3.05845E-03)) == cmu.capacitance()
+
+    mainframe.ask.return_value = "NCC-1.55713E-06,NCD-3.15845E-03," \
+                                 "NCV-1.52342E-03,NCV+0.14235E-03"
+
+    assert pytest.approx((-1.55713E-06, -3.15845E-03)) == cmu.capacitance()
 
 
 def test_raise_error_on_unsupported_result_format(cmu):


### PR DESCRIPTION
For an unknown reason the get_capacitance method was checking for dtype to be of 'Y'. However, the impedance model does not allow the secondary parameter to be 'Y'.

This PR removes this check. 

Also if ac_dc_volt_monitor is on then the length of output (primary parameter, secondary parameter, ac voltage, dc voltage) is 4 instead of 2. 

![Screenshot 2020-05-26 at 11 48 47](https://user-images.githubusercontent.com/18750964/82886536-efec7680-9f46-11ea-9f21-f47d59c0ed0c.png)
 
This is quick fix. A better capacitance parameter would be which also sets proper labels and units depending on the impedance model. This is already planned and will be taken up in another later.

@astafan8 
