### PR TITLE
add explicit tests for paramspec equality

### DIFF
--- a/qcodes/tests/dataset/test_paramspec.py
+++ b/qcodes/tests/dataset/test_paramspec.py
@@ -299,3 +299,49 @@ def test_base_version(paramspecs):
                             unit=kwargs['unit'])
 
     assert ps.base_version() == ps_base
+
+
+def test_not_eq_for_list_attr():
+    """
+    test that two paramspecs that differ only
+    in list attrs are different
+    """
+
+    p1 = ParamSpec(name='foo',
+                   paramtype='numeric',
+                   depends_on=['a', 'b'])
+    p2 = ParamSpec(name='foo',
+                   paramtype='numeric',
+                   depends_on=['c', 'd'])
+    assert p1 != p2
+
+
+def test_not_eq_for_str_attr():
+    """
+    test that two paramspecs that differ only
+    in str attrs are different
+    """
+
+    p1 = ParamSpec(name='foo',
+                   label='myfoo',
+                   paramtype='numeric',
+                   depends_on=['a', 'b'])
+    p2 = ParamSpec(name='foo',
+                   label='someotherfoo',
+                   paramtype='numeric',
+                   depends_on=['a', 'b'])
+    assert p1 != p2
+
+
+def test_not_eq_non_paramspec():
+    """
+    test that two paramspecs that differ only
+    in str attrs are different
+    """
+
+    p1 = ParamSpec(name='foo',
+                   label='myfoo',
+                   paramtype='numeric',
+                   depends_on=['a', 'b'])
+    p2 = 1
+    assert p1 != p2


### PR DESCRIPTION
Some of the branches in ParamSpecs implementation of `__eq__` seem to flip between being covered and not causing jobs like https://github.com/QCoDeS/Qcodes/pull/2260 to report a drop in coverage.
This is probaby because hypothesis may or may not generate input that covers all of them. This pr adds explicit tests for all 3 failure branches


