### PR TITLE
Add optional shape metadata to dataset 

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -366,15 +366,18 @@ class DataSet(Sized):
             self._run_id = run_id
             self._completed = False
             self._started = False
+
             if isinstance(specs, InterDependencies_):
-                self._interdeps = specs
+                interdeps = specs
             elif specs is not None:
-                self._interdeps = old_to_new(InterDependencies(*specs))
+                interdeps = old_to_new(InterDependencies(*specs))
             else:
-                self._interdeps = InterDependencies_()
-            RunDescriber._verify_interdeps_shape(interdeps=self._interdeps,
-                                                 shapes=shapes)
-            self._shapes = shapes
+                interdeps = InterDependencies_()
+
+            self.set_interdependencies(
+                interdeps=interdeps,
+                shapes=shapes)
+
             self._metadata = get_metadata_from_run_id(self.conn, self.run_id)
             self._parent_dataset_links = []
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -639,8 +639,10 @@ class DataSet(Sized):
                               interdeps: InterDependencies_,
                               shapes: Shapes = None) -> None:
         """
-        Overwrite the interdependencies object (which holds all added
-        parameters and their relationships) of this dataset
+        Set the interdependencies object (which holds all added
+        parameters and their relationships) of this dataset and
+        optionally the shapes object that holds information about
+        the shape of the data to be measured.
         """
         if not isinstance(interdeps, InterDependencies_):
             raise TypeError('Wrong input type. Expected InterDepencies_, '

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -372,8 +372,8 @@ class DataSet(Sized):
                 self._interdeps = old_to_new(InterDependencies(*specs))
             else:
                 self._interdeps = InterDependencies_()
-            RunDescriber._verify_interdeps_grid_shape(interdeps=self._interdeps,
-                                                      shapes=shapes)
+            RunDescriber._verify_interdeps_shape(interdeps=self._interdeps,
+                                                 shapes=shapes)
             self._shapes = shapes
             self._metadata = get_metadata_from_run_id(self.conn, self.run_id)
             self._parent_dataset_links = []
@@ -653,7 +653,7 @@ class DataSet(Sized):
                     'been started.')
             raise RuntimeError(mssg)
 
-        RunDescriber._verify_interdeps_grid_shape(interdeps, shapes)
+        RunDescriber._verify_interdeps_shape(interdeps, shapes)
         self._interdeps = interdeps
         self._shapes = shapes
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1,4 +1,3 @@
-import atexit
 import functools
 import importlib
 import json

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -43,20 +43,27 @@ class DataSetCache:
         if self._dataset.completed:
             self._loaded_from_completed_ds = True
 
-        rundescriber = get_rundescriber_from_result_table_name(self._dataset.conn, self._dataset.table_name)
+        rundescriber = get_rundescriber_from_result_table_name(
+            self._dataset.conn,
+            self._dataset.table_name
+        )
         interdeps = rundescriber.interdeps
         parameters = tuple(ps.name for ps in interdeps.non_dependencies)
 
         for parameter in parameters:
             start = self._read_status.get(parameter, 0) + 1
 
-            data, n_rows_read = get_parameter_data_for_one_paramtree(self._dataset.conn,
-                                                              self._dataset.table_name,
-                                                              rundescriber=rundescriber,
-                                                              output_param=parameter,
-                                                              start=start,
-                                                              end=None)
-            self._data[parameter] = self._merge_data_dicts_inner(self._data.get(parameter, {}), data)
+            data, n_rows_read = get_parameter_data_for_one_paramtree(
+                self._dataset.conn,
+                self._dataset.table_name,
+                rundescriber=rundescriber,
+                output_param=parameter,
+                start=start,
+                end=None)
+            self._data[parameter] = self._merge_data_dicts_inner(
+                self._data.get(parameter, {}),
+                data
+            )
             self._read_status[parameter] = self._read_status.get(parameter, 0) + n_rows_read
 
     @staticmethod

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Dict, Optional
 import numpy as np
 
 from qcodes.dataset.sqlite.queries import (
+    get_rundescriber_from_result_table_name,
     get_interdeps_from_result_table_name, completed,
     get_parameter_data_for_one_paramtree)
 
@@ -42,7 +43,8 @@ class DataSetCache:
         if self._dataset.completed:
             self._loaded_from_completed_ds = True
 
-        interdeps = get_interdeps_from_result_table_name(self._dataset.conn, self._dataset.table_name)
+        rundescriber = get_rundescriber_from_result_table_name(self._dataset.conn, self._dataset.table_name)
+        interdeps = rundescriber.interdeps
         parameters = tuple(ps.name for ps in interdeps.non_dependencies)
 
         for parameter in parameters:
@@ -50,7 +52,7 @@ class DataSetCache:
 
             data, n_rows_read = get_parameter_data_for_one_paramtree(self._dataset.conn,
                                                               self._dataset.table_name,
-                                                              interdeps=interdeps,
+                                                              rundescriber=rundescriber,
                                                               output_param=parameter,
                                                               start=start,
                                                               end=None)

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -3,12 +3,13 @@ from typing import TYPE_CHECKING, Dict, Optional
 import numpy as np
 
 from qcodes.dataset.sqlite.queries import (
-    get_rundescriber_from_result_table_name,
-    get_interdeps_from_result_table_name, completed,
-    get_parameter_data_for_one_paramtree)
+    completed, get_interdeps_from_result_table_name,
+    get_parameter_data_for_one_paramtree,
+    get_rundescriber_from_result_table_name)
 
 if TYPE_CHECKING:
     import pandas as pd
+
     from .data_set import DataSet, ParameterData
 
 

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -1,12 +1,10 @@
-from typing import TYPE_CHECKING, Dict, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Optional
 
 import numpy as np
 
 from qcodes.dataset.sqlite.queries import (
-    get_rundescriber_from_result_table_name, completed,
+    get_interdeps_from_result_table_name, completed,
     get_parameter_data_for_one_paramtree)
-from qcodes.dataset.descriptions.rundescriber import RunDescriber
-from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -27,9 +25,7 @@ class DataSetCache:
         self._data: ParameterData = {}
         #: number of rows read per parameter tree (by the name of the dependent parameter)
         self._read_status: Dict[str, int] = {}
-        self._write_status: Dict[str, Optional[int]] = {}
         self._loaded_from_completed_ds = False
-        self.rundesciber: Optional[RunDescriber] = None
 
     def load_data_from_db(self) -> None:
         """
@@ -46,86 +42,37 @@ class DataSetCache:
         if self._dataset.completed:
             self._loaded_from_completed_ds = True
 
-        if self.rundesciber is None:
-            self.rundesciber = get_rundescriber_from_result_table_name(self._dataset.conn, self._dataset.table_name)
-
-        parameters = tuple(ps.name for ps in self.rundesciber.interdeps.non_dependencies)
+        interdeps = get_interdeps_from_result_table_name(self._dataset.conn, self._dataset.table_name)
+        parameters = tuple(ps.name for ps in interdeps.non_dependencies)
 
         for parameter in parameters:
             start = self._read_status.get(parameter, 0) + 1
 
             data, n_rows_read = get_parameter_data_for_one_paramtree(self._dataset.conn,
                                                               self._dataset.table_name,
-                                                              rundesciber=self.rundesciber,
+                                                              interdeps=interdeps,
                                                               output_param=parameter,
                                                               start=start,
                                                               end=None)
-            shapes = self.rundesciber.shapes
-            if shapes is not None:
-                shape = shapes.get(parameter, None)
-            else:
-                shape = None
-
-            self._data[parameter], self._write_status = self._merge_data_dicts_inner(
-                self._data.get(parameter, {}), data,
-                shape=shape,
-                write_status=self._write_status
-            )
+            self._data[parameter] = self._merge_data_dicts_inner(self._data.get(parameter, {}), data)
             self._read_status[parameter] = self._read_status.get(parameter, 0) + n_rows_read
 
     @staticmethod
     def _merge_data_dicts_inner(existing_data: Dict[str, np.ndarray],
-                                new_data: Dict[str, np.ndarray],
-                                shape: Optional[Tuple[int, ...]],
-                                write_status: Dict[str, Optional[int]]
-                                ) -> Tuple[Dict[str, np.ndarray],
-                                           Dict[str, Optional[int]]]:
+                                new_data: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
         merged_data = {}
         parameters = set(existing_data.keys()) | set(new_data.keys())
-        new_write_status: Optional[int]
 
         for parameter in parameters:
             existing_values = existing_data.get(parameter)
             new_values = new_data.get(parameter)
             if existing_values is not None and new_values is not None:
-                merged_data[parameter], new_write_status = DataSetCache._insert_into_data_dict(
-                    existing_values,
-                    new_values,
-                    write_status.get(parameter)
-                )
-                write_status[parameter] = new_write_status
+                merged_data[parameter] = np.append(existing_values, new_values, axis=0)
             elif new_values is not None:
-                merged_data[parameter], new_write_status = DataSetCache._create_new_data_dict(
-                    new_values,
-                    shape
-                )
-                write_status[parameter] = new_write_status
+                merged_data[parameter] = new_values
             elif existing_values is not None:
                 merged_data[parameter] = existing_values
-        return merged_data, write_status
-
-    @staticmethod
-    def _create_new_data_dict(new_values: np.ndarray,
-                              shape: Optional[Tuple[int, ...]]
-                              ) -> Tuple[np.ndarray, Optional[int]]:
-        if shape is None:
-            return new_values, None
-        else:
-            data = np.zeros(shape, dtype=new_values.dtype)
-            data[:] = np.nan
-            data.ravel()[0:len(new_values)] = new_values
-            return data, len(new_values)
-
-    @staticmethod
-    def _insert_into_data_dict(
-            existing_values: np.ndarray,
-            new_values: np.ndarray,
-            write_status: Optional[int]) -> Tuple[np.ndarray, Optional[int]]:
-        if write_status is None:
-            return np.append(existing_values, new_values, axis=0), None
-        else:
-            existing_values.ravel()[write_status:write_status+len(new_values)] = new_values
-            return existing_values, write_status+len(new_values)
+        return merged_data
 
     def data(self) -> 'ParameterData':
         """

