### PR TITLE
Updating the broken link for conda-environment-update in Qcodes docum…

### DIFF
--- a/docs/start/index.rst
+++ b/docs/start/index.rst
@@ -113,7 +113,7 @@ explained above and run the same commands from a directory containing that file.
 The first line ensures that the ``conda`` package manager it self is
 up to date and the second line will ensure that the latest versions of the
 packages used by QCoDeS are installed. See
-`here <https://conda.io/docs/commands/env/conda-env-update.html>`__ for more
+`here <https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#updating-an-environment>`__ for more
 documentation on ``conda env update``.
 
 If you using QCoDeS from an editable install you should also reinstall QCoDeS using
@@ -160,4 +160,3 @@ Getting started
 
 Have a look at `15 minutes to Qcodes <../examples/15_minutes_to_QCoDeS.ipynb>`__, and or browse
 `the examples notebooks <../examples/index.rst>`__.
-


### PR DESCRIPTION
The link https://conda.io/docs/commands/env/conda-env-update.html for documentation of conda-environment-update does not exist anymore.
The link is updated to a new related documentation link.
@jenshnielsen 
