### PR TITLE
remove dataclasses requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ install_requires = [
     'opencensus>=0.7.10, <0.8.0',
     'opencensus-ext-azure>=1.0.4, <2.0.0',
     'matplotlib>=2.2.3',
-    "dataclasses;python_version<'3.7'",  # can be removed once we drop support for python 3.6
     "requirements-parser",
     "importlib-metadata;python_version<'3.8'",
     "typing_extensions",


### PR DESCRIPTION
Because of the Python >=3.7 requirement.