--- a/qcodes/dataset/database_extract_runs.py
+++ b/qcodes/dataset/database_extract_runs.py
@@ -191,7 +191,9 @@ def _extract_single_dataset_into_db(dataset: DataSet,
         param_names = dataset.parameters.split(',')
     else:
         param_names = []
-    parspecs_dict = {p.name: p for p in new_to_old(dataset.description.interdeps).paramspecs}
+    parspecs_dict = {
+        p.name: p for p in new_to_old(dataset.description.interdeps).paramspecs
+    }
     parspecs = [parspecs_dict[p] for p in param_names]
 
     metadata = dataset.metadata

--- a/qcodes/dataset/database_extract_runs.py
+++ b/qcodes/dataset/database_extract_runs.py
@@ -189,7 +189,7 @@ def _extract_single_dataset_into_db(dataset: DataSet,
         param_names = dataset.parameters.split(',')
     else:
         param_names = []
-    parspecs_dict = {p.name: p for p in new_to_old(dataset._interdeps).paramspecs}
+    parspecs_dict = {p.name: p for p in new_to_old(dataset._rundescriber.interdeps).paramspecs}
     parspecs = [parspecs_dict[p] for p in param_names]
 
     metadata = dataset.metadata

--- a/qcodes/dataset/database_extract_runs.py
+++ b/qcodes/dataset/database_extract_runs.py
@@ -1,21 +1,23 @@
-from typing import Union, Optional
-from warnings import warn
 import os
+from typing import Optional, Union
+from warnings import warn
 
 import numpy as np
 
-from qcodes.dataset.descriptions.versioning.converters import new_to_old
 from qcodes.dataset.data_set import DataSet
-from qcodes.dataset.experiment_container import load_or_create_experiment
-from qcodes.dataset.sqlite.connection import atomic, ConnectionPlus
-from qcodes.dataset.sqlite.database import connect, \
-    get_db_version_and_newest_available_version
-from qcodes.dataset.sqlite.queries import add_meta_data, create_run, \
-    get_exp_ids_from_run_ids, get_matching_exp_ids, get_runid_from_guid, \
-    is_run_id_in_database, mark_run_complete, new_experiment
-from qcodes.dataset.sqlite.query_helpers import select_many_where, \
-    sql_placeholder_string
+from qcodes.dataset.descriptions.versioning.converters import new_to_old
 from qcodes.dataset.linked_datasets.links import links_to_str
+from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic
+from qcodes.dataset.sqlite.database import (
+    connect, get_db_version_and_newest_available_version)
+from qcodes.dataset.sqlite.queries import (add_meta_data, create_run,
+                                           get_exp_ids_from_run_ids,
+                                           get_matching_exp_ids,
+                                           get_runid_from_guid,
+                                           is_run_id_in_database,
+                                           mark_run_complete, new_experiment)
+from qcodes.dataset.sqlite.query_helpers import (select_many_where,
+                                                 sql_placeholder_string)
 
 
 def extract_runs_into_db(source_db_path: str,
@@ -189,7 +191,7 @@ def _extract_single_dataset_into_db(dataset: DataSet,
         param_names = dataset.parameters.split(',')
     else:
         param_names = []
-    parspecs_dict = {p.name: p for p in new_to_old(dataset._rundescriber.interdeps).paramspecs}
+    parspecs_dict = {p.name: p for p in new_to_old(dataset.description.interdeps).paramspecs}
     parspecs = [parspecs_dict[p] for p in param_names]
 
     metadata = dataset.metadata

--- a/qcodes/dataset/descriptions/dependencies.py
+++ b/qcodes/dataset/descriptions/dependencies.py
@@ -426,9 +426,9 @@ class InterDependencies_:
                                     .union(old_standalones))
         else:
             raise ValueError(f'Inconsistent InterDependencies_ object '
-                             f'parameter: {parameter}. is in list of'
-                             f'parameters but neither a "standalone",'
-                             f'"dependency" or  "inference"')
+                             f'parameter: {parameter} is in list of'
+                             f'parameters but is neither a "standalone", '
+                             f'"dependency" or "inference"')
 
         idps = InterDependencies_(dependencies=new_deps, inferences=new_inffs,
                                   standalones=new_standalones)

--- a/qcodes/dataset/descriptions/dependencies.py
+++ b/qcodes/dataset/descriptions/dependencies.py
@@ -156,7 +156,7 @@ class InterDependencies_:
 
     @staticmethod
     def validate_paramspectree(
-        paramspectree: ParamSpecTree) -> Optional[ErrorTuple]:
+            paramspectree: ParamSpecTree) -> Optional[ErrorTuple]:
         """
         Validate a ParamSpecTree. Apart from adhering to the type, a
         ParamSpecTree must not have any cycles.

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -11,17 +11,18 @@ from qcodes.utils.validators import Arrays
 def get_shape_of_measurement(meas_param: _BaseParameter,
                              *steps: Union[int, Sequence[Any], np.ndarray]) -> Dict[str, Tuple[int, ...]]:
     """
-    Due to the way MultiParameter works there is not a one to one correspondence
-    between Parameters registered and ParamSpecs in the dataset.
-    E.g. one Parameter may result in multiple ParamSpecs. Therefor this returns
-    a Dict[name, shape]
+    Construct the shape of a measurement of a dependent parameter from the
+    parameter and the axes it is to be sweept over.
 
     Args:
-        meas_param:
-        *steps:
+        meas_param: The dependent parameter to construct the shape for
+        *steps: Zero or more dimensions that the parameter is to be sweept over.
+           These can be given either as the length of the dimension or as
+           a sequence of numbers to sweep over.
 
     Returns:
-
+        A dictionary from the parameter name to a tuple of integers describing
+        the shape.
     """
     shapes: Dict[str, Tuple[int, ...]]
 

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -18,7 +18,7 @@ def detect_shape_of_measurement(
     Construct the shape of a measurement of a dependent parameter from the
     parameter and the axes it is to be sweept over. Note that the
     steps should be given in the order from outer to inner loop and
-    the shape will be returned in c order with the inner loop at the
+    the shape will be returned in C order with the inner loop at the
     end.
 
     Args:

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -1,13 +1,12 @@
-from typing import Union, Sequence, Dict, Tuple, Sized, List
-from numbers import Integral
 from collections import abc
+from numbers import Integral
+from typing import Dict, List, Sequence, Sized, Tuple, Union
 
 import numpy as np
 
-from qcodes.instrument.parameter import (_BaseParameter,
-                                         ArrayParameter,
-                                         MultiParameter,
-                                         ParameterWithSetpoints)
+from qcodes.instrument.parameter import (ArrayParameter, MultiParameter,
+                                         ParameterWithSetpoints,
+                                         _BaseParameter)
 from qcodes.utils.validators import Arrays
 
 

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -98,6 +98,12 @@ def _get_shape_of_arrayparam(param: _BaseParameter) -> Tuple[int, ...]:
             raise TypeError("Cannot infer shape of a ParameterWithSetpoints "
                             "without an unknown shape in its validator.")
         return shape
+    elif isinstance(param.vals, Arrays):
+        shape = param.vals.shape
+        if shape is None:
+            raise TypeError("Cannot infer shape of a Parameter "
+                            "with Array validator without a known shape.")
+        return shape
     else:
         raise TypeError(f"Invalid parameter type: Expected an array like "
                         f"parameter got: {type(param)}")

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -82,7 +82,7 @@ def _get_shape_of_arrayparam(param: _BaseParameter) -> Tuple[int, ...]:
     elif isinstance(param, ParameterWithSetpoints):
         if not isinstance(param.vals, Arrays):
             raise TypeError("ParameterWithSetpoints must have an"
-                            " array type validator.")
+                            " array type validator in order to detect it's shape.")
         shape = param.vals.shape
         if shape is None:
             raise TypeError("Cannot infer shape of a ParameterWithSetpoints "

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -37,7 +37,7 @@ def get_shape_of_measurement(
         meas_shape = _get_shape_of_arrayparam(meas_param)
         shapes = {meas_param.full_name: meas_shape}
     else:
-        shapes = {meas_param.name: ()}
+        shapes = {meas_param.full_name: ()}
 
     for step in steps:
         for name in shapes.keys():

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -94,8 +94,9 @@ def _get_shape_of_arrayparam(param: _BaseParameter) -> Tuple[int, ...]:
         return tuple(param.shape)
     elif isinstance(param, ParameterWithSetpoints):
         if not isinstance(param.vals, Arrays):
-            raise TypeError("ParameterWithSetpoints must have an"
-                            " array type validator in order to detect it's shape.")
+            raise TypeError("ParameterWithSetpoints must have an "
+                            "array type validator in order "
+                            "to detect it's shape.")
         shape = param.vals.shape
         if shape is None:
             raise TypeError("Cannot infer shape of a ParameterWithSetpoints "

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -13,7 +13,7 @@ from qcodes.utils.validators import Arrays
 
 def get_shape_of_measurement(
         parameters: Sequence[_BaseParameter],
-        steps: Optional[Union[Sequence[int], Sequence[Sized]]] = None
+        steps: Union[Sequence[int], Sequence[Sized]] = ()
 ) -> Dict[str, Tuple[int, ...]]:
     """
     Construct the shape of a measurement of a dependent parameter from the
@@ -39,6 +39,7 @@ def get_shape_of_measurement(
             shapes[param.full_name] = _get_shape_of_arrayparam(param)
         else:
             shapes[param.full_name] = ()
+
 
         for step in steps:
             for name in shapes.keys():

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -4,12 +4,17 @@ from collections import abc
 
 import numpy as np
 
-from qcodes.instrument.parameter import _BaseParameter, ArrayParameter, MultiParameter, ParameterWithSetpoints
+from qcodes.instrument.parameter import (_BaseParameter,
+                                         ArrayParameter,
+                                         MultiParameter,
+                                         ParameterWithSetpoints)
 from qcodes.utils.validators import Arrays
 
 
-def get_shape_of_measurement(meas_param: _BaseParameter,
-                             *steps: Union[int, Sequence[Any], np.ndarray]) -> Dict[str, Tuple[int, ...]]:
+def get_shape_of_measurement(
+        meas_param: _BaseParameter,
+        *steps: Union[int, Sequence[Any], np.ndarray]
+) -> Dict[str, Tuple[int, ...]]:
     """
     Construct the shape of a measurement of a dependent parameter from the
     parameter and the axes it is to be sweept over.
@@ -41,7 +46,9 @@ def get_shape_of_measurement(meas_param: _BaseParameter,
     return shapes
 
 
-def _get_shape_of_step(step: Union[int, np.integer, Sequence[Any], np.ndarray]) -> int:
+def _get_shape_of_step(
+        step: Union[int, np.integer, Sequence[Any], np.ndarray]
+) -> int:
     if isinstance(step, Integral):
         return int(step)
     elif isinstance(step, abc.Sequence):
@@ -51,8 +58,9 @@ def _get_shape_of_step(step: Union[int, np.integer, Sequence[Any], np.ndarray]) 
             raise TypeError("A step must b|e a one dimensional sweep")
         return int(step.shape[0])
     else:
-        raise TypeError(f"get_shape_of_step takes either an integer or a sequence"
-                        f" not: {type(step)}")
+        raise TypeError(f"get_shape_of_step takes "
+                        f"either an integer or a sequence "
+                        f"not: {type(step)}")
 
 
 def _param_is_array_like(meas_param: _BaseParameter) -> bool:
@@ -81,7 +89,9 @@ def _get_shape_of_arrayparam(param: _BaseParameter) -> Tuple[int, ...]:
                         f"parameter got: {type(param)}")
 
 
-def _get_shapes_of_multi_parameter(param: MultiParameter) -> Dict[str, Tuple[int, ...]]:
+def _get_shapes_of_multi_parameter(
+        param: MultiParameter
+) -> Dict[str, Tuple[int, ...]]:
     shapes: Dict[str, Tuple[int, ...]] = {}
 
     for i, name in enumerate(param.full_names):

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -1,4 +1,4 @@
-from typing import Union, Sequence, Dict, Any, Tuple
+from typing import Union, Sequence, Dict, Any, Tuple, Optional, Sized
 from numbers import Integral
 from collections import abc
 
@@ -12,15 +12,15 @@ from qcodes.utils.validators import Arrays
 
 
 def get_shape_of_measurement(
-        meas_param: _BaseParameter,
-        *steps: Union[int, Sequence[Any], np.ndarray]
+        parameters: Sequence[_BaseParameter],
+        steps: Optional[Union[Sequence[int], Sequence[Sized]]] = None
 ) -> Dict[str, Tuple[int, ...]]:
     """
     Construct the shape of a measurement of a dependent parameter from the
     parameter and the axes it is to be sweept over.
 
     Args:
-        meas_param: The dependent parameter to construct the shape for
+        parameters: The dependent parameters to construct the shape for
         *steps: Zero or more dimensions that the parameter is to be sweept over.
            These can be given either as the length of the dimension or as
            a sequence of numbers to sweep over.
@@ -29,34 +29,38 @@ def get_shape_of_measurement(
         A dictionary from the parameter name to a tuple of integers describing
         the shape.
     """
-    shapes: Dict[str, Tuple[int, ...]]
+    shapes: Dict[str, Tuple[int, ...]] = {}
 
-    if isinstance(meas_param, MultiParameter):
-        shapes = _get_shapes_of_multi_parameter(param=meas_param)
-    elif _param_is_array_like(meas_param):
-        meas_shape = _get_shape_of_arrayparam(meas_param)
-        shapes = {meas_param.full_name: meas_shape}
-    else:
-        shapes = {meas_param.full_name: ()}
+    for param in parameters:
 
-    for step in steps:
-        for name in shapes.keys():
-            shapes[name] = shapes[name] + (_get_shape_of_step(step),)
+        if isinstance(param, MultiParameter):
+            shapes.update(_get_shapes_of_multi_parameter(param=param))
+        elif _param_is_array_like(param):
+            shapes[param.full_name] = _get_shape_of_arrayparam(param)
+        else:
+            shapes[param.full_name] = ()
+
+        for step in steps:
+            for name in shapes.keys():
+                shapes[name] = shapes[name] + (_get_shape_of_step(step),)
 
     return shapes
 
 
 def _get_shape_of_step(
-        step: Union[int, np.integer, Sequence[Any], np.ndarray]
+        step: Union[int, np.integer, Sized, np.ndarray]
 ) -> int:
     if isinstance(step, Integral):
         return int(step)
-    elif isinstance(step, abc.Sequence):
-        return len(step)
     elif isinstance(step, np.ndarray):
+        # we explicitly check for numpy arrays
+        # even if the numpy array is sized
+        # to verify that they are one dimensional
         if not len(step.shape) == 1:
-            raise TypeError("A step must b|e a one dimensional sweep")
+            raise TypeError("A step must be a one dimensional sweep")
         return int(step.shape[0])
+    elif isinstance(step, abc.Sized):
+        return len(step)
     else:
         raise TypeError(f"get_shape_of_step takes "
                         f"either an integer or a sequence "

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -23,7 +23,7 @@ def detect_shape_of_measurement(
 
     Args:
         parameters: The dependent parameters to construct the shape for
-        *steps: Zero or more dimensions that the parameter is to be sweept over.
+        steps: Zero or more dimensions that the parameter is to be sweept over.
            These can be given either as the length of the dimension or as
            a sequence of numbers to sweep over.
 

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -57,13 +57,13 @@ def _get_shape_of_step(
         # even if the numpy array is sized
         # to verify that they are one dimensional
         if not len(step.shape) == 1:
-            raise TypeError("A step must be a one dimensional sweep")
+            raise TypeError("A step must be a one dimensional array")
         return int(step.shape[0])
     elif isinstance(step, abc.Sized):
         return len(step)
     else:
         raise TypeError(f"get_shape_of_step takes "
-                        f"either an integer or a sequence "
+                        f"either an integer or a sized sequence "
                         f"not: {type(step)}")
 
 

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -11,7 +11,7 @@ from qcodes.instrument.parameter import (_BaseParameter,
 from qcodes.utils.validators import Arrays
 
 
-def get_shape_of_measurement(
+def detect_shape_of_measurement(
         parameters: Sequence[_BaseParameter],
         steps: Union[Sequence[int], Sequence[Sized]] = ()
 ) -> Dict[str, Tuple[int, ...]]:

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -1,4 +1,4 @@
-from typing import Union, Sequence, Dict, Any, Tuple, Optional, Sized
+from typing import Union, Sequence, Dict, Tuple, Sized, List
 from numbers import Integral
 from collections import abc
 
@@ -33,10 +33,10 @@ def detect_shape_of_measurement(
         the shape.
     """
 
-    loop_shape = ()
+    loop_shape: List[int] = []
 
     for step in steps:
-        loop_shape += (_get_shape_of_step(step),)
+        loop_shape.append(_get_shape_of_step(step))
 
     array_shapes: Dict[str, Tuple[int, ...]] = {}
 
@@ -52,7 +52,7 @@ def detect_shape_of_measurement(
     shapes: Dict[str, Tuple[int, ...]] = {}
 
     for param_name in array_shapes.keys():
-        shapes[param_name] = loop_shape + array_shapes[param_name]
+        shapes[param_name] = tuple(loop_shape) + array_shapes[param_name]
 
     return shapes
 

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -47,7 +47,7 @@ def _get_shape_of_step(step: Union[int, np.integer, Sequence[Any], np.ndarray]) 
         return len(step)
     elif isinstance(step, np.ndarray):
         if not len(step.shape) == 1:
-            raise TypeError("A step must be a one dimensional sweep")
+            raise TypeError("A step must b|e a one dimensional sweep")
         return int(step.shape[0])
     else:
         raise TypeError(f"get_shape_of_step takes either an integer or a sequence"

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -40,10 +40,9 @@ def get_shape_of_measurement(
         else:
             shapes[param.full_name] = ()
 
-
-        for step in steps:
-            for name in shapes.keys():
-                shapes[name] = shapes[name] + (_get_shape_of_step(step),)
+    for step in steps:
+        for name in shapes.keys():
+            shapes[name] = shapes[name] + (_get_shape_of_step(step),)
 
     return shapes
 

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -31,6 +31,10 @@ def detect_shape_of_measurement(
     Returns:
         A dictionary from the parameter name to a tuple of integers describing
         the shape.
+
+    Raises:
+        TypeError: If the shape cannot be detected due to incorrect types of
+            parameters or steps supplied.
     """
 
     loop_shape: List[int] = []
@@ -96,7 +100,7 @@ def _get_shape_of_arrayparam(param: _BaseParameter) -> Tuple[int, ...]:
         shape = param.vals.shape
         if shape is None:
             raise TypeError("Cannot infer shape of a ParameterWithSetpoints "
-                            "without an unknown shape in its validator.")
+                            "with an unknown shape in its validator.")
         return shape
     elif isinstance(param.vals, Arrays):
         shape = param.vals.shape

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 
 from .versioning.converters import new_to_old, old_to_new
-from .versioning.rundescribertypes import (GridDict, RunDescriberDicts,
+from .versioning.rundescribertypes import (RunDescriberDicts,
                                            RunDescriberV0Dict,
                                            RunDescriberV1Dict,
                                            RunDescriberV2Dict,
@@ -26,17 +26,15 @@ class RunDescriber:
     """
 
     def __init__(self, interdeps: InterDependencies_,
-                 grids: GridDict = None,
                  shapes: Shapes = None) -> None:
 
         if not isinstance(interdeps, InterDependencies_):
             raise ValueError('The interdeps arg must be of type: '
                              'InterDependencies_. '
                              f'Got {type(interdeps)}.')
-        self._verify_interdeps_grid_shape(interdeps, grids, shapes)
+        self._verify_interdeps_grid_shape(interdeps, shapes)
 
         self.interdeps = interdeps
-        self._grids = grids
         self._shapes = shapes
         self._version = 3
 
@@ -45,16 +43,11 @@ class RunDescriber:
         return self._version
 
     @property
-    def grids(self) -> GridDict:
-        return self._grids
-
-    @property
     def shapes(self) -> Shapes:
         return self._shapes
 
     @staticmethod
     def _verify_interdeps_grid_shape(interdeps: InterDependencies_,
-                                     grids: GridDict,
                                      shapes: Shapes) -> None:
         """
         Verify that interdeps, grid and shape are consistent
@@ -71,7 +64,6 @@ class RunDescriber:
             'version': self._version,
             'interdependencies': new_to_old(self.interdeps)._to_dict(),
             'interdependencies_': self.interdeps._to_dict(),
-            'grids': self.grids,
             'shapes': self.shapes
 
         }
@@ -105,7 +97,6 @@ class RunDescriber:
             ser = cast(RunDescriberV3Dict, ser)
             rundesc = cls(
                 InterDependencies_._from_dict(ser['interdependencies_']),
-                grids=ser['grids'],
                 shapes=ser['shapes']
             )
         else:
@@ -122,4 +113,4 @@ class RunDescriber:
         return True
 
     def __repr__(self) -> str:
-        return f"RunDescriber({self.interdeps}, Grids:{self._grids}, Shapes:{self._shapes})"
+        return f"RunDescriber({self.interdeps}, Shapes:{self._shapes})"

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -58,7 +58,8 @@ class RunDescriber:
                 if shape is not None:
                     if len(shape) != len(dependencies):
                         raise ValueError(f"Found inconsistency between "
-                                         f"InterDependencies and shape metadata. "
+                                         f"InterDependencies and shape "
+                                         f"metadata. "
                                          f"{dependent.name} has "
                                          f"{len(dependencies)} but it's shape "
                                          f"is given as {shape}")

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -123,4 +123,4 @@ class RunDescriber:
         return True
 
     def __repr__(self) -> str:
-        return f"RunDescriber({self.interdeps}, Shapes:{self._shapes})"
+        return f"RunDescriber({self.interdeps}, Shapes: {self._shapes})"

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple, cast
+from typing import Any, cast
 
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -34,7 +34,7 @@ class RunDescriber:
                              f'Got {type(interdeps)}.')
         self._verify_interdeps_shape(interdeps, shapes)
 
-        self.interdeps = interdeps
+        self._interdeps = interdeps
         self._shapes = shapes
         self._version = 3
 
@@ -45,6 +45,11 @@ class RunDescriber:
     @property
     def shapes(self) -> Shapes:
         return self._shapes
+
+    @property
+    def interdeps(self) -> InterDependencies_:
+        return self._interdeps
+
 
     @staticmethod
     def _verify_interdeps_shape(interdeps: InterDependencies_,

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -32,8 +32,7 @@ class RunDescriber:
             raise ValueError('The interdeps arg must be of type: '
                              'InterDependencies_. '
                              f'Got {type(interdeps)}.')
-        residual_shapes = self._verify_interdeps_shape(interdeps, shapes)
-        self._residual_shapes = residual_shapes
+        self._verify_interdeps_shape(interdeps, shapes)
 
         self.interdeps = interdeps
         self._shapes = shapes
@@ -49,19 +48,14 @@ class RunDescriber:
 
     @staticmethod
     def _verify_interdeps_shape(interdeps: InterDependencies_,
-                                shapes: Shapes) -> Shapes:
+                                shapes: Shapes) -> None:
         """
         Verify that interdeps and shape are consistent
         """
-        residual_shapes: Dict[str, Tuple[int, ...]] = {}
         for dependent, dependencies in interdeps.dependencies.items():
             if shapes is not None:
                 shape = shapes.get(dependent.name)
                 if shape is not None:
-                    if len(shape) == len(dependencies):
-                        residual_shapes[dependent.name] = ()
-                    if len(shape) > len(dependencies):
-                        residual_shapes[dependent.name] = shapes[dependent.name][len(dependencies):]
                     if len(shape) < len(dependencies):
                         raise ValueError(f"Found inconsistency between "
                                          f"InterDependencies and shape "
@@ -70,7 +64,6 @@ class RunDescriber:
                                          f"{len(dependencies)} dependencies "
                                          f"but it's shape "
                                          f"is given as {shape}")
-        return residual_shapes
 
     def _to_dict(self) -> RunDescriberV3Dict:
         """

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -32,7 +32,7 @@ class RunDescriber:
             raise ValueError('The interdeps arg must be of type: '
                              'InterDependencies_. '
                              f'Got {type(interdeps)}.')
-        self._verify_interdeps_grid_shape(interdeps, shapes)
+        self._verify_interdeps_shape(interdeps, shapes)
 
         self.interdeps = interdeps
         self._shapes = shapes
@@ -47,13 +47,21 @@ class RunDescriber:
         return self._shapes
 
     @staticmethod
-    def _verify_interdeps_grid_shape(interdeps: InterDependencies_,
-                                     shapes: Shapes) -> None:
+    def _verify_interdeps_shape(interdeps: InterDependencies_,
+                                shapes: Shapes) -> None:
         """
         Verify that interdeps, grid and shape are consistent
-        TODO: implement
         """
-        pass
+        for dependent, dependencies in interdeps.dependencies.items():
+            if shapes is not None:
+                shape = shapes.get(dependent.name)
+                if shape is not None:
+                    if len(shape) != len(dependencies):
+                        raise ValueError(f"Found inconsistency between "
+                                         f"InterDependencies and shape metadata. "
+                                         f"{dependent.name} has "
+                                         f"{len(dependencies)} but it's shape "
+                                         f"is given as {shape}")
 
     def _to_dict(self) -> RunDescriberV3Dict:
         """

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, Dict, Tuple
+from typing import Any, Dict, Tuple, cast
 
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -61,7 +61,8 @@ class RunDescriber:
                                          f"InterDependencies and shape "
                                          f"metadata. "
                                          f"{dependent.name} has "
-                                         f"{len(dependencies)} but it's shape "
+                                         f"{len(dependencies)} dependencies "
+                                         f"but it's shape "
                                          f"is given as {shape}")
 
     def _to_dict(self) -> RunDescriberV3Dict:

--- a/qcodes/dataset/descriptions/versioning/converters.py
+++ b/qcodes/dataset/descriptions/versioning/converters.py
@@ -133,7 +133,7 @@ def v1_to_v3(old: RunDescriberV1Dict) -> RunDescriberV3Dict:
 
 
 def v3_to_v2(new: RunDescriberV3Dict) -> RunDescriberV2Dict:
-    return RunDescriberV2Dict(version=3,
+    return RunDescriberV2Dict(version=2,
                               interdependencies=new['interdependencies'],
                               interdependencies_=new['interdependencies_'],
                               )

--- a/qcodes/dataset/descriptions/versioning/converters.py
+++ b/qcodes/dataset/descriptions/versioning/converters.py
@@ -11,7 +11,8 @@ from ..dependencies import InterDependencies_
 from ..param_spec import ParamSpec, ParamSpecBase
 from .v0 import InterDependencies
 
-from .rundescribertypes import RunDescriberV3Dict, RunDescriberV2Dict, RunDescriberV1Dict, RunDescriberV0Dict
+from .rundescribertypes import (RunDescriberV3Dict, RunDescriberV2Dict,
+                                RunDescriberV1Dict, RunDescriberV0Dict)
 
 
 def old_to_new(idps: InterDependencies) -> InterDependencies_:

--- a/qcodes/dataset/descriptions/versioning/converters.py
+++ b/qcodes/dataset/descriptions/versioning/converters.py
@@ -9,10 +9,9 @@ from typing import Dict, List
 
 from ..dependencies import InterDependencies_
 from ..param_spec import ParamSpec, ParamSpecBase
+from .rundescribertypes import (RunDescriberV0Dict, RunDescriberV1Dict,
+                                RunDescriberV2Dict, RunDescriberV3Dict)
 from .v0 import InterDependencies
-
-from .rundescribertypes import (RunDescriberV3Dict, RunDescriberV2Dict,
-                                RunDescriberV1Dict, RunDescriberV0Dict)
 
 
 def old_to_new(idps: InterDependencies) -> InterDependencies_:

--- a/qcodes/dataset/descriptions/versioning/converters.py
+++ b/qcodes/dataset/descriptions/versioning/converters.py
@@ -112,7 +112,6 @@ def v2_to_v3(old: RunDescriberV2Dict) -> RunDescriberV3Dict:
     return RunDescriberV3Dict(version=3,
                               interdependencies=old['interdependencies'],
                               interdependencies_=old['interdependencies_'],
-                              grids=None,
                               shapes=None
                               )
 

--- a/qcodes/dataset/descriptions/versioning/rundescribertypes.py
+++ b/qcodes/dataset/descriptions/versioning/rundescribertypes.py
@@ -13,7 +13,7 @@ instance of InterDependencies (which contains ParamSpecs) and
 interdependencies_, which is an instance of InterDependencies_
 (which contains ParamSpecBases)
 """
-from typing import Dict, List, Tuple, Union, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 from typing_extensions import TypedDict
 

--- a/qcodes/dataset/descriptions/versioning/rundescribertypes.py
+++ b/qcodes/dataset/descriptions/versioning/rundescribertypes.py
@@ -49,7 +49,11 @@ class RunDescriberV2Dict(RunDescriberV0Dict):
 
 
 class RunDescriberV3Dict(RunDescriberV2Dict):
-    shapes: Shapes  # dict from dependent to dict from depenency to num points in grid
+    shapes: Shapes
+    # dict from dependent to dict from depenency to num points in grid
 
 
-RunDescriberDicts = Union[RunDescriberV0Dict, RunDescriberV1Dict, RunDescriberV2Dict, RunDescriberV3Dict]
+RunDescriberDicts = Union[RunDescriberV0Dict,
+                          RunDescriberV1Dict,
+                          RunDescriberV2Dict,
+                          RunDescriberV3Dict]

--- a/qcodes/dataset/descriptions/versioning/rundescribertypes.py
+++ b/qcodes/dataset/descriptions/versioning/rundescribertypes.py
@@ -13,7 +13,6 @@ instance of InterDependencies (which contains ParamSpecs) and
 interdependencies_, which is an instance of InterDependencies_
 (which contains ParamSpecBases)
 """
-import enum
 from typing import Dict, List, Tuple, Union, Optional
 
 from typing_extensions import TypedDict
@@ -30,6 +29,7 @@ class InterDependencies_Dict(TypedDict):
     dependencies: Dict[str, List[str]]
     inferences: Dict[str, List[str]]
     standalones: List[str]
+
 
 Shapes = Optional[Dict[str, Tuple[int, ...]]]
 

--- a/qcodes/dataset/descriptions/versioning/rundescribertypes.py
+++ b/qcodes/dataset/descriptions/versioning/rundescribertypes.py
@@ -31,14 +31,6 @@ class InterDependencies_Dict(TypedDict):
     inferences: Dict[str, List[str]]
     standalones: List[str]
 
-
-class GridType(enum.Enum):
-    unknown = enum.auto()
-    grid = enum.auto()
-    equidistantgrid = enum.auto()
-
-
-GridDict = Optional[Dict[str, GridType]]
 Shapes = Optional[Dict[str, Tuple[int, ...]]]
 
 
@@ -57,7 +49,6 @@ class RunDescriberV2Dict(RunDescriberV0Dict):
 
 
 class RunDescriberV3Dict(RunDescriberV2Dict):
-    grids: GridDict  # dict from dependents to their grid
     shapes: Shapes  # dict from dependent to dict from depenency to num points in grid
 
 

--- a/qcodes/dataset/descriptions/versioning/serialization.py
+++ b/qcodes/dataset/descriptions/versioning/serialization.py
@@ -37,9 +37,13 @@ from qcodes.utils.helpers import YAML
 
 from .. import rundescriber as current
 
-from .rundescribertypes import RunDescriberV3Dict, RunDescriberV2Dict, RunDescriberV1Dict, RunDescriberV0Dict, RunDescriberDicts
-from .converters import (v0_to_v1, v0_to_v2, v0_to_v3, v1_to_v0, v1_to_v2, v1_to_v3,
-                         v2_to_v0, v2_to_v1, v2_to_v3, v3_to_v0, v3_to_v1, v3_to_v2)
+from .rundescribertypes import (RunDescriberV3Dict, RunDescriberV2Dict,
+                                RunDescriberV1Dict, RunDescriberV0Dict,
+                                RunDescriberDicts)
+from .converters import (v0_to_v1, v0_to_v2, v0_to_v3,
+                         v1_to_v0, v1_to_v2, v1_to_v3,
+                         v2_to_v0, v2_to_v1, v2_to_v3,
+                         v3_to_v0, v3_to_v1, v3_to_v2)
 
 STORAGE_VERSION = 3
 # the version of :class:`RunDescriber` object that is used by the data storage

--- a/qcodes/dataset/descriptions/versioning/serialization.py
+++ b/qcodes/dataset/descriptions/versioning/serialization.py
@@ -36,14 +36,12 @@ from typing import Callable, Dict, Tuple, cast
 from qcodes.utils.helpers import YAML
 
 from .. import rundescriber as current
-
-from .rundescribertypes import (RunDescriberV3Dict, RunDescriberV2Dict,
-                                RunDescriberV1Dict, RunDescriberV0Dict,
-                                RunDescriberDicts)
-from .converters import (v0_to_v1, v0_to_v2, v0_to_v3,
-                         v1_to_v0, v1_to_v2, v1_to_v3,
-                         v2_to_v0, v2_to_v1, v2_to_v3,
-                         v3_to_v0, v3_to_v1, v3_to_v2)
+from .converters import (v0_to_v1, v0_to_v2, v0_to_v3, v1_to_v0, v1_to_v2,
+                         v1_to_v3, v2_to_v0, v2_to_v1, v2_to_v3, v3_to_v0,
+                         v3_to_v1, v3_to_v2)
+from .rundescribertypes import (RunDescriberDicts, RunDescriberV0Dict,
+                                RunDescriberV1Dict, RunDescriberV2Dict,
+                                RunDescriberV3Dict)
 
 STORAGE_VERSION = 3
 # the version of :class:`RunDescriber` object that is used by the data storage

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -16,28 +16,30 @@ from numbers import Number
 from time import perf_counter
 from types import TracebackType
 from typing import (Any, Callable, Dict, List, Mapping, MutableMapping,
-                    MutableSequence, Optional, Sequence, Tuple, Type,
-                    TypeVar, Union, cast)
+                    MutableSequence, Optional, Sequence, Tuple, Type, TypeVar,
+                    Union, cast)
 
 import numpy as np
 
 import qcodes as qc
 import qcodes.utils.validators as vals
 from qcodes import Station
-from qcodes.dataset.data_set import VALUE, DataSet, load_by_guid, setpoints_type, res_type, values_type
+from qcodes.dataset.data_set import (VALUE, DataSet, load_by_guid, res_type,
+                                     setpoints_type, values_type)
 from qcodes.dataset.descriptions.dependencies import (DependencyError,
                                                       InferenceError,
                                                       InterDependencies_)
-from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 from qcodes.dataset.descriptions.param_spec import ParamSpec, ParamSpecBase
+from qcodes.dataset.descriptions.rundescriber import RunDescriber
+from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 from qcodes.dataset.experiment_container import Experiment
 from qcodes.dataset.linked_datasets.links import Link
 from qcodes.instrument.parameter import (ArrayParameter, MultiParameter,
                                          Parameter, ParameterWithSetpoints,
-                                         _BaseParameter, expand_setpoints_helper)
+                                         _BaseParameter,
+                                         expand_setpoints_helper)
 from qcodes.utils.delaykeyboardinterrupt import DelayedKeyboardInterrupt
 from qcodes.utils.helpers import NumpyJSONEncoder
-from qcodes.dataset.descriptions.rundescriber import RunDescriber
 
 log = logging.getLogger(__name__)
 

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -28,7 +28,7 @@ from qcodes.dataset.data_set import VALUE, DataSet, load_by_guid, setpoints_type
 from qcodes.dataset.descriptions.dependencies import (DependencyError,
                                                       InferenceError,
                                                       InterDependencies_)
-from qcodes.dataset.descriptions.versioning.rundescribertypes import GridDict, Shapes
+from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 from qcodes.dataset.descriptions.param_spec import ParamSpec, ParamSpecBase
 from qcodes.dataset.experiment_container import Experiment
 from qcodes.dataset.linked_datasets.links import Link
@@ -425,7 +425,6 @@ class Runner:
             parent_datasets: Sequence[Dict] = (),
             extra_log_info: str = '',
             write_in_background: bool = False,
-            grids: GridDict = None,
             shapes: Shapes = None) -> None:
 
         if write_in_background and (write_period is not None):
@@ -445,7 +444,6 @@ class Runner:
         self.experiment = experiment
         self.station = station
         self._interdependencies = interdeps
-        self._grids: GridDict = grids
         self._shapes: Shapes = shapes
         # here we use 5 s as a sane default, but that value should perhaps
         # be read from some config file
@@ -487,7 +485,6 @@ class Runner:
             raise RuntimeError("No parameters supplied")
         else:
             self.ds.set_interdependencies(self._interdependencies,
-                                          self._grids,
                                           self._shapes)
 
         links = [Link(head=self.ds.guid, **pdict)
@@ -581,7 +578,6 @@ class Measurement:
         self.name = name
         self._write_period: Optional[float] = None
         self._interdeps = InterDependencies_()
-        self._grids: GridDict = None
         self._shapes: Shapes = None
         self._parent_datasets: List[Dict] = []
         self._extra_log_info: str = ''
@@ -1064,12 +1060,8 @@ class Measurement:
 
         return self
 
-    def set_grids_and_shapes(self,
-                             grids: GridDict,
-                             shapes: Shapes) -> None:
-        self._grids = grids
+    def set_shapes(self, shapes: Shapes) -> None:
         self._shapes = shapes
-
 
     def run(self, write_in_background: bool = False) -> Runner:
         """
@@ -1090,5 +1082,4 @@ class Measurement:
                       parent_datasets=self._parent_datasets,
                       extra_log_info=self._extra_log_info,
                       write_in_background=write_in_background,
-                      grids=self._grids,
                       shapes=self._shapes)

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -134,6 +134,19 @@ class DataSaver:
         for partial_result in res_tuple:
             parameter = partial_result[0]
             data = partial_result[1]
+
+            if isinstance(parameter, _BaseParameter) and isinstance(parameter.vals, vals.Arrays):
+                if not isinstance(data, np.ndarray):
+                    raise TypeError(
+                        "Expected ")
+
+                if (parameter.vals.shape is not None
+                        and data.shape != parameter.vals.shape):
+                    raise TypeError(
+                        "Expected data with shape {parameter.vals.shape}, "
+                        "but got {data.shae}"
+                    )
+
             if isinstance(parameter, ArrayParameter):
                 results_dict.update(
                     self._unpack_arrayparameter(partial_result))
@@ -146,10 +159,6 @@ class DataSaver:
                         data, parameter, parameter_names, partial_result
                     )
                 )
-            elif isinstance(parameter.vals, vals.Arrays):
-                if (parameter.vals.shape is not None
-                        and data.shape != parameter.vals.shape):
-                    raise TypeError("")
             else:
                 results_dict.update(
                     self._unpack_partial_result(partial_result)

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -146,6 +146,10 @@ class DataSaver:
                         data, parameter, parameter_names, partial_result
                     )
                 )
+            elif isinstance(parameter.vals, vals.Arrays):
+                if (parameter.vals.shape is not None
+                        and data.shape != parameter.vals.shape):
+                    raise TypeError("")
             else:
                 results_dict.update(
                     self._unpack_partial_result(partial_result)

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -149,7 +149,7 @@ class DataSaver:
                         and data.shape != parameter.vals.shape):
                     raise TypeError(
                         "Expected data with shape {parameter.vals.shape}, "
-                        "but got {data.shae}"
+                        "but got {data.shape}"
                     )
 
             if isinstance(parameter, ArrayParameter):

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -138,7 +138,8 @@ class DataSaver:
             parameter = partial_result[0]
             data = partial_result[1]
 
-            if isinstance(parameter, _BaseParameter) and isinstance(parameter.vals, vals.Arrays):
+            if (isinstance(parameter, _BaseParameter) and
+                    isinstance(parameter.vals, vals.Arrays)):
                 if not isinstance(data, np.ndarray):
                     raise TypeError(
                         f"Expected data for Parameter with Array validator "

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -1061,6 +1061,14 @@ class Measurement:
         return self
 
     def set_shapes(self, shapes: Shapes) -> None:
+        """
+        Set the shapes of the data to be recorded in this
+        measurement.
+
+        Args:
+            shapes: Dictionary from names of dependent parameters to a tuple
+                of integers describing the shape of the measurement.
+        """
         self._shapes = shapes
 
     def run(self, write_in_background: bool = False) -> Runner:

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -37,6 +37,7 @@ from qcodes.instrument.parameter import (ArrayParameter, MultiParameter,
                                          _BaseParameter, expand_setpoints_helper)
 from qcodes.utils.delaykeyboardinterrupt import DelayedKeyboardInterrupt
 from qcodes.utils.helpers import NumpyJSONEncoder
+from qcodes.dataset.descriptions.rundescriber import RunDescriber
 
 log = logging.getLogger(__name__)
 
@@ -138,7 +139,8 @@ class DataSaver:
             if isinstance(parameter, _BaseParameter) and isinstance(parameter.vals, vals.Arrays):
                 if not isinstance(data, np.ndarray):
                     raise TypeError(
-                        "Expected ")
+                        f"Expected data for Parameter with Array validator "
+                        f"to be a numpy array but got: {type(data)}")
 
                 if (parameter.vals.shape is not None
                         and data.shape != parameter.vals.shape):
@@ -1082,6 +1084,8 @@ class Measurement:
             shapes: Dictionary from names of dependent parameters to a tuple
                 of integers describing the shape of the measurement.
         """
+        RunDescriber._verify_interdeps_shape(interdeps=self._interdeps,
+                                             shapes=shapes)
         self._shapes = shapes
 
     def run(self, write_in_background: bool = False) -> Runner:

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -198,9 +198,9 @@ def get_interdeps_from_result_table_name(conn: ConnectionPlus, result_table_name
     return interdeps
 
 
-def get_parameter_data_for_one_paramtree(conn: ConnectionPlus, table_name: str, rundesciber: RunDescriber,
+def get_parameter_data_for_one_paramtree(conn: ConnectionPlus, table_name: str, rundescriber: RunDescriber,
                                          output_param: str, start: Optional[int], end: Optional[int]) -> Tuple[Dict[str, np.ndarray], int]:
-    interdeps = rundesciber.interdeps
+    interdeps = rundescriber.interdeps
     data, paramspecs, n_rows = _get_data_for_one_param_tree(conn, table_name, interdeps, output_param, start, end)
     if not paramspecs[0].name == output_param:
         raise ValueError("output_param should always be the first parameter in a parameter tree. It is not")

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -181,8 +181,10 @@ def get_parameter_data(conn: ConnectionPlus,
     return output
 
 
-def get_rundescriber_from_result_table_name(conn: ConnectionPlus,
-                                           result_table_name: str) -> RunDescriber:
+def get_rundescriber_from_result_table_name(
+        conn: ConnectionPlus,
+        result_table_name: str
+) -> RunDescriber:
     sql = """
     SELECT run_id FROM runs WHERE result_table_name = ?
     """
@@ -198,12 +200,21 @@ def get_interdeps_from_result_table_name(conn: ConnectionPlus, result_table_name
     return interdeps
 
 
-def get_parameter_data_for_one_paramtree(conn: ConnectionPlus, table_name: str, rundescriber: RunDescriber,
-                                         output_param: str, start: Optional[int], end: Optional[int]) -> Tuple[Dict[str, np.ndarray], int]:
+def get_parameter_data_for_one_paramtree(
+        conn: ConnectionPlus,
+        table_name: str,
+        rundescriber: RunDescriber,
+        output_param: str,
+        start: Optional[int],
+        end: Optional[int]
+) -> Tuple[Dict[str, np.ndarray], int]:
     interdeps = rundescriber.interdeps
-    data, paramspecs, n_rows = _get_data_for_one_param_tree(conn, table_name, interdeps, output_param, start, end)
+    data, paramspecs, n_rows = _get_data_for_one_param_tree(
+        conn, table_name, interdeps, output_param, start, end
+    )
     if not paramspecs[0].name == output_param:
-        raise ValueError("output_param should always be the first parameter in a parameter tree. It is not")
+        raise ValueError("output_param should always be the first "
+                         "parameter in a parameter tree. It is not")
     _expand_data_to_arrays(data, paramspecs)
     # Benchmarking shows that transposing the data with python types is
     # faster than transposing the data using np.array.transpose

--- a/qcodes/tests/dataset/conftest.py
+++ b/qcodes/tests/dataset/conftest.py
@@ -651,3 +651,14 @@ def _make_dummy_instrument() -> Iterator[DummyChannelInstrument]:
         yield inst
     finally:
         inst.close()
+
+
+class ArrayshapedParam(Parameter):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def get_raw(self):
+        shape = self.vals.shape
+
+        return np.random.rand(*shape)

--- a/qcodes/tests/dataset/test_converters.py
+++ b/qcodes/tests/dataset/test_converters.py
@@ -1,18 +1,20 @@
 from deepdiff import DeepDiff
 
-from qcodes.dataset.descriptions.versioning.v0 import InterDependencies
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
-from qcodes.dataset.descriptions.versioning.serialization import from_dict_to_current
+from qcodes.dataset.descriptions.versioning.converters import (new_to_old,
+                                                               old_to_new,
+                                                               v0_to_v1,
+                                                               v0_to_v2,
+                                                               v1_to_v0,
+                                                               v1_to_v2,
+                                                               v2_to_v0,
+                                                               v2_to_v1)
 from qcodes.dataset.descriptions.versioning.rundescribertypes import (
-    RunDescriberV0Dict,
-    RunDescriberV1Dict,
-    RunDescriberV2Dict,
-    RunDescriberV3Dict
-)
-from qcodes.dataset.descriptions.versioning.converters import (
-    v0_to_v1, v0_to_v2, v1_to_v0, v1_to_v2,
-    v2_to_v0, v2_to_v1, old_to_new, new_to_old
-)
+    RunDescriberV0Dict, RunDescriberV1Dict, RunDescriberV2Dict,
+    RunDescriberV3Dict)
+from qcodes.dataset.descriptions.versioning.serialization import \
+    from_dict_to_current
+from qcodes.dataset.descriptions.versioning.v0 import InterDependencies
 
 
 def test_convert_v0_to_newer(some_paramspecs):

--- a/qcodes/tests/dataset/test_converters.py
+++ b/qcodes/tests/dataset/test_converters.py
@@ -68,7 +68,7 @@ def _assert_dicts_are_related_as_expected(v0, v1, v2):
     assert len(v2) == 3
 
 
-def test_construct_currect_rundesciber_from_v0(some_paramspecs):
+def test_construct_currect_rundescriber_from_v0(some_paramspecs):
 
     pgroup1 = some_paramspecs[1]
 
@@ -94,7 +94,7 @@ def test_construct_currect_rundesciber_from_v0(some_paramspecs):
                     ignore_order=True) == {}
 
 
-def test_construct_currect_rundesciber_from_v1(some_interdeps):
+def test_construct_currect_rundescriber_from_v1(some_interdeps):
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -113,7 +113,7 @@ def test_construct_currect_rundesciber_from_v1(some_interdeps):
     assert rds2._to_dict() == expected_v3_dict
 
 
-def test_construct_currect_rundesciber_from_v2(some_interdeps):
+def test_construct_currect_rundescriber_from_v2(some_interdeps):
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -134,7 +134,7 @@ def test_construct_currect_rundesciber_from_v2(some_interdeps):
     assert rds2._to_dict() == expected_v3_dict
 
 
-def test_construct_currect_rundesciber_from_v3(some_interdeps):
+def test_construct_currect_rundescriber_from_v3(some_interdeps):
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -148,7 +148,7 @@ def test_construct_currect_rundesciber_from_v3(some_interdeps):
     assert rds2._to_dict() == v3
 
 
-def test_construct_currect_rundesciber_from_fake_v4(some_interdeps):
+def test_construct_currect_rundescriber_from_fake_v4(some_interdeps):
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 

--- a/qcodes/tests/dataset/test_converters.py
+++ b/qcodes/tests/dataset/test_converters.py
@@ -82,7 +82,6 @@ def test_construct_currect_rundesciber_from_v0(some_paramspecs):
         interdependencies=interdeps._to_dict(),
         interdependencies_=old_to_new(interdeps)._to_dict(),
         version=3,
-        grids=None,
         shapes=None,
     )
     assert DeepDiff(rds1._to_dict(), expected_v3_dict,
@@ -104,7 +103,6 @@ def test_construct_currect_rundesciber_from_v1(some_interdeps):
         interdependencies=interdeps._to_dict(),
         interdependencies_=interdeps_._to_dict(),
         version=3,
-        grids=None,
         shapes=None,
     )
     assert rds1._to_dict() == expected_v3_dict
@@ -123,7 +121,6 @@ def test_construct_currect_rundesciber_from_v2(some_interdeps):
         interdependencies=interdeps._to_dict(),
         interdependencies_=interdeps_._to_dict(),
         version=3,
-        grids=None,
         shapes=None,
     )
     rds1 = RunDescriber._from_dict(v2)
@@ -140,7 +137,6 @@ def test_construct_currect_rundesciber_from_v3(some_interdeps):
     v3 = RunDescriberV3Dict(interdependencies=interdeps._to_dict(),
                             interdependencies_=interdeps_._to_dict(),
                             version=3,
-                            grids=None,
                             shapes=None)
     rds1 = RunDescriber._from_dict(v3)
     rds2 = from_dict_to_current(v3)
@@ -155,7 +151,6 @@ def test_construct_currect_rundesciber_from_fake_v4(some_interdeps):
     v4 = RunDescriberV3Dict(interdependencies=interdeps._to_dict(),
                             interdependencies_=interdeps_._to_dict(),
                             version=4,
-                            grids=None,
                             shapes=None)
     v4['foobar'] = {"foo": ["bar"]}
     rds1 = RunDescriber._from_dict(v4)

--- a/qcodes/tests/dataset/test_converters.py
+++ b/qcodes/tests/dataset/test_converters.py
@@ -3,12 +3,16 @@ from deepdiff import DeepDiff
 from qcodes.dataset.descriptions.versioning.v0 import InterDependencies
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.versioning.serialization import from_dict_to_current
-from qcodes.dataset.descriptions.versioning.rundescribertypes import (RunDescriberV0Dict,
-                                                                      RunDescriberV1Dict,
-                                                                      RunDescriberV2Dict,
-                                                                      RunDescriberV3Dict)
-from qcodes.dataset.descriptions.versioning.converters import (v0_to_v1, v0_to_v2, v1_to_v0, v1_to_v2,
-                                                               v2_to_v0, v2_to_v1, old_to_new, new_to_old)
+from qcodes.dataset.descriptions.versioning.rundescribertypes import (
+    RunDescriberV0Dict,
+    RunDescriberV1Dict,
+    RunDescriberV2Dict,
+    RunDescriberV3Dict
+)
+from qcodes.dataset.descriptions.versioning.converters import (
+    v0_to_v1, v0_to_v2, v1_to_v0, v1_to_v2,
+    v2_to_v0, v2_to_v1, old_to_new, new_to_old
+)
 
 
 def test_convert_v0_to_newer(some_paramspecs):

--- a/qcodes/tests/dataset/test_converters.py
+++ b/qcodes/tests/dataset/test_converters.py
@@ -80,7 +80,7 @@ def test_construct_currect_rundescriber_from_v0(some_paramspecs):
     v0 = RunDescriberV0Dict(interdependencies=interdeps._to_dict(), version=0)
     rds1 = RunDescriber._from_dict(v0)
 
-    rds_from_func = from_dict_to_current(v0)
+    rds_upgraded = from_dict_to_current(v0)
 
     expected_v3_dict = RunDescriberV3Dict(
         interdependencies=interdeps._to_dict(),
@@ -90,7 +90,7 @@ def test_construct_currect_rundescriber_from_v0(some_paramspecs):
     )
     assert DeepDiff(rds1._to_dict(), expected_v3_dict,
                     ignore_order=True) == {}
-    assert DeepDiff(rds2._to_dict(), expected_v3_dict,
+    assert DeepDiff(rds_upgraded._to_dict(), expected_v3_dict,
                     ignore_order=True) == {}
 
 
@@ -101,7 +101,7 @@ def test_construct_current_rundescriber_from_v1(some_interdeps):
     v1 = RunDescriberV1Dict(interdependencies=interdeps_._to_dict(),
                             version=1)
     rds1 = RunDescriber._from_dict(v1)
-    rds2 = from_dict_to_current(v1)
+    rds_upgraded = from_dict_to_current(v1)
 
     expected_v3_dict = RunDescriberV3Dict(
         interdependencies=interdeps._to_dict(),
@@ -110,7 +110,7 @@ def test_construct_current_rundescriber_from_v1(some_interdeps):
         shapes=None,
     )
     assert rds1._to_dict() == expected_v3_dict
-    assert rds2._to_dict() == expected_v3_dict
+    assert rds_upgraded._to_dict() == expected_v3_dict
 
 
 def test_construct_current_rundescriber_from_v2(some_interdeps):
@@ -128,10 +128,10 @@ def test_construct_current_rundescriber_from_v2(some_interdeps):
         shapes=None,
     )
     rds1 = RunDescriber._from_dict(v2)
-    rds2 = from_dict_to_current(v2)
+    rds_upgraded = from_dict_to_current(v2)
 
     assert rds1._to_dict() == expected_v3_dict
-    assert rds2._to_dict() == expected_v3_dict
+    assert rds_upgraded._to_dict() == expected_v3_dict
 
 
 def test_construct_current_rundescriber_from_v3(some_interdeps):
@@ -143,9 +143,9 @@ def test_construct_current_rundescriber_from_v3(some_interdeps):
                             version=3,
                             shapes=None)
     rds1 = RunDescriber._from_dict(v3)
-    rds2 = from_dict_to_current(v3)
+    rds_upgraded = from_dict_to_current(v3)
     assert rds1._to_dict() == v3
-    assert rds2._to_dict() == v3
+    assert rds_upgraded._to_dict() == v3
 
 
 def test_construct_current_rundescriber_from_fake_v4(some_interdeps):
@@ -158,9 +158,9 @@ def test_construct_current_rundescriber_from_fake_v4(some_interdeps):
                             shapes=None)
     v4['foobar'] = {"foo": ["bar"]}
     rds1 = RunDescriber._from_dict(v4)
-    rds2 = from_dict_to_current(v4)
+    rds_upgraded = from_dict_to_current(v4)
     v3 = v4.copy()
     v3.pop('foobar')
     v3['version'] = 3
     assert rds1._to_dict() == v3
-    assert rds2._to_dict() == v3
+    assert rds_upgraded._to_dict() == v3

--- a/qcodes/tests/dataset/test_converters.py
+++ b/qcodes/tests/dataset/test_converters.py
@@ -70,7 +70,7 @@ def _assert_dicts_are_related_as_expected(v0, v1, v2):
     assert len(v2) == 3
 
 
-def test_construct_currect_rundescriber_from_v0(some_paramspecs):
+def test_construct_current_rundescriber_from_v0(some_paramspecs):
 
     pgroup1 = some_paramspecs[1]
 

--- a/qcodes/tests/dataset/test_converters.py
+++ b/qcodes/tests/dataset/test_converters.py
@@ -80,7 +80,7 @@ def test_construct_currect_rundescriber_from_v0(some_paramspecs):
     v0 = RunDescriberV0Dict(interdependencies=interdeps._to_dict(), version=0)
     rds1 = RunDescriber._from_dict(v0)
 
-    rds2 = from_dict_to_current(v0)
+    rds_from_func = from_dict_to_current(v0)
 
     expected_v3_dict = RunDescriberV3Dict(
         interdependencies=interdeps._to_dict(),
@@ -94,7 +94,7 @@ def test_construct_currect_rundescriber_from_v0(some_paramspecs):
                     ignore_order=True) == {}
 
 
-def test_construct_currect_rundescriber_from_v1(some_interdeps):
+def test_construct_current_rundescriber_from_v1(some_interdeps):
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -113,7 +113,7 @@ def test_construct_currect_rundescriber_from_v1(some_interdeps):
     assert rds2._to_dict() == expected_v3_dict
 
 
-def test_construct_currect_rundescriber_from_v2(some_interdeps):
+def test_construct_current_rundescriber_from_v2(some_interdeps):
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -134,7 +134,7 @@ def test_construct_currect_rundescriber_from_v2(some_interdeps):
     assert rds2._to_dict() == expected_v3_dict
 
 
-def test_construct_currect_rundescriber_from_v3(some_interdeps):
+def test_construct_current_rundescriber_from_v3(some_interdeps):
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -148,7 +148,7 @@ def test_construct_currect_rundescriber_from_v3(some_interdeps):
     assert rds2._to_dict() == v3
 
 
-def test_construct_currect_rundescriber_from_fake_v4(some_interdeps):
+def test_construct_current_rundescriber_from_fake_v4(some_interdeps):
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -10,17 +10,20 @@ import qcodes as qc
 import qcodes.dataset.descriptions.versioning.serialization as serial
 import qcodes.tests.dataset
 from qcodes import new_data_set, new_experiment
+from qcodes.dataset.data_set import (load_by_counter, load_by_id,
+                                     load_by_run_spec)
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.versioning.v0 import InterDependencies
 from qcodes.dataset.guids import parse_guid
-from qcodes.dataset.sqlite.connection import atomic_transaction, ConnectionPlus
+from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic_transaction
 from qcodes.dataset.sqlite.database import (
     connect, get_db_version_and_newest_available_version, initialise_database,
     initialise_or_create_database_at)
 # pylint: disable=unused-import
 from qcodes.dataset.sqlite.db_upgrades import (_latest_available_version,
                                                get_user_version,
+                                               perform_db_upgrade,
                                                perform_db_upgrade_0_to_1,
                                                perform_db_upgrade_1_to_2,
                                                perform_db_upgrade_2_to_3,
@@ -29,14 +32,11 @@ from qcodes.dataset.sqlite.db_upgrades import (_latest_available_version,
                                                perform_db_upgrade_5_to_6,
                                                perform_db_upgrade_6_to_7,
                                                perform_db_upgrade_7_to_8,
-                                               perform_db_upgrade,
-                                               set_user_version,
-                                               perform_db_upgrade_8_to_9)
+                                               perform_db_upgrade_8_to_9,
+                                               set_user_version)
 from qcodes.dataset.sqlite.queries import get_run_description, update_GUIDs
 from qcodes.dataset.sqlite.query_helpers import is_column_in_table, one
 from qcodes.tests.common import error_caused_by
-from qcodes.dataset.data_set import (
-    load_by_counter, load_by_id, load_by_run_spec)
 from qcodes.tests.dataset.conftest import temporarily_copied_DB
 
 fixturepath = os.sep.join(qcodes.tests.dataset.__file__.split(os.sep)[:-1])
@@ -765,9 +765,10 @@ def test_perform_actual_upgrade_6_to_newest_add_new_data():
     Insert new runs on top of existing runs upgraded and verify that they
     get the correct captured_run_id and captured_counter
     """
+    import numpy as np
+
     from qcodes.dataset.measurements import Measurement
     from qcodes.instrument.parameter import Parameter
-    import numpy as np
 
     fixpath = os.path.join(fixturepath, 'db_files', 'version6')
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -595,7 +595,7 @@ def test_get_description(experiment, some_interdeps):
 
     ds.set_interdependencies(some_interdeps[1])
 
-    assert ds._interdeps == some_interdeps[1]
+    assert ds.description.interdeps == some_interdeps[1]
 
     # the run description gets written as the dataset is marked as started,
     # so now no description should be stored in the database

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1,30 +1,30 @@
 import itertools
-from copy import copy
-import re
-from unittest.mock import patch
-import random
-from typing import Sequence, Dict, Tuple, Optional, List
 import os
+import random
+import re
+from copy import copy
+from typing import Dict, List, Optional, Sequence, Tuple
+from unittest.mock import patch
 
-import pytest
-import numpy as np
-from hypothesis import given, settings
 import hypothesis.strategies as hst
+import numpy as np
+import pytest
+from hypothesis import given, settings
 
 import qcodes as qc
-from qcodes import new_data_set, new_experiment, experiments
-from qcodes import load_by_id, load_by_counter
-from qcodes.dataset.descriptions.rundescriber import RunDescriber
+from qcodes import (experiments, load_by_counter, load_by_id, new_data_set,
+                    new_experiment)
+from qcodes.dataset.data_set import CompletedError, DataSet
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
-from qcodes.dataset.sqlite.queries import _unicode_categories
-from qcodes.tests.common import error_caused_by
-from qcodes.dataset.sqlite.database import get_DB_location
-from qcodes.dataset.data_set import CompletedError, DataSet
+from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.guids import parse_guid
 from qcodes.dataset.sqlite.connection import path_to_dbfile
-from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.dataset.sqlite.database import get_DB_location
+from qcodes.dataset.sqlite.queries import _unicode_categories
+from qcodes.tests.common import error_caused_by
 from qcodes.tests.dataset.test_links import generate_some_links
+from qcodes.utils.deprecate import QCoDeSDeprecationWarning
 
 pytest.register_assert_rewrite('qcodes.tests.dataset.helper_functions')
 from qcodes.tests.dataset.helper_functions import verify_data_dict

--- a/qcodes/tests/dataset/test_descriptions.py
+++ b/qcodes/tests/dataset/test_descriptions.py
@@ -142,9 +142,9 @@ def test_default_dictization_for_storage(some_interdeps):
     assert serial.to_dict_for_storage(new_desc) == old_desc
 
 
-def test_dictization_of_version_3(some_interdeps):
+def test_dictization_of_current_version(some_interdeps):
     """
-    Test conversion to dictionary of a RunDescriber version 2 object
+    Test conversion to dictionary of a RunDescriber
     """
     for idps in some_interdeps:
         desc = RunDescriber(idps)

--- a/qcodes/tests/dataset/test_descriptions.py
+++ b/qcodes/tests/dataset/test_descriptions.py
@@ -43,7 +43,6 @@ def test_keys_of_result_of_to_dict(some_interdeps):
         assert list(ser_desc.keys()) == ['version',
                                          'interdependencies',
                                          'interdependencies_',
-                                         'grids',
                                          'shapes']
 
 
@@ -73,7 +72,6 @@ def test_yaml_creation_and_loading(some_interdeps):
         assert list(ydict.keys()) == ['version',
                                       'interdependencies',
                                       'interdependencies_',
-                                      'grids',
                                       'shapes']
         assert ydict['version'] == serial.STORAGE_VERSION
 
@@ -106,7 +104,6 @@ def test_default_jsonization_for_storage(some_interdeps):
     expected_json = json.dumps({'version': 3,
                                 'interdependencies': idps_old._to_dict(),
                                 'interdependencies_': idps_new._to_dict(),
-                                'grids': None,
                                 'shapes': None})
 
     assert serial.to_json_for_storage(new_desc) == expected_json
@@ -140,7 +137,6 @@ def test_default_dictization_for_storage(some_interdeps):
     old_desc = {'version': 3,
                 'interdependencies': idps_old._to_dict(),
                 'interdependencies_': idps_new._to_dict(),
-                'grids': None,
                 'shapes': None}
 
     assert serial.to_dict_for_storage(new_desc) == old_desc
@@ -158,6 +154,5 @@ def test_dictization_of_version_3(some_interdeps):
         assert ser['version'] == 3
         assert ser['interdependencies'] == idps_old._to_dict()
         assert ser['interdependencies_'] == idps._to_dict()
-        assert ser['grids'] is None
         assert ser['shapes'] is None
-        assert len(ser.keys()) == 5
+        assert len(ser.keys()) == 4

--- a/qcodes/tests/dataset/test_descriptions.py
+++ b/qcodes/tests/dataset/test_descriptions.py
@@ -2,11 +2,11 @@ import json
 
 import pytest
 
-from qcodes.dataset.descriptions.rundescriber import RunDescriber
-from qcodes.utils.helpers import YAML
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
-from qcodes.dataset.descriptions.versioning.converters import new_to_old
+from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.versioning import serialization as serial
+from qcodes.dataset.descriptions.versioning.converters import new_to_old
+from qcodes.utils.helpers import YAML
 
 
 def test_wrong_input_type_raises():

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -13,7 +13,7 @@ from qcodes.tests.instrument_mocks import (
     Multi2DSetPointParam2Sizes,
     DummyChannelInstrument
 )
-
+from qcodes.utils.validators import Arrays
 
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
 def test_get_shape_for_parameter_from_len(loop_shape):
@@ -127,6 +127,31 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
                                         tuple(param.vals.shape))
     assert shapes == expected_shapes
     assert (dummyinstrument.A.dummy_n_points(),) == param.vals.shape
+
+
+@given(
+    loop_shape=hst.lists(
+        hst.integers(min_value=1, max_value=1000),
+        min_size=1,
+        max_size=10
+    )
+)
+def test_get_shape_for_param_with_array_validator_from_shape(
+        loop_shape):
+    class ArrayshapedParam(Parameter):
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+        def get_raw(self):
+            shape = self.vals.shape
+
+            return np.random.rand(*shape)
+
+    param = ArrayshapedParam(name='paramwitharrayval', vals=Arrays(shape=(10,)))
+
+    shapes = detect_shape_of_measurement((param,), loop_shape)
+    assert shapes == {"paramwitharrayval": tuple(loop_shape) + param.vals.shape}
 
 
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10),

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -18,7 +18,7 @@ from qcodes.tests.instrument_mocks import (
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
 def test_get_shape_for_parameter_from_len(loop_shape):
     a = Parameter(name='a', initial_cache_value=10)
-    shape = get_shape_of_measurement(a, *loop_shape)
+    shape = get_shape_of_measurement((a,), loop_shape)
     assert shape == {'a': tuple(loop_shape)}
 
 
@@ -27,15 +27,15 @@ def test_get_shape_for_parameter_from_len(loop_shape):
 @pytest.mark.parametrize("range_func", [range, np.arange])
 def test_get_shape_for_parameter_from_sequence(loop_shape, range_func):
     a = Parameter(name='a', initial_cache_value=10)
-    loop_sequence = (range_func(x) for x in loop_shape)
-    shape = get_shape_of_measurement(a, *loop_sequence)
+    loop_sequence = tuple(range_func(x) for x in loop_shape)
+    shape = get_shape_of_measurement((a,), loop_sequence)
     assert shape == {'a': tuple(loop_shape)}
 
 
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
 def test_get_shape_for_array_parameter_from_len(loop_shape):
     a = ArraySetPointParam(name='a')
-    shape = get_shape_of_measurement(a, *loop_shape)
+    shape = get_shape_of_measurement((a,), loop_shape)
     expected_shape = tuple(a.shape) + tuple(loop_shape)
     assert shape == {'a': expected_shape}
 
@@ -45,8 +45,8 @@ def test_get_shape_for_array_parameter_from_len(loop_shape):
 @pytest.mark.parametrize("range_func", [range, np.arange])
 def test_get_shape_for_array_parameter_from_shape(loop_shape, range_func):
     a = ArraySetPointParam(name='a')
-    loop_sequence = (range_func(x) for x in loop_shape)
-    shape = get_shape_of_measurement(a, *loop_sequence)
+    loop_sequence = tuple(range_func(x) for x in loop_shape)
+    shape = get_shape_of_measurement((a,), loop_sequence)
     expected_shape = tuple(a.shape) + tuple(loop_shape)
     assert shape == {'a': expected_shape}
 
@@ -57,7 +57,7 @@ def test_get_shape_for_array_parameter_from_shape(loop_shape, range_func):
                                             Multi2DSetPointParam2Sizes])
 def test_get_shape_for_multiparam_from_len(loop_shape, multiparamtype):
     param = multiparamtype(name='meas_param')
