### PR TITLE
Update contact to new qcodes alias 

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,15 +4,14 @@ Contributing
 Hi, thanks for your interest in the project! We welcome pull requests
 from developers of all skill levels.
 
-Jens H. Nielsen (Jens.Nielsen@microsoft.com), William H.P Nielsen
-(wihpniel@microsoft.com@nbi.ku.dk), Mikhail Astafev (Mikhail.Astafev@microsoft.com),
-and Trevor Morgan (Trevor.Morgan@microsoft.com) are the current maintainers of
-QCoDeS (aka core developers), along with a group of talented and smart
-volunteers. Please don't hesitate to reach out if you have any
-questions, or just need a little help getting started.
+Jens H. Nielsen, William H.P Nielsen, Mikhail Astafev and Trevor Morgan
+are the current maintainers of QCoDeS (aka core developers), along with a 
+group of talented and smart volunteers. Please don't hesitate to reach out at
+qcodes-support@microsoft.com if you have any questions, or just need a 
+little help getting started.
 
-Join us on Slack, where informal discussion is more than welcome. (For
-now email one of us to be invited)
+Join us on Slack, where informal discussion is more than welcome.
+(Please email us to be invited!)
 
 .. contents::
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -5,9 +5,9 @@ Hi, thanks for your interest in the project! We welcome pull requests
 from developers of all skill levels.
 
 Jens H. Nielsen, William H.P Nielsen, Mikhail Astafev and Trevor Morgan
-are the current maintainers of QCoDeS (aka core developers), along with a 
+are the current maintainers of QCoDeS (aka core developers), along with a
 group of talented and smart volunteers. Please don't hesitate to reach out at
-qcodes-support@microsoft.com if you have any questions, or just need a 
+qcodes-support@microsoft.com if you have any questions, or just need a
 little help getting started.
 
 Join us on Slack, where informal discussion is more than welcome.

--- a/docs/help.rst
+++ b/docs/help.rst
@@ -13,7 +13,7 @@ Chat
 
 We discuss things on slack, join us!
 You can find the maintainers' email on their commits.
-Please send a mail to Jens.Nielsen(at)microsoft.com if you want to join
+Please send a mail to qcodes-support(at)microsoft.com if you want to join
 the slack channel. Please include a few lines about who you are and
 how you use or want to use QCoDeS.
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(name='qcodes',
       cmdclass=versioneer.get_cmdclass(),
       use_2to3=False,
 
-      maintainer='Jens H Nielsen',
-      maintainer_email='Jens.Nielsen@microsoft.com',
+      maintainer='QCoDeS Core Developers',
+      maintainer_email='qcodes-support@microsoft.com',
       description='Python-based data acquisition framework developed by the '
                   'Copenhagen / Delft / Sydney / Microsoft quantum computing '
                   'consortium',


### PR DESCRIPTION
Update to new qcodes support distribution list email.

@jenshnielsen these were the only references I could find. Do you know if there are any others floating around in the docs?