### PR TITLE
Add types to keysight drivers

### DIFF
--- a/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -1,6 +1,6 @@
 from functools import partial
 import logging
-from typing import Union
+from typing import Union, Any
 
 from qcodes import VisaInstrument, validators as vals
 from qcodes.instrument.channel import InstrumentChannel
@@ -253,7 +253,7 @@ class SyncChannel(InstrumentChannel):
     single channel instruments
     """
 
-    def __init__(self, parent, name):
+    def __init__(self, parent: Instrument, name: str):
 
         super().__init__(parent, name)
 
@@ -281,13 +281,14 @@ class WaveformGenerator_33XXX(KeysightErrorQueueMixin, VisaInstrument):
     waveform generators
     """
 
-    def __init__(self, name, address, silent=False, **kwargs):
+    def __init__(self, name: str, address: str,
+                 silent: bool = False, **kwargs: Any):
         """
         Args:
-            name (str): The name of the instrument used internally
+            name: The name of the instrument used internally
                 by QCoDeS. Must be unique.
-            address (str): The VISA resource name.
-            silent (Optional[bool]): If True, no connect message is printed.
+            address: The VISA resource name.
+            silent: If True, no connect message is printed.
         """
 
         super().__init__(name, address, terminator='\n', **kwargs)

--- a/qcodes/instrument_drivers/Keysight/Keysight_B2962A.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_B2962A.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Optional
+
 from qcodes import VisaInstrument
 from qcodes import Instrument
 from qcodes.instrument.channel import InstrumentChannel
@@ -10,10 +12,9 @@ class B2962AChannel(InstrumentChannel):
     def __init__(self, parent: Instrument, name: str, chan: int) -> None:
         """
         Args:
-            parent (Instrument): The instrument to which the channel is
-            attached.
-            name (str): The name of the channel
-            channum (int): The number of the channel in question (1-2)
+            parent: The instrument to which the channel is attached.
+            name: The name of the channel
+            chan: The number of the channel in question (1-2)
         """
         # Sanity Check inputs
         if name not in ['ch1', 'ch2']:
@@ -95,7 +96,7 @@ class B2962A(VisaInstrument):
         - Similar drivers have special handlers to map return values of
           9.9e+37 to inf, is this needed?
     """
-    def __init__(self, name, address, **kwargs):
+    def __init__(self, name: str, address: str, **kwargs: Any):
         super().__init__(name, address, terminator='\n', **kwargs)
 
         # The B2962A supports two channels
@@ -106,9 +107,10 @@ class B2962A(VisaInstrument):
 
         self.connect_message()
 
-    def get_idn(self):
-        IDN = self.ask_raw('*IDN?')
-        vendor, model, serial, firmware = map(str.strip, IDN.split(','))
-        IDN = {'vendor': vendor, 'model': model,
-               'serial': serial, 'firmware': firmware}
+    def get_idn(self) -> Dict[str, Optional[str]]:
+        IDN_str = self.ask_raw('*IDN?')
+        vendor, model, serial, firmware = map(str.strip, IDN_str.split(','))
+        IDN: Dict[str, Optional[str]] = {
+            'vendor': vendor, 'model': model,
+            'serial': serial, 'firmware': firmware}
         return IDN

--- a/qcodes/instrument_drivers/Keysight/Keysight_N6705B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N6705B.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from qcodes import VisaInstrument
 from qcodes import Instrument
 from qcodes.instrument.channel import InstrumentChannel
@@ -59,7 +61,7 @@ class N6705BChannel(InstrumentChannel):
 
 
 class N6705B(VisaInstrument):
-    def __init__(self, name, address, **kwargs) -> None:
+    def __init__(self, name: str, address: str, **kwargs: Any) -> None:
         super().__init__(name, address, terminator='\n', **kwargs)
         self.channels:  List[N6705BChannel] = []
         for ch_num in [1, 2, 3, 4]:

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Optional
+
 from qcodes import VisaInstrument
 from qcodes.utils.validators import Numbers
 
@@ -8,7 +10,7 @@ class N51x1(VisaInstrument):
     It has been tested with N5171B, N5181A, N5171B, N5183B
     """
 
-    def __init__(self, name, address, **kwargs):
+    def __init__(self, name: str, address: str, **kwargs: Any):
         super().__init__(name, address, terminator='\n', **kwargs)
 
         self.add_parameter('power',
@@ -46,10 +48,10 @@ class N51x1(VisaInstrument):
 
         self.connect_message()
 
-
-    def get_idn(self):
-        IDN = self.ask_raw('*IDN?')
-        vendor, model, serial, firmware = map(str.strip, IDN.split(','))
-        IDN = {'vendor': vendor, 'model': model,
-               'serial': serial, 'firmware': firmware}
+    def get_idn(self) -> Dict[str, Optional[str]]:
+        IDN_str = self.ask_raw('*IDN?')
+        vendor, model, serial, firmware = map(str.strip, IDN_str.split(','))
+        IDN: Dict[str, Optional[str]] = {
+            'vendor': vendor, 'model': model,
+            'serial': serial, 'firmware': firmware}
         return IDN

--- a/qcodes/instrument_drivers/Keysight/N5230C.py
+++ b/qcodes/instrument_drivers/Keysight/N5230C.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from . import N52xx
 
 class N5230C(N52xx.PNABase):
-    def __init__(self, name, address, **kwargs):
+    def __init__(self, name: str, address: str, **kwargs: Any):
         super().__init__(name, address,
                          min_freq=300e3, max_freq=13.5e9,
                          min_power=-90, max_power=13,

--- a/qcodes/instrument_drivers/Keysight/N5245A.py
+++ b/qcodes/instrument_drivers/Keysight/N5245A.py
@@ -1,7 +1,9 @@
+from typing import Any
+
 from . import N52xx
 
 class N5245A(N52xx.PNAxBase):
-    def __init__(self, name, address, **kwargs):
+    def __init__(self, name: str, address: str, **kwargs: Any):
         super().__init__(name, address,
                          min_freq=10e6, max_freq=50e9,
                          min_power=-30, max_power=13,

--- a/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -28,6 +28,7 @@ class PNASweep(ArrayParameter):
         if self._instrument is None:
             return (0,)
         return (self._instrument.root_instrument.points(),)
+
     @shape.setter
     def shape(self, val: Sequence[int]) -> None:
         pass
@@ -43,6 +44,7 @@ class PNASweep(ArrayParameter):
     @setpoints.setter
     def setpoints(self, val: Sequence[int]) -> None:
         pass
+
 
 class FormattedSweep(PNASweep):
     """
@@ -86,6 +88,7 @@ class FormattedSweep(PNASweep):
 
         return data
 
+
 class PNAPort(InstrumentChannel):
     """
     Allow operations on individual PNA ports.
@@ -122,6 +125,7 @@ class PNAPort(InstrumentChannel):
         """
         self.source_power.vals = Numbers(min_value=min_power,
                                          max_value=max_power)
+
 
 class PNATrace(InstrumentChannel):
     """
@@ -263,6 +267,7 @@ class PNATrace(InstrumentChannel):
         if not re.match("S[1-4][1-4]", val):
             raise ValueError("Invalid S parameter spec")
         self.write(f"CALC:PAR:MOD:EXT \"{val}\"")
+
 
 class PNABase(VisaInstrument):
     """
@@ -484,7 +489,7 @@ class PNABase(VisaInstrument):
         # Query the instrument for what options are installed
         return self.ask('*OPT?').strip('"').split(',')
 
-    def get_trace_catalog(self):
+    def get_trace_catalog(self) -> str:
         """
         Get the trace catalog, that is a list of trace and sweep types
         from the PNA.
@@ -504,19 +509,19 @@ class PNABase(VisaInstrument):
         self.write(f"CALC:PAR:SEL '{trace_name}'")
         return self.active_trace()
 
-    def reset_averages(self):
+    def reset_averages(self) -> None:
         """
         Reset averaging
         """
         self.write("SENS:AVER:CLE")
 
-    def averages_on(self):
+    def averages_on(self) -> None:
         """
         Turn on trace averaging
         """
         self.averages_enabled(True)
 
-    def averages_off(self):
+    def averages_off(self) -> None:
         """
         Turn off trace averaging
         """
@@ -532,6 +537,7 @@ class PNABase(VisaInstrument):
                                   max_value=max_power)
         for port in self.ports:
             port._set_power_limits(min_power, max_power)
+
 
 class PNAxBase(PNABase):
     def _enable_fom(self) -> None:

--- a/qcodes/instrument_drivers/Keysight/keysight_34934a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_34934a.py
@@ -51,7 +51,7 @@ class Keysight34934A(KeysightSwitchMatrixSubModule):
             int(num) for num in re.findall(r'\d+', layout)
         ]
 
-    def write(self, cmd: str):
+    def write(self, cmd: str) -> None:
         """
         When the module is safety interlocked, users can not make any
         connections. There will be no effect when try to connect any channels.
@@ -74,10 +74,10 @@ class Keysight34934A(KeysightSwitchMatrixSubModule):
         if (row > self.row) or (column > self.column):
             raise ValueError('row/column value out of range')
 
-    def _get_relay_protection_mode(self):
+    def _get_relay_protection_mode(self) -> str:
         return self.ask(f'SYSTem:MODule:ROW:PROTection? {self.slot}')
 
-    def _set_relay_protection_mode(self, mode: str):
+    def _set_relay_protection_mode(self, mode: str) -> None:
         self.write(f'SYSTem:MODule:ROW:PROTection {self.slot}, {mode}')
 
     def to_channel_list(
@@ -168,7 +168,7 @@ class Keysight34934A(KeysightSwitchMatrixSubModule):
         channels_per_row = 800 / rows
         offset += 100 - int(channels_per_row)
 
-        def numbering_function(row, col):
+        def numbering_function(row: int, col: int) -> str:
             return str(int(channels_per_row * row + col + offset))
 
         return numbering_function

--- a/qcodes/instrument_drivers/Keysight/keysight_34980a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_34980a.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 import re
 from functools import wraps
+from typing import Any, TypeVar, Dict
 from .keysight_34980a_submodules import KeysightSubModule
 from .keysight_34934a import Keysight34934A
 from qcodes.instrument.visa import VisaInstrument
@@ -12,7 +13,10 @@ from typing import Callable, Optional
 KEYSIGHT_MODELS = {'34934A': Keysight34934A}
 
 
-def post_execution_status_poll(func: Callable) -> Callable:
+T = TypeVar('T')
+
+
+def post_execution_status_poll(func: Callable[..., T]) -> Callable[..., T]:
     """
     Generates a decorator that clears the instrument's status registers
     before executing the actual call and reads the status register after the
@@ -22,7 +26,7 @@ def post_execution_status_poll(func: Callable) -> Callable:
         func: function to wrap
     """
     @wraps(func)
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: "Keysight34980A", *args: Any, **kwargs: Any) -> T:
         self.clear_status()
         retval = func(self, *args, **kwargs)
 
@@ -41,7 +45,11 @@ class Keysight34980A(VisaInstrument):
     """
     QCodes driver for 34980A switch/measure unit
     """
-    def __init__(self, name, address, terminator='\n', **kwargs):
+    def __init__(self,
+                 name: str,
+                 address: str,
+                 terminator: str = '\n',
+                 **kwargs: Any):
         """
         Create an instance of the instrument.
 
@@ -126,12 +134,12 @@ class Keysight34980A(VisaInstrument):
                                 f'in slot {slot}')
 
     @property