-    shapes = get_shape_of_measurement(param, *loop_shape)
+    shapes = get_shape_of_measurement((param,), loop_shape)
     expected_shapes = {}
     for i, name in enumerate(param.full_names):
         expected_shapes[name] = tuple(param.shapes[i]) + tuple(loop_shape)
@@ -76,8 +76,8 @@ def test_get_shape_for_multiparam_from_shape(
         range_func
 ):
     param = multiparamtype(name='meas_param')
-    loop_sequence = (range_func(x) for x in loop_shape)
-    shapes = get_shape_of_measurement(param, *loop_sequence)
+    loop_sequence = tuple(range_func(x) for x in loop_shape)
+    shapes = get_shape_of_measurement((param,), loop_sequence)
     expected_shapes = {}
     for i, name in enumerate(param.full_names):
         expected_shapes[name] = tuple(param.shapes[i]) + tuple(loop_shape)
@@ -98,7 +98,7 @@ def _make_dummy_instrument() -> Iterator[DummyChannelInstrument]:
 def test_get_shape_for_pws_from_len(dummyinstrument, loop_shape, n_points):
     param = dummyinstrument.A.dummy_parameter_with_setpoints
     dummyinstrument.A.dummy_n_points(n_points)
-    shapes = get_shape_of_measurement(param, *loop_shape)
+    shapes = get_shape_of_measurement((param,), loop_shape)
 
     expected_shapes = {}
     expected_shapes[param.full_name] = (tuple(param.vals.shape)
@@ -120,8 +120,8 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
                                       n_points):
     param = dummyinstrument.A.dummy_parameter_with_setpoints
     dummyinstrument.A.dummy_n_points(n_points)
