### PR TITLE
Removed logging.info message from spyder part of helpers.py

### DIFF
--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -570,7 +570,6 @@ def add_to_spyder_UMR_excludelist(modulename: str) -> None:
             except ImportError:
                 pass
             else:
-                logging.info("found spyder kernels site")
                 sitecustomize_found = True
 
         if sitecustomize_found is False:


### PR DESCRIPTION
This PR fixes unwanted logging messages at INFO and DEBUG levels in the Spyder's console. 