### PR TITLE
Reverse logic for which modules are typed

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -3,7 +3,7 @@
 # flake8: noqa (we don't need the "<...> imported but unused" error)
 
 # config
-
+from typing import Any
 import qcodes.configuration as qcconfig
 from qcodes.logger.logger import conditionally_start_all_logging
 from qcodes.utils.helpers import add_to_spyder_UMR_excludelist
@@ -109,7 +109,7 @@ import atexit
 atexit.register(Instrument.close_all)
 
 
-def test(**kwargs):
+def test(**kwargs: Any) -> int:
     """
     Run QCoDeS tests. This requires the test requirements given
     in test_requirements.txt to be installed.
@@ -121,7 +121,7 @@ def test(**kwargs):
         settings(deadline=1000)
     except ImportError:
         print("Need pytest and hypothesis to run tests")
-        return
+        return 1
     args = ['--pyargs', 'qcodes.tests']
     retcode = pytest.main(args, **kwargs)
     return retcode

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,29 +26,17 @@ no_implicit_optional = True
 [mypy-qcodes._version]
 ignore_errors = True
 
-[mypy-qcodes.instrument.*]
+[mypy-qcodes.*]
 disallow_untyped_defs = True
+
+[mypy-qcodes.actions.*]
+disallow_untyped_defs = False
+
+[mypy-qcodes.data.*]
+disallow_untyped_defs = False
 
 [mypy-qcodes.instrument.mockers.ami430]
 disallow_untyped_defs = False
-
-[mypy-qcodes.dataset.*]
-disallow_untyped_defs = True
-
-[mypy-qcodes.logger.*]
-disallow_untyped_defs = True
-
-[mypy-qcodes.monitor.*]
-disallow_untyped_defs = True
-
-[mypy-qcodes.station]
-disallow_untyped_defs = True
-
-[mypy-qcodes.config.*]
-disallow_untyped_defs = True
-
-[mypy-qcodes.instrument_drivers.*]
-disallow_untyped_defs = True
 
 [mypy-qcodes.instrument_drivers.AlazarTech.*]
 disallow_untyped_defs = False
@@ -77,8 +65,56 @@ disallow_untyped_defs = False
 [mypy-qcodes.instrument_drivers.ZI.*]
 disallow_untyped_defs = False
 
-[mypy-qcodes.interactive_widget.*]
-disallow_untyped_defs = True
+[mypy-qcodes.loops]
+disallow_untyped_defs = False
+
+[mypy-qcodes.math_utils.*]
+disallow_untyped_defs = False
+
+[mypy-qcodes.measure]
+disallow_untyped_defs = False
+
+[mypy-qcodes.plots.*]
+disallow_untyped_defs = False
+
+[mypy-qcodes.tests.*]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.command]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.dataset.*]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.delaykeyboardinterrupt]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.deprecate]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.helpers]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.installation]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.magic]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.metadata]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.slack]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.plotting]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.threading]
+disallow_untyped_defs = False
+
+[mypy-qcodes.utils.validators]
+disallow_untyped_defs = False
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
This way a module must explicitly be marked as not typed. This should help ensure that all new code is marked typed.

And add the remaing types to `__init__.py`