-    loop_sequence = (range_func(x) for x in loop_shape)
-    shapes = get_shape_of_measurement(param, *loop_sequence)
+    loop_sequence = tuple(range_func(x) for x in loop_shape)
+    shapes = get_shape_of_measurement((param,), loop_sequence)
     expected_shapes = {}
     expected_shapes[param.full_name] = (tuple(param.vals.shape)
                                         + tuple(loop_shape))

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -36,7 +36,7 @@ def test_get_shape_for_parameter_from_sequence(loop_shape, range_func):
 def test_get_shape_for_array_parameter_from_len(loop_shape):
     a = ArraySetPointParam(name='a')
     shape = detect_shape_of_measurement((a,), loop_shape)
-    expected_shape = tuple(a.shape) + tuple(loop_shape)
+    expected_shape = tuple(loop_shape) + tuple(a.shape)
     assert shape == {'a': expected_shape}
 
 
@@ -47,7 +47,7 @@ def test_get_shape_for_array_parameter_from_shape(loop_shape, range_func):
     a = ArraySetPointParam(name='a')
     loop_sequence = tuple(range_func(x) for x in loop_shape)
     shape = detect_shape_of_measurement((a,), loop_sequence)
-    expected_shape = tuple(a.shape) + tuple(loop_shape)
+    expected_shape = tuple(loop_shape) + tuple(a.shape)
     assert shape == {'a': expected_shape}
 
 
