### PR TITLE
restrict pyvisa to less than 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {k: '>='.join(v) for k, v in extras.items()}
 
 install_requires = [
     'numpy>=1.10',
-    'pyvisa>=1.9.1',
+    'pyvisa>=1.9.1, <1.11',
     'h5py>=2.6',
     'websockets>=7.0',
     'jsonschema',


### PR DESCRIPTION
As https://github.com/QCoDeS/Qcodes/pull/2161 reveals that there are some potential issues with this release