### PR TITLE
Remove slave master references

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
@@ -2,6 +2,8 @@ from functools import wraps
 from operator import xor
 from typing import List, Union, Callable, TypeVar, cast, Optional
 
+from qcodes.utils.deprecate import issue_deprecation_warning
+
 from . import constants
 
 
@@ -2589,10 +2591,26 @@ class MessageBuilder:
         return self
 
     def pch(self,
-            master: Union[constants.ChNr, int],
-            slave: Union[constants.ChNr, int]
+            controller: Union[constants.ChNr, int, None] = None,
+            worker: Union[constants.ChNr, int, None] = None,
+            master: Union[constants.ChNr, int, None] = None,
+            slave: Union[constants.ChNr, int, None] = None
             ) -> 'MessageBuilder':
-        cmd = f'PCH {master},{slave}'
+        if master is not None:
+            issue_deprecation_warning("'master' kwarg", "",
+                                      "'controller' kwarg")
+            controller = master
+        if slave is not None:
+            issue_deprecation_warning("'slave' kwarg", "",
+                                      "'worker' kwarg")
+            worker = slave
+
+        if controller is None:
+            raise TypeError("pch() missing required argument: 'controller'")
+        if worker is None:
+            raise TypeError("pch() missing required argument: 'worker'")
+
+        cmd = f'PCH {controller},{worker}'
 
         self._msg.append(cmd)
         return self

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1565,9 +1565,6 @@ class ZIUHFLI(Instrument):
                            val_mapping = {'ON': 1, 'OFF': 0},
                            vals=vals.Enum('ON', 'OFF'))
 
-        # TODO: make scope_trig_holdoffmode change according to
-        # parameter off scope_holdoff_seconds
-        # and scope_holdoff_events
         self.add_parameter('scope_trig_holdoffmode',
                             label="Scope trigger holdoff mode",
                             set_cmd=partial(self._setter, 'scopes', 0,

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1398,7 +1398,7 @@ class ZIUHFLI(Instrument):
                            vals=vals.Enum(*[1.8e9 / 2 ** v for v in
                                             self._samplingrate_codes.values()]),
                            docstring=""" A numeric representation of the scope's
-                             samplingrate parameter. Sets and gets the sampling 
+                             samplingrate parameter. Sets and gets the sampling
                              rate by using the scope_samplingrate parameter."""
                            )
 
@@ -1565,7 +1565,8 @@ class ZIUHFLI(Instrument):
                            val_mapping = {'ON': 1, 'OFF': 0},
                            vals=vals.Enum('ON', 'OFF'))
 
-        # make this a slave parameter off scope_holdoff_seconds
+        # TODO: make scope_trig_holdoffmode change according to
+        # parameter off scope_holdoff_seconds
         # and scope_holdoff_events
         self.add_parameter('scope_trig_holdoffmode',
                             label="Scope trigger holdoff mode",

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -9,6 +9,7 @@ import numpy as np
 from qcodes.instrument.channel import InstrumentChannel
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.math_utils.field_vector import FieldVector
+from qcodes.utils.deprecate import issue_deprecation_warning
 
 log = logging.getLogger(__name__)
 visalog = logging.getLogger('qcodes.instrument.visa')
@@ -204,6 +205,16 @@ class MercuryWorkerPS(InstrumentChannel):
 
         # TODO: we could use the opportunity to check that we did set/achieve
         #  the intended value
+
+
+class MercurySlavePS(MercuryWorkerPS):
+    """
+    Deprecated class
+    """
+    def __init__(self, parent: VisaInstrument, name: str, UID: str) -> None:
+        issue_deprecation_warning("MercurySlavePS class", "",
+                                  "MercuryWorkerPS class")
+        super().__init__(self, parent, name, UID)
 
 
 class MercuryiPS(VisaInstrument):

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -9,7 +9,7 @@ import numpy as np
 from qcodes.instrument.channel import InstrumentChannel
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.math_utils.field_vector import FieldVector
-from qcodes.utils.deprecate import issue_deprecation_warning
+from qcodes.utils.deprecate import deprecate
 
 log = logging.getLogger(__name__)
 visalog = logging.getLogger('qcodes.instrument.visa')
@@ -207,14 +207,9 @@ class MercuryWorkerPS(InstrumentChannel):
         #  the intended value
 
 
+@deprecate("", "the class <MercuryWorkerPS>")
 class MercurySlavePS(MercuryWorkerPS):
-    """
-    Deprecated class
-    """
-    def __init__(self, parent: VisaInstrument, name: str, UID: str) -> None:
-        issue_deprecation_warning("MercurySlavePS class", "",
-                                  "MercuryWorkerPS class")
-        super().__init__(self, parent, name, UID)
+    pass
 
 
 class MercuryiPS(VisaInstrument):

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -51,9 +51,9 @@ def _signal_parser(our_scaling: float, response: str) -> float:
     return float(digits)*their_scaling*our_scaling
 
 
-class MercurySlavePS(InstrumentChannel):
+class MercuryWorkerPS(InstrumentChannel):
     """
-    Class to hold a slave power supply for the MercuryiPS
+    Class to hold a worker power supply for the MercuryiPS
     """
 
     def __init__(self, parent: VisaInstrument, name: str, UID: str) -> None:
@@ -109,7 +109,7 @@ class MercurySlavePS(InstrumentChannel):
                            unit='T',
                            get_parser=partial(_signal_parser, 1))
 