@@ -60,7 +60,7 @@ def test_get_shape_for_multiparam_from_len(loop_shape, multiparamtype):
     shapes = detect_shape_of_measurement((param,), loop_shape)
     expected_shapes = {}
     for i, name in enumerate(param.full_names):
-        expected_shapes[name] = tuple(param.shapes[i]) + tuple(loop_shape)
+        expected_shapes[name] = tuple(loop_shape) + tuple(param.shapes[i])
     assert shapes == expected_shapes
 
 
@@ -80,7 +80,7 @@ def test_get_shape_for_multiparam_from_shape(
     shapes = detect_shape_of_measurement((param,), loop_sequence)
     expected_shapes = {}
     for i, name in enumerate(param.full_names):
-        expected_shapes[name] = tuple(param.shapes[i]) + tuple(loop_shape)
+        expected_shapes[name] = tuple(loop_shape) + tuple(param.shapes[i])
     assert shapes == expected_shapes
 
 
@@ -101,8 +101,8 @@ def test_get_shape_for_pws_from_len(dummyinstrument, loop_shape, n_points):
     shapes = detect_shape_of_measurement((param,), loop_shape)
 
     expected_shapes = {}
-    expected_shapes[param.full_name] = (tuple(param.vals.shape)
-                                        + tuple(loop_shape))
+    expected_shapes[param.full_name] = (tuple(loop_shape) +
+                                        tuple(param.vals.shape))
     assert shapes == expected_shapes
     assert (dummyinstrument.A.dummy_n_points(),) == param.vals.shape
 
@@ -123,8 +123,8 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
     loop_sequence = tuple(range_func(x) for x in loop_shape)
     shapes = detect_shape_of_measurement((param,), loop_sequence)
     expected_shapes = {}
-    expected_shapes[param.full_name] = (tuple(param.vals.shape)
-                                        + tuple(loop_shape))
+    expected_shapes[param.full_name] = (tuple(loop_shape) +
+                                        tuple(param.vals.shape))
     assert shapes == expected_shapes
     assert (dummyinstrument.A.dummy_n_points(),) == param.vals.shape
 
@@ -141,10 +141,10 @@ def test_get_shape_for_multiple_parameters(dummyinstrument, loop_shape,
     shapes = detect_shape_of_measurement((param1, param2), loop_shape)
 
     expected_shapes = {}
-    expected_shapes[param1.full_name] = (tuple(param1.vals.shape)
-                                         + tuple(loop_shape))
-    expected_shapes[param2.full_name] = (tuple(param2.vals.shape)
-                                         + tuple(loop_shape))
+    expected_shapes[param1.full_name] = (tuple(loop_shape) +
+                                         tuple(param1.vals.shape))
+    expected_shapes[param2.full_name] = (tuple(loop_shape) +
+                                         tuple(param2.vals.shape))
     assert shapes == expected_shapes
     assert (dummyinstrument.A.dummy_n_points(),) == param1.vals.shape
     assert (dummyinstrument.B.dummy_n_points(),) == param2.vals.shape

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -86,15 +86,6 @@ def test_get_shape_for_multiparam_from_shape(
     assert shapes == expected_shapes
 
 
-@pytest.fixture(name='dummyinstrument')
-def _make_dummy_instrument() -> Iterator[DummyChannelInstrument]:
-    inst = DummyChannelInstrument('dummyinstrument')
-    try:
-        yield inst
-    finally:
-        inst.close()
-
-
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10),
        n_points=hst.integers(min_value=1, max_value=1000))
 def test_get_shape_for_pws_from_len(dummyinstrument, loop_shape, n_points):

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -127,3 +127,24 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
                                         + tuple(loop_shape))
     assert shapes == expected_shapes
     assert (dummyinstrument.A.dummy_n_points(),) == param.vals.shape
