### PR TITLE
Station: Pass name as kwarg so that its order in instrument class is not relevant

### DIFF
--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -459,7 +459,7 @@ class Station(Metadatable, DelegateAttributes):
             instr_class_name = instr_cfg['type'].split('.')[-1]
         module = importlib.import_module(module_name)
         instr_class = getattr(module, instr_class_name)
-        instr = instr_class(name, **instr_kwargs)
+        instr = instr_class(name=name, **instr_kwargs)
 
         def resolve_instrument_identifier(
             instrument: ChannelOrInstrumentBase,

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -544,6 +544,22 @@ def test_name_init_kwarg(simple_mock_station):
     assert st.components['test'] is mock
 
 
+def test_name_specified_in_init_in_yaml_is_used():
+    st = station_from_config_str(
+        """
+instruments:
+  mock:
+    type: qcodes.tests.instrument_mocks.DummyInstrument
+    init:
+      name: dummy
+        """)
+
+    mock = st.load_instrument('mock')
+    assert isinstance(mock, DummyInstrument)
+    assert mock.name == 'dummy'
+    assert st.components['dummy'] is mock
+
+
 class InstrumentWithNameAsNotFirstArgument(Instrument):
     def __init__(self, first_arg, name):
         super(InstrumentWithNameAsNotFirstArgument, self).__init__(name)

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -544,6 +544,26 @@ def test_name_init_kwarg(simple_mock_station):
     assert st.components['test'] is mock
 
 
+class InstrumentWithNameAsNotFirstArgument(Instrument):
+    def __init__(self, first_arg, name):
+        super(InstrumentWithNameAsNotFirstArgument, self).__init__(name)
+        self._first_arg = first_arg
+
+
+def test_able_to_load_instrument_with_name_argument_not_being_the_first():
+    st = station_from_config_str(
+        """
+instruments:
+  name_goes_second:
+    type: qcodes.tests.test_station.InstrumentWithNameAsNotFirstArgument
+        """)
+
+    instr = st.load_instrument('name_goes_second', first_arg=42)
+    assert isinstance(instr, InstrumentWithNameAsNotFirstArgument)
+    assert instr.name == 'name_goes_second'
+    assert st.components['name_goes_second'] is instr
+
+
 def test_setup_alias_parameters():
     st = station_from_config_str("""
 instruments:


### PR DESCRIPTION
Orginal issue:
```yaml
my_qwe:
    type: foo.bar.Qwe
    init:
        ...
```
```python
# in foo/bar.py
from qcodes.instrument.base import Instrument

class Qwe(Instrument):
    def __init__(some_arg, name, ...)
        super().__init__(name, ...)
        ....
```
```python
# after Station initialization from yaml config
my_qwe = station.load_instrument('my_qwe', some_arg='some_value')
# this line resulting in "TypeError: __init__() got multiple values for argument 'some_arg'"
```

This PR solves this issue. (inspired by https://github.com/qdev-dk/qdev-wrappers/blob/master/qdev_wrappers/station_configurator.py#L164)

Also:
- [x] test having a class in the config whose "name" argument is NOT the first - expect load_instrument to work without exceptions
- [x] extra test for having "name" set up in the config in the "init" section - expect the "identifyer" to be used for closing old instances and stuff, but the instrument will be created with "name" (see code)