### PR TITLE
Measurements.py Sligth improvments to types

### DIFF
--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -342,7 +342,7 @@ class DataSaver:
 
     @staticmethod
     def _validate_result_types(
-            results_dict: Dict[ParamSpecBase, np.ndarray]) -> None:
+            results_dict: Mapping[ParamSpecBase, np.ndarray]) -> None:
         """
         Validate the type of the results
         """

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -567,7 +567,7 @@ class Runner:
             subscribers: Sequence[Tuple[Callable,
                                         Union[MutableSequence,
                                               MutableMapping]]] = None,
-            parent_datasets: List[Dict] = [],
+            parent_datasets: Sequence[Dict] = (),
             extra_log_info: str = '',
             write_in_background: bool = False) -> None:
 


### PR DESCRIPTION
* Use Sequence for parent_datasets not List. This makes it clear that parent_datasets is not modified and avoid mutable default argument.
* Use Mapping for another input argument to make it clear that this is not mutable. 