+
+
+@given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10),
+       n_points_1=hst.integers(min_value=1, max_value=1000),
+       n_points_2=hst.integers(min_value=1, max_value=1000))
+def test_get_shape_for_multiple_parameters(dummyinstrument, loop_shape,
+                                           n_points_1, n_points_2):
+    param1 = dummyinstrument.A.dummy_parameter_with_setpoints
+    dummyinstrument.A.dummy_n_points(n_points_1)
+    param2 = dummyinstrument.B.dummy_parameter_with_setpoints
+    dummyinstrument.B.dummy_n_points(n_points_2)
+    shapes = get_shape_of_measurement((param1, param2), loop_shape)
+
+    expected_shapes = {}
+    expected_shapes[param1.full_name] = (tuple(param1.vals.shape)
+                                         + tuple(loop_shape))
+    expected_shapes[param2.full_name] = (tuple(param2.vals.shape)
+                                         + tuple(loop_shape))
+    assert shapes == expected_shapes
+    assert (dummyinstrument.A.dummy_n_points(),) == param1.vals.shape
+    assert (dummyinstrument.B.dummy_n_points(),) == param2.vals.shape

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -14,6 +14,8 @@ from qcodes.tests.instrument_mocks import (
     DummyChannelInstrument
 )
 from qcodes.utils.validators import Arrays
+from .conftest import ArrayshapedParam
+
 
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
 def test_get_shape_for_parameter_from_len(loop_shape):
@@ -138,16 +140,6 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
 )
 def test_get_shape_for_param_with_array_validator_from_shape(
         loop_shape):
-    class ArrayshapedParam(Parameter):
-
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
-        def get_raw(self):
-            shape = self.vals.shape
-
-            return np.random.rand(*shape)
-
     param = ArrayshapedParam(name='paramwitharrayval', vals=Arrays(shape=(10,)))
 
     shapes = detect_shape_of_measurement((param,), loop_shape)

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -123,7 +123,8 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
     loop_sequence = (range_func(x) for x in loop_shape)
     shapes = get_shape_of_measurement(param, *loop_sequence)
     expected_shapes = {}
-    expected_shapes[param.full_name] = tuple(param.vals.shape) + tuple(loop_shape)
+    expected_shapes[param.full_name] = (tuple(param.vals.shape)
+                                        + tuple(loop_shape))
     assert shapes == expected_shapes
     assert (dummyinstrument.A.dummy_n_points(),) == param.vals.shape
 

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -4,7 +4,7 @@ import hypothesis.strategies as hst
 import numpy as np
 import pytest
 
-from qcodes.dataset.descriptions.detect_shapes import get_shape_of_measurement
+from qcodes.dataset.descriptions.detect_shapes import detect_shape_of_measurement
 from qcodes.instrument.parameter import Parameter
 from qcodes.tests.instrument_mocks import (
     ArraySetPointParam,
@@ -18,7 +18,7 @@ from qcodes.tests.instrument_mocks import (
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
 def test_get_shape_for_parameter_from_len(loop_shape):
     a = Parameter(name='a', initial_cache_value=10)
-    shape = get_shape_of_measurement((a,), loop_shape)
+    shape = detect_shape_of_measurement((a,), loop_shape)
     assert shape == {'a': tuple(loop_shape)}
 
 
@@ -28,14 +28,14 @@ def test_get_shape_for_parameter_from_len(loop_shape):
 def test_get_shape_for_parameter_from_sequence(loop_shape, range_func):
     a = Parameter(name='a', initial_cache_value=10)
     loop_sequence = tuple(range_func(x) for x in loop_shape)
-    shape = get_shape_of_measurement((a,), loop_sequence)
+    shape = detect_shape_of_measurement((a,), loop_sequence)
     assert shape == {'a': tuple(loop_shape)}
 
 
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
 def test_get_shape_for_array_parameter_from_len(loop_shape):
     a = ArraySetPointParam(name='a')
-    shape = get_shape_of_measurement((a,), loop_shape)
+    shape = detect_shape_of_measurement((a,), loop_shape)
     expected_shape = tuple(a.shape) + tuple(loop_shape)
     assert shape == {'a': expected_shape}
 
@@ -46,7 +46,7 @@ def test_get_shape_for_array_parameter_from_len(loop_shape):
 def test_get_shape_for_array_parameter_from_shape(loop_shape, range_func):
     a = ArraySetPointParam(name='a')
     loop_sequence = tuple(range_func(x) for x in loop_shape)
-    shape = get_shape_of_measurement((a,), loop_sequence)
+    shape = detect_shape_of_measurement((a,), loop_sequence)
     expected_shape = tuple(a.shape) + tuple(loop_shape)
     assert shape == {'a': expected_shape}
 
@@ -57,7 +57,7 @@ def test_get_shape_for_array_parameter_from_shape(loop_shape, range_func):
                                             Multi2DSetPointParam2Sizes])
 def test_get_shape_for_multiparam_from_len(loop_shape, multiparamtype):
     param = multiparamtype(name='meas_param')
-    shapes = get_shape_of_measurement((param,), loop_shape)
+    shapes = detect_shape_of_measurement((param,), loop_shape)
     expected_shapes = {}
     for i, name in enumerate(param.full_names):
         expected_shapes[name] = tuple(param.shapes[i]) + tuple(loop_shape)
@@ -77,7 +77,7 @@ def test_get_shape_for_multiparam_from_shape(
 ):
     param = multiparamtype(name='meas_param')
     loop_sequence = tuple(range_func(x) for x in loop_shape)
-    shapes = get_shape_of_measurement((param,), loop_sequence)
+    shapes = detect_shape_of_measurement((param,), loop_sequence)
     expected_shapes = {}
     for i, name in enumerate(param.full_names):
         expected_shapes[name] = tuple(param.shapes[i]) + tuple(loop_shape)
@@ -98,7 +98,7 @@ def _make_dummy_instrument() -> Iterator[DummyChannelInstrument]:
 def test_get_shape_for_pws_from_len(dummyinstrument, loop_shape, n_points):
     param = dummyinstrument.A.dummy_parameter_with_setpoints
     dummyinstrument.A.dummy_n_points(n_points)
