### PR TITLE
make importlib_metadata requirements consistent across requirementes files

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -15,7 +15,7 @@ docutils==0.16
 entrypoints==0.3
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.1.0
+importlib-metadata==3.1.0;python_version<'3.8'
 ipykernel==5.3.4
 ipython==7.19.0
 ipython-genutils==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ google-auth~=1.23.0
 googleapis-common-protos~=1.52.0
 h5py~=3.1.0
 idna~=2.10
-importlib-metadata<3.0.0;python_version<'3.8'
+importlib-metadata==3.1.0;python_version<'3.8'
 ipykernel~=5.3.4
 ipython~=7.19.0
 ipython-genutils~=0.2.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,7 +12,7 @@ gitdb==4.0.5
 GitPython==3.1.11
 hypothesis==5.41.3
 idna==2.10
-importlib-metadata==3.1.0
+importlib-metadata==3.1.0;python_version<'3.8'
 iniconfig==1.1.1
 lxml==4.6.1
 mypy==0.790


### PR DESCRIPTION
I think this went out of sync since dependabot does not handle env markers correctly 
