### PR TITLE
Use the latest json schema draft supported by python jsonschema validator

### DIFF
--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "type" : "object",
     "description": "schema for a qcodes config file",
     "properties":{

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -9,7 +9,7 @@
             "properties" : {
                 "default_fmt": {
                     "type" : "string",
-                    "description": "default location formatter",
+                    "description": "default location formatter used for the legacy dataset",
                     "default": "data/{date}/#{counter}_{name}_{time}"
                 },
                 "loglevel" :{
@@ -37,7 +37,8 @@
                     ]
                 },
                 "register_magic" : {
-                    "description": "Register QCoDeS magic when in iPython. Can be set to True, False, or a list of magic commands to be registered",
+                    "description": "Register QCoDeS magic when in IPython. Can be set to True, False, or a list of magic commands to be registered",
+
                     "anyOf" : [
                         {"type": "boolean"},
                         {"type": "array"}
@@ -188,10 +189,10 @@
         },
         "plotting" : {
             "type" : "object",
-            "description": "controls plotting functions i.e. `plot_by_id`",
+            "description": "controls plotting functions i.e. `plot_dataset`",
             "properties" : {
                 "default_color_map":{
-                    "description": "Default colormap to use for `plot_by_id`.",
+                    "description": "Default colormap to use for `plot_dataset`.",
                     "type": "string",
                     "default": "viridis"
                 },

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ install_requires = [
     'pyvisa>=1.10.1, <1.12',
     'h5py>=2.6',
     'websockets>=7.0',
-    'jsonschema',
+    'jsonschema>=3.0.0',
     'ruamel.yaml!=0.16.6',
     'wrapt',
     'pandas',


### PR DESCRIPTION
This is in preparation for eventually being able to use draft 2019-09 (aka. draft-08) which adds support for deprecating properties https://stackoverflow.com/questions/48461197/how-do-i-mark-a-property-in-json-schema-as-deprecated as soon as that is supported by the python jsonschema package. https://github.com/Julian/jsonschema/issues/613 
