### PR TITLE
Update zenodo DOI to 0.16.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,5 +81,5 @@ See `License <https://github.com/QCoDeS/Qcodes/tree/master/LICENSE.rst>`__.
     :target: https://travis-ci.com/QCoDeS/Qcodes
 .. |DOCS| image:: https://img.shields.io/badge/read%20-thedocs-ff66b4.svg
    :target: http://qcodes.github.io/Qcodes
-.. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3903234.svg
-   :target: https://doi.org/10.5281/zenodo.3903234
+.. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.3952330.svg
+   :target: https://doi.org/10.5281/zenodo.3952330


### PR DESCRIPTION
Update the zenodo DOI to point to the latest release.

@astafan8 
