### PR TITLE
limit pytest xdist to version 1.x

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,7 +2,7 @@ coverage!=4.5.0
 pytest-cov
 pytest
 pytest-rerunfailures
-pytest-xdist
+pytest-xdist<2.0.0
 codacy-coverage
 hypothesis<5.6.0 # large number of warnings due to change in 5.6.0 https://hypothesis.readthedocs.io/en/latest/changes.html#v5-6-0
 mypy==0.782


### PR DESCRIPTION
Will hopefully fix the test failure in #2114 
