### PR TITLE
B1500: Output NaN instead of 199.999e99

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_base.py
@@ -5,7 +5,8 @@ from collections import defaultdict
 
 from qcodes import VisaInstrument, MultiParameter
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_module \
-    import _FMTResponse, fmt_response_base_parser, StatusMixin
+    import _FMTResponse, fmt_response_base_parser, StatusMixin, \
+    convert_dummy_val_to_nan
 from qcodes.utils.helpers import create_on_off_val_mapping
 from .KeysightB1530A import B1530A
 from .KeysightB1520A import B1520A
@@ -505,5 +506,8 @@ class IVSweepMeasurement(MultiParameter, StatusMixin):
 
         self.shapes = ((len(self.source_voltage.value),),) * 2
         self.setpoints = ((self.source_voltage.value,),) * 2
+
+        convert_dummy_val_to_nan(self.param1)
+        convert_dummy_val_to_nan(self.param2)
 
         return self.param1.value, self.param2.value

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -243,6 +243,24 @@ def get_measurement_summary(status_array: np.ndarray) -> str:
 
     return summary
 
+
+def convert_dummy_val_to_nan(param: _FMTResponse):
+    """
+    Converts dummy value to NaN. Instrument may output dummy value (
+    199.999E+99) if measurement data is over the measurement range. Or the
+    sweep measurement was aborted by the automatic stop function or power
+    compliance. Or if any abort condition is detected. Dummy data
+    199.999E+99 will be returned for the data after abort."
+
+    Args:
+        param: This must be of type named tuple _FMTResponse.
+
+    """
+    for index, value in enumerate(param.status):
+        if param.value[index] == 199.999e99:
+            param.value[index] = float('nan')
+
+
 class B1500Module(InstrumentChannel):
     """Base class for all modules of B1500 Parameter Analyzer
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -256,8 +256,8 @@ def convert_dummy_val_to_nan(param: _FMTResponse):
         param: This must be of type named tuple _FMTResponse.
 
     """
-    for index, value in enumerate(param.status):
-        if param.value[index] == 199.999e99:
+    for index, value in enumerate(param.value):
+        if value == 199.999e99:
             param.value[index] = float('nan')
 
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -257,7 +257,7 @@ def convert_dummy_val_to_nan(param: _FMTResponse):
 
     """
     for index, value in enumerate(param.value):
-        if value == 199.999e99:
+        if value > 1e99:
             param.value[index] = float('nan')
 
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_sampling_measurement.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_sampling_measurement.py
@@ -7,7 +7,7 @@ from qcodes.instrument.parameter import ParameterWithSetpoints
 from .message_builder import MessageBuilder
 from . import constants
 from .KeysightB1500_module import fmt_response_base_parser, _FMTResponse, \
-    MeasurementNotTaken
+    MeasurementNotTaken, convert_dummy_val_to_nan
 
 if TYPE_CHECKING:
     from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A \
@@ -68,6 +68,7 @@ class SamplingMeasurement(ParameterWithSetpoints):
                 MessageBuilder().xe().message)
 
         self.data = fmt_response_base_parser(raw_data)
+        convert_dummy_val_to_nan(self.data)
         return numpy.array(self.data.value)
 
     def compliance(self):

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -11,7 +11,8 @@ import qcodes.utils.validators as vals
 from .KeysightB1500_module import B1500Module, parse_dcorr_query_response, \
     format_dcorr_response, _DCORRResponse, parse_dcv_measurement_response, \
     _FMTResponse, fmt_response_base_parser, fixed_negative_float, \
-    get_name_label_unit_of_impedance_model, StatusMixin
+    get_name_label_unit_of_impedance_model, StatusMixin, \
+    convert_dummy_val_to_nan
 from .message_builder import MessageBuilder
 from . import constants
 from .constants import ModuleKind, ChNr, MM
@@ -908,6 +909,9 @@ class CVSweepMeasurement(MultiParameter, StatusMixin):
 
             self.shapes = ((len(self.dc_voltage.value),),) * 2
             self.setpoints = ((self.dc_voltage.value,),) * 2
+
+        convert_dummy_val_to_nan(self.param1)
+        convert_dummy_val_to_nan(self.param2)
 
         return self.param1.value, self.param2.value
 

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
@@ -103,8 +103,8 @@ def test_convert_dummy_val_to_nan():
     status = ['C', 'V', 'N', 'V', 'N', 'N']
     value = [0, 199.999e99, 1, 199.999e99, 2, 3]
     channel = [1, 1, 1, 1, 1, 1]
-    type = ['V', 'V', 'V', 'V', 'V', 'V']
-    param = _FMTResponse(value, status, channel, type)
+    param_type = ['V', 'V', 'V', 'V', 'V', 'V']
+    param = _FMTResponse(value, status, channel, param_type)
     convert_dummy_val_to_nan(param)
     assert math.isnan(param.value[1])
     assert math.isnan(param.value[3])

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
@@ -1,10 +1,13 @@
+import math
 from unittest.mock import MagicMock
 
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import \
     B1517A
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_module import \
     parse_module_query_response, format_dcorr_response, _DCORRResponse, \
-    fixed_negative_float, get_name_label_unit_of_impedance_model
+    fixed_negative_float, get_name_label_unit_of_impedance_model, \
+    convert_dummy_val_to_nan, _FMTResponse, \
+    convert_dummy_val_to_nan
 from qcodes.instrument_drivers.Keysight.keysightb1500.constants import \
     SlotNr, DCORR, IMP
 
@@ -94,3 +97,16 @@ def test_get_name_label_unit_of_impedance_model():
     assert name == ('admittance', 'phase')
     assert label == ('Admittance', 'Phase')
     assert unit == ('S', 'degree')
+
+
+def test_convert_dummy_val_to_nan():
+    status = ['C', 'V', 'N', 'V', 'N', 'N']
+    value = [0, 199.999e99, 1, 199.999e99, 2, 3]
+    channel = [1, 1, 1, 1, 1, 1]
+    type = ['V', 'V', 'V', 'V', 'V', 'V']
+    param = _FMTResponse(value, status, channel, type)
+    convert_dummy_val_to_nan(param)
+    assert math.isnan(param.value[1])
+    assert math.isnan(param.value[3])
+
+

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_sampling_measurement.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_sampling_measurement.py
@@ -61,8 +61,7 @@ def test_measurement_requires_timing_parameters_to_be_set(smu):
 def test_sampling_measurement(smu_sampling_measurement,
                               smu_output):
     smu_sampling_measurement, _, _, _ = smu_sampling_measurement
-    n_samples, _ = smu_output
-    data_to_return = smu_output[1]
+    n_samples, data_to_return = smu_output
     smu_sampling_measurement.timing_parameters(h_bias=0,
                                                interval=0.1,
                                                number=n_samples)


### PR DESCRIPTION
Instead of passing dummy value 199.999e99 due to power compliance being reached in sampling measurements or measurement being aborted, NaN value is output.

Some relevant lines from Manual:
"Measurement data is over the measurement range. Or the sweep measurement was aborted by the automatic stop function or power compliance. D will be 199.999E+99 (no meaning)."

"The B1500 returns the data measured before any abort condition is detected. Dummy data 199.999E+99 will be returned for the data after abort."

@astafan8 @jenshnielsen 