### PR TITLE
sync dependency of zipp here with other reqirements files

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -85,4 +85,4 @@ webencodings==0.5.1
 widgetsnbextension==3.5.1
 wincertstore==0.2
 xarray==0.16.1
-zipp==3.3.0
+zipp==3.3.1


### PR DESCRIPTION
Due to the way these files were introduced the required version of zipp between them has gone out of sync. It seems like dependabot does not correct this (but will keep them in sync) so fix this manually
