### PR TITLE
Fix guid tests overwriting home config

### DIFF
--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -1,9 +1,15 @@
-from typing import Callable, Type, TYPE_CHECKING
+import os
+import tempfile
+from typing import Callable, Type, TYPE_CHECKING, Optional
+from contextlib import contextmanager
 from functools import wraps
 from time import sleep
 import cProfile
+import copy
 
+import qcodes
 from qcodes.utils.metadata import Metadatable
+from qcodes.configuration import Config, DotDict
 
 if TYPE_CHECKING:
     from _pytest._code.code import ExceptionInfo
@@ -134,3 +140,55 @@ class DumyPar(Metadatable):
     def set(self, value):
         value = value * 2
         return value
+
+
+@contextmanager
+def default_config(user_config: Optional[str] = None):
+    """
+    Context manager to temporarily establish default config settings.
+    This is achieved by overwriting the config paths of the user-,
+    environment-, and current directory-config files with the path of the
+    config file in the qcodes repository.
+    Additionally the current config object `qcodes.config` gets copied and
+    reestablished.
+
+    Args:
+        user_config: represents the user config file content.
+    """
+    home_file_name = Config.home_file_name
+    schema_home_file_name = Config.schema_home_file_name
+    env_file_name = Config.env_file_name
+    schema_env_file_name = Config.schema_env_file_name
+    cwd_file_name = Config.cwd_file_name
+    schema_cwd_file_name = Config.schema_cwd_file_name
+
+    Config.home_file_name = ''
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file_name = os.path.join(tmpdirname, 'user_config.json')
+        file_name_schema = os.path.join(tmpdirname, 'user_config_schema.json')
+        if user_config is not None:
+            with open(file_name, 'w') as f:
+                f.write(user_config)
+
+        Config.home_file_name = file_name
+        Config.schema_home_file_name = file_name_schema
+        Config.env_file_name = ''
+        Config.schema_env_file_name = ''
+        Config.cwd_file_name = ''
+        Config.schema_cwd_file_name = ''
+
+        default_config_obj: Optional[DotDict] = copy.\
+            deepcopy(qcodes.config.current_config)
+        qcodes.config = Config()
+
+        try:
+            yield
+        finally:
+            Config.home_file_name = home_file_name
+            Config.schema_home_file_name = schema_home_file_name
+            Config.env_file_name = env_file_name
+            Config.schema_env_file_name = schema_env_file_name
+            Config.cwd_file_name = cwd_file_name
+            Config.schema_cwd_file_name = schema_cwd_file_name
+
+            qcodes.config.current_config = default_config_obj

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -1,6 +1,4 @@
 import time
-from copy import deepcopy
-from contextlib import contextmanager
 from uuid import uuid4
 
 import pytest
@@ -14,7 +12,7 @@ from qcodes.dataset.guids import (generate_guid, parse_guid,
                                   set_guid_work_station_code,
                                   validate_guid_format,
                                   filter_guids_by_parts)
-from qcodes.tests.test_config import default_config
+from qcodes.tests.common import default_config
 
 
 @settings(max_examples=50, deadline=1000)

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -14,21 +14,7 @@ from qcodes.dataset.guids import (generate_guid, parse_guid,
                                   set_guid_work_station_code,
                                   validate_guid_format,
                                   filter_guids_by_parts)
-from qcodes.configuration import DotDict
-
-@contextmanager
-def protected_config():
-    """
-    Context manager to be used in all tests that modify the config to ensure
-    that the config is left untouched even if the tests fail
-    """
-    ocfg: DotDict = qc.config.current_config
-    original_config = deepcopy(ocfg)
-
-    try:
-        yield
-    finally:
-        qc.config.current_config = original_config
+from qcodes.tests.test_config import default_config
 
 
 @settings(max_examples=50, deadline=1000)
@@ -36,7 +22,7 @@ def protected_config():
        smpl=hst.integers(0, 4294967295))
 def test_generate_guid(loc, stat, smpl):
     # update config to generate a particular guid. Read it back to verify
-    with protected_config():
+    with default_config():
         cfg = qc.config
         cfg['GUID_components']['location'] = loc
         cfg['GUID_components']['work_station'] = stat
@@ -61,11 +47,9 @@ def test_generate_guid(loc, stat, smpl):
 def test_set_guid_location_code(loc, monkeypatch):
     monkeypatch.setattr('builtins.input', lambda x: str(loc))
 
-    orig_cfg = qc.config
-
-    original_loc = orig_cfg['GUID_components']['location']
-
-    with protected_config():
+    with default_config():
+        orig_cfg = qc.config
+        original_loc = orig_cfg['GUID_components']['location']
         set_guid_location_code()
 
         cfg = qc.config
@@ -78,14 +62,13 @@ def test_set_guid_location_code(loc, monkeypatch):
 
 @settings(max_examples=50, deadline=1000)
 @given(ws=hst.integers(-10, 17000000))
-def test_set_guid_workstatio_code(ws, monkeypatch):
+def test_set_guid_workstation_code(ws, monkeypatch):
     monkeypatch.setattr('builtins.input', lambda x: str(ws))
 
-    orig_cfg = qc.config
+    with default_config():
+        orig_cfg = qc.config
+        original_ws = orig_cfg['GUID_components']['work_station']
 
-    original_ws = orig_cfg['GUID_components']['work_station']
-
-    with protected_config():
         set_guid_work_station_code()
 
         cfg = qc.config
@@ -123,7 +106,7 @@ def test_filter_guid(locs, stats, smpls):
 
         return guid
 
-    with protected_config():
+    with default_config():
 
         guids = []
         cfg = qc.config

