### PR TITLE
throw in test if not all guids unique

### DIFF
--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -472,6 +472,12 @@ def test_combine_runs(two_empty_temp_db_connections,
     source_2_datasets = [DataSet(conn=source_conn_2,
                                  exp_id=source_2_exp.exp_id) for i in range(10)]
 
+    guids_1 = set(dataset.guid for dataset in source_1_datasets)
+    guids_2 = set(dataset.guid for dataset in source_2_datasets)
+
+    guids = guids_1 | guids_2
+    assert len(guids) == 20
+
     source_all_datasets = source_1_datasets + source_2_datasets
 
     shuffled_datasets = source_all_datasets.copy()


### PR DESCRIPTION
This test generates a lot of datasets quickly after each other. There is a chance that these may not have unique guids
