### PR TITLE
handling TypeError in write_raw (pyvisa 1.11)

### DIFF
--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -210,27 +210,10 @@ class VisaInstrument(Instrument):
         with DelayedKeyboardInterrupt():
             self.visa_log.debug(f"Writing: {cmd}")
             response = self.visa_handle.write(cmd)
-            self.check_error(ret_code)
 
-    def write_raw(self, cmd: str) -> None:
-        """
-        Low-level interface to ``visa_handle.write``.
-
-        Args:
-            cmd: The command to send to the instrument.
-        """
-        with DelayedKeyboardInterrupt():
-            self.visa_log.debug(f"Writing: {cmd}")
-            response = self.visa_handle.write(cmd)
-            nr_bytes_written = None
-
-            if type(response) is tuple and len(response) == 2:
-                nr_bytes_written = response[0]
+            if isinstance(response, tuple) and len(response) == 2:
                 ret_code = response[1]
                 self.check_error(ret_code)
-            else:
-                nr_bytes_written = response
-
 
     def ask_raw(self, cmd: str) -> str:
         """

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -209,8 +209,28 @@ class VisaInstrument(Instrument):
         """
         with DelayedKeyboardInterrupt():
             self.visa_log.debug(f"Writing: {cmd}")
-            nr_bytes_written, ret_code = self.visa_handle.write(cmd)
+            response = self.visa_handle.write(cmd)
             self.check_error(ret_code)
+
+    def write_raw(self, cmd: str) -> None:
+        """
+        Low-level interface to ``visa_handle.write``.
+
+        Args:
+            cmd: The command to send to the instrument.
+        """
+        with DelayedKeyboardInterrupt():
+            self.visa_log.debug(f"Writing: {cmd}")
+            response = self.visa_handle.write(cmd)
+            nr_bytes_written = None
+
+            if type(response) is tuple and len(response) == 2:
+                nr_bytes_written = response[0]
+                ret_code = response[1]
+                self.check_error(ret_code)
+            else:
+                nr_bytes_written = response
+
 
     def ask_raw(self, cmd: str) -> str:
         """


### PR DESCRIPTION
After updating qcodes to the following version,  
```
$ pip show qcodes
Name: qcodes
Version: 0.17.0+139.g11417d944
Summary: Python-based data acquisition framework developed by the Copenhagen / Delft / Sydney / Microsoft quantum computing consortium
Home-page: https://github.com/QCoDeS/Qcodes
[...]
```
I was not able to initialize a keysight device any more (using the driver in `qcodes/instrument_drivers/Keysight/N52xx.py`), 
since it gave me a `TypeError`, more specifically: 

```
Traceback (most recent call last):
  File "qcodes_keysight_example.py", line 43, in <module>
    pna = N5245A("VNA2", "TCPIP0::maip-franck::hislip0,4880::INSTR",
  File "qcodes_keysight_example.py", line 32, in __init__
    super().__init__(name, address,
  File "c:\users\nanospin\misc\qcodes\qcodes\instrument_drivers\Keysight\N52xx.py", line 422, in __init__
    trace1 = self.traces[0]
  File "c:\users\nanospin\misc\qcodes\qcodes\instrument_drivers\Keysight\N52xx.py", line 471, in traces
    trace_num = self.select_trace_by_name(trace_name)
  File "c:\users\nanospin\misc\qcodes\qcodes\instrument_drivers\Keysight\N52xx.py", line 504, in select_trace_by_name
    self.write(f"CALC:PAR:SEL '{trace_name}'")
  File "c:\users\nanospin\misc\qcodes\qcodes\instrument\base.py", line 712, in write
    raise e
  File "c:\users\nanospin\misc\qcodes\qcodes\instrument\base.py", line 708, in write
    self.write_raw(cmd)
  File "c:\users\nanospin\misc\qcodes\qcodes\instrument\visa.py", line 212, in write_raw
    nr_bytes_written, ret_code = self.visa_handle.write(cmd)
TypeError: ('cannot unpack non-iterable int object', 'writing "CALC:PAR:SEL \'CH1_S11_1\'" to <N5245A: VNA2>')
```

So I tracked it down and indeed, in my case `self.visa_handle.write(cmd)` returned only an `int`, not a tuple!
```
> c:\users\nanospin\appdata\local\continuum\anaconda3\envs\qcodes_sandbox\lib\site-packages\pyvisa\ctwrapper\functions.py(2797)write()
-> return return_count.value, ret
(Pdb) ll
2772    def write(library, session, data):
2773        """Write data to device or interface synchronously.
2774
2775        Corresponds to viWrite function of the VISA library.
2776
2777        Parameters
2778        ----------
2779        library : ctypes.WinDLL or ctypes.CDLL
2780            ctypes wrapped library.
2781        session : VISASession
2782            Unique logical identifier to a session.
2783        data : bytes
2784            Data to be written.
2785
2786        Returns
2787        -------
2788        int
2789            Number of bytes actually transferred
2790        constants.StatusCode
2791            Return value of the library call.
2792
2793        """
2794        return_count = ViUInt32()
2795        # [ViSession, ViBuf, ViUInt32, ViPUInt32]
2796        ret = library.viWrite(session, data, len(data), byref(return_count))
2797 ->     return return_count.value, ret
(Pdb) return_count.value
25
```
I then edited `write_raw` in `qcodes/instrument/visa.py` to account for this case (and not break): 
```
 def write_raw(self, cmd: str) -> None:
        """
        Low-level interface to ``visa_handle.write``.

        Args:
            cmd: The command to send to the instrument.
        """
        with DelayedKeyboardInterrupt():
            self.visa_log.debug(f"Writing: {cmd}")
            response = self.visa_handle.write(cmd)
            nr_bytes_written = None

            if type(response) is tuple and len(response) == 2:
                nr_bytes_written = response[0]
                ret_code = response[1]
                self.check_error(ret_code)
            else:
                nr_bytes_written = response
```
I minimally altered the code to circumvent this error. Now the connection to the device works again.