-        # NB: The current ramp rate slavishly follows the field ramp rate
+        # NB: The current ramp rate follows the field ramp rate
         # (converted via the ATOB param)
         self.add_parameter('current_ramp_rate',
                            label='Ramp rate (current)',
@@ -215,7 +215,7 @@ class MercuryiPS(VisaInstrument):
     def __init__(self, name: str, address: str, visalib=None,
                  field_limits: Optional[Callable[[float,
                                                   float,
-                                                  float], bool]]=None,
+                                                  float], bool]] = None,
                  **kwargs) -> None:
         """
         Args:
@@ -256,7 +256,7 @@ class MercuryiPS(VisaInstrument):
         # TODO: Query instrument to ensure which PSUs are actually present
         for grp in ['GRPX', 'GRPY', 'GRPZ']:
             psu_name = grp
-            psu = MercurySlavePS(self, psu_name, grp)
+            psu = MercuryWorkerPS(self, psu_name, grp)
             self.add_submodule(psu_name, psu)
 
         self._field_limits = (field_limits if field_limits else
@@ -285,17 +285,17 @@ class MercuryiPS(VisaInstrument):
                                unit=unit,
                                docstring='A safe ramp for each coordinate',
                                get_cmd=partial(self._get_component, coord),
-                               set_cmd=partial(self._set_target_and_ramp, 
+                               set_cmd=partial(self._set_target_and_ramp,
                                                coord, 'safe'))
-            
+
             if coord in ['r', 'theta', 'phi', 'rho']:
                 self.add_parameter(name=f'{coord}_simulramp',
                                    label=f'{coord.upper()} ramp field',
                                    unit=unit,
-                                   docstring='A simultaneous blocking ramp for a '
-                                             'combined coordinate',
+                                   docstring='A simultaneous blocking ramp for'
+                                             ' a combined coordinate',
                                    get_cmd=partial(self._get_component, coord),
-                                   set_cmd=partial(self._set_target_and_ramp, 
+                                   set_cmd=partial(self._set_target_and_ramp,
                                                    coord, 'simul_block'))
 
         # FieldVector-valued parameters #
@@ -381,13 +381,13 @@ class MercuryiPS(VisaInstrument):
         # update our internal target cache
         self._target_vector.set_component(**{coordinate: target})
 
-        # actually assign the target on the slaves
+        # actually assign the target on the workers
         cartesian_targ = self._target_vector.get_components('x', 'y', 'z')
-        for targ, slave in zip(cartesian_targ, self.submodules.values()):
-            if not isinstance(slave, MercurySlavePS):
-                raise RuntimeError(f"Expected a MercurySlavePS but got "
-                                   f"{type(slave)}")
-            slave.field_target(targ)
+        for targ, worker in zip(cartesian_targ, self.submodules.values()):
+            if not isinstance(worker, MercuryWorkerPS):
+                raise RuntimeError(f"Expected a MercuryWorkerPS but got "
+                                   f"{type(worker)}")
+            worker.field_target(targ)
 
     def _set_target_field(self, field: FieldVector) -> None:
         for coord in 'xyz':
@@ -414,11 +414,11 @@ class MercuryiPS(VisaInstrument):
         ramp rates. NOTE: there is NO guarantee that this does not take you
         out of your safe region. Use with care.
         """
-        for slave in self.submodules.values():
-            if not isinstance(slave, MercurySlavePS):
-                raise RuntimeError(f"Expected a MercurySlavePS but got "
-                                   f"{type(slave)}")
-            slave.ramp_to_target()
+        for worker in self.submodules.values():
+            if not isinstance(worker, MercuryWorkerPS):
+                raise RuntimeError(f"Expected a MercuryWorkerPS but got "
+                                   f"{type(worker)}")
+            worker.ramp_to_target()
 
     def _ramp_simultaneously_blocking(self) -> None:
         """
@@ -428,12 +428,12 @@ class MercuryiPS(VisaInstrument):
         """
         self._ramp_simultaneously()
 