-    shapes = get_shape_of_measurement((param,), loop_shape)
+    shapes = detect_shape_of_measurement((param,), loop_shape)
 
     expected_shapes = {}
     expected_shapes[param.full_name] = (tuple(param.vals.shape)
@@ -121,7 +121,7 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
     param = dummyinstrument.A.dummy_parameter_with_setpoints
     dummyinstrument.A.dummy_n_points(n_points)
     loop_sequence = tuple(range_func(x) for x in loop_shape)
-    shapes = get_shape_of_measurement((param,), loop_sequence)
+    shapes = detect_shape_of_measurement((param,), loop_sequence)
     expected_shapes = {}
     expected_shapes[param.full_name] = (tuple(param.vals.shape)
                                         + tuple(loop_shape))
@@ -138,7 +138,7 @@ def test_get_shape_for_multiple_parameters(dummyinstrument, loop_shape,
     dummyinstrument.A.dummy_n_points(n_points_1)
     param2 = dummyinstrument.B.dummy_parameter_with_setpoints
     dummyinstrument.B.dummy_n_points(n_points_2)
-    shapes = get_shape_of_measurement((param1, param2), loop_shape)
+    shapes = detect_shape_of_measurement((param1, param2), loop_shape)
 
     expected_shapes = {}
     expected_shapes[param1.full_name] = (tuple(param1.vals.shape)

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -1,5 +1,3 @@
-from typing import Iterator
-
 import hypothesis.strategies as hst
 import numpy as np
 import pytest
@@ -9,7 +7,6 @@ from qcodes.dataset.descriptions.detect_shapes import \
     detect_shape_of_measurement
 from qcodes.instrument.parameter import Parameter
 from qcodes.tests.instrument_mocks import (ArraySetPointParam,
-                                           DummyChannelInstrument,
                                            Multi2DSetPointParam,
                                            Multi2DSetPointParam2Sizes,
                                            MultiSetPointParam)

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -1,19 +1,20 @@
 from typing import Iterator
-from hypothesis import given
+
 import hypothesis.strategies as hst
 import numpy as np
 import pytest
+from hypothesis import given
 
-from qcodes.dataset.descriptions.detect_shapes import detect_shape_of_measurement
+from qcodes.dataset.descriptions.detect_shapes import \
+    detect_shape_of_measurement
 from qcodes.instrument.parameter import Parameter
-from qcodes.tests.instrument_mocks import (
-    ArraySetPointParam,
-    MultiSetPointParam,
-    Multi2DSetPointParam,
-    Multi2DSetPointParam2Sizes,
-    DummyChannelInstrument
-)
+from qcodes.tests.instrument_mocks import (ArraySetPointParam,
+                                           DummyChannelInstrument,
+                                           Multi2DSetPointParam,
+                                           Multi2DSetPointParam2Sizes,
+                                           MultiSetPointParam)
 from qcodes.utils.validators import Arrays
+
 from .conftest import ArrayshapedParam
 
 

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -6,7 +6,13 @@ import pytest
 
 from qcodes.dataset.descriptions.detect_shapes import get_shape_of_measurement
 from qcodes.instrument.parameter import Parameter
-from qcodes.tests.instrument_mocks import ArraySetPointParam, MultiSetPointParam, Multi2DSetPointParam, Multi2DSetPointParam2Sizes, DummyChannelInstrument
+from qcodes.tests.instrument_mocks import (
+    ArraySetPointParam,
+    MultiSetPointParam,
+    Multi2DSetPointParam,
+    Multi2DSetPointParam2Sizes,
+    DummyChannelInstrument
+)
 
 
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
@@ -64,7 +70,11 @@ def test_get_shape_for_multiparam_from_len(loop_shape, multiparamtype):
                                             Multi2DSetPointParam,
                                             Multi2DSetPointParam2Sizes])
 @pytest.mark.parametrize("range_func", [range, np.arange])
-def test_get_shape_for_multiparam_from_shape(loop_shape, multiparamtype, range_func):
+def test_get_shape_for_multiparam_from_shape(
+        loop_shape,
+        multiparamtype,
+        range_func
+):
     param = multiparamtype(name='meas_param')
     loop_sequence = (range_func(x) for x in loop_shape)
     shapes = get_shape_of_measurement(param, *loop_sequence)
@@ -91,14 +101,21 @@ def test_get_shape_for_pws_from_len(dummyinstrument, loop_shape, n_points):
     shapes = get_shape_of_measurement(param, *loop_shape)
 
     expected_shapes = {}
-    expected_shapes[param.full_name] = tuple(param.vals.shape) + tuple(loop_shape)
+    expected_shapes[param.full_name] = (tuple(param.vals.shape)
+                                        + tuple(loop_shape))
     assert shapes == expected_shapes
     assert (dummyinstrument.A.dummy_n_points(),) == param.vals.shape
 
 
 @pytest.mark.parametrize("range_func", [range, np.arange])
-@given(loop_shape=hst.lists(hst.integers(min_value=1, max_value=1000), min_size=1, max_size=10),
-       n_points=hst.integers(min_value=1, max_value=1000))
+@given(
+    loop_shape=hst.lists(
+        hst.integers(min_value=1, max_value=1000),
+        min_size=1,
+        max_size=10
+    ),
+    n_points=hst.integers(min_value=1, max_value=1000)
+)
 def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
                                       n_points):
     param = dummyinstrument.A.dummy_parameter_with_setpoints

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -127,4 +127,3 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
                                         + tuple(loop_shape))
     assert shapes == expected_shapes
     assert (dummyinstrument.A.dummy_n_points(),) == param.vals.shape
-

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -16,7 +16,8 @@ from qcodes.tests.instrument_mocks import (
     Multi2DSetPointParam,
     Multi2DSetPointParam2Sizes
 )
-
+from qcodes.utils.validators import Arrays
+from .conftest import ArrayshapedParam
 
 import pytest
 import matplotlib.pyplot as plt
