### PR TITLE
No implicit any generics outside drivers and tests

### DIFF
--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -418,7 +418,7 @@ class Config:
         return output
 
 
-class DotDict(dict):
+class DotDict(Dict[Any, Any]):
     """
     Wrapper dict that allows to get dotted attributes
 

--- a/qcodes/data/data_set.py
+++ b/qcodes/data/data_set.py
@@ -681,7 +681,7 @@ class DataSet(DelegateAttributes):
         return out
 
 
-class _PrettyPrintDict(dict):
+class _PrettyPrintDict(Dict[Any, Any]):
     """
     simple wrapper for a dict to repr its items on separate lines
     with a bit of indentation

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -74,7 +74,7 @@ class ValidationWarning(Warning):
     pass
 
 
-class StationConfig(UserDict):
+class StationConfig(Dict[Any, Any]):
     def snapshot(self, update: bool = True) -> 'StationConfig':
         return self
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ filterwarnings = ignore:.*which is reset between function calls but not between 
 [mypy]
 strict_optional = True
 disallow_untyped_decorators = True
+disallow_any_generics = True
 ignore_missing_imports = True
 show_column_numbers = True
 warn_unused_ignores = True
@@ -37,6 +38,9 @@ disallow_untyped_defs = False
 
 [mypy-qcodes.instrument.mockers.ami430]
 disallow_untyped_defs = False
+
+[mypy-qcodes.instrument_drivers.*]
+disallow_any_generics = False
 
 [mypy-qcodes.instrument_drivers.Harvard.*]
 disallow_untyped_defs = False
@@ -70,6 +74,7 @@ disallow_untyped_defs = False
 
 [mypy-qcodes.tests.*]
 disallow_untyped_defs = False
+disallow_any_generics = False
 
 [mypy-qcodes.utils.command]
 disallow_untyped_defs = False


### PR DESCRIPTION
The last few changes required to enforce disallow_any_generics  outside drivers and tests.

This requires Sub classing generic types. It seems like there is no Generic UserDict so I have replaced it with a regular dict. According to the documentation of UserDict there is no strong reason to use this anymore. It is perfectly ok to subclass a regular dict