### PR TITLE
Fix: convert spyder kernels site print statement to logging message

### DIFF
--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -569,7 +569,7 @@ def add_to_spyder_UMR_excludelist(modulename: str):
             except ImportError:
                 pass
             else:
-                print("found kernels site")
+                logging.info("found spyder kernels site")
                 sitecustomize_found = True
 
         if sitecustomize_found is False:


### PR DESCRIPTION
In the spyder environment for each new console a message is printed about the site kernels. This PR converts the message to a logging statement and adds the text spyder to make it more informative

@astafan8 
