### PR TITLE
Widget only list completed

### DIFF
--- a/qcodes/interactive_widget.py
+++ b/qcodes/interactive_widget.py
@@ -9,7 +9,7 @@ import traceback
 from datetime import datetime
 from functools import partial, reduce
 from typing import Any, Callable, Dict, Optional, Sequence, Iterable, \
-    TYPE_CHECKING
+    TYPE_CHECKING, cast
 
 import matplotlib.pyplot as plt
 from IPython.core.display import display
@@ -516,12 +516,15 @@ def experiments_widget(
             initialise_or_create_database_at(db)
         data_sets = [
             ds for exp in qcodes.experiments() for ds in exp.data_sets()
+            if ds.completed
         ]
     if sort_by == "run_id":
         data_sets = sorted(data_sets, key=lambda ds: ds.run_id)
     elif sort_by == "timestamp":
+        # since we only list completed runs it is safe to assume that
+        # run_timestamp_raw is not None
         data_sets = sorted(
-            data_sets, key=lambda ds: ds.run_timestamp_raw, reverse=True
+            data_sets, key=lambda ds: cast(float, ds.run_timestamp_raw), reverse=True
         )
 
     title = HTML("<h1>QCoDeS experiments widget</h1>")

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,7 +6,7 @@ pytest-xdist~=2.1.0
 pytest-mock~=3.3.1
 codacy-coverage~=1.3.11
 hypothesis~=5.37.1
-mypy==0.782
+mypy==0.790
 git+https://github.com/QCoDeS/pyvisa-sim.git
 lxml~=4.5.2
 codecov~=2.1.10


### PR DESCRIPTION
The experiments widget assumes that run_timestamp_raw is set to not None 
This is not the case for pristine runs that have not been started.

It seems like the widget should only show completed runs so this pr filters the non completed runs away. 
Note we could also just filter away the pristine runs and show started runs? 

replaces #2268 since mypy .790 now checks the signature of keys given to sorted