### PR TITLE
Simplify instrument destructor

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -504,7 +504,7 @@ class Instrument(InstrumentBase, AbstractInstrument):
         try:
             self.close()
         except BaseException:
-            log.exception("Failed to close instrument in destructor")
+            pass
 
     def close(self) -> None:
         """

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -502,12 +502,9 @@ class Instrument(InstrumentBase, AbstractInstrument):
     def __del__(self) -> None:
         """Close the instrument and remove its instance record."""
         try:
-            wr = weakref.ref(self)
-            if wr in getattr(self, '_instances', []):
-                self._instances.remove(wr)
             self.close()
-        except:
-            pass
+        except BaseException:
+            log.exception("Failed to close instrument in destructor")
 
     def close(self) -> None:
         """

--- a/qcodes/instrument/ip.py
+++ b/qcodes/instrument/ip.py
@@ -201,9 +201,6 @@ class IPInstrument(Instrument):
             self._send(cmd)
             return self._recv()
 
-    def __del__(self) -> None:
-        self.close()
-
     def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None
                       ) -> Dict:


### PR DESCRIPTION
Currently `__del__` first tries to remove the instrument from the instances list and then calls close which does the same + more.
It seems better to just call close. This also enables us to get rid of a subclassing of `__del__` in IPInstrument that does just that  
