### PR TITLE
Fix Ithaco CurrentParameter so it can be measured correctly

### DIFF
--- a/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
+++ b/qcodes/instrument_drivers/ithaco/Ithaco_1211.py
@@ -38,6 +38,7 @@ class CurrentParameter(MultiParameter):
         super().__init__(name=name,
                          names=(p_name+'_raw', name),
                          shapes=((), ()),
+                         setpoints=((), ()),
                          instrument=c_amp_ins,
                          snapshot_value=True)
 


### PR DESCRIPTION
The measurement context manager does not support measureing Multiparameters that do not have setpoints defined. So explicitly define the setpoints of this Multiparameter as empty (since the values are scalar)  @FarBo 
