### PR TITLE
Build docs with Sphinx 3

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -403,7 +403,7 @@ templates_path = ['_templates']
 # want to store them locally.
 suppress_warnings = ['image.nonlocal_uri']
 
-nitpicky = True
+nitpicky = False
 
 # we allow most types from the typing modules to be used in
 # docstrings even if they don't resolve

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -376,8 +376,8 @@ texinfo_show_urls = 'footnote'
 intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'matplotlib': ('https://matplotlib.org/', None),
-    'python': ('https://docs.python.org/3.6', None),
-    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'python': ('https://docs.python.org/3.7/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
     'py': ('https://pylib.readthedocs.io/en/stable/', None),
     'pyvisa': ('https://pyvisa.readthedocs.io/en/master/', None),
     'IPython': ('https://ipython.readthedocs.io/en/stable/', None)}

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.4.4
+sphinx==3.1.1
 sphinx_rtd_theme
 sphinx-jsonschema
 nbsphinx

--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -147,19 +147,6 @@ class DataSet(DelegateAttributes):
             between saves to disk. If not ``LOCAL``, the ``DataServer`` handles
             this and generally writes more often. Use None to disable writing
             from calls to ``self.store``. Default 5.
-
-    Attributes:
-        background_functions (collections.OrderedDict[Callable]): Class
-            attribute, ``{key: fn}``: ``fn`` is a callable accepting no
-            arguments, and ``key`` is a name to identify the function and help
-            you attach and remove it.
-
-            In ``DataSet.complete`` we call each of these periodically, in the
-            order that they were attached.
-
-            Note that because this is a class attribute, the functions will
-            apply to every DataSet. If you want specific functions for one
-            DataSet you can override this with an instance attribute.
     """
 
     # ie data_set.arrays['vsd'] === data_set.vsd
@@ -170,6 +157,18 @@ class DataSet(DelegateAttributes):
     location_provider = FormatLocation()
 
     background_functions: Dict[str, Callable] = OrderedDict()
+    """
+    The value ``fn`` is a callable accepting no
+    arguments, and ``key`` is a name to identify the function and help
+    you attach and remove it.
+
+    In ``DataSet.complete`` we call each of these periodically, in the
+    order that they were attached.
+
+    Note that because this is a class attribute, the functions will
+    apply to every DataSet. If you want specific functions for one
+    DataSet you can override this with an instance attribute.
+    """
 
     def __init__(self, location=None, arrays=None, formatter=None, io=None,
                  write_period=5):

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -23,7 +23,6 @@ class InstrumentChannel(InstrumentBase):
         name: The name of this channel.
 
     Attributes:
-        name (str): The name of this channel.
 
         parameters (Dict[Parameter]): All the parameters supported by this
           channel. Usually populated via ``add_parameter``.

--- a/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
+++ b/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
@@ -141,16 +141,17 @@ class WrappedDll(metaclass=DllWrapperMeta):
     Method ``_sync_dll_call`` is supposed to be called when a subclass
     implements calls to functions of the loaded DLL.
 
-    Attributes:
-        signatures: :mod:`ctypes` signatures for loaded DLL functions;
-            it is to be filled with :class:`Signature` instances for the DLL
-            functions of interest in a subclass.
-
     Args:
         dll_path: Path to the DLL library to load and wrap
     """
 
     signatures: Dict[str, Signature] = {}
+    """
+    Signatures for loaded DLL functions;
+    It is to be filled with :class:`Signature` instances for the DLL
+    functions of interest in a subclass.
+    """
+
 
     # This is the DLL library instance.
     _dll: ctypes.CDLL

--- a/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
+++ b/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
@@ -126,8 +126,8 @@ class WrappedDll(metaclass=DllWrapperMeta):
 
     Note that this class is still quite specific to Alazar ATS DLL library.
 
-    This class uses dictionary of the :attr:``signatures`` attribute in order
-    to assign ``argtypes`` and ``restype`` atttributes for functions of
+    This class uses dictionary of the :attr:`signatures` attribute in order
+    to assign ``argtypes`` and ``restype`` attributes for functions of
     a loaded DLL library (from the ``_dll`` attribute of the class).
     If ``restype`` is of type ``RETURN_CODE``, then an exception is
     raised in case the return code is an Alazar error code. For string-alike

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -67,8 +67,6 @@ class FrequencySweep(ArrayParameter):
         npts: number of points in frequency sweep
 
     Methods:
-          set_sweep(start, stop, npts): sets the shapes and
-              setpoint arrays of the parameter to correspond with the sweep
           get(): executes a sweep and returns magnitude and phase arrays
 
     """
@@ -88,6 +86,16 @@ class FrequencySweep(ArrayParameter):
         self._channel = channel
 
     def set_sweep(self, start: float, stop: float, npts: int) -> None:
+        """
+        sets the shapes and setpoint arrays of the parameter to
+        correspond with the sweep
+
+        Args:
+            start: Starting frequency of the sweep
+            stop: Stopping frequency of the sweep
+            npts: Number of points in the sweep
+
+        """
         # Needed to update config of the software parameter on sweep change
         # freq setpoints tuple as needs to be hashable for look up.
         f = tuple(np.linspace(int(start), int(stop), num=npts))

--- a/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/USB_SA124B.py
@@ -103,8 +103,6 @@ class FrequencySweep(ArrayParameter):
         stepsize: Size of a frequency step
 
     Methods:
-          set_sweep(sweep_len, start_freq, stepsize): sets the shapes and
-              setpoint arrays of the parameter to correspond with the sweep
           get(): executes a sweep and returns magnitude and phase arrays
 
     """


### PR DESCRIPTION
* Move some attibute docs inline so that we avoid duplicate entries and failures resulting from that.
* Disable nitpicky. Sphinx now tries to resolve all types to links. It does not seem meaningful to fix all of these

Also updated two intersphinx links. Python 3.6 -> 3.7 and redirect of numpy docs