### PR TITLE
GitHub actions cleanup

### DIFF
--- a/.github/actions/setup-ubuntu-latest-xvfb/action.yml
+++ b/.github/actions/setup-ubuntu-latest-xvfb/action.yml
@@ -5,6 +5,6 @@ runs:
   steps:
     - name: Setup xvfb on ubuntu
       run: |
-        sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
+        sudo apt install xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
       shell: bash

--- a/.github/actions/setup-ubuntu-latest-xvfb/action.yml
+++ b/.github/actions/setup-ubuntu-latest-xvfb/action.yml
@@ -3,7 +3,7 @@ description: "Setup xvfb on ubuntu"
 runs:
   using: "composite"
   steps:
-    - name: upgrade pip setuptools wheel
+    - name: Setup xvfb on ubuntu
       run: |
         sudo apt install libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0
         /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,8 +25,6 @@ jobs:
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
     - name: install pandoc ubuntu
       run: sudo apt install pandoc
-    - name: install libhdf5-dev ubuntu
-      run: sudo apt install libhdf5-dev
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,12 +42,12 @@ jobs:
 
     - name: install requirements.txt
       run: |
-        pip install -r requirements.txt --use-feature=2020-resolver
+        pip install -r requirements.txt
     - name: install docs_requirements.txt
       run: |
-        pip install -r docs_requirements.txt --use-feature=2020-resolver
+        pip install -r docs_requirements.txt
     - name: install qcodes
-      run: pip install . --use-feature=2020-resolver
+      run: pip install .
     - name: Build docs
       run: |
         cd docs

--- a/.github/workflows/pytest-non-local.yaml
+++ b/.github/workflows/pytest-non-local.yaml
@@ -41,14 +41,14 @@ jobs:
           ${{ runner.os }}-${{ matrix.python-version }}-pip-
     - name: install requirements.txt
       run: |
-        pip install -r requirements.txt --use-feature=2020-resolver
+        pip install -r requirements.txt
     - name: install test_requirements.txt
       run: |
-        pip install -r test_requirements.txt --use-feature=2020-resolver
+        pip install -r test_requirements.txt
     - name: generate test dbs
       uses: ./.github/actions/generate-test-dbs
     - name: install qcodes
-      run: pip install . --use-feature=2020-resolver
+      run: pip install .
     - name: Test with pytest
       run: |
         cd ..

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -44,14 +44,14 @@ jobs:
           ${{ runner.os }}-${{ matrix.python-version }}-pip-
     - name: install requirements.txt
       run: |
-        pip install -r requirements.txt --use-feature=2020-resolver
+        pip install -r requirements.txt
     - name: install test_requirements.txt
       run: |
-        pip install -r test_requirements.txt --use-feature=2020-resolver
+        pip install -r test_requirements.txt
     - name: generate test dbs
       uses: ./.github/actions/generate-test-dbs
     - name: install qcodes
-      run: pip install . --use-feature=2020-resolver
+      run: pip install .
     - name: Run Mypy
       run: mypy qcodes
     - name: Run tests

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -28,8 +28,6 @@ jobs:
         fetch-depth: '0'
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
-    - name: install 3.9 build deps ubuntu
-      run: sudo apt install libhdf5-dev libxml2-dev libxml2 libxslt1.1 libxslt1-dev
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/verify-science-deps-installable.yaml
+++ b/.github/workflows/verify-science-deps-installable.yaml
@@ -40,9 +40,9 @@ jobs:
           ${{ runner.os }}-${{ matrix.python-version }}-pip-
     - name: install requirements.txt
       run: |
-        pip install -r requirements.txt --use-feature=2020-resolver
+        pip install -r requirements.txt
     - name: install science_requirements.txt
       run: |
-        pip install -r science_requirements.txt --use-feature=2020-resolver
+        pip install -r science_requirements.txt
     - name: install qcodes
-      run: pip install . --use-feature=2020-resolver
+      run: pip install .


### PR DESCRIPTION
* Correct an incorrect name of a task
* Remove dependencies previously required to build 3.9 packages from source
* Explicitly install xvfb (its installed by default but that looks likely to change in ubuntu 20.04 which will soon be the new latest image)
* Stop using now deprecated flag to enable 2020 resolver. The resolver is now on by default