### PR TITLE
set higher timeout for Azure jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ pr:
 
 jobs:
   - job: "run_the_tests"
+    timeoutInMinutes: 90
     strategy:
       matrix:
         linux:


### PR DESCRIPTION
For whatever reason Azure jobs on windows are sometimes subject to slowdown and timeout just before the job is done. To try to work around that this pr increases the timeout from 60 min to 90 min.

An example can be seen here https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/results?buildId=18670&view=logs&j=45dcd969-b885-5520-9571-e72cfd95beb6