--- a/qcodes/tests/dataset/test_subscribing.py
+++ b/qcodes/tests/dataset/test_subscribing.py
@@ -10,9 +10,8 @@ import qcodes
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.sqlite.connection import atomic_transaction
-from qcodes.tests.dataset.test_dataset_basic import make_shadow_dataset
 
-from qcodes.tests.test_config import default_config
+from qcodes.tests.common import default_config
 from qcodes.tests.common import retry_until_does_not_throw
 
 

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -162,12 +162,13 @@ def default_config(user_config: Optional[str] = None):
     Config.home_file_name = ''
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_name = os.path.join(tmpdirname, 'user_config.json')
+        file_name_schema = os.path.join(tmpdirname, 'user_config_schema.json')
         if user_config is not None:
             with open(file_name, 'w') as f:
                 f.write(user_config)
 
         Config.home_file_name = file_name
-        Config.schema_home_file_name = ''
+        Config.schema_home_file_name = file_name_schema
         Config.env_file_name = ''
         Config.schema_env_file_name = ''
         Config.cwd_file_name = ''

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -6,15 +6,13 @@ import unittest
 from pathlib import Path
 
 from functools import partial
-from contextlib import contextmanager
 from unittest.mock import mock_open, patch, PropertyMock
 from unittest import TestCase
-from typing import Optional
 import pytest
-import tempfile
 import qcodes
+from qcodes.tests.common import default_config
 
-from qcodes.configuration import Config, DotDict
+from qcodes.configuration import Config
 
 VALID_JSON = "{}"
 ENV_KEY = "/dev/random"
@@ -137,58 +135,6 @@ BAD_CONFIG_MAP = {Config.default_file_name: {"z": 1, "a": 1, "b": 0},
                   Config.schema_env_file_name: SCHEMA,
                   Config.schema_default_file_name: SCHEMA,
                   }
-
-
-@contextmanager
-def default_config(user_config: Optional[str] = None):
-    """
-    Context manager to temporarily establish default config settings.
-    This is achieved by overwriting the config paths of the user-,
-    environment-, and current directory-config files with the path of the
-    config file in the qcodes repository.
-    Additionally the current config object `qcodes.config` gets copied and
-    reestablished.
-
-    Args:
-        user_config: represents the user config file content.
-    """
-    home_file_name = Config.home_file_name
-    schema_home_file_name = Config.schema_home_file_name
-    env_file_name = Config.env_file_name
-    schema_env_file_name = Config.schema_env_file_name
-    cwd_file_name = Config.cwd_file_name
-    schema_cwd_file_name = Config.schema_cwd_file_name
-
-    Config.home_file_name = ''
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        file_name = os.path.join(tmpdirname, 'user_config.json')
-        file_name_schema = os.path.join(tmpdirname, 'user_config_schema.json')
-        if user_config is not None:
-            with open(file_name, 'w') as f:
-                f.write(user_config)
-
-        Config.home_file_name = file_name
-        Config.schema_home_file_name = file_name_schema
-        Config.env_file_name = ''
-        Config.schema_env_file_name = ''
-        Config.cwd_file_name = ''
-        Config.schema_cwd_file_name = ''
-
-        default_config_obj: Optional[DotDict] = copy.\
-            deepcopy(qcodes.config.current_config)
-        qcodes.config = Config()
-
-        try:
-            yield
-        finally:
-            Config.home_file_name = home_file_name
-            Config.schema_home_file_name = schema_home_file_name
-            Config.env_file_name = env_file_name
-            Config.schema_env_file_name = schema_env_file_name
-            Config.cwd_file_name = cwd_file_name
-            Config.schema_cwd_file_name = schema_cwd_file_name
-
-            qcodes.config.current_config = default_config_obj
 
 
 def side_effect(map, name):

--- a/qcodes/tests/test_generic_formatter.py
+++ b/qcodes/tests/test_generic_formatter.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import numpy as np
 
 import qcodes
+import qcodes.measure
 from qcodes.data.hdf5_format import HDF5Format, HDF5FormatMetadata
 from qcodes.data.gnuplot_format import GNUPlotFormat
 from qcodes.data.data_set import load_data

--- a/qcodes/tests/test_plot_utils.py
+++ b/qcodes/tests/test_plot_utils.py
@@ -13,7 +13,7 @@ from matplotlib import pyplot as plt
 from qcodes.tests.dataset.conftest import (empty_temp_db,
                                            experiment, dataset)
 
-from qcodes.tests.test_config import default_config
+from qcodes.tests.common import default_config
 from qcodes.dataset.plotting import plot_by_id
 from .dataset_generators import dataset_with_outliers_generator
 import qcodes

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -1,7 +1,6 @@
 import pytest
 from contextlib import contextmanager
 import tempfile
-import json
 import warnings
 from pathlib import Path
 import os
@@ -21,7 +20,7 @@ from qcodes.instrument.parameter import Parameter
 from qcodes.monitor.monitor import Monitor
 from qcodes.tests.instrument_mocks import (
     DummyInstrument)
-from qcodes.tests.test_config import default_config
+from qcodes.tests.common import default_config
 from qcodes.utils.helpers import NumpyJSONEncoder
 from qcodes.utils.helpers import YAML
 from .common import DumyPar


### PR DESCRIPTION
The context manager used to protect the config in the guid tests that overwrites home config was insuffisient as it did not relocate the home config. Use the default_config config manager instead that does this correctly. 

In the process of debugging this issue I found that `test_generic_formatter` cannot be run standalone so fix that too. 

Since we use the `default_config` context manager in multiple locations I also moved that to a common location
