### PR TITLE
Add default terminator for Agilent E8527D

### DIFF
--- a/qcodes/instrument_drivers/agilent/E8527D.py
+++ b/qcodes/instrument_drivers/agilent/E8527D.py
@@ -17,8 +17,10 @@ class Agilent_E8527D(VisaInstrument):
     only the ones most commonly used.
     """
     def __init__(self, name: str, address: str,
-                 step_attenuator: bool = False, **kwargs: Any) -> None:
-        super().__init__(name, address, **kwargs)
+                 step_attenuator: bool = False,
+                 terminator: str = '\n',
+                 **kwargs: Any) -> None:
+        super().__init__(name, address, terminator=terminator, **kwargs)
 
         self.add_parameter(name='frequency',
                            label='Frequency',


### PR DESCRIPTION
As a result of #2030, querying the value of the `status` parameter causes an exception, because  without specifying the terminator, the query returns `"1\n"` or `"0\n"`, which the val_mapping doesn't accept. This fixes that. Sorry for not testing this properly before.

@astafan8 