### PR TITLE
Allow diffing snapshots of stations and instruments

### DIFF
--- a/qcodes/tests/test_metadata.py
+++ b/qcodes/tests/test_metadata.py
@@ -49,49 +49,82 @@ class TestMetadatable(TestCase):
         self.assertEqual(s.snapshot_base(), {})
         self.assertEqual(s.metadata, {8: 9})
 
-    def test_diff(self):
-        left = {
-            "station": {
-                "parameters": {
-                    "apple": {
-                        "value": "orange"
+    dataset_left = {
+        "station": {
+            "parameters": {
+                "apple": {
+                    "value": "orange"
+                }
+            },
+            "instruments": {
+                "correct": {
+                    "parameters": {
+                        "horse": {
+                            "value": "battery"
+                        },
+                        "left": {
+                            "value": "only"
+                        }
                     }
                 },
-                "instruments": {
-                    "correct": {
-                        "parameters": {
-                            "horse": {
-                                "value": "battery"
-                            },
-                            "left": {
-                                "value": "only"
-                            }
+                "another": {
+                    "parameters": {}
+                }
+            }
+        }
+    }
+    dataset_right = {
+        "station": {
+            "parameters": {
+                "apple": {
+                    "value": "grape"
+                }
+            },
+            "instruments": {
+                "correct": {
+                    "parameters": {
+                        "horse": {
+                            "value": "staple"
+                        },
+                        "right": {
+                            "value": "only"
+                        }
+                    }
+                },
+                "another": {
+                    "parameters": {
+                        "pi": {
+                            "value": 3.1
                         }
                     }
                 }
             }
         }
-        right = {
-            "station": {
-                "parameters": {
-                    "apple": {
-                        "value": "grape"
-                    }
-                },
-                "instruments": {
-                    "correct": {
-                        "parameters": {
-                            "horse": {
-                                "value": "staple"
-                            },
-                            "right": {
-                                "value": "only"
-                            }
-                        }
-                    }
-                }
+    }
+
+    def test_dataset_diff(self):
+        diff = diff_param_values(self.dataset_left, self.dataset_right)
+        self.assertEqual(
+            diff.changed, {
+                "apple": ("orange", "grape"),
+                ("correct", "horse"): ("battery", "staple"),
             }
-        }
+        )
+        self.assertEqual(
+            diff.left_only, {
+                ("correct", "left"): "only"
+            }
+        )
+        self.assertEqual(
+            diff.right_only, {
+                ("correct", "right"): "only",
+                ("another", "pi"): 3.1,
+            }
+        )
+
+    def test_station_diff(self):
+        left = self.dataset_left["station"]
+        right = self.dataset_right["station"]
 
         diff = diff_param_values(left, right)
         self.assertEqual(
@@ -107,6 +140,21 @@ class TestMetadatable(TestCase):
         )
         self.assertEqual(
             diff.right_only, {
-                ("correct", "right"): "only"
+                ("correct", "right"): "only",
+                ("another", "pi"): 3.1,
+            }
+        )
+
+    def test_instrument_diff(self):
+        left = self.dataset_left["station"]["instruments"]["another"]
+        right = self.dataset_right["station"]["instruments"]["another"]
+
+        diff = diff_param_values(left, right)
+
+        self.assertEqual(diff.changed, {})
+        self.assertEqual(diff.left_only, {})
+        self.assertEqual(
+            diff.right_only, {
+                 "pi": 3.1
             }
         )

--- a/qcodes/utils/metadata.py
+++ b/qcodes/utils/metadata.py
@@ -82,14 +82,17 @@ def extract_param_values(snapshot: Snapshot) -> Dict[ParameterKey, Any]:
     instrument and parameter names onto parameter values.
     """
     parameters = {}
-    for param_name, param in snapshot['station']['parameters'].items():
+    snapshot = snapshot.get('station', snapshot)
+    for param_name, param in snapshot['parameters'].items():
         parameters[param_name] = param['value']
-    for instrument_name, instrument in snapshot['station']['instruments'].items():
-        for param_name, param in instrument['parameters'].items():
-            if 'value' in param:
-                parameters[instrument_name, param_name] = param['value']
+    if 'instruments' in snapshot:
+        for instrument_name, instrument in snapshot['instruments'].items():
+            for param_name, param in instrument['parameters'].items():
+                if 'value' in param:
+                    parameters[instrument_name, param_name] = param['value']
 
     return parameters
+
 
 
 def diff_param_values(left_snapshot: Snapshot,


### PR DESCRIPTION
Hi,

Currently, `metadata.diff_param_values` allows only diffing snapshots genearated for datasets. It assumes the snapshots have the keys `"station"` and inside that `"instruments"`.

This PR allows diffing snapshots generated by Stations and Instruments. It only assumes that `"parameters"` is found in the snapshot. 
For example this works:
```
before = dummy_instrument.snapshot()
dummy_instrument.dac1(3)
after = dummy_instrument.snapshot()
diff_param_values(before, after)
```

This allows more flexible use of the diff tool.
Also included some new tests to check the different cases.

@jenshnielsen 
