### PR TITLE
remove pylint and its deps from test_requirements

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,4 @@
 apipkg==1.5
-astroid==2.4.2
 atomicwrites==1.4.0
 attrs==20.2.0
 certifi==2020.6.20
@@ -15,10 +14,7 @@ hypothesis==5.37.3
 idna==2.10
 importlib-metadata==2.0.0
 iniconfig==1.1.1
-isort==5.6.4
-lazy-object-proxy==1.4.3
 lxml==4.5.2
-mccabe==0.6.1
 mypy==0.790
 mypy-extensions==0.4.3
 numpy==1.17.5
@@ -27,7 +23,6 @@ ordered-set==4.0.2
 packaging==20.4
 pluggy==0.13.1
 py==1.9.0
-pylint==2.6.0
 pyparsing==2.4.7
 pytest==6.1.1
 pytest-cov==2.10.1


### PR DESCRIPTION
We are currently not using pylint in ci so no need to install it. 
Pylint is used via codecov 
