### PR TITLE
allow importlib metadata 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ google-auth~=1.21.3
 googleapis-common-protos~=1.52.0
 h5py~=2.10.0
 idna~=2.10
-importlib-metadata~=1.7.0;python_version<'3.8'
+importlib-metadata<3.0.0;python_version<'3.8'
 ipykernel~=5.3.4
 ipython~=7.18.1
 ipython-genutils~=0.2.0

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     'opencensus-ext-azure>=1.0.4, <2.0.0',
     'matplotlib>=2.2.3',
     "requirements-parser",
-    "importlib-metadata;python_version<'3.8'",
+    "importlib-metadata<3.0.0;python_version<'3.8'",
     "typing_extensions",
     "packaging>=20.0",
     "ipywidgets",


### PR DESCRIPTION
@astafan8  It seems like dependabot does not touch lines with environmental markers 