### PR TITLE
Add support for type checking with upcomming Numpy 1.20 release. 

### DIFF
--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -384,8 +384,8 @@ def reshape_2D_data(x: np.ndarray, y: np.ndarray, z: np.ndarray
         z_to_plot = np.full((ny, nx), '', dtype=z.dtype)
     else:
         z_to_plot = np.full((ny, nx), np.nan)
-    x_index = np.zeros_like(x, dtype=np.int)
-    y_index = np.zeros_like(y, dtype=np.int)
+    x_index = np.zeros_like(x, dtype=int)
+    y_index = np.zeros_like(y, dtype=int)
     for i, xval in enumerate(xrow):
         x_index[np.where(x == xval)[0]] = i
     for i, yval in enumerate(yrow):

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -122,12 +122,12 @@ def _all_steps_multiples_of_min_step(rows: np.ndarray) -> bool:
         The answer to the question
     """
 
-    steps: List[np.ndarray] = []
+    steps_list: List[np.ndarray] = []
     for row in rows:
         # TODO: What is an appropriate precision?
-        steps += list(np.unique(np.diff(row).round(decimals=15)))
+        steps_list += list(np.unique(np.diff(row).round(decimals=15)))
 
-    steps = np.unique(steps)
+    steps = np.unique(steps_list)
     remainders = np.mod(steps[1:]/steps[0], 1)
 
     # TODO: What are reasonable tolerances for allclose?

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -384,8 +384,8 @@ def reshape_2D_data(x: np.ndarray, y: np.ndarray, z: np.ndarray
         z_to_plot = np.full((ny, nx), '', dtype=z.dtype)
     else:
         z_to_plot = np.full((ny, nx), np.nan)
-    x_index = np.zeros_like(x, dtype=int)
-    y_index = np.zeros_like(y, dtype=int)
+    x_index = np.zeros_like(x, dtype=np.dtype(int))
+    y_index = np.zeros_like(y, dtype=np.dtype(int))
     for i, xval in enumerate(xrow):
         x_index[np.where(x == xval)[0]] = i
     for i, yval in enumerate(yrow):

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -384,8 +384,8 @@ def reshape_2D_data(x: np.ndarray, y: np.ndarray, z: np.ndarray
         z_to_plot = np.full((ny, nx), '', dtype=z.dtype)
     else:
         z_to_plot = np.full((ny, nx), np.nan)
-    x_index = np.zeros_like(x, dtype=np.dtype(int))
-    y_index = np.zeros_like(y, dtype=np.dtype(int))
+    x_index = np.zeros_like(x, dtype=np.dtype(np.int_))
+    y_index = np.zeros_like(y, dtype=np.dtype(np.int_))
     for i, xval in enumerate(xrow):
         x_index[np.where(x == xval)[0]] = i
     for i, yval in enumerate(yrow):

--- a/qcodes/dataset/descriptions/detect_shapes.py
+++ b/qcodes/dataset/descriptions/detect_shapes.py
@@ -1,6 +1,6 @@
 from collections import abc
 from numbers import Integral
-from typing import Dict, List, Sequence, Sized, Tuple, Union
+from typing import Any, Dict, List, Sequence, Sized, Tuple, Union
 
 import numpy as np
 
@@ -61,7 +61,7 @@ def detect_shape_of_measurement(
 
 
 def _get_shape_of_step(
-        step: Union[int, np.integer, Sized, np.ndarray]
+        step: Union[int, "np.integer[Any]", Sized, np.ndarray]
 ) -> int:
     if isinstance(step, Integral):
         return int(step)

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -14,11 +14,16 @@ import numpy as np
 from numpy import ndarray
 
 from qcodes.dataset.sqlite.connection import ConnectionPlus
-from qcodes.dataset.sqlite.db_upgrades import _latest_available_version, \
-    get_user_version, perform_db_upgrade
+from qcodes.dataset.sqlite.db_upgrades import (
+    _latest_available_version,
+    get_user_version,
+    perform_db_upgrade
+)
 from qcodes.dataset.sqlite.initial_schema import init_db
 import qcodes
-from qcodes.utils.types import numpy_ints, numpy_floats, complex_types, complex_type_union
+from qcodes.utils.types import (
+    numpy_ints, numpy_floats, complex_types, complex_type_union
+)
 
 
 # utility function to allow sqlite/numpy type

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -150,14 +150,14 @@ def connect(name: str, debug: bool = False,
 
     # Make sure numpy ints and floats types are inserted properly
     for numpy_int in [
-        np.int, np.int8, np.int16, np.int32, np.int64,
+        np.int_, np.int8, np.int16, np.int32, np.int64,
         np.uint, np.uint8, np.uint16, np.uint32, np.uint64
     ]:
         sqlite3.register_adapter(numpy_int, int)
 
     sqlite3.register_converter("numeric", _convert_numeric)
 
-    for numpy_float in [np.float, np.float16, np.float32, np.float64]:
+    for numpy_float in [np.float_, np.float16, np.float32, np.float64]:
         sqlite3.register_adapter(numpy_float, _adapt_float)
 
     for complex_type in complex_types:

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -18,7 +18,7 @@ from qcodes.dataset.sqlite.db_upgrades import _latest_available_version, \
     get_user_version, perform_db_upgrade
 from qcodes.dataset.sqlite.initial_schema import init_db
 import qcodes
-from qcodes.utils.types import complex_types, complex_type_union
+from qcodes.utils.types import numpy_ints, numpy_floats, complex_types, complex_type_union
 
 
 # utility function to allow sqlite/numpy type
@@ -149,15 +149,12 @@ def connect(name: str, debug: bool = False,
     conn.row_factory = sqlite3.Row
 
     # Make sure numpy ints and floats types are inserted properly
-    for numpy_int in [
-        np.int_, np.int8, np.int16, np.int32, np.int64,
-        np.uint, np.uint8, np.uint16, np.uint32, np.uint64
-    ]:
+    for numpy_int in numpy_ints:
         sqlite3.register_adapter(numpy_int, int)
 
     sqlite3.register_converter("numeric", _convert_numeric)
 
-    for numpy_float in [float, np.float_, np.float16, np.float32, np.float64]:
+    for numpy_float in (float,) + numpy_floats:
         sqlite3.register_adapter(numpy_float, _adapt_float)
 
     for complex_type in complex_types:

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -157,7 +157,7 @@ def connect(name: str, debug: bool = False,
 
     sqlite3.register_converter("numeric", _convert_numeric)
 
-    for numpy_float in [np.float_, np.float16, np.float32, np.float64]:
+    for numpy_float in [float, np.float_, np.float16, np.float32, np.float64]:
         sqlite3.register_adapter(numpy_float, _adapt_float)
 
     for complex_type in complex_types:

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -318,7 +318,7 @@ def _expand_data_to_arrays(data: List[List[Any]], paramspecs: Sequence[ParamSpec
             for element in numeric_elms:
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=np.float64)
+                                            dtype=np.dtype(np.float64))
                 # todo should we handle int/float types here
                 # we would in practice have to perform another
                 # loop to check that all elements of a given can be cast to
@@ -327,12 +327,12 @@ def _expand_data_to_arrays(data: List[List[Any]], paramspecs: Sequence[ParamSpec
             for element in complex_elms:
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=np.complex128)
+                                            dtype=np.dtype(np.complex128))
             for element in text_elms:
                 strlen = len(row[element])
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=f'U{strlen}')
+                                            dtype=np.dtype(f'U{strlen}'))
 
 
 def _get_data_for_one_param_tree(conn: ConnectionPlus, table_name: str,

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -297,7 +297,7 @@ def get_parameter_data_for_one_paramtree(
         except:
             # Not clear which error to catch here. This will only be clarified
             # once numpy actually starts to raise here.
-            param_data[paramspec.name] = np.array(column_data, dtype=np.object)
+            param_data[paramspec.name] = np.array(column_data, dtype=object)
     return param_data, n_rows
 
 
@@ -318,7 +318,7 @@ def _expand_data_to_arrays(data: List[List[Any]], paramspecs: Sequence[ParamSpec
             for element in numeric_elms:
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=np.float)
+                                            dtype=np.double)
                 # todo should we handle int/float types here
                 # we would in practice have to perform another
                 # loop to check that all elements of a given can be cast to
@@ -327,12 +327,12 @@ def _expand_data_to_arrays(data: List[List[Any]], paramspecs: Sequence[ParamSpec
             for element in complex_elms:
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=np.complex)
+                                            dtype=np.dtype(np.complex128))
             for element in text_elms:
                 strlen = len(row[element])
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=f'U{strlen}')
+                                            dtype=np.dtype(f'U{strlen}'))
 
 
 def _get_data_for_one_param_tree(conn: ConnectionPlus, table_name: str,

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -318,7 +318,7 @@ def _expand_data_to_arrays(data: List[List[Any]], paramspecs: Sequence[ParamSpec
             for element in numeric_elms:
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=np.double)
+                                            dtype=np.float64)
                 # todo should we handle int/float types here
                 # we would in practice have to perform another
                 # loop to check that all elements of a given can be cast to
@@ -327,12 +327,12 @@ def _expand_data_to_arrays(data: List[List[Any]], paramspecs: Sequence[ParamSpec
             for element in complex_elms:
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=np.dtype(np.complex128))
+                                            dtype=np.complex128)
             for element in text_elms:
                 strlen = len(row[element])
                 row[element] = np.full_like(row[first_array_element],
                                             row[element],
-                                            dtype=np.dtype(f'U{strlen}'))
+                                            dtype=f'U{strlen}')
 
 
 def _get_data_for_one_param_tree(conn: ConnectionPlus, table_name: str,

--- a/qcodes/instrument_drivers/AlazarTech/ATS9360.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9360.py
@@ -368,4 +368,4 @@ class AlazarTech_ATS9360(AlazarTech_ATS):
             # otherwise
             disable_mask = ~np.uint32(1 << 26)
             new_value = current_value & disable_mask
-        self._write_register(58, new_value)
+        self._write_register(58, int(new_value))

--- a/qcodes/instrument_drivers/AlazarTech/ATS9373.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9373.py
@@ -383,4 +383,4 @@ class AlazarTech_ATS9373(AlazarTech_ATS):
             # otherwise
             disable_mask = ~np.uint32(1 << 26)
             new_value = current_value & disable_mask
-        self._write_register(58, new_value)
+        self._write_register(58, int(new_value))

--- a/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -102,6 +102,7 @@ class Demodulation_AcquisitionController(AcquisitionController[float]):
         See AcquisitionController
         :return:
         """
+        assert self.buffer is not None
         self.buffer += data
 
     def post_acquire(self) -> float:

--- a/qcodes/instrument_drivers/agilent/E8267C.py
+++ b/qcodes/instrument_drivers/agilent/E8267C.py
@@ -84,9 +84,9 @@ class E8267(VisaInstrument):
 
     # functions to convert between rad and deg
     @staticmethod
-    def deg_to_rad(angle_deg: numbertypes) -> np.float:
+    def deg_to_rad(angle_deg: numbertypes) -> np.floating[Any]:
         return np.deg2rad(float(angle_deg))
 
     @staticmethod
-    def rad_to_deg(angle_rad: numbertypes) -> np.float:
+    def rad_to_deg(angle_rad: numbertypes) -> np.floating[Any]:
         return np.rad2deg(float(angle_rad))

--- a/qcodes/instrument_drivers/agilent/E8267C.py
+++ b/qcodes/instrument_drivers/agilent/E8267C.py
@@ -84,9 +84,9 @@ class E8267(VisaInstrument):
 
     # functions to convert between rad and deg
     @staticmethod
-    def deg_to_rad(angle_deg: numbertypes) -> np.floating[Any]:
+    def deg_to_rad(angle_deg: numbertypes) -> "np.floating[Any]":
         return np.deg2rad(float(angle_deg))
 
     @staticmethod
-    def rad_to_deg(angle_rad: numbertypes) -> np.floating[Any]:
+    def rad_to_deg(angle_rad: numbertypes) -> "np.floating[Any]":
         return np.rad2deg(float(angle_rad))

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -16,7 +16,7 @@ from qcodes.utils.deprecate import QCoDeSDeprecationWarning
 log = logging.getLogger(__name__)
 
 CartesianFieldLimitFunction = \
-    Callable[[numbers.Real, numbers.Real, numbers.Real], bool]
+    Callable[[float, float, float], bool]
 
 T = TypeVar('T')
 
@@ -665,7 +665,7 @@ class AMI430_3D(Instrument):
 
     def _verify_safe_setpoint(
             self,
-            setpoint_values: Tuple[numbers.Real, numbers.Real, numbers.Real]
+            setpoint_values: Tuple[float, float, float]
     ) -> bool:
         if isinstance(self._field_limit, float):
             return np.linalg.norm(setpoint_values) < self._field_limit
@@ -677,7 +677,7 @@ class AMI430_3D(Instrument):
 
     def _adjust_child_instruments(
             self,
-            values: Tuple[numbers.Real, numbers.Real, numbers.Real]
+            values: Tuple[float, float, float]
     ) -> None:
         """
         Set the fields of the x/y/z magnets. This function is called
@@ -787,7 +787,7 @@ class AMI430_3D(Instrument):
     def _set_setpoints(
             self,
             names: Sequence[str],
-            values: Sequence[numbers.Real]
+            values: Sequence[float]
     ) -> None:
 
         kwargs = dict(zip(names, np.atleast_1d(values)))

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -115,7 +115,7 @@ class FixedFrequencyPointIQ(MultiParameter):
         """
         assert isinstance(self.instrument, ZNBChannel)
         i, q = self.instrument._get_cw_data()
-        return np.mean(i), np.mean(q)
+        return float(np.mean(i)), float(np.mean(q))
 
 
 class FixedFrequencyPointMagPhase(MultiParameter):

--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -368,7 +368,7 @@ class Tektronix_AWG5014(VisaInstrument):
                                get_cmd=filter_cmd + '?',
                                set_cmd=filter_cmd + ' {}',
                                vals=vals.Enum(20e6, 100e6,
-                                              np.float('inf'),
+                                              float('inf'),
                                               'INF', 'INFinity'),
                                get_parser=self._tek_outofrange_get_parser)
             self.add_parameter(f'ch{i}_DC_out',
@@ -430,7 +430,7 @@ class Tektronix_AWG5014(VisaInstrument):
         # note that 9.9e37 is used as a generic out of range value
         # in tektronix instruments
         if val >= 9.9e37:
-            val = np.float('INF')
+            val = float('INF')
         return val
 
     # Functions

--- a/qcodes/instrument_drivers/tektronix/Keithley_2450.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2450.py
@@ -484,11 +484,10 @@ class Source2450(InstrumentChannel):
             raise ValueError(
                 "Please setup the sweep before getting values of this parameter"
             )
-
         return np.linspace(
             start=self._sweep_arguments["start"],
             stop=self._sweep_arguments["stop"],
-            num=self._sweep_arguments["step_count"]
+            num=int(self._sweep_arguments["step_count"])
         )
 
     def sweep_setup(

--- a/qcodes/instrument_drivers/tektronix/keithley_7510.py
+++ b/qcodes/instrument_drivers/tektronix/keithley_7510.py
@@ -49,7 +49,14 @@ class GeneratedSetPoints(Parameter):
         self._n_points = n_points
 
     def get_raw(self) -> np.ndarray:
-        return np.linspace(self._start(), self._stop(), self._n_points())
+        start = self._start()
+        assert start is not None
+        stop = self._stop()
+        assert stop is not None
+        n_points = self._n_points()
+        assert n_points is not None
+
+        return np.linspace(start, stop, n_points)
 
 
 class Buffer7510(InstrumentChannel):

--- a/qcodes/math_utils/field_vector.py
+++ b/qcodes/math_utils/field_vector.py
@@ -331,6 +331,8 @@ class FieldVector:
 
     @property
     def theta(self) -> Optional[float]:
+        if self._theta is None:
+            return None
         return float(np.degrees(self._theta))
 
     @property
@@ -339,6 +341,8 @@ class FieldVector:
 
     @property
     def phi(self) -> Optional[float]:
+        if self._phi is None:
+            return None
         return float(np.degrees(self._phi))
 
     # Representation Methods #

--- a/qcodes/tests/dataset/conftest.py
+++ b/qcodes/tests/dataset/conftest.py
@@ -157,7 +157,7 @@ def scalar_dataset(dataset):
 
     dataset.set_interdependencies(idps)
     dataset.mark_started()
-    dataset.add_results([{p.name: np.int(n_rows*10*pn+i)
+    dataset.add_results([{p.name: int(n_rows*10*pn+i)
                           for pn, p in enumerate(all_params)}
                          for i in range(n_rows)])
     dataset.mark_completed()
@@ -359,7 +359,7 @@ def standalone_parameters_dataset(dataset):
     dataset.set_interdependencies(idps)
 
     dataset.mark_started()
-    dataset.add_results([{p.name: np.int(n_rows*10*pn+i)
+    dataset.add_results([{p.name: int(n_rows*10*pn+i)
                           for pn, p in enumerate(params_all)}
                          for i in range(n_rows)])
     dataset.mark_completed()

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -25,7 +25,7 @@ from qcodes.dataset.sqlite.queries import _unicode_categories
 from qcodes.tests.common import error_caused_by
 from qcodes.tests.dataset.test_links import generate_some_links
 from qcodes.utils.deprecate import QCoDeSDeprecationWarning
-from qcodes.utils.types import numpy_ints
+from qcodes.utils.types import numpy_ints, numpy_floats
 
 pytest.register_assert_rewrite('qcodes.tests.dataset.helper_functions')
 from qcodes.tests.dataset.helper_functions import verify_data_dict
@@ -530,7 +530,6 @@ def test_numpy_floats(dataset):
     dataset.set_interdependencies(idps)
     dataset.mark_started()
 
-    numpy_floats = [np.float_, np.float16, np.float32, np.float64]
     results = [{"y": tp(1.2)} for tp in numpy_floats]
     dataset.add_results(results)
     expected_result = np.array([tp(1.2) for tp in numpy_floats])

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -515,7 +515,7 @@ def test_numpy_ints(dataset):
     dataset.mark_started()
 
     numpy_ints = [
-        np.int, np.int8, np.int16, np.int32, np.int64,
+        np.int_, np.int8, np.int16, np.int32, np.int64,
         np.uint, np.uint8, np.uint16, np.uint32, np.uint64
     ]
 
@@ -534,7 +534,7 @@ def test_numpy_floats(dataset):
     dataset.set_interdependencies(idps)
     dataset.mark_started()
 
-    numpy_floats = [np.float, np.float16, np.float32, np.float64]
+    numpy_floats = [np.float_, np.float16, np.float32, np.float64]
     results = [{"y": tp(1.2)} for tp in numpy_floats]
     dataset.add_results(results)
     expected_result = np.array([tp(1.2) for tp in numpy_floats])

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -25,6 +25,7 @@ from qcodes.dataset.sqlite.queries import _unicode_categories
 from qcodes.tests.common import error_caused_by
 from qcodes.tests.dataset.test_links import generate_some_links
 from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.utils.types import numpy_ints
 
 pytest.register_assert_rewrite('qcodes.tests.dataset.helper_functions')
 from qcodes.tests.dataset.helper_functions import verify_data_dict
@@ -513,11 +514,6 @@ def test_numpy_ints(dataset):
     idps = InterDependencies_(standalones=(xparam,))
     dataset.set_interdependencies(idps)
     dataset.mark_started()
-
-    numpy_ints = [
-        np.int_, np.int8, np.int16, np.int32, np.int64,
-        np.uint, np.uint8, np.uint16, np.uint32, np.uint64
-    ]
 
     results = [{"x": tp(1)} for tp in numpy_ints]
     dataset.add_results(results)

--- a/qcodes/tests/helpers/test_json_encoder.py
+++ b/qcodes/tests/helpers/test_json_encoder.py
@@ -30,7 +30,7 @@ def test_complex_types():
     e = NumpyJSONEncoder()
     assert e.encode(complex(1, 2)) == \
            '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
-    assert e.encode(np.complex(1, 2)) == \
+    assert e.encode(np.complex128(complex(1, 2))) == \
            '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
     assert e.encode(np.complex64(complex(1, 2))) == \
            '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
@@ -39,7 +39,7 @@ def test_complex_types():
 def test_numpy_int_types():
     e = NumpyJSONEncoder()
 
-    numpy_ints = (np.int, np.int_, np.int8, np.int16, np.int32,
+    numpy_ints = (np.int_, np.int_, np.int8, np.int16, np.int32,
                   np.int64, np.intc, np.intp,
                   np.uint, np.uint8, np.uint16, np.uint32, np.uint64,
                   np.uintc, np.uintp)
@@ -51,7 +51,7 @@ def test_numpy_int_types():
 def test_numpy_float_types():
     e = NumpyJSONEncoder()
 
-    numpy_floats = (np.float, np.float_, np.float16, np.float32,
+    numpy_floats = (np.float_, np.float_, np.float16, np.float32,
                     np.float64)
 
     for float_type in numpy_floats:

--- a/qcodes/tests/helpers/test_json_encoder.py
+++ b/qcodes/tests/helpers/test_json_encoder.py
@@ -51,7 +51,7 @@ def test_numpy_int_types():
 def test_numpy_float_types():
     e = NumpyJSONEncoder()
 
-    numpy_floats = (np.float_, np.float_, np.float16, np.float32,
+    numpy_floats = (np.float_, np.float16, np.float32,
                     np.float64)
 
     for float_type in numpy_floats:

--- a/qcodes/tests/helpers/test_json_encoder.py
+++ b/qcodes/tests/helpers/test_json_encoder.py
@@ -4,6 +4,7 @@ import json
 import numpy as np
 import pytest
 from qcodes.utils.helpers import NumpyJSONEncoder
+from qcodes.utils.types import numpy_ints, numpy_floats, numpy_complex
 
 
 def test_python_types():
@@ -30,19 +31,13 @@ def test_complex_types():
     e = NumpyJSONEncoder()
     assert e.encode(complex(1, 2)) == \
            '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
-    assert e.encode(np.complex128(complex(1, 2))) == \
-           '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
-    assert e.encode(np.complex64(complex(1, 2))) == \
-           '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
+    for complex_type in numpy_complex:
+        assert e.encode(complex_type(complex(1, 2))) == \
+               '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
 
 
 def test_numpy_int_types():
     e = NumpyJSONEncoder()
-
-    numpy_ints = (np.int_, np.int_, np.int8, np.int16, np.int32,
-                  np.int64, np.intc, np.intp,
-                  np.uint, np.uint8, np.uint16, np.uint32, np.uint64,
-                  np.uintc, np.uintp)
 
     for int_type in numpy_ints:
         assert e.encode(int_type(3)) == '3'
@@ -50,9 +45,6 @@ def test_numpy_int_types():
 
 def test_numpy_float_types():
     e = NumpyJSONEncoder()
-
-    numpy_floats = (np.float_, np.float16, np.float32,
-                    np.float64)
 
     for float_type in numpy_floats:
         assert e.encode(float_type(2.5)) == '2.5'

--- a/qcodes/tests/validators/test_complex.py
+++ b/qcodes/tests/validators/test_complex.py
@@ -2,7 +2,9 @@ import hypothesis.strategies as hst
 import numpy as np
 import pytest
 from hypothesis import given
+
 from qcodes.utils.validators import ComplexNumbers
+from qcodes.utils.types import numpy_complex
 
 
 @given(complex_val=hst.complex_numbers())
@@ -11,9 +13,10 @@ def test_complex(complex_val):
     n = ComplexNumbers()
     assert str(n) == '<Complex Number>'
     n.validate(complex_val)
-    n.validate(np.complex_(complex_val))
-    n.validate(np.complex64(complex_val))
-    n.validate(np.complex128(complex_val))
+    n.validate(complex(complex_val))
+
+    for complex_type in numpy_complex:
+        n.validate(complex_type(complex_val))
 
 
 @given(val=hst.one_of(hst.floats(), hst.integers(), hst.characters()))

--- a/qcodes/tests/validators/test_complex.py
+++ b/qcodes/tests/validators/test_complex.py
@@ -11,7 +11,7 @@ def test_complex(complex_val):
     n = ComplexNumbers()
     assert str(n) == '<Complex Number>'
     n.validate(complex_val)
-    n.validate(np.complex(complex_val))
+    n.validate(np.complex_(complex_val))
     n.validate(np.complex64(complex_val))
     n.validate(np.complex128(complex_val))
 

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -321,9 +321,11 @@ def make_sweep(start: float,
                 'the the given `start`, `stop`, and `step` '
                 'values. \nNumber of points is {:d} or {:d}.'
                 .format(steps_lo + 1, steps_hi + 1))
-        num = steps_lo + 1
+        num_steps = steps_lo + 1
+    elif num is not None:
+        num_steps = num
 
-    output_list = np.linspace(start, stop, num=num).tolist()
+    output_list = np.linspace(start, stop, num=num_steps).tolist()
     return cast(List[float], output_list)
 
 

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -23,7 +23,11 @@ numpy_non_concrete_ints_instantiable = (np.int_, np.uint)
 Default integer types. The size may be platform dependent.
 """
 
-numpy_ints = numpy_concrete_ints + numpy_c_ints + numpy_non_concrete_ints_instantiable
+numpy_ints = (
+        numpy_concrete_ints +
+        numpy_c_ints +
+        numpy_non_concrete_ints_instantiable
+)
 """
 All numpy integer types
 """
@@ -33,7 +37,7 @@ numpy_concrete_floats = (np.float16, np.float32, np.float64)
 """
 Floating point types with fixed sizes.
 """
-numpy_c_floats = (np.half, np.single, np.double)  # todo can we add np.longdouble
+numpy_c_floats = (np.half, np.single, np.double)
 """
 Floating point types that matches C types.
 """
@@ -42,7 +46,11 @@ numpy_non_concrete_floats_instantiable = (np.float_, )
 Default floating point types. The size may be platform dependent.
 """
 
-numpy_floats = numpy_concrete_floats + numpy_c_floats + numpy_non_concrete_floats_instantiable
+numpy_floats = (
+        numpy_concrete_floats +
+        numpy_c_floats +
+        numpy_non_concrete_floats_instantiable
+)
 """
 All numpy float types
 """
@@ -51,7 +59,7 @@ numpy_concrete_complex = (np.complex64, np.complex128)
 """
 Complex types with fixed sizes.
 """
-numpy_c_complex = (np.csingle, np.cdouble) # todo can we add np.clongdouble
+numpy_c_complex = (np.csingle, np.cdouble)
 """
 Complex types that matches C types.
 """
@@ -60,13 +68,21 @@ numpy_non_concrete_complex_instantiable = (np.complex_, )
 Default complex types. The size may be platform dependent.
 """
 
-numpy_complex = numpy_concrete_complex + numpy_c_complex + numpy_non_concrete_complex_instantiable
+numpy_complex = (
+        numpy_concrete_complex +
+        numpy_c_complex +
+        numpy_non_concrete_complex_instantiable
+)
 """
 All numpy complex types
 """
 
 concrete_complex_types = numpy_concrete_complex + (complex,)
-complex_types = numpy_concrete_complex + numpy_non_concrete_complex_instantiable + (complex,)
+complex_types = (
+        numpy_concrete_complex +
+        numpy_non_concrete_complex_instantiable +
+        (complex,)
+)
 
 # These are the same types as a above unfortunately there does not seem to be
 # a good way to convert a tuple of types to a Union

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -6,22 +6,67 @@ Useful collections of types used around QCoDeS
 import numpy as np
 from typing import Union
 
+
 numpy_concrete_ints = (np.int8, np.int16, np.int32, np.int64,
                        np.uint8, np.uint16, np.uint32, np.uint64)
+"""
+Integer types with fixed sizes.
+"""
+numpy_c_ints = (np.uintp, np.uintc, np.intp, np.intc,
+                np.short, np.byte, np.ushort, np.ubyte,
+                np.longlong, np.ulonglong)
+"""
+Integer types that matches C types.
+"""
 numpy_non_concrete_ints_instantiable = (np.int_, np.uint)
-numpy_non_concrete_ints = \
-    numpy_non_concrete_ints_instantiable + (np.integer,)
+"""
+Default integer types. The size may be platform dependent.
+"""
+
+numpy_ints = numpy_concrete_ints + numpy_c_ints + numpy_non_concrete_ints_instantiable
+"""
+All numpy integer types
+"""
+
 
 numpy_concrete_floats = (np.float16, np.float32, np.float64)
+"""
+Floating point types with fixed sizes.
+"""
+numpy_c_floats = (np.half, np.single, np.double)  # todo can we add np.longdouble
+"""
+Floating point types that matches C types.
+"""
 numpy_non_concrete_floats_instantiable = (np.float_, )
-numpy_non_concrete_floats = \
-    numpy_non_concrete_floats_instantiable + (np.floating,)
+"""
+Default floating point types. The size may be platform dependent.
+"""
+
+numpy_floats = numpy_concrete_floats + numpy_c_floats + numpy_non_concrete_floats_instantiable
+"""
+All numpy float types
+"""
 
 numpy_concrete_complex = (np.complex64, np.complex128)
-numpy_non_concrete_complex = (np.complex_, np.complexfloating)
+"""
+Complex types with fixed sizes.
+"""
+numpy_c_complex = (np.csingle, np.cdouble) # todo can we add np.clongdouble
+"""
+Complex types that matches C types.
+"""
+numpy_non_concrete_complex_instantiable = (np.complex_, )
+"""
+Default complex types. The size may be platform dependent.
+"""
+
+numpy_complex = numpy_concrete_complex + numpy_c_complex + numpy_non_concrete_complex_instantiable
+"""
+All numpy complex types
+"""
 
 concrete_complex_types = numpy_concrete_complex + (complex,)
-complex_types = numpy_concrete_complex + numpy_non_concrete_complex + (complex,)
+complex_types = numpy_concrete_complex + numpy_non_concrete_complex_instantiable + (complex,)
 
 # These are the same types as a above unfortunately there does not seem to be
 # a good way to convert a tuple of types to a Union

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -13,7 +13,7 @@ numpy_non_concrete_ints = \
     numpy_non_concrete_ints_instantiable + (np.integer,)
 
 numpy_concrete_floats = (np.float16, np.float32, np.float64)
-numpy_non_concrete_floats_instantiable = (np.float_)
+numpy_non_concrete_floats_instantiable = (np.float_, )
 numpy_non_concrete_floats = \
     numpy_non_concrete_floats_instantiable + (np.floating,)
 

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -8,22 +8,22 @@ from typing import Union
 
 numpy_concrete_ints = (np.int8, np.int16, np.int32, np.int64,
                        np.uint8, np.uint16, np.uint32, np.uint64)
-numpy_non_concrete_ints_instantiable = (np.int, np.int_, np.uint)
+numpy_non_concrete_ints_instantiable = (np.int_, np.uint)
 numpy_non_concrete_ints = \
     numpy_non_concrete_ints_instantiable + (np.integer,)
 
 numpy_concrete_floats = (np.float16, np.float32, np.float64)
-numpy_non_concrete_floats_instantiable = (np.float, np.float_)
+numpy_non_concrete_floats_instantiable = (np.float_)
 numpy_non_concrete_floats = \
     numpy_non_concrete_floats_instantiable + (np.floating,)
 
 numpy_concrete_complex = (np.complex64, np.complex128)
-numpy_non_concrete_complex = (np.complex, np.complex_, np.complexfloating)
+numpy_non_concrete_complex = (np.complex_, np.complexfloating)
 
 concrete_complex_types = numpy_concrete_complex + (complex,)
 complex_types = numpy_concrete_complex + numpy_non_concrete_complex + (complex,)
 
 # These are the same types as a above unfortunately there does not seem to be
 # a good way to convert a tuple of types to a Union
-complex_type_union = Union[np.complex64, np.complex128, np.complex,
+complex_type_union = Union[np.complex64, np.complex128,
                            np.complex_, np.complexfloating, complex]

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -43,8 +43,8 @@ def validate_all(*args: Tuple["Validator[Any]", Any],
         validator.validate(value, 'argument ' + str(i) + context)
 
 
-def range_str(min_val: Optional[Union[float, np.floating, np.integer]],
-              max_val: Optional[Union[float, np.floating, np.integer]],
+def range_str(min_val: Optional[Union[float, "np.floating[Any]", "np.integer[Any]"]],
+              max_val: Optional[Union[float, "np.floating[Any]", "np.integer[Any]"]],
               name: str) -> str:
     """
     Utility to represent ranges in Validator repr's.
@@ -290,7 +290,7 @@ class Numbers(Validator[numbertypes]):
         return '<Numbers{}>'.format(range_str(minv, maxv, 'v'))
 
 
-class Ints(Validator[Union[int, np.integer]]):
+class Ints(Validator[Union[int, "np.integer[Any]"]]):
     """
     Requires an integer.
     Optional parameters min_value and max_value, enforce
@@ -376,7 +376,7 @@ class PermissiveInts(Ints):
         Raises:
             TypeError: If not an int or close to it.
         """
-        castvalue: Union[int, np.integer]
+        castvalue: Union[int, "np.integer[Any]"]
         if isinstance(value, (float, np.floating)):
             intrepr = int(round(value))
             remainder = abs(value - intrepr)
@@ -390,7 +390,7 @@ class PermissiveInts(Ints):
         super().validate(castvalue, context=context)
 
 
-class ComplexNumbers(Validator[Union[complex, np.complexfloating]]):
+class ComplexNumbers(Validator[Union[complex, "np.complexfloating[Any]"]]):
     """
     A validator for complex numbers.
     """
@@ -403,7 +403,7 @@ class ComplexNumbers(Validator[Union[complex, np.complexfloating]]):
 
     def validate(
             self,
-            value: Union[complex, np.complexfloating],
+            value: Union[complex, "np.complexfloating[Any]"],
             context: str = ''
     ) -> None:
         """
@@ -494,7 +494,7 @@ class Multiples(Ints):
         self._valid_values = (divisor,)
 
     def validate(self,
-                 value: Union[int, np.integer],
+                 value: Union[int, "np.integer[Any]"],
                  context: str = '') -> None:
         """
         Validates if the value is a integer multiple of divisor else raises
@@ -753,8 +753,7 @@ class Arrays(Validator[np.ndarray]):
         if valid_type == np.complexfloating:
             valid_type = np.complex128
 
-        shape = self.shape
-        if shape is None:
+        if self.shape is None:
             return (np.array([self._min_value], dtype=valid_type),)
         else:
             val_arr = np.empty(self.shape, dtype=valid_type)

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -43,9 +43,11 @@ def validate_all(*args: Tuple["Validator[Any]", Any],
         validator.validate(value, 'argument ' + str(i) + context)
 
 
-def range_str(min_val: Optional[Union[float, "np.floating[Any]", "np.integer[Any]"]],
-              max_val: Optional[Union[float, "np.floating[Any]", "np.integer[Any]"]],
-              name: str) -> str:
+def range_str(
+        min_val: Optional[Union[float, "np.floating[Any]", "np.integer[Any]"]],
+        max_val: Optional[Union[float, "np.floating[Any]", "np.integer[Any]"]],
+        name: str
+) -> str:
     """
     Utility to represent ranges in Validator repr's.
     """

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -378,8 +378,8 @@ class PermissiveInts(Ints):
         """
         castvalue: Union[int, "np.integer[Any]"]
         if isinstance(value, (float, np.floating)):
-            intrepr = int(round(value))
-            remainder = abs(value - intrepr)
+            intrepr = int(np.round(value))
+            remainder = np.abs(value - intrepr)
             if remainder < 1e-05:
                 castvalue = intrepr
             else:
@@ -390,7 +390,7 @@ class PermissiveInts(Ints):
         super().validate(castvalue, context=context)
 
 
-class ComplexNumbers(Validator[Union[complex, "np.complexfloating[Any]"]]):
+class ComplexNumbers(Validator[Union[complex, "np.complexfloating[Any,Any]"]]):
     """
     A validator for complex numbers.
     """
@@ -403,7 +403,7 @@ class ComplexNumbers(Validator[Union[complex, "np.complexfloating[Any]"]]):
 
     def validate(
             self,
-            value: Union[complex, "np.complexfloating[Any]"],
+            value: Union[complex, "np.complexfloating[Any,Any]"],
             context: str = ''
     ) -> None:
         """
@@ -571,7 +571,7 @@ class PermissiveMultiples(Validator[numbertypes]):
             # multiply our way out of the problem by constructing true
             # multiples in the relevant range and see if `value` is one
             # of them (within rounding errors)
-            divs = int(divmod(value, self.divisor)[0])
+            divs = int(np.divmod(value, self.divisor)[0])
             true_vals = np.array(
                 [n * self.divisor for n in range(divs, divs + 2)])
             abs_errs = [abs(tv - value) for tv in true_vals]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -18,7 +18,6 @@ lxml==4.6.2
 mypy==0.790
 mypy-extensions==0.4.3
 numpy==1.19.3
-numpy-stubs @ git+https://github.com/numpy/numpy-stubs.git@f3c6315738489983f5f37e1477ac68373d71b470
 ordered-set==4.0.2
 packaging==20.8
 pluggy==0.13.1


### PR DESCRIPTION
Checked locally with numpy 1.20 rc1

* Some numpy types are now generic so give them an explicit Any. Use types in strings to support older numpy versions
* np.int, np.float and np.complex which are aliases for the build in python types are deprecated. 
* Use the dtype constructor explicitly when needed
* Various fixes for interaction between the python types and numpy types

EDIT:
while this does run with older versions of numpy it does not type check. Not sure what the best solution is.
We can add ignores to those lines or just wait until numpy 1.20 is officially released. Or we could disable the non explicit generics for now. 
