### PR TITLE
Make gettable/settable a read only property and raise

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -301,10 +301,10 @@ class _BaseParameter(Metadatable):
             and not getattr(self.get_raw,
                             '__qcodes_is_abstract_method__', False)
         )
-        self.gettable = False
+        self._gettable = False
         if implements_get_raw:
             self.get = self._wrap_get(self.get_raw)
-            self.gettable = True
+            self._gettable = True
         elif hasattr(self, 'get'):
             raise RuntimeError(f'Overwriting get in a subclass of '
                                f'_BaseParameter: '
@@ -316,10 +316,10 @@ class _BaseParameter(Metadatable):
             and not getattr(self.set_raw,
                             '__qcodes_is_abstract_method__', False)
         )
-        self.settable = False
+        self._settable = False
         if implements_set_raw:
             self.set = self._wrap_set(self.set_raw)
-            self.settable = True
+            self._settable = True
         elif hasattr(self, 'set'):
             raise RuntimeError(f'Overwriting set in a subclass of '
                                f'_BaseParameter: '
@@ -867,6 +867,20 @@ class _BaseParameter(Metadatable):
         name_parts.append(self.short_name)
         return name_parts
 
+    @property
+    def gettable(self) -> bool:
+        """
+        Is it allowed to call get on this parameter?
+        """
+        return self._gettable
+
+    @property
+    def settable(self) -> bool:
+        """
+        Is it allowed to call set on this parameter?
+        """
+        return self._settable
+
 
 class Parameter(_BaseParameter):
     """
@@ -1047,7 +1061,7 @@ class Parameter(_BaseParameter):
                 self.get_raw = Command(arg_count=0,  # type: ignore[assignment]
                                        cmd=get_cmd,
                                        exec_str=exec_str_ask)
-            self.gettable = True
+            self._gettable = True
             self.get = self._wrap_get(self.get_raw)
 
         if self.settable and set_cmd not in (None, False):
@@ -1062,7 +1076,7 @@ class Parameter(_BaseParameter):
                     if instrument else None
                 self.set_raw = Command(arg_count=1, cmd=set_cmd,
                                        exec_str=exec_str_write)
-            self.settable = True
+            self._settable = True
             self.set = self._wrap_set(self.set_raw)
 
         self._meta_attrs.extend(['label', 'unit', 'vals'])

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -556,6 +556,8 @@ class _BaseParameter(Metadatable):
             Callable[..., ParamDataType]:
         @wraps(get_function)
         def get_wrapper(*args: Any, **kwargs: Any) -> ParamDataType:
+            if not self.gettable:
+                raise TypeError("Trying to get a parameter that is not gettable.")
             try:
                 # There might be cases where a .get also has args/kwargs
                 raw_value = get_function(*args, **kwargs)
@@ -580,6 +582,9 @@ class _BaseParameter(Metadatable):
         @wraps(set_function)
         def set_wrapper(value: ParamDataType, **kwargs: Any) -> None:
             try:
+                if not self.settable:
+                    raise TypeError("Trying to set a parameter that is not settable.")
+
                 self.validate(value)
 
                 # In some cases intermediate sweep values must be used.

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -557,7 +557,8 @@ class _BaseParameter(Metadatable):
         @wraps(get_function)
         def get_wrapper(*args: Any, **kwargs: Any) -> ParamDataType:
             if not self.gettable:
-                raise TypeError("Trying to get a parameter that is not gettable.")
+                raise TypeError("Trying to get a parameter"
+                                " that is not gettable.")
             try:
                 # There might be cases where a .get also has args/kwargs
                 raw_value = get_function(*args, **kwargs)
@@ -583,7 +584,8 @@ class _BaseParameter(Metadatable):
         def set_wrapper(value: ParamDataType, **kwargs: Any) -> None:
             try:
                 if not self.settable:
-                    raise TypeError("Trying to set a parameter that is not settable.")
+                    raise TypeError("Trying to set a parameter"
+                                    " that is not settable.")
 
                 self.validate(value)
 

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -2402,3 +2402,16 @@ def test_snapshot_of_gettable_parameter_depends_on_update(update, cache_is_valid
         assert s['raw_value'] == 69
         assert p.get.call_count() == 1
 
+
+def test_get_on_parameter_marked_as_non_gettable_raises():
+    a = Parameter("param")
+    a.gettable = False
+    with pytest.raises(TypeError, match="Trying to get a parameter that is not gettable."):
+        a.get()
+
+
+def test_set_on_parameter_marked_as_non_settable_raises():
+    a = Parameter("param", set_cmd=None)
+    a.settable = False
+    with pytest.raises(TypeError, match="Trying to set a parameter that is not settable."):
+        a.get()

--- a/qcodes/tests/test_parameter.py
+++ b/qcodes/tests/test_parameter.py
@@ -2405,13 +2405,16 @@ def test_snapshot_of_gettable_parameter_depends_on_update(update, cache_is_valid
 
 def test_get_on_parameter_marked_as_non_gettable_raises():
     a = Parameter("param")
-    a.gettable = False
+    a._gettable = False
     with pytest.raises(TypeError, match="Trying to get a parameter that is not gettable."):
         a.get()
 
 
 def test_set_on_parameter_marked_as_non_settable_raises():
     a = Parameter("param", set_cmd=None)
-    a.settable = False
+    a.set(2)
+    assert a.get() == 2
+    a._settable = False
     with pytest.raises(TypeError, match="Trying to set a parameter that is not settable."):
-        a.get()
+        a.set(1)
+    assert a.get() == 2


### PR DESCRIPTION
* Make gettable/settable readonly as they always should have been
* Raise if you somehow manage to call get/set on a non gettable/settable parameter. This should never happen if only the public api is used. 
