### PR TITLE
Keithley3706A: Convert _get_slot_id to a public method

### DIFF
--- a/qcodes/instrument_drivers/tektronix/Keithley_3706A.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_3706A.py
@@ -400,7 +400,7 @@ class Keithley_3706A(VisaInstrument):
                                'ranges, slots, or "allslots".')
         return self.ask(f"channel.getbackplane('{val}')")
 
-    def _get_slot_ids(self) -> List[str]:
+    def get_slot_ids(self) -> List[str]:
         """
         Returns the slot ids of the installed cards.
         """
@@ -413,7 +413,7 @@ class Keithley_3706A(VisaInstrument):
         Returns the names of the slots as "slotX",
         where "X" is the slot id.
         """
-        slot_id = self._get_slot_ids()
+        slot_id = self.get_slot_ids()
         slot_names = [f'slot{x}' for x in slot_id]
         return slot_names
 
@@ -421,7 +421,7 @@ class Keithley_3706A(VisaInstrument):
         """
         Returns the total number of rows of the installed cards.
         """
-        slot_id = self._get_slot_ids()
+        slot_id = self.get_slot_ids()
         total_number_of_rows = [int(float(self.ask(
             f'slot[{i}].rows.matrix')))
             for i in slot_id
@@ -432,7 +432,7 @@ class Keithley_3706A(VisaInstrument):
         """
         Returns the total number of columns of the installed cards.
         """
-        slot_id = self._get_slot_ids()
+        slot_id = self.get_slot_ids()
         total_number_of_columns = [int(float(self.ask(
             f'slot[{i}].columns.matrix')))
             for i in slot_id
@@ -472,7 +472,7 @@ class Keithley_3706A(VisaInstrument):
         channels list and join them via a colon to define a channel range.
         """
         range_list = []
-        for i in self._get_slot_ids():
+        for i in self.get_slot_ids():
             channel = self.get_channels_by_slot(int(i))
             for element in itertools.combinations(channel, 2):
                 range_list.append(':'.join(element))
@@ -487,7 +487,7 @@ class Keithley_3706A(VisaInstrument):
         the usage of channel attributes of the instrument driver does
         not depend on the functionality of this method.
         """
-        slot_id = self._get_slot_ids()
+        slot_id = self.get_slot_ids()
         row_list = self._get_rows()
         column_list = self._get_columns()
         matrix_channels = []
@@ -503,7 +503,7 @@ class Keithley_3706A(VisaInstrument):
         Args:
             slot_no: An integer value specifying the slot number.
         """
-        slot_id = self._get_slot_ids()
+        slot_id = self.get_slot_ids()
         if str(slot_no) not in slot_id:
             raise UnknownOrEmptySlot("Please provide a valid slot identifier. "
                                      f'Available slots are {slot_id}.')
@@ -524,7 +524,7 @@ class Keithley_3706A(VisaInstrument):
         """
         backplane_common_number = '9'
         backplane_relay_common_numbers = ['11', '12', '13', '14', '15', '16']
-        slot_id = self._get_slot_ids()
+        slot_id = self.get_slot_ids()
         analog_backplane_relays = []
         for element in itertools.product(slot_id, backplane_common_number,
                                          backplane_relay_common_numbers):
@@ -541,7 +541,7 @@ class Keithley_3706A(VisaInstrument):
         if action not in ["connect", "disconnect"]:
             raise ValueError("The action should be identified as either "
                              "'connect' or 'disconnect'.")
-        slots = self._get_slot_ids()
+        slots = self.get_slot_ids()
         slot = str(slot_id)
         if slot not in slots:
             raise UnknownOrEmptySlot("Please provide a valid slot identifier. "
@@ -573,7 +573,7 @@ class Keithley_3706A(VisaInstrument):
         if action not in ["connect", "disconnect"]:
             raise ValueError("The action should be identified as either "
                              "'connect' or 'disconnect'.")
-        slots = self._get_slot_ids()
+        slots = self.get_slot_ids()
         slot = str(slot_id)
         if slot not in slots:
             raise UnknownOrEmptySlot("Please provide a valid slot identifier. "
@@ -720,7 +720,7 @@ class Keithley_3706A(VisaInstrument):
         measurements through the switching card, as the analog backplanes
         cannot be energized.
         """
-        slot_id = self._get_slot_ids()
+        slot_id = self.get_slot_ids()
         interlock_status = {0: 'Interlock is disengaged',
                             1: 'Interlock is engaged'}
         states: List[Dict[str, str]] = []

--- a/qcodes/tests/drivers/test_keithley_3706A.py
+++ b/qcodes/tests/drivers/test_keithley_3706A.py
@@ -72,7 +72,7 @@ def test_switch_card_idn(driver):
 
 
 def test_installed_card_id(driver):
-    assert ['1', '2', '3'] == driver._get_slot_ids()
+    assert ['1', '2', '3'] == driver.get_slot_ids()
 
 
 def test_slot_names(driver):


### PR DESCRIPTION
This method would useful upstream as a public method. This PR is simply converting `_get_slot_id` to `get_slot_id`
