### PR TITLE
rewrite monitor tests with pytest

### DIFF
--- a/qcodes/monitor/monitor.py
+++ b/qcodes/monitor/monitor.py
@@ -88,7 +88,7 @@ def _get_metadata(*parameters: Parameter) -> Dict[str, Any]:
     return state
 
 
-def _handler(parameters: Sequence[Parameter], interval: int) \
+def _handler(parameters: Sequence[Parameter], interval: float) \
         -> Callable[[websockets.WebSocketServerProtocol, str], Awaitable[None]]:
     """
     Return the websockets server handler.
@@ -125,7 +125,7 @@ class Monitor(Thread):
     """
     running = None
 
-    def __init__(self, *parameters: Parameter, interval: int = 1):
+    def __init__(self, *parameters: Parameter, interval: float = 1):
         """
         Monitor qcodes parameters.
 

--- a/qcodes/tests/test_monitor.py
+++ b/qcodes/tests/test_monitor.py
@@ -8,137 +8,150 @@ import json
 import random
 import websockets
 
+import pytest
 from qcodes.monitor import monitor
 from qcodes.instrument.base import Parameter
 from qcodes.tests.instrument_mocks import DummyInstrument
 
 monitor.WEBSOCKET_PORT = random.randint(50000, 60000)
 
-class TestMonitor(TestCase):
+
+@pytest.fixture(name="inst_and_monitor")
+def _make_inst_and_monitor():
+    instr = DummyInstrument("MonitorDummy")
+    param = Parameter("DummyParam",
+                      unit="V",
+                      get_cmd=None,
+                      set_cmd=None)
+    param(1)
+    monitor_parameters = tuple(instr.parameters.values())[1:]
+    my_monitor = monitor.Monitor(*monitor_parameters, param, interval=0.1)
+    try:
+        yield instr, my_monitor, monitor_parameters, param
+    finally:
+        my_monitor.stop()
+        instr.close()
+
+# Test cases for the qcodes monitor
+
+def test_setup_teardown(request):
     """
-    Test cases for the qcodes monitor
+    Check that monitor starts up and closes correctly
     """
-    def test_setup_teardown(self):
-        """
-        Check that monitor starts up and closes correctly
-        """
-        m = monitor.Monitor()
-        self.assertTrue(m.is_alive())
-        self.assertTrue(m.loop.is_running())
-        self.assertEqual(monitor.Monitor.running, m)
-        m.stop()
-        self.assertFalse(m.loop.is_running())
-        self.assertTrue(m.loop.is_closed())
-        self.assertFalse(m.is_alive())
-        self.assertIsNone(monitor.Monitor.running)
-
-    def test_monitor_replace(self):
-        """
-        Check that monitors get correctly replaced
-        """
-        m = monitor.Monitor()
-        self.assertEqual(monitor.Monitor.running, m)
-        m2 = monitor.Monitor()
-        self.assertEqual(monitor.Monitor.running, m2)
-        self.assertTrue(m.loop.is_closed())
-        self.assertFalse(m.is_alive())
-        self.assertTrue(m2.is_alive())
-        m2.stop()
-
-    def test_double_join(self):
-        """
-        Check that a double join doesn't cause a hang
-        """
-        m = monitor.Monitor()
-        self.assertEqual(monitor.Monitor.running, m)
-        m.stop()
-        m.stop()
+    m = monitor.Monitor()
+    request.addfinalizer(m.stop)
+    assert m.is_alive()
+    assert m.loop.is_running()
+    assert monitor.Monitor.running == m
+    m.stop()
+    assert not m.loop.is_running()
+    assert m.loop.is_closed()
+    assert not m.is_alive()
+    assert monitor.Monitor.running is None
 
 
-    def test_connection(self):
-        """
-        Test that we can connect to a monitor instance
-        """
-        m = monitor.Monitor()
-
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-
-        async def async_test_connection():
-            websocket = await websockets.connect(f"ws://localhost:{monitor.WEBSOCKET_PORT}")
-            await websocket.close()
-        loop.run_until_complete(async_test_connection())
-
-        m.stop()
-
-class TestMonitorWithInstr(TestCase):
+def test_monitor_replace(request):
     """
