### PR TITLE
correct 2 small typos in alazar drivers

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS9373.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9373.py
@@ -393,7 +393,7 @@ class AlazarTech_ATS9373(AlazarTech_ATS):
         fwversion = self.get_idn()['firmware']
         if LooseVersion(fwversion) < \
                 LooseVersion(self._trigger_holdoff_min_fw_version):
-            raise RuntimeError(f"Alazar 9360 requires at least firmware "
+            raise RuntimeError(f"Alazar 9373 requires at least firmware "
                                f"version {self._trigger_holdoff_min_fw_version}"
                                f" for trigger holdoff support. "
                                f"You have version {fwversion}")

--- a/qcodes/instrument_drivers/AlazarTech/ATS9870.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9870.py
@@ -128,7 +128,7 @@ class AlazarTech_ATS9870(AlazarTech_ATS):
                                parameter_class=TraceParameter,
                                label='Trigger Engine ' + i,
                                unit=None,
-                               initial_value='TRIG_ENGINE_' + ('J' if i == 0 else 'K'),
+                               initial_value='TRIG_ENGINE_' + ('J' if i == '1' else 'K'),
                                val_mapping={'TRIG_ENGINE_J': 0,
                                             'TRIG_ENGINE_K': 1})
             self.add_parameter(name='trigger_source' + i,


### PR DESCRIPTION
Fix two small issues.

In 9870 driver i is a string that can be either '1' or '2' so compare it against that and not the number 0
In 9373 driver correct a typo (wrong model number) in error message