### PR TITLE
Qdac drivers: Don't check return from visa write

### DIFF
--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -643,8 +643,7 @@ class QDac(VisaInstrument):
 
         log.debug(f"Writing to instrument {self.name}: {cmd}")
 
-        nr_bytes_written, ret_code = self.visa_handle.write(cmd)
-        self.check_error(ret_code)
+        self.visa_handle.write(cmd)
         for _ in range(cmd.count(';')+1):
             self._write_response = self.visa_handle.read()
 

--- a/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
+++ b/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
@@ -770,8 +770,7 @@ class QDac(VisaInstrument):
         """
 
         LOG.debug(f"Writing to instrument {self.name}: {cmd}")
-        _, ret_code = self.visa_handle.write(cmd)
-        self.check_error(ret_code)
+        self.visa_handle.write(cmd)
         for _ in range(cmd.count(';')+1):
             self._write_response = self.visa_handle.read()
 


### PR DESCRIPTION
These two drivers have their own write routine that also needs update to support pyvisa 1.11

This was not found since the code is not type checked by mypy yet (I will add that later in another pr) 

@trevormorgan 