### PR TITLE
B1500: Transient fix for converting str as '-0.-1' to float 

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -140,6 +140,20 @@ def parse_dcorr_query_response(response: str) -> _DCORRResponse:
                           secondary=float(secondary))
 
 
+def fixed_negative_float(response: str) -> float:
+    """
+    Keysight sometimes responds for ex. '-0.-1' as an output when you input
+    '-0.1'. This fixed_float function can convert such strings also float.
+    """
+    if len(response.split('.')) != 2:
+        raise Exception('String must of format a.b')
+
+    number, decimal = response.split('.')
+    decimal = decimal.replace("-", "")
+    output = ".".join([number, decimal])
+    return float(output)
+
+
 _dcorr_labels_units_map = {
     constants.DCORR.Mode.Cp_G: dict(
         primary=dict(label='Cp', unit='F'),

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -146,7 +146,7 @@ def fixed_negative_float(response: str) -> float:
     '-0.1'. This fixed_float function can convert such strings also float.
     """
     if len(response.split('.')) != 2:
-        raise Exception('String must of format a.b')
+        raise ValueError('String must of format a.b')
 
     number, decimal = response.split('.')
     decimal = decimal.replace("-", "")

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -143,13 +143,17 @@ def parse_dcorr_query_response(response: str) -> _DCORRResponse:
 def fixed_negative_float(response: str) -> float:
     """
     Keysight sometimes responds for ex. '-0.-1' as an output when you input
-    '-0.1'. This fixed_float function can convert such strings also float.
+    '-0.1'. This function can convert such strings also to float.
     """
-    if len(response.split('.')) != 2:
-        raise ValueError('String must of format a.b')
+    if len(response.split('.')) > 2:
+        raise ValueError('String must of format `a` or `a.b`')
 
-    number, decimal = response.split('.')
+    parts = response.split('.')
+    number = parts[0]
+    decimal = parts[1] if len(parts) > 1 else '0'
+
     decimal = decimal.replace("-", "")
+
     output = ".".join([number, decimal])
     return float(output)
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -594,13 +594,15 @@ class B1520A(B1500Module):
         if not match:
             raise ValueError('Sweep steps (WDCV) not found.')
 
-        out_str = match.groupdict()
-        out_dict = cast(Dict[str, Union[int, float]], out_str)
-        out_dict['chan'] = int(out_dict['chan'])
-        out_dict['sweep_mode'] = int(out_dict['sweep_mode'])
-        out_dict['sweep_start'] = fixed_negative_float(out_dict['sweep_start'])
-        out_dict['sweep_end'] = fixed_negative_float(out_dict['sweep_end'])
-        out_dict['sweep_steps'] = int(out_dict['sweep_steps'])
+        resp_dict = match.groupdict()
+
+        out_dict: Dict[str, Union[int, float]] = {}
+        out_dict['chan'] = int(resp_dict['chan'])
+        out_dict['sweep_mode'] = int(resp_dict['sweep_mode'])
+        out_dict['sweep_start'] = fixed_negative_float(resp_dict['sweep_start'])
+        out_dict['sweep_end'] = fixed_negative_float(resp_dict['sweep_end'])
+        out_dict['sweep_steps'] = int(resp_dict['sweep_steps'])
+
         return out_dict
 
     @staticmethod

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -10,7 +10,7 @@ import qcodes.utils.validators as vals
 
 from .KeysightB1500_module import B1500Module, parse_dcorr_query_response, \
     format_dcorr_response, _DCORRResponse, parse_dcv_measurement_response, \
-    _FMTResponse, parse_fmt_1_0_response
+    _FMTResponse, parse_fmt_1_0_response, fixed_negative_float
 from .message_builder import MessageBuilder
 from . import constants
 from .constants import ModuleKind, ChNr, MM
@@ -598,8 +598,8 @@ class B1520A(B1500Module):
         out_dict = cast(Dict[str, Union[int, float]], out_str)
         out_dict['chan'] = int(out_dict['chan'])
         out_dict['sweep_mode'] = int(out_dict['sweep_mode'])
-        out_dict['sweep_start'] = float(out_dict['sweep_start'])
-        out_dict['sweep_end'] = float(out_dict['sweep_end'])
+        out_dict['sweep_start'] = fixed_negative_float(out_dict['sweep_start'])
+        out_dict['sweep_end'] = fixed_negative_float(out_dict['sweep_end'])
         out_dict['sweep_steps'] = int(out_dict['sweep_steps'])
         return out_dict
 

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import \
     B1517A
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_module import \
-    parse_module_query_response, format_dcorr_response, _DCORRResponse
+    parse_module_query_response, format_dcorr_response, _DCORRResponse, \
+    fixed_negative_float
 from qcodes.instrument_drivers.Keysight.keysightb1500.constants import \
     SlotNr, DCORR
 
@@ -70,3 +71,10 @@ def test_format_dcorr_response():
     resp_str2 = format_dcorr_response(
         _DCORRResponse(mode=DCORR.Mode.Ls_Rs, primary=0.2, secondary=3.0))
     assert resp_str2 == 'Mode: Ls_Rs, Primary Ls: 0.2 H, Secondary Rs: 3.0 Ω'
+
+
+def test_fixed_negative_float():
+    assert fixed_negative_float('-0.-1') == -0.1
+    assert fixed_negative_float('-1.-1') == -1.1
+    assert fixed_negative_float('0.1') == 0.1
+

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
@@ -77,4 +77,6 @@ def test_fixed_negative_float():
     assert fixed_negative_float('-0.-1') == -0.1
     assert fixed_negative_float('-1.-1') == -1.1
     assert fixed_negative_float('0.1') == 0.1
-
+    assert fixed_negative_float('1.0') == 1.0
+    assert fixed_negative_float('1') == 1.0
+    assert fixed_negative_float('-1') == -1.0


### PR DESCRIPTION
Keysight B1500 responds with a string containing decimal numbers but with signs on both sides of the decimal. For ex: '-0.-1' this PR add function to covert such strings to float.

Once this is fixed in Keysight firmware the commits in this PR can be reverted.



