### PR TITLE
use ubuntu 20.04 in github jobs

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -19,7 +19,7 @@ on:
   status: {}
 jobs:
   automerge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: automerge
         uses: "pascalgn/automerge-action@v0.12.0"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/pytest-non-local.yaml
+++ b/.github/workflows/pytest-non-local.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: [3.7, 3.8, 3.9]
     env:
       DISPLAY: ':99.0'

--- a/.github/workflows/verify-science-deps-installable.yaml
+++ b/.github/workflows/verify-science-deps-installable.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version: [3.7]
     env:
       DISPLAY: ':99.0'


### PR DESCRIPTION
Github actions warns that ubuntu-latest will soon be ubuntu 20.04 so lest make that explicit
