### PR TITLE
Use in memory config and do not save to home in guids

### DIFF
--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -99,6 +99,7 @@ def set_guid_location_code() -> None:
         return
 
     cfg['GUID_components']['location'] = location
+    cfg.save_to_home()
 
 
 def set_guid_work_station_code() -> None:
@@ -124,6 +125,7 @@ def set_guid_work_station_code() -> None:
         return
 
     cfg['GUID_components']['work_station'] = work_station
+    cfg.save_to_home()
 
 
 def filter_guids_by_parts(guids: Sequence[str],

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -4,7 +4,7 @@ import re
 
 import numpy as np
 
-from qcodes.configuration import Config
+import qcodes as qc
 
 _guid_pattern = re.compile(r'^[\da-f]{8}-([\da-f]{4}-){3}[\da-f]{12}$')
 
@@ -25,7 +25,7 @@ def generate_guid(timeint: Union[int, None]=None,
         timeint: An integer of miliseconds since unix epoch time
         sampleint: A code for the sample
     """
-    cfg = Config()
+    cfg = qc.config
 
     try:
         guid_comp = cfg['GUID_components']
@@ -81,7 +81,7 @@ def set_guid_location_code() -> None:
     """
     Interactive function to set the location code.
     """
-    cfg = Config()
+    cfg = qc.config
     old_loc = cfg['GUID_components']['location']
     print(f'Updating GUID location code. Current location code is: {old_loc}')
     if old_loc != 0:
@@ -99,14 +99,13 @@ def set_guid_location_code() -> None:
         return
 
     cfg['GUID_components']['location'] = location
-    cfg.save_to_home()
 
 
 def set_guid_work_station_code() -> None:
     """
     Interactive function to set the work station code
     """
-    cfg = Config()
+    cfg = qc.config
     old_ws = cfg['GUID_components']['work_station']
     print('Updating GUID work station code. '
           f'Current work station code is: {old_ws}')
@@ -125,7 +124,6 @@ def set_guid_work_station_code() -> None:
         return
 
     cfg['GUID_components']['work_station'] = work_station
-    cfg.save_to_home()
 
 
 def filter_guids_by_parts(guids: Sequence[str],


### PR DESCRIPTION
This PR removes the usage of `Config()` in favor of `qcode.config` and removes `save_to_home()` calls in guids.py. This PR is necessary for [#2016](https://github.com/QCoDeS/Qcodes/pull/2016) to pass. With these changes test_database_creation_and_upgrading.py passes with and without xdist-parallel without the need of a temp config.

@jenshnielsen 