### PR TITLE
Add formatting to the log messages of Telemetry

### DIFF
--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -70,6 +70,18 @@ def get_formatter() -> logging.Formatter:
     return logging.Formatter(format_string)
 
 
+def get_formatter_for_telemetry() -> logging.Formatter:
+    """
+    Returns :class:`logging.Formatter` according to
+    :data:`FORMAT_STRING_DICT`
+    """
+    format_string_items = [f'%({name}){fmt}'
+                           for name, fmt in FORMAT_STRING_DICT.items()
+                           if name in ['message', 'name']]
+    format_string = LOGGING_SEPARATOR.join(format_string_items)
+    return logging.Formatter(format_string)
+
+
 def get_console_handler() -> Optional[logging.Handler]:
     """
     Get handle that prints messages from the root logger to the console.
@@ -229,7 +241,7 @@ def start_logger() -> None:
                               f'{qc.config.telemetry.instrumentation_key}')
         telemetry_handler.add_telemetry_processor(callback_function)
         telemetry_handler.setLevel(logging.INFO)
-        telemetry_handler.setFormatter(get_formatter())
+        telemetry_handler.setFormatter(get_formatter_for_telemetry())
         root_logger.addHandler(telemetry_handler)
 
     log.info("QCoDes logger setup completed")

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -72,8 +72,8 @@ def get_formatter() -> logging.Formatter:
 
 def get_formatter_for_telemetry() -> logging.Formatter:
     """
-    Returns :class:`logging.Formatter` according to
-    :data:`FORMAT_STRING_DICT`
+    Returns :class:`logging.Formatter` with only message and name keywords
+    from FORMAT_STRING_DICT
     """
     format_string_items = [f'%({name}){fmt}'
                            for name, fmt in FORMAT_STRING_DICT.items()

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -72,12 +72,12 @@ def get_formatter() -> logging.Formatter:
 
 def get_formatter_for_telemetry() -> logging.Formatter:
     """
-    Returns :class:`logging.Formatter` with only message and name keywords
-    from FORMAT_STRING_DICT
+    Returns :class:`logging.Formatter` with only name, function name and
+    message keywords from FORMAT_STRING_DICT
     """
     format_string_items = [f'%({name}){fmt}'
                            for name, fmt in FORMAT_STRING_DICT.items()
-                           if name in ['message', 'name']]
+                           if name in ['message', 'name', 'funcName']]
     format_string = LOGGING_SEPARATOR.join(format_string_items)
     return logging.Formatter(format_string)
 

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -229,6 +229,7 @@ def start_logger() -> None:
                               f'{qc.config.telemetry.instrumentation_key}')
         telemetry_handler.add_telemetry_processor(callback_function)
         telemetry_handler.setLevel(logging.INFO)
+        telemetry_handler.setFormatter(get_formatter())
         root_logger.addHandler(telemetry_handler)
 
     log.info("QCoDes logger setup completed")


### PR DESCRIPTION
Currently telemetry only captures messages which are not formatted to contain logger name and other things. Here we make it similar to logging of file handler and console handler



@jenshnielsen 
