### PR TITLE
ensure that links and dataset does not share guid before testing

### DIFF
--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -680,6 +680,9 @@ def test_parent_dataset_links_invalid_input():
 
     ds = DataSet()
 
+    for link in links:
+        assert link.head != ds.guid
+
     match = re.escape('Invalid input. Did not receive a list of Links')
     with pytest.raises(ValueError, match=match):
         ds.parent_dataset_links = [ds.guid]


### PR DESCRIPTION
In `test_parent_dataset_links_invalid_input` we have seen ocational falilures since the merge of #2016 
I suspect this is due to the links and dataset being created within the same ms and therefore having the same guid. This extra assertion will confirm or disprove this hypothesis