-        for slave in self.submodules.values():
-            if not isinstance(slave, MercurySlavePS):
-                raise RuntimeError(f"Expected a MercurySlavePS but got "
-                                   f"{type(slave)}")
+        for worker in self.submodules.values():
+            if not isinstance(worker, MercuryWorkerPS):
+                raise RuntimeError(f"Expected a MercuryWorkerPS but got "
+                                   f"{type(worker)}")
             # wait for the ramp to finish, we don't care about the order
-            while slave.ramp_status() == 'TO SET':
+            while worker.ramp_status() == 'TO SET':
                 time.sleep(0.1)
 
         self.update_field()
@@ -447,14 +447,14 @@ class MercuryiPS(VisaInstrument):
         targ_vals = self._target_vector.get_components('x', 'y', 'z')
         order = np.argsort(np.abs(np.array(targ_vals) - np.array(meas_vals)))
 
-        for slave in np.array(list(self.submodules.values()))[order]:
-            slave.ramp_to_target()
+        for worker in np.array(list(self.submodules.values()))[order]:
+            worker.ramp_to_target()
             # now just wait for the ramp to finish
             # (unless we are testing)
             if self.visabackend == 'sim':
                 pass
             else:
-                while slave.ramp_status() == 'TO SET':
+                while worker.ramp_status() == 'TO SET':
                     time.sleep(0.1)
 
         self.update_field()
@@ -464,8 +464,8 @@ class MercuryiPS(VisaInstrument):
         Update all the field components.
         """
         coords = ['x', 'y', 'z', 'r', 'theta', 'phi', 'rho']
-        meas_field = self._get_field()
-        [getattr(self,f'{i}_measured').get() for i in coords]
+        _ = self._get_field()
+        [getattr(self, f'{i}_measured').get() for i in coords]
 
     def is_ramping(self) -> bool:
         """
@@ -498,7 +498,7 @@ class MercuryiPS(VisaInstrument):
 
         self._field_limits = limit_func
 
-    def ramp(self, mode: str="safe") -> None:
+    def ramp(self, mode: str = "safe") -> None:
         """
         Ramp the fields to their present target value
 
@@ -513,31 +513,31 @@ class MercuryiPS(VisaInstrument):
         """
         if mode not in ['simul', 'safe', 'simul_block']:
             raise ValueError('Invalid ramp mode. Please provide either "simul"'
-                                ',"safe" or "simul_block".')
+                             ', "safe" or "simul_block".')
 
         meas_vals = self._get_measured(['x', 'y', 'z'])
         # we asked for three coordinates, so we know that we got a list
         meas_vals = cast(List[float], meas_vals)
 
-        for cur, slave in zip(meas_vals, self.submodules.values()):
-            if not isinstance(slave, MercurySlavePS):
-                raise RuntimeError(f"Expected a MercurySlavePS but got "
-                                   f"{type(slave)}")
-            if slave.field_target() != cur:
-                if slave.field_ramp_rate() == 0:
-                    raise ValueError(f'Can not ramp {slave}; ramp rate set to'
-                                        ' zero!')
+        for cur, worker in zip(meas_vals, self.submodules.values()):
+            if not isinstance(worker, MercuryWorkerPS):
+                raise RuntimeError(f"Expected a MercuryWorkerPS but got "
+                                   f"{type(worker)}")
+            if worker.field_target() != cur:
+                if worker.field_ramp_rate() == 0:
+                    raise ValueError(f'Can not ramp {worker}; ramp rate set to'
+                                     ' zero!')
 
         # then the actual ramp
         {'simul': self._ramp_simultaneously,
-        'safe': self._ramp_safely,
-        'simul_block':self._ramp_simultaneously_blocking}[mode]()
+         'safe': self._ramp_safely,
+         'simul_block': self._ramp_simultaneously_blocking}[mode]()
 
     def _set_target_and_ramp(self, coordinate: str, mode: str, target: float) -> None:
         """Convenient method to combine setting target and ramping"""
         self._set_target(coordinate, target)
         self.ramp(mode)
-    
+
     def ask(self, cmd: str) -> str:
         """
         Since Oxford Instruments implement their own version of a SCPI-like


### PR DESCRIPTION
This PR deprecates the use of "slave" as an argument name for a function and as a class name and variable name for magnet power supplies. We have one un-addressed master/slave reference in the code, but that is in `versioneer.py`, which should be addressed upstream.

I have played it safe by deprecation, but perhaps we can more aggressively simply remove/rename?

@QCoDeS/core 
