### PR TITLE
Add support for pytest 6

### DIFF
--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -11,6 +11,7 @@ import qcodes
 from qcodes.utils.metadata import Metadatable
 from qcodes.configuration import Config, DotDict
 
+from _pytest._code.code import ExceptionChainRepr
 if TYPE_CHECKING:
     from _pytest._code.code import ExceptionInfo
 
@@ -111,7 +112,10 @@ def error_caused_by(excinfo: 'ExceptionInfo', cause: str) -> bool:
         excinfo: the output of with pytest.raises() as excinfo
         cause: the error message or a substring of it
     """
-    chain = excinfo.getrepr().chain
+
+    exc_repr = excinfo.getrepr()
+    assert isinstance(exc_repr, ExceptionChainRepr)
+    chain = exc_repr.chain
     # first element of the chain is info about the root exception
     error_location = chain[0][1]
     root_traceback = chain[0][0]

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -18,11 +18,9 @@ pytest_version = version.parse(pytest.__version__)
 assert isinstance(pytest_version, version.Version)
 
 if pytest_version.major >= 6:
-    pytest6 = True
-    num_pytest_loggers = 2
+    NUM_PYTEST_LOGGERS = 2
 else:
-    pytest6 = False
-    num_pytest_loggers = 1
+    NUM_PYTEST_LOGGERS = 1
 
 
 @pytest.fixture
@@ -136,7 +134,7 @@ def test_start_logger_twice():
     # there is one or two loggers registered from pytest
     # depending on the version
     # and the telemetry logger is always off in the tests
-    assert len(handlers) == 2+num_pytest_loggers
+    assert len(handlers) == 2+NUM_PYTEST_LOGGERS
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
@@ -146,7 +144,7 @@ def test_set_level_without_starting_raises():
             pass
     # there is one or two loggers registered from pytest
     # depending on the version
-    assert len(logging.getLogger().handlers) == num_pytest_loggers
+    assert len(logging.getLogger().handlers) == NUM_PYTEST_LOGGERS
 
 
 @pytest.mark.usefixtures("remove_root_handlers")

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -1,15 +1,16 @@
 """
 Tests for `qcodes.utils.logger`.
 """
-import pytest
-import os
 import logging
+import os
 from copy import copy
+
+import pytest
 from packaging import version
+
+import qcodes as qc
 import qcodes.logger as logger
 from qcodes.logger.log_analysis import capture_dataframe
-import qcodes as qc
-
 
 TEST_LOG_MESSAGE = 'test log message'
 

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -15,6 +15,7 @@ from qcodes.logger.log_analysis import capture_dataframe
 TEST_LOG_MESSAGE = 'test log message'
 
 pytest_version = version.parse(pytest.__version__)
+assert isinstance(pytest_version, version.Version)
 
 if pytest_version.major >= 6:
     pytest6 = True

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -160,6 +160,7 @@ def test_handler_level():
             logging.debug(TEST_LOG_MESSAGE)
     assert logs.value.strip() == TEST_LOG_MESSAGE
 
+
 @pytest.mark.usefixtures("remove_root_handlers")
 def test_filter_instrument(AMI430_3D):
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ install_requires = [
     "dataclasses;python_version<'3.7'",  # can be removed once we drop support for python 3.6
     "requirements-parser",
     "importlib-metadata;python_version<'3.8'",
-    "typing_extensions"
+    "typing_extensions",
+    "packaging"
 ]
 
 setup(name='qcodes',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ install_requires = [
     "requirements-parser",
     "importlib-metadata;python_version<'3.8'",
     "typing_extensions",
-    "packaging"
+    "packaging>=20.0"
 ]
 
 setup(name='qcodes',


### PR DESCRIPTION
To be released very soon (rc1 is out) 

This changes the logger slightly so that there are now 2 default loggers for pytest. 
It also adds types to pytest :) So fix one error related to that