### PR TITLE
fix setup.py importlib metadata version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ install_requires = [
     'opencensus-ext-azure>=1.0.4, <2.0.0',
     'matplotlib>=2.2.3',
     "requirements-parser",
-    "importlib-metadata<3.0.0;python_version<'3.8'",
+    "importlib-metadata<4.0.0;python_version<'3.8'",
     "typing_extensions",
     "packaging>=20.0",
     "ipywidgets",


### PR DESCRIPTION
Fix for #2460 

It seems that dependabot has an issue with env markers that prevents it to bump the dependency correctly