-    def system_slots_info(self):
+    def system_slots_info(self) -> Dict[int, Dict[str, str]]:
         if self._system_slots_info_dict is None:
             self._system_slots_info_dict = self._system_slots_info()
         return self._system_slots_info_dict
 
-    def _system_slots_info(self) -> dict:
+    def _system_slots_info(self) -> Dict[int, Dict[str, str]]:
         """
         the command SYST:CTYP? returns the following:
         Agilent Technologies,<Model Number>,<Serial Number>,<Firmware Rev>

--- a/qcodes/instrument_drivers/Keysight/keysight_b220x.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_b220x.py
@@ -1,13 +1,16 @@
+from typing import Any, TypeVar, Sequence, Set, Tuple, Callable
+
 import re
 import warnings
 from functools import wraps
 
 from qcodes import VisaInstrument
 from qcodes.utils.validators import MultiType, Ints, Enum, Lists
-from typing import List, Tuple, Callable
+
+T = TypeVar('T')
 
 
-def post_execution_status_poll(func: Callable) -> Callable:
+def post_execution_status_poll(func: Callable[..., T]) -> Callable[..., T]:
     """
     Generates a decorator that clears the instrument's status registers
     before executing the actual call and reads the status register after the
@@ -17,7 +20,7 @@ def post_execution_status_poll(func: Callable) -> Callable:
     """
 
     @wraps(func)
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: "KeysightB220X", *args: Any, **kwargs: Any) -> T:
         self.clear_status()
         retval = func(self, *args, **kwargs)
 
@@ -47,7 +50,7 @@ class KeysightB220X(VisaInstrument):
     _available_input_ports = Ints(1, 14)
     _available_output_ports = Ints(1, 48)
 
-    def __init__(self, name, address, **kwargs):
+    def __init__(self, name: str, address: str, **kwargs: Any):
         super().__init__(name, address, terminator='\n', **kwargs)
 
         self._card = 0
@@ -181,7 +184,7 @@ class KeysightB220X(VisaInstrument):
         self.connect_message()
 
     @post_execution_status_poll
-    def connect(self, input_ch, output_ch):
+    def connect(self, input_ch: int, output_ch: int) -> None:
         """Connect given input/output pair.
 
         :param input_ch: Input channel number 1-14
