### PR TITLE
Keithley 2600: remove new line char in visa_handle.write

### DIFF
--- a/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
@@ -708,7 +708,7 @@ class Keithley_2600(VisaInstrument):
             list item, e.g. ['for ii = 1, 10 do', 'print(ii)', 'end' ]
         """
         mainprog = '\r\n'.join(program) + '\r\n'
-        wrapped = f'loadandrunscript\r\n{mainprog}endscript\n'
+        wrapped = f'loadandrunscript\r\n{mainprog}endscript'
         if debug:
             log.debug('Wrapped the following script:')
             log.debug(wrapped)


### PR DESCRIPTION
This PR is to fix the following warning message that was seen during testing with the Keithley 2600 SMU

`c:\users\redlabq\repositories\qcodes\qcodes\instrument\visa.py:212: UserWarning: write message already ends with termination characters
  nr_bytes_written, ret_code = self.visa_handle.write(cmd)`

The visa handle already end with termination character so passing in `\n` is not needed in the message