### PR TITLE
Remove Config call from queries

### DIFF
--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -26,7 +26,6 @@ from qcodes.dataset.sqlite.query_helpers import (
     select_many_where, insert_values, insert_column, is_column_in_table,
     VALUES, update_where)
 from qcodes.utils.deprecate import deprecate
-from qcodes.configuration import Config
 
 
 log = logging.getLogger(__name__)
@@ -1593,7 +1592,7 @@ def update_GUIDs(conn: ConnectionPlus) -> None:
 
     log.info('Commencing update of all GUIDs in database')
 
-    cfg = Config()
+    cfg = qc.config
 
     location = cfg['GUID_components']['location']
     work_station = cfg['GUID_components']['work_station']


### PR DESCRIPTION
This PR removes the `Config()` call in favor of `qc.config`.

@jenshnielsen 