-    Test monitor values from instruments
+    Check that monitors get correctly replaced
     """
-    def setUp(self):
-        """
-        Create a dummy instrument for use in monitor tests, and hook it into
-        a monitor
-        """
-        self.instr = DummyInstrument("MonitorDummy")
-        self.param = Parameter("DummyParam",
-                               unit="V",
-                               get_cmd=None,
-                               set_cmd=None)
-        self.param(1)
-        self.monitor_parameters = tuple(self.instr.parameters.values())[1:]
-        self.monitor = monitor.Monitor(*self.monitor_parameters, self.param, interval=0.1)
+    m = monitor.Monitor()
+    request.addfinalizer(m.stop)
+    assert monitor.Monitor.running == m
+    m2 = monitor.Monitor()
+    request.addfinalizer(m2.stop)
+    assert monitor.Monitor.running == m2
+    assert m.loop.is_closed()
+    assert not m.is_alive()
+    assert m2.is_alive()
+    m2.stop()
 
-    def tearDown(self):
-        """
-        Close the dummy instrument
-        """
-        self.monitor.stop()
-        self.instr.close()
 
-    def test_parameter(self):
-        """
-        Test instrument updates
-        """
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+def test_double_join(request):
+    """
+    Check that a double join doesn't cause a hang
+    """
+    m = monitor.Monitor()
+    request.addfinalizer(m.stop)
+    assert monitor.Monitor.running == m
+    m.stop()
+    m.stop()
 
-        async def async_test_monitor():
-            websocket = await websockets.connect(f"ws://localhost:{monitor.WEBSOCKET_PORT}")
 
-            # Recieve data from monitor
-            data = await websocket.recv()
-            data = json.loads(data)
-            # Check fields
-            self.assertIn("ts", data)
-            self.assertIn("parameters", data)
-            # Check one instrument and "No Instrument" is being sent
-            self.assertEqual(len(data["parameters"]), 2)
-            self.assertEqual(data["parameters"][1]["instrument"], "Unbound Parameter")
-            metadata = data["parameters"][0]
-            self.assertEqual(metadata["instrument"], str(self.instr))
+def test_connection(request):
+    """
+    Test that we can connect to a monitor instance
+    """
+    m = monitor.Monitor()
+    request.addfinalizer(m.stop)
+    loop = asyncio.new_event_loop()
 
-            # Check parameter values
-            old_timestamps = {}
-            for local, mon in zip(self.monitor_parameters, metadata["parameters"]):
-                self.assertEqual(str(local.get_latest()), mon["value"])
-                self.assertEqual(local.label, mon["name"])
-                old_timestamps[local.label] = float(mon["ts"])
-                local(random.random())
+    def cleanup_loop():
+        loop.stop()
+        loop.close()
+    request.addfinalizer(cleanup_loop)
+    asyncio.set_event_loop(loop)
 
-            # Check parameter updates
-            data = await websocket.recv()
-            data = await websocket.recv()
-            data = json.loads(data)
-            metadata = data["parameters"][0]
-            for local, mon in zip(self.monitor_parameters, metadata["parameters"]):
-                self.assertEqual(str(local.get_latest()), mon["value"])
-                self.assertEqual(local.label, mon["name"])
-                self.assertGreater(float(mon["ts"]), old_timestamps[local.label])
+    async def async_test_connection():
+        websocket = await websockets.connect(f"ws://localhost:{monitor.WEBSOCKET_PORT}")
+        await websocket.close()
+    loop.run_until_complete(async_test_connection())
 
-            # Check unbound parameter
-            metadata = data["parameters"][1]["parameters"]
-            self.assertEqual(len(metadata), 1)
-            self.assertEqual(self.param.label, metadata[0]["name"])
+    m.stop()
 
-        loop.run_until_complete(async_test_monitor())
+
+def test_parameter(request, inst_and_monitor):
+    """
+    Test instrument updates
+    """
+    loop = asyncio.new_event_loop()
+
+    def cleanup_loop():
+        loop.stop()
+        loop.close()
+    request.addfinalizer(cleanup_loop)
+
+    asyncio.set_event_loop(loop)
+    instr, my_monitor, monitor_parameters, param = inst_and_monitor
+
+    async def async_test_monitor():
+        websocket = await websockets.connect(f"ws://localhost:{monitor.WEBSOCKET_PORT}")
+
+        # Recieve data from monitor
+        data = await websocket.recv()
+        data = json.loads(data)
+        # Check fields
+        assert "ts" in data
+        assert "parameters" in data
+        # Check one instrument and "No Instrument" is being sent
+        assert len(data["parameters"]) == 2
+        assert data["parameters"][1]["instrument"] == "Unbound Parameter"
+        metadata = data["parameters"][0]
+        assert metadata["instrument"] == str(instr)
+
+        # Check parameter values
+        old_timestamps = {}
+        for local_param, mon in zip(monitor_parameters, metadata["parameters"]):
+            assert str(local_param.get_latest()) == mon["value"]
+            assert local_param.label == mon["name"]
+            old_timestamps[local_param.label] = float(mon["ts"])
+            local_param(random.random())
+
+        # Check parameter updates
+        data_str = await websocket.recv()
+        data_str = await websocket.recv()
+        data = json.loads(data_str)
+        metadata = data["parameters"][0]
+        for local_param, mon in zip(monitor_parameters, metadata["parameters"]):
+            assert str(local_param.get_latest()) == mon["value"]
+            assert local_param.label == mon["name"]
+            assert float(mon["ts"]) > old_timestamps[local_param.label]
+
+        # Check unbound parameter
+        metadata = data["parameters"][1]["parameters"]
+        assert len(metadata) == 1
+        assert param.label == metadata[0]["name"]
+
+    loop.run_until_complete(async_test_monitor())
+
+
+


### PR DESCRIPTION
I ocationally get failurs related to ports not beeing available when setting up the monitor tests locally. This seems likely to be due to the tests not probably closing down their websockets if interrupted so I have rewritten the tests using pytest fixtures and finalize to hopefully make this more robust. 