### PR TITLE
Fix error when calling mark_complted twice

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -779,6 +779,8 @@ class DataSet(Sized):
         """
         Mark :class:`.DataSet` as complete and thus read only and notify the subscribers
         """
+        if self.completed:
+            return
         if self.pristine:
             raise RuntimeError('Can not mark DataSet as complete before it '
                                'has been marked as started.')

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -897,13 +897,13 @@ class DataSet(Sized):
             while self.run_id in writer_status.active_datasets:
                 time.sleep(self.background_sleep_time)
         else:
-            writer_status.active_datasets.remove(self.run_id)
+            if self.run_id in writer_status.active_datasets:
+                writer_status.active_datasets.remove(self.run_id)
         if len(writer_status.active_datasets) == 0:
             writer_status.write_in_background = None
             if writer_status.bg_writer is not None:
                 writer_status.bg_writer.shutdown()
                 writer_status.bg_writer = None
-
 
     @staticmethod
     def _validate_parameters(*params: Union[str, ParamSpec, _BaseParameter]

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -152,6 +152,19 @@ def test_dataset_states():
         ds.add_results([{parameter.name: 1}])
 
 
+@pytest.mark.parametrize("start_bg_writer", (True, False))
+@pytest.mark.usefixtures('experiment')
+def test_mark_completed_twice(start_bg_writer):
+    """
+    Ensure that its not an error to call mark_completed
+    on an already completed dataset
+    """
+    ds = DataSet()
+    ds.mark_started(start_bg_writer=start_bg_writer)
+    ds.mark_completed()
+    ds.mark_completed()
+
+
 @pytest.mark.usefixtures('experiment')
 def test_timestamps_are_none():
     ds = DataSet()


### PR DESCRIPTION
The code would try to remove a non existing element from a set. 
Fix this by both checking for the element first and never do the complete action for an already complted ds

Basic test included

@liangosc 
