### PR TITLE
Require pyvisa 1.11.1 as a minimum

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ extras_require = {k: '>='.join(v) for k, v in extras.items()}
 
 install_requires = [
     'numpy>=1.10',
-    'pyvisa>=1.9.1, <1.12',
+    'pyvisa>=1.11.1, <1.12',
     'h5py>=2.6',
     'websockets>=7.0',
     'jsonschema',


### PR DESCRIPTION
The constants used in device_clear are only avilable in 1.11