### PR TITLE
Remove warning about complex numbers in R&S ZNB driver

### DIFF
--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -103,14 +103,7 @@ class FrequencySweep(ArrayParameter):
         self.shape = (npts,)
 
     def get_raw(self):
-        data = self._instrument._get_sweep_data()
-        if self._instrument.format() in ['Polar', 'Complex',
-                                         'Smith', 'Inverse Smith']:
-            log.warning("QCoDeS Dataset does not currently support Complex "
-                        "values. Will discard the imaginary part. In order to "
-                        "acquire phase and amplitude use the "
-                        "FrequencySweepMagPhase parameter.")
-        return data
+        return self._instrument._get_sweep_data()
 
 
 class ZNBChannel(InstrumentChannel):


### PR DESCRIPTION
As of https://github.com/QCoDeS/Qcodes/pull/1493, this warning seems redundant. We've checked in an experiment that the measured complex values get stored and can be read out/plotted properly.

@astafan8 