### PR TITLE
remove nose config from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -83,10 +83,6 @@ disallow_untyped_defs = False
 [mypy-qcodes.interactive_widget.*]
 disallow_untyped_defs = True
 
-[nosetests]
-with-coverage=1
-cover-package=qcodes
-
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
We are not and have not for a long time been using nose to run our tests so lets remove it from setup.cfg