@@ -193,17 +196,17 @@ class KeysightB220X(VisaInstrument):
         self.write(f":CLOS (@{self._card:01d}{input_ch:02d}{output_ch:02d})")
 
     @post_execution_status_poll
-    def connect_paths(self, paths: List[Tuple[int, int]]):
+    def connect_paths(self, paths: Sequence[Tuple[int, int]]) -> None:
         channel_list_str = self.to_channel_list(paths)
         self.write(f":CLOS {channel_list_str}")
 
     @post_execution_status_poll
-    def disconnect_paths(self, paths: List[Tuple[int, int]]):
+    def disconnect_paths(self, paths: Sequence[Tuple[int, int]]) -> None:
         channel_list_str = self.to_channel_list(paths)
         self.write(f":OPEN {channel_list_str}")
 
     @post_execution_status_poll
-    def disconnect(self, input_ch, output_ch):
+    def disconnect(self, input_ch: int, output_ch: int) -> None:
         """Disconnect given Input/Output pair.
 
         :param input_ch: Input channel number 1-14
@@ -215,7 +218,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f":OPEN (@{self._card:01d}{input_ch:02d}{output_ch:02d})")
 
     @post_execution_status_poll
-    def disconnect_all(self):
+    def disconnect_all(self) -> None:
         """
         opens all connections.
 
@@ -225,7 +228,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f':OPEN:CARD {self._card}')
 
     @post_execution_status_poll
-    def bias_disable_all_outputs(self):
+    def bias_disable_all_outputs(self) -> None:
         """
         Removes all outputs from list of ports that will be connected to GND
         input if port is unused and bias mode is enabled.
@@ -233,7 +236,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f':BIAS:CHAN:DIS:CARD {self._card}')
 
     @post_execution_status_poll
-    def bias_enable_all_outputs(self):
+    def bias_enable_all_outputs(self) -> None:
         """
         Adds all outputs to list of ports that will be connected to bias input
         if port is unused and bias mode is enabled.
@@ -241,7 +244,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f':BIAS:CHAN:ENAB:CARD {self._card}')
 
     @post_execution_status_poll
-    def bias_enable_output(self, output):
+    def bias_enable_output(self, output: int) -> None:
         """
         Adds `output` to list of ports that will be connected to bias input
         if port is unused and bias mode is enabled.
@@ -254,7 +257,7 @@ class KeysightB220X(VisaInstrument):
                    )
 
     @post_execution_status_poll
-    def bias_disable_output(self, output):
+    def bias_disable_output(self, output: int) -> None:
         """
         Removes `output` from list of ports that will be connected to bias
         input if port is unused and bias mode is enabled.
@@ -266,7 +269,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f':BIAS:CHAN:DIS (@{self._card}01{output:02d})')
 
     @post_execution_status_poll
-    def gnd_enable_output(self, output):
+    def gnd_enable_output(self, output: int) -> None:
         """
         Adds `output` to list of ports that will be connected to GND input
         if port is unused and bias mode is enabled.
@@ -278,7 +281,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f':AGND:CHAN:ENAB (@{self._card}01{output:02d})')
 
     @post_execution_status_poll
-    def gnd_disable_output(self, output):
+    def gnd_disable_output(self, output: int) -> None:
         """
         Removes `output` from list of ports that will be connected to GND
         input if port is unused and bias mode is enabled.
@@ -290,7 +293,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f':AGND:CHAN:DIS (@{self._card}01{output:02d})')
 
     @post_execution_status_poll
