### PR TITLE
filter urllib3.connection related warnings from console logger

### DIFF
--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -60,10 +60,16 @@ telemetry_handler: Optional[AzureLogHandler] = None
 
 
 _opencensus_filter = logging.Filter(name="opencensus")
+_urllib3_connection_filter = logging.Filter(name="urllib3.connection")
 
 
 def filter_out_telemetry_log_records(record: logging.LogRecord) -> int:
-    return not _opencensus_filter.filter(record)
+    """
+    here we filter any message that is likely to be thrown from
+    opencensus so it is not shown in the user console
+    """
+    return (not _opencensus_filter.filter(record)
+            and not _urllib3_connection_filter.filter(record))
 
 
 def get_formatter() -> logging.Formatter:


### PR DESCRIPTION
opencensus seems to sometime have invalid certificates that will trigger warnings from `urllib3.connections` 

@astafan8 The default Filter only supports filtering by name. Here I have just opted for the simple solution. We could also add a subclass that allows us to filter by message. What do you think?