### PR TITLE
add pyupgrade to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,8 @@ repos:
     - id: check-yaml
     - id: debug-statements
     - id: check-ast
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.2
+    hooks:
+    - id: pyupgrade
+      args: ['--py37-plus']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,4 @@ repos:
     hooks:
     - id: pyupgrade
       args: ['--py37-plus']
+      exclude: _version.py|versioneer.py


### PR DESCRIPTION
As a followup from https://github.com/QCoDeS/Qcodes/pull/1945.

This adds pyupgrade as pre-commit filter.

This PR is blocked by
- #2201
- #2202
- #2203
- #2204
- #2205
- #2206
- #2207
- #2208
- #2209
- #2210
- #2211