-    def gnd_enable_all_outputs(self):
+    def gnd_enable_all_outputs(self) -> None:
         """
         Adds all outputs to list of ports that will be connected to GND input
         if port is unused and bias mode is enabled.
@@ -298,7 +301,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f':AGND:CHAN:ENAB:CARD {self._card}')
 
     @post_execution_status_poll
-    def gnd_disable_all_outputs(self):
+    def gnd_disable_all_outputs(self) -> None:
         """
         Removes all outputs from list of ports that will be connected to GND
         input if port is unused and bias mode is enabled.
@@ -306,7 +309,7 @@ class KeysightB220X(VisaInstrument):
         self.write(f':AGND:CHAN:DIS:CARD {self._card}')
 
     @post_execution_status_poll
-    def couple_port_autodetect(self):
+    def couple_port_autodetect(self) -> None:
         """Autodetect Kelvin connections on Input ports
 
         This will detect Kelvin connections on the input ports and enable
@@ -319,11 +322,11 @@ class KeysightB220X(VisaInstrument):
         """
         self.write(':COUP:PORT:DET')
 
-    def clear_status(self):
+    def clear_status(self) -> None:
         """Clears status register and error queue of the instrument."""
         self.write('*CLS')
 
-    def reset(self):
+    def reset(self) -> None:
         """Performs an instrument reset.
 
         Does not reset error queue!
@@ -331,7 +334,7 @@ class KeysightB220X(VisaInstrument):
         self.write('*RST')
 
     @post_execution_status_poll
-    def _set_connection_rule(self, mode):
+    def _set_connection_rule(self, mode: str) -> None:
         if 'free' == self.connection_rule() and 'SROU' == mode:
             warnings.warn('When going from *free* to *single* mode existing '
                           'connections are not released.')
@@ -339,11 +342,11 @@ class KeysightB220X(VisaInstrument):
         self.write(f':CONN:RULE {self._card},{mode}')
 
     @post_execution_status_poll
-    def _get_connection_rule(self):
+    def _get_connection_rule(self) -> str:
         return self.ask(f':CONN:RULE? {self._card}')
 
     @staticmethod
-    def parse_channel_list(channel_list: str):
+    def parse_channel_list(channel_list: str) -> Set[Tuple[int, int]]:
         """Generate a set of (input, output) tuples from a SCPI channel
         list string.
         """
@@ -352,7 +355,7 @@ class KeysightB220X(VisaInstrument):
         return {(int(match['input']), int(match['output'])) for match in
                 re.finditer(pattern, channel_list)}
 
-    def to_channel_list(self, paths: List[Tuple[int, int]]):
+    def to_channel_list(self, paths: Sequence[Tuple[int, int]]) -> str:
         l = [f'{self._card:01d}{i:02d}{o:02d}' for i, o in paths]
         channel_list = f"(@{','.join(l)})"
         return channel_list

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,26 +46,14 @@ disallow_untyped_defs = True
 [mypy-qcodes.config.*]
 disallow_untyped_defs = True
 
-[mypy-qcodes.instrument_drivers.Keysight.private.Keysight_344xxA_submodules]
+[mypy-qcodes.instrument_drivers.Keysight.*]
 disallow_untyped_defs = True
 
-[mypy-qcodes.instrument_drivers.Keysight.Keysight_34410A_submodules.*]
-disallow_untyped_defs = True
+[mypy-qcodes.instrument_drivers.Keysight.SD_common.*]
+disallow_untyped_defs = False
 
-[mypy-qcodes.instrument_drivers.Keysight.Keysight_34460A_submodules.*]
-disallow_untyped_defs = True
-
-[mypy-qcodes.instrument_drivers.Keysight.Keysight_34461A_submodules.*]
-disallow_untyped_defs = True
-
-[mypy-qcodes.instrument_drivers.Keysight.Keysight_34465A_submodules.*]
-disallow_untyped_defs = True
-
-[mypy-qcodes.instrument_drivers.Keysight.Keysight_34470A_submodules.*]
-disallow_untyped_defs = True
-
-[mypy-qcodes.instrument_drivers.Keysight.Keysight_34480A_submodules.*]
-disallow_untyped_defs = True
+[mypy-qcodes.instrument_drivers.Keysight.keysightb1500.*]
+disallow_untyped_defs = False
 
 [mypy-qcodes.interactive_widget.*]
 disallow_untyped_defs = True


### PR DESCRIPTION
Missing b1500 and SD_common module

SD_common module is unused in qcodes and should removed. It has been copied to qcodes_contrib_drivers along with the drivers using it
