### PR TITLE
Use Pips new resolver when installing dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ python:
 # we install here, although we uninstall below
 install:
     - pip install --upgrade pip
-    - pip install cython # this can go once we have scipy wheels for 3.8
     - pip install -r requirements.txt
     - pip install -r test_requirements.txt --upgrade --upgrade-strategy only-if-needed
     - pip install -r docs_requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ python:
 install:
     - pip install --upgrade pip
     - pip install -r requirements.txt
-    - pip install -r test_requirements.txt --upgrade --upgrade-strategy only-if-needed
+    - pip install -r test_requirements.txt
     - pip install -r docs_requirements.txt
     - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ python:
 # We want to fail early if there is an installation problem, so
 # we install here, although we uninstall below
 install:
-    - pip install --upgrade pip
+    - pip install --upgrade pip setuptools wheel
     - pip install -r requirements.txt --use-feature=2020-resolver
     - pip install -r test_requirements.txt --use-feature=2020-resolver
     - pip install -r docs_requirements.txt --use-feature=2020-resolver

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ python:
 # we install here, although we uninstall below
 install:
     - pip install --upgrade pip
-    - pip install -r requirements.txt
-    - pip install -r test_requirements.txt
-    - pip install -r docs_requirements.txt
+    - pip install -r requirements.txt --use-feature=2020-resolver
+    - pip install -r test_requirements.txt --use-feature=2020-resolver
+    - pip install -r docs_requirements.txt --use-feature=2020-resolver
     - pip install .
 
 before_script: # fetch full history so we can generate db fixtures


### PR DESCRIPTION
This should make incorrect dependencies such as https://github.com/QCoDeS/Qcodes/pull/2166 a hard error.
The new resolver is documented [here](https://pip.pypa.io/en/stable/user_guide/#resolver-changes-2020) and will 
be the defaul in the future


Along with a few more cleanups along the way

* Don't install cython (this is no longer needed as we have all the wheels already)
* Don't pass upgrade to test requirements install. This is not needed as we specify dependencies already
* Ensure setuptools and wheel is up to date
