### PR TITLE
Add Zurich Instruments drivers 

### DIFF
--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -22,6 +22,8 @@ from qcodes.instrument.base import Instrument
 from qcodes.instrument.channel import InstrumentChannel, ChannelList
 from qcodes.utils import validators as vals
 
+from qcodes.utils.deprecate import deprecate
+
 log = logging.getLogger(__name__)
 
 class AUXOutputChannel(InstrumentChannel):
@@ -674,6 +676,8 @@ class ZIUHFLI(Instrument):
         * Add zoom-FFT
     """
 
+    @deprecate(reason="There is a new UHFLI driver from Zurich Instruments",
+               alternative="instrument_drivers.zurich_instruments.uhfli.UHFLI")
     def __init__(self, name: str, device_ID: str, **kwargs) -> None:
         """
         Create an instance of the instrument.

--- a/qcodes/instrument_drivers/zurich_instruments/__init__.py
+++ b/qcodes/instrument_drivers/zurich_instruments/__init__.py
@@ -1,0 +1,1 @@
+# empty __init__ file

--- a/qcodes/instrument_drivers/zurich_instruments/hdawg.py
+++ b/qcodes/instrument_drivers/zurich_instruments/hdawg.py
@@ -1,0 +1,12 @@
+# Zurich Instrument HDAWG stub
+#
+# For the real implementation, please look into the package zhinst-qcodes
+# at https://github.com/zhinst/zhinst-qcodes
+
+
+try:
+    from zhinst.qcodes.hdawg import *
+except ImportError:
+    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
+                         Please install package zhinst-qcodes.
+                      ''')

--- a/qcodes/instrument_drivers/zurich_instruments/mfli.py
+++ b/qcodes/instrument_drivers/zurich_instruments/mfli.py
@@ -1,0 +1,12 @@
+# Zurich Instrument MFLI stub
+#
+# For the real implementation, please look into the package zhinst-qcodes
+# at https://github.com/zhinst/zhinst-qcodes
+
+
+try:
+    from zhinst.qcodes.mfli import *
+except ImportError:
+    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
+                         Please install package zhinst-qcodes.
+                      ''')

--- a/qcodes/instrument_drivers/zurich_instruments/uhfli.py
+++ b/qcodes/instrument_drivers/zurich_instruments/uhfli.py
@@ -1,0 +1,12 @@
+# Zurich Instrument UHFLI stub
+#
+# For the real implementation, please look into the package zhinst-qcodes
+# at https://github.com/zhinst/zhinst-qcodes
+
+
+try:
+    from zhinst.qcodes.uhfli import *
+except ImportError:
+    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
+                         Please install package zhinst-qcodes.
+                      ''')

--- a/qcodes/instrument_drivers/zurich_instruments/uhfqa.py
+++ b/qcodes/instrument_drivers/zurich_instruments/uhfqa.py
@@ -1,0 +1,12 @@
+# Zurich Instrument UHFQA stub
+#
+# For the real implementation, please look into the package zhinst-qcodes
+# at https://github.com/zhinst/zhinst-qcodes
+
+
+try:
+    from zhinst.qcodes.uhfqa import *
+except ImportError:
+    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
+                         Please install package zhinst-qcodes.
+                      ''')

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ extras = {
     'MatPlot': ('matplotlib', '2.2.3'),
     'QtPlot': ('pyqtgraph', '0.10.0'),
     'coverage tests': ('coverage', '4.0'),
-    'Slack': ('slacker', '0.9.42')
+    'Slack': ('slacker', '0.9.42'),
+    'ZurichInstruments': ('zhinst-qcodes', '0.1.1')
 }
 extras_require = {k: '>='.join(v) for k, v in extras.items()}
 


### PR DESCRIPTION
This PR add support for Zurich Instruments devices as drivers inside of QCodes.

The actual implementation is in https://github.com/zhinst/zhinst-qcodes/ as described in
https://blogs.zhinst.com/andrea/2020/05/24/control-your-measurements-with-qcodes-and-labber/
Here we propose to add stubs in Qcodes to help user to find and install such drivers.

We propose deprecation of the existing ZIUHF, since its functionality is replaced by this PR.

A new optional installation option, 'ZurichInstruments' is introduced. That add the package zhinst-qcodes as optional dependency of Qcodes, if the user wish so. 

@jenshnielsen 