@@ -187,6 +188,14 @@ def test_do0d_verify_shape(_param, _param_complex, multiparamtype,
     assert results[0].description.shapes == expected_shapes
 
 
+@pytest.mark.usefixtures("temp_exp", "temp_db")
+def test_do0d_parameter_with_array_vals():
+    param = ArrayshapedParam(name='paramwitharrayval', vals=Arrays(shape=(10,)))
+    results = do0d(param)
+    expected_shapes = {'paramwitharrayval': (10,)}
+    assert results[0].description.shapes == expected_shapes
+
+
 @pytest.mark.usefixtures("plot_close", "temp_exp", "temp_db")
 @pytest.mark.parametrize('delay', [0, 0.1, 1])
 def test_do1d_with_real_parameter(_param_set, _param, delay):
@@ -281,7 +290,21 @@ def test_do1d_verify_shape(_param, _param_complex, _param_set, multiparamtype,
     expected_shapes['simple_parameter'] = (num_points, )
     expected_shapes['simple_complex_parameter'] = (num_points, )
     expected_shapes[paramwsetpoints.full_name] = (num_points, n_points_pws)
-    assert results[0]._shapes == expected_shapes
+    assert results[0].description.shapes == expected_shapes
+
+
+@pytest.mark.usefixtures("temp_exp", "temp_db")
+def test_do1d_parameter_with_array_vals(_param_set):
+    param = ArrayshapedParam(name='paramwitharrayval', vals=Arrays(shape=(10,)))
+    start = 0
+    stop = 1
+    num_points = 15  #  make param
+    delay = 0
+
+    results = do1d(_param_set, start, stop, num_points, delay,
+                   param, do_plot=False)
+    expected_shapes = {'paramwitharrayval': (num_points, 10)}
+    assert results[0].description.shapes == expected_shapes
 
 
 @pytest.mark.usefixtures("plot_close", "temp_exp", "temp_db")

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -465,6 +465,37 @@ def test_do1d_additional_setpoints(_param, _param_complex, _param_set):
             plt.close('all')
 
 
+@given(num_points_p1=hst.integers(min_value=1, max_value=10))
+@pytest.mark.usefixtures("temp_exp", "temp_db")
+def test_do1d_additional_setpoints_shape(_param, _param_complex, _param_set,
+                                         num_points_p1):
+    arrayparam = ArraySetPointParam(name='arrayparam')
+    array_shape = arrayparam.shape
+    additional_setpoints = [Parameter(
+        f'additional_setter_parameter_{i}',
+        set_cmd=None,
+        get_cmd=None) for i in range(2)]
+    start_p1 = 0
+    stop_p1 = 0.5
+    delay_p1 = 0
+
+    x = 1
+    y = 2
+
+    additional_setpoints[0](x)
+    additional_setpoints[1](y)
+    results = do1d(
+        _param_set, start_p1, stop_p1, num_points_p1, delay_p1,
+        _param, arrayparam,
+        additional_setpoints=additional_setpoints,
+        do_plot=False)
+    expected_shapes = {
+        'arrayparam': (1, 1, num_points_p1, array_shape[0]),
+        'simple_parameter': (1, 1, num_points_p1)
+    }
+    assert results[0].description.shapes == expected_shapes
+
+
 @pytest.mark.usefixtures("plot_close", "temp_exp", "temp_db")
 def test_do2d_additional_setpoints(_param, _param_complex,
                                    _param_set, _param_set_2):
@@ -493,3 +524,43 @@ def test_do2d_additional_setpoints(_param, _param_complex,
             for deps in results[0].description.interdeps.dependencies.values():
                 assert len(deps) == 2 + len(additional_setpoints)
             plt.close('all')
+
+
+@given(num_points_p1=hst.integers(min_value=1, max_value=10),
+       num_points_p2=hst.integers(min_value=1, max_value=10))
+@pytest.mark.usefixtures("temp_exp", "temp_db")
+def test_do2d_additional_setpoints_shape(
+        _param, _param_complex,
+        _param_set, _param_set_2,
+        num_points_p1, num_points_p2):
+    arrayparam = ArraySetPointParam(name='arrayparam')
+    array_shape = arrayparam.shape
+    additional_setpoints = [Parameter(
+        f'additional_setter_parameter_{i}',
+        set_cmd=None,
+        get_cmd=None) for i in range(2)]
+    start_p1 = 0
+    stop_p1 = 0.5
+    delay_p1 = 0
+
+    start_p2 = 0.5
+    stop_p2 = 1
+    delay_p2 = 0.0
+
+    x = 1
+    y = 2
+
+    additional_setpoints[0](x)
+    additional_setpoints[1](y)
+    results = do2d(
+        _param_set, start_p1, stop_p1, num_points_p1, delay_p1,
+        _param_set_2, start_p2, stop_p2, num_points_p2, delay_p2,
+        _param, _param_complex, arrayparam,
+        additional_setpoints=additional_setpoints,
+        do_plot=False)
+    expected_shapes = {
+        'arrayparam': (1, 1, num_points_p1, num_points_p2, array_shape[0]),
+        'simple_complex_parameter': (1, 1, num_points_p1, num_points_p2),
+        'simple_parameter': (1, 1, num_points_p1, num_points_p2)
+    }
+    assert results[0].description.shapes == expected_shapes

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -184,7 +184,7 @@ def test_do0d_verify_shape(_param, _param_complex, multiparamtype,
     expected_shapes['simple_parameter'] = ()
     expected_shapes['simple_complex_parameter'] = ()
     expected_shapes[paramwsetpoints.full_name] = (n_points_pws, )
-    assert results[0]._shapes == expected_shapes
+    assert results[0].description.shapes == expected_shapes
 
 
 @pytest.mark.usefixtures("plot_close", "temp_exp", "temp_db")

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -276,11 +276,11 @@ def test_do1d_verify_shape(_param, _param_complex, _param_set, multiparamtype,
                    do_plot=False)
     expected_shapes = {}
     for i, name in enumerate(multiparam.full_names):
-        expected_shapes[name] = tuple(multiparam.shapes[i]) + (num_points, )
-    expected_shapes['arrayparam'] = tuple(arrayparam.shape) + (num_points, )
+        expected_shapes[name] = (num_points, ) + tuple(multiparam.shapes[i])
+    expected_shapes['arrayparam'] = (num_points, ) + tuple(arrayparam.shape)
     expected_shapes['simple_parameter'] = (num_points, )
     expected_shapes['simple_complex_parameter'] = (num_points, )
-    expected_shapes[paramwsetpoints.full_name] = (n_points_pws, num_points, )
+    expected_shapes[paramwsetpoints.full_name] = (num_points, n_points_pws)
     assert results[0]._shapes == expected_shapes
 
 
@@ -402,15 +402,15 @@ def test_do2d_verify_shape(_param, _param_complex, _param_set, _param_set_2,
                    flush_columns=columns, do_plot=False)
     expected_shapes = {}
     for i, name in enumerate(multiparam.full_names):
-        expected_shapes[name] = (tuple(multiparam.shapes[i]) +
-                                 (num_points_p1, num_points_p2))
-    expected_shapes['arrayparam'] = (tuple(arrayparam.shape) +
-                                     (num_points_p1, num_points_p2))
+        expected_shapes[name] = ((num_points_p1, num_points_p2) +
+                                 tuple(multiparam.shapes[i]))
+    expected_shapes['arrayparam'] = ((num_points_p1, num_points_p2) +
+                                     tuple(arrayparam.shape))
     expected_shapes['simple_parameter'] = (num_points_p1, num_points_p2)
     expected_shapes['simple_complex_parameter'] = (num_points_p1, num_points_p2)
-    expected_shapes[paramwsetpoints.full_name] = (n_points_pws,
-                                                  num_points_p1,
-                                                  num_points_p2)
+    expected_shapes[paramwsetpoints.full_name] = (num_points_p1,
+                                                  num_points_p2,
+                                                  n_points_pws)
 
     assert results[0]._shapes == expected_shapes
 

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -245,7 +245,6 @@ def test_do1d_output_data(_param, _param_set):
     np.testing.assert_array_equal(loaded_data[_param_set.name], np.linspace(0, 1, 5))
 
 
-
 @pytest.mark.usefixtures("temp_exp", "temp_db")
 @pytest.mark.parametrize("multiparamtype", [MultiSetPointParam,
                                             Multi2DSetPointParam,
@@ -370,7 +369,8 @@ def test_do2d_output_data(_param, _param_complex, _param_set, _param_set_2):
        num_points_p2=hst.integers(min_value=1, max_value=10),
        n_points_pws=hst.integers(min_value=1, max_value=1000))
 @settings(deadline=None)
-def test_do2d_verify_shape(_param, _param_complex, _param_set, multiparamtype,
+def test_do2d_verify_shape(_param, _param_complex, _param_set, _param_set_2,
+                           multiparamtype,
                            dummyinstrument,
                            sweep, columns,
                            num_points_p1, num_points_p2, n_points_pws):
@@ -390,7 +390,7 @@ def test_do2d_verify_shape(_param, _param_complex, _param_set, multiparamtype,
     delay_p2 = 0
 
     results = do2d(_param_set, start_p1, stop_p1, num_points_p1, delay_p1,
-                   _param_set, start_p2, stop_p2, num_points_p2, delay_p2,
+                   _param_set_2, start_p2, stop_p2, num_points_p2, delay_p2,
                    arrayparam, multiparam, paramwsetpoints,
                    _param, _param_complex,
                    set_before_sweep=sweep,

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -412,7 +412,7 @@ def test_do2d_verify_shape(_param, _param_complex, _param_set, _param_set_2,
                                                   num_points_p2,
                                                   n_points_pws)
 
-    assert results[0]._shapes == expected_shapes
+    assert results[0].description.shapes == expected_shapes
 
 
 @pytest.mark.usefixtures("plot_close", "temp_exp", "temp_db")

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -10,7 +10,12 @@ from qcodes.instrument.parameter import Parameter
 from qcodes import config
 from qcodes.utils import validators
 from qcodes.tests.dataset.conftest import experiment, empty_temp_db
-from qcodes.tests.instrument_mocks import ArraySetPointParam, MultiSetPointParam, Multi2DSetPointParam, Multi2DSetPointParam2Sizes, DummyChannelInstrument
+from qcodes.tests.instrument_mocks import (
+    ArraySetPointParam,
+    MultiSetPointParam,
+    Multi2DSetPointParam,
+    Multi2DSetPointParam2Sizes
+)
 
 
 import pytest
@@ -397,11 +402,15 @@ def test_do2d_verify_shape(_param, _param_complex, _param_set, _param_set_2,
                    flush_columns=columns, do_plot=False)
     expected_shapes = {}
     for i, name in enumerate(multiparam.full_names):
-        expected_shapes[name] = tuple(multiparam.shapes[i]) + (num_points_p1, num_points_p2)
-    expected_shapes['arrayparam'] = tuple(arrayparam.shape) + (num_points_p1, num_points_p2)
+        expected_shapes[name] = (tuple(multiparam.shapes[i]) +
+                                 (num_points_p1, num_points_p2))
+    expected_shapes['arrayparam'] = (tuple(arrayparam.shape) +
+                                     (num_points_p1, num_points_p2))
     expected_shapes['simple_parameter'] = (num_points_p1, num_points_p2)
     expected_shapes['simple_complex_parameter'] = (num_points_p1, num_points_p2)
-    expected_shapes[paramwsetpoints.full_name] = (n_points_pws, num_points_p1, num_points_p2)
+    expected_shapes[paramwsetpoints.full_name] = (n_points_pws,
+                                                  num_points_p1,
+                                                  num_points_p2)
 
     assert results[0]._shapes == expected_shapes
 

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -1,26 +1,25 @@
 """
 These are the basic black box tests for the doNd functions.
 """
-from hypothesis import given, settings
 import hypothesis.strategies as hst
-import numpy as np
-from qcodes.dataset.data_set import DataSet
-from qcodes.utils.dataset.doNd import do0d, do1d, do2d
-from qcodes.instrument.parameter import Parameter
-from qcodes import config
-from qcodes.utils import validators
-from qcodes.tests.dataset.conftest import experiment, empty_temp_db
-from qcodes.tests.instrument_mocks import (
-    ArraySetPointParam,
-    MultiSetPointParam,
-    Multi2DSetPointParam,
-    Multi2DSetPointParam2Sizes
-)
-from qcodes.utils.validators import Arrays
-from .conftest import ArrayshapedParam
-
-import pytest
 import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from hypothesis import given, settings
+
+from qcodes import config
+from qcodes.dataset.data_set import DataSet
+from qcodes.instrument.parameter import Parameter
+from qcodes.tests.dataset.conftest import empty_temp_db, experiment
+from qcodes.tests.instrument_mocks import (ArraySetPointParam,
+                                           Multi2DSetPointParam,
+                                           Multi2DSetPointParam2Sizes,
+                                           MultiSetPointParam)
+from qcodes.utils import validators
+from qcodes.utils.dataset.doNd import do0d, do1d, do2d
+from qcodes.utils.validators import Arrays
+
+from .conftest import ArrayshapedParam
 
 temp_db = empty_temp_db
 temp_exp = experiment

--- a/qcodes/tests/dataset/test_doNd.py
+++ b/qcodes/tests/dataset/test_doNd.py
@@ -461,6 +461,3 @@ def test_do2d_additional_setpoints(_param, _param_complex,
             for deps in results[0].description.interdeps.dependencies.values():
                 assert len(deps) == 2 + len(additional_setpoints)
             plt.close('all')
-
-
-

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -11,7 +11,7 @@ from qcodes.dataset.measurements import Measurement, res_type
 from qcodes.instrument.base import _BaseParameter
 from qcodes.dataset.plotting import plot_dataset
 from qcodes.dataset.descriptions.detect_shapes import get_shape_of_measurement
-from qcodes.dataset.descriptions.versioning.rundescribertypes import GridType, GridDict, Shapes
+from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 from qcodes import config
 
 ActionsT = Sequence[Callable[[], None]]
@@ -41,14 +41,13 @@ def _register_parameters(
         meas: Measurement,
         param_meas: Sequence[ParamMeasT],
         setpoints: Optional[Sequence[_BaseParameter]] = None,
-        grids: GridDict = None,
         shapes: Shapes = None
         ) -> None:
     for parameter in param_meas:
         if isinstance(parameter, _BaseParameter):
             meas.register_parameter(parameter,
                                     setpoints=setpoints)
-    meas.set_grids_and_shapes(grids=grids, shapes=shapes)
+    meas.set_shapes(shapes=shapes)
 
 
 def _register_actions(
@@ -109,11 +108,9 @@ def do0d(
     meas = Measurement()
 
     shapes = {}
-    grids = {}
     for param in param_meas:
         if isinstance(param, _BaseParameter):
             shapes.update(get_shape_of_measurement(param))
-            grids[param.full_name] = GridType.grid
 
     _register_parameters(meas, param_meas, shapes=shapes)
     _set_write_period(meas, write_period)
@@ -171,11 +168,9 @@ def do1d(
         s for s in additional_setpoints)
 
     shapes = {}
-    grids = {}
     for param in param_meas:
         if isinstance(param, _BaseParameter):
             shapes.update(get_shape_of_measurement(param, num_points))
-            grids[param.full_name] = GridType.grid
 
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,
@@ -260,11 +255,9 @@ def do2d(
             s for s in additional_setpoints)
 
     shapes = {}
-    grids = {}
     for param in param_meas:
         if isinstance(param, _BaseParameter):
             shapes.update(get_shape_of_measurement(param, num_points1, num_points2))
-            grids[param.full_name] = GridType.grid
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,
                          shapes=shapes)

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -1,19 +1,19 @@
-from contextlib import contextmanager
-from typing import Callable, Sequence, Union, Tuple, List,\
-    Optional, Iterator
-import os
 import logging
+import os
+from contextlib import contextmanager
+from typing import Callable, Iterator, List, Optional, Sequence, Tuple, Union
 
-import numpy as np
 import matplotlib
+import numpy as np
 
-from qcodes.dataset.data_set import DataSet
-from qcodes.dataset.measurements import Measurement, res_type
-from qcodes.instrument.base import _BaseParameter
-from qcodes.dataset.plotting import plot_dataset
-from qcodes.dataset.descriptions.detect_shapes import detect_shape_of_measurement
-from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 from qcodes import config
+from qcodes.dataset.data_set import DataSet
+from qcodes.dataset.descriptions.detect_shapes import \
+    detect_shape_of_measurement
+from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
+from qcodes.dataset.measurements import Measurement, res_type
+from qcodes.dataset.plotting import plot_dataset
+from qcodes.instrument.base import _BaseParameter
 
 ActionsT = Sequence[Callable[[], None]]
 

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -257,7 +257,9 @@ def do2d(
     shapes = {}
     for param in param_meas:
         if isinstance(param, _BaseParameter):
-            shapes.update(get_shape_of_measurement(param, num_points1, num_points2))
+            shapes.update(
+                get_shape_of_measurement(param, num_points1, num_points2)
+            )
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,
                          shapes=shapes)

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -107,10 +107,11 @@ def do0d(
     """
     meas = Measurement()
 
-    shapes = {}
-    for param in param_meas:
-        if isinstance(param, _BaseParameter):
-            shapes.update(get_shape_of_measurement(param))
+    measured_parameters = tuple(param for param in param_meas
+                                if isinstance(param, _BaseParameter))
+
+    shapes = get_shape_of_measurement(measured_parameters)
+
 
     _register_parameters(meas, param_meas, shapes=shapes)
     _set_write_period(meas, write_period)
@@ -167,10 +168,10 @@ def do1d(
     all_setpoint_params = (param_set,) + tuple(
         s for s in additional_setpoints)
 
-    shapes = {}
-    for param in param_meas:
-        if isinstance(param, _BaseParameter):
-            shapes.update(get_shape_of_measurement(param, num_points))
+    measured_parameters = tuple(param for param in param_meas
+                                if isinstance(param, _BaseParameter))
+
+    shapes = get_shape_of_measurement(measured_parameters, (num_points,))
 
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,
@@ -254,12 +255,13 @@ def do2d(
     all_setpoint_params = (param_set1, param_set2,) + tuple(
             s for s in additional_setpoints)
 
-    shapes = {}
-    for param in param_meas:
-        if isinstance(param, _BaseParameter):
-            shapes.update(
-                get_shape_of_measurement(param, num_points1, num_points2)
-            )
+
+    measured_parameters = tuple(param for param in param_meas
+                                if isinstance(param, _BaseParameter))
+
+    shapes = get_shape_of_measurement(measured_parameters,
+                                      (num_points1, num_points2))
+
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,
                          shapes=shapes)

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -117,7 +117,7 @@ def do0d(
         shapes: Shapes = detect_shape_of_measurement(
             measured_parameters,
         )
-    except TypeError as e:
+    except TypeError:
         LOG.exception(
             f"Could not detect shape of {measured_parameters} "
             f"falling back to unkown shape.")
@@ -186,7 +186,7 @@ def do1d(
             measured_parameters,
             loop_shape
         )
-    except TypeError as e:
+    except TypeError:
         LOG.exception(
             f"Could not detect shape of {measured_parameters} "
             f"falling back to unkown shape.")
@@ -286,7 +286,7 @@ def do2d(
             measured_parameters,
             loop_shape
         )
-    except TypeError as e:
+    except TypeError:
         LOG.exception(
             f"Could not detect shape of {measured_parameters} "
             f"falling back to unkown shape.")

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -10,7 +10,7 @@ from qcodes.dataset.data_set import DataSet
 from qcodes.dataset.measurements import Measurement, res_type
 from qcodes.instrument.base import _BaseParameter
 from qcodes.dataset.plotting import plot_dataset
-from qcodes.dataset.descriptions.detect_shapes import get_shape_of_measurement
+from qcodes.dataset.descriptions.detect_shapes import detect_shape_of_measurement
 from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 from qcodes import config
 
@@ -110,7 +110,7 @@ def do0d(
     measured_parameters = tuple(param for param in param_meas
                                 if isinstance(param, _BaseParameter))
 
-    shapes = get_shape_of_measurement(measured_parameters)
+    shapes = detect_shape_of_measurement(measured_parameters)
 
 
     _register_parameters(meas, param_meas, shapes=shapes)
@@ -171,7 +171,7 @@ def do1d(
     measured_parameters = tuple(param for param in param_meas
                                 if isinstance(param, _BaseParameter))
 
-    shapes = get_shape_of_measurement(measured_parameters, (num_points,))
+    shapes = detect_shape_of_measurement(measured_parameters, (num_points,))
 
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,
@@ -259,8 +259,8 @@ def do2d(
     measured_parameters = tuple(param for param in param_meas
                                 if isinstance(param, _BaseParameter))
 
-    shapes = get_shape_of_measurement(measured_parameters,
-                                      (num_points1, num_points2))
+    shapes = detect_shape_of_measurement(measured_parameters,
+                                         (num_points1, num_points2))
 
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 from typing import Callable, Sequence, Union, Tuple, List,\
     Optional, Iterator
 import os
+import logging
 
 import numpy as np
 import matplotlib
@@ -25,6 +26,8 @@ AxesTupleListWithDataSet = Tuple[DataSet, List[matplotlib.axes.Axes],
                                  List[Optional[matplotlib.colorbar.Colorbar]]]
 
 OutType = List[res_type]
+
+LOG = logging.getLogger(__name__)
 
 
 def _process_params_meas(param_meas: Sequence[ParamMeasT]) -> OutType:
@@ -110,7 +113,15 @@ def do0d(
     measured_parameters = tuple(param for param in param_meas
                                 if isinstance(param, _BaseParameter))
 
-    shapes = detect_shape_of_measurement(measured_parameters)
+    try:
+        shapes = detect_shape_of_measurement(
+            measured_parameters,
+        )
+    except TypeError as e:
+        LOG.exception(
+            f"Could not detect shape of {measured_parameters} "
+            f"falling back to unkown shape.")
+        shapes = None
 
     _register_parameters(meas, param_meas, shapes=shapes)
     _set_write_period(meas, write_period)
@@ -169,8 +180,16 @@ def do1d(
 
     measured_parameters = tuple(param for param in param_meas
                                 if isinstance(param, _BaseParameter))
-
-    shapes = detect_shape_of_measurement(measured_parameters, (num_points,))
+    try:
+        shapes = detect_shape_of_measurement(
+            measured_parameters,
+            (num_points,)
+        )
+    except TypeError as e:
+        LOG.exception(
+            f"Could not detect shape of {measured_parameters} "
+            f"falling back to unkown shape.")
+        shapes = None
 
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,
@@ -258,8 +277,15 @@ def do2d(
     measured_parameters = tuple(param for param in param_meas
                                 if isinstance(param, _BaseParameter))
 
-    shapes = detect_shape_of_measurement(measured_parameters,
-                                         (num_points1, num_points2))
+    try:
+        shapes = detect_shape_of_measurement(
+            measured_parameters,
+            (num_points1, num_points2))
+    except TypeError as e:
+        LOG.exception(
+            f"Could not detect shape of {measured_parameters} "
+            f"falling back to unkown shape.")
+        shapes = None
 
     _register_parameters(meas, all_setpoint_params)
     _register_parameters(meas, param_meas, setpoints=all_setpoint_params,

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -114,7 +114,7 @@ def do0d(
                                 if isinstance(param, _BaseParameter))
 
     try:
-        shapes = detect_shape_of_measurement(
+        shapes: Shapes = detect_shape_of_measurement(
             measured_parameters,
         )
     except TypeError as e:
@@ -182,7 +182,7 @@ def do1d(
                                 if isinstance(param, _BaseParameter))
     try:
         loop_shape = tuple(1 for _ in additional_setpoints) + (num_points,)
-        shapes = detect_shape_of_measurement(
+        shapes: Shapes = detect_shape_of_measurement(
             measured_parameters,
             loop_shape
         )
@@ -282,7 +282,7 @@ def do2d(
         loop_shape = tuple(
             1 for _ in additional_setpoints
         ) + (num_points1, num_points2)
-        shapes = detect_shape_of_measurement(
+        shapes: Shapes = detect_shape_of_measurement(
             measured_parameters,
             loop_shape
         )

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -181,9 +181,10 @@ def do1d(
     measured_parameters = tuple(param for param in param_meas
                                 if isinstance(param, _BaseParameter))
     try:
+        loop_shape = tuple(1 for _ in additional_setpoints) + (num_points,)
         shapes = detect_shape_of_measurement(
             measured_parameters,
-            (num_points,)
+            loop_shape
         )
     except TypeError as e:
         LOG.exception(
@@ -278,9 +279,13 @@ def do2d(
                                 if isinstance(param, _BaseParameter))
 
     try:
+        loop_shape = tuple(
+            1 for _ in additional_setpoints
+        ) + (num_points1, num_points2)
         shapes = detect_shape_of_measurement(
             measured_parameters,
-            (num_points1, num_points2))
+            loop_shape
+        )
     except TypeError as e:
         LOG.exception(
             f"Could not detect shape of {measured_parameters} "

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -165,8 +165,7 @@ def do1d(
         write_period: The time after which the data is actually written to the
             database.
         additional_setpoints: A list of setpoint parameters to be registered in
-            the measurement but not scanned. TODO it should be enforced that
-            these are scalar parameters
+            the measurement but not scanned.
         do_plot: should png and pdf versions of the images be saved after the
             run.
 

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -112,7 +112,6 @@ def do0d(
 
     shapes = detect_shape_of_measurement(measured_parameters)
 
-
     _register_parameters(meas, param_meas, shapes=shapes)
     _set_write_period(meas, write_period)
 

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -120,7 +120,7 @@ def do0d(
     except TypeError:
         LOG.exception(
             f"Could not detect shape of {measured_parameters} "
-            f"falling back to unkown shape.")
+            f"falling back to unknown shape.")
         shapes = None
 
     _register_parameters(meas, param_meas, shapes=shapes)
@@ -189,7 +189,7 @@ def do1d(
     except TypeError:
         LOG.exception(
             f"Could not detect shape of {measured_parameters} "
-            f"falling back to unkown shape.")
+            f"falling back to unknown shape.")
         shapes = None
 
     _register_parameters(meas, all_setpoint_params)
@@ -289,7 +289,7 @@ def do2d(
     except TypeError:
         LOG.exception(
             f"Could not detect shape of {measured_parameters} "
-            f"falling back to unkown shape.")
+            f"falling back to unknown shape.")
         shapes = None
 
     _register_parameters(meas, all_setpoint_params)


### PR DESCRIPTION
Add shape information that can optionally be set for a dataset and extend dond functions to set this when generating a measurement. 


TODO:
- [x] Extend handling within dond to take Paramters internal shape into account
- [ ] Use the information in dataset.cache and dataset.get_parameter_data (Will do this in a second pr)
- [ ] Documentation (Will add the docs along with the use of this)
