### PR TITLE
awg70000 add test of warning when waveform is clipped

### DIFF
--- a/qcodes/tests/drivers/test_tektronix_AWG70000A.py
+++ b/qcodes/tests/drivers/test_tektronix_AWG70000A.py
@@ -1,4 +1,5 @@
 from io import StringIO, BytesIO
+import logging
 import zipfile
 
 import pytest
@@ -175,6 +176,21 @@ def test_seqxfilefromfs_failing(forged_sequence):
         make_seqx(forged_sequence, [1, 1, 1],
                   seqname='dummyname',
                   channel_mapping={1: 10, 2: 8, 3: -1})
+
+
+def test_seqxfilefromfs_warns(forged_sequence, caplog):
+    """
+    Test that a warning is logged when waveform is clipped
+    """
+    make_seqx = AWG70000A.make_SEQX_from_forged_sequence
+
+    max_elem = forged_sequence[1]['content'][1]['data'][1]['wfm'].max()
+    amplitude = max_elem/2
+    with caplog.at_level(logging.WARNING):
+        seqx = make_seqx(forged_sequence, [amplitude, amplitude, amplitude], 'myseq')
+    assert len(caplog.messages) > 0
+    for message in caplog.messages:
+        assert "Waveform exceeds specified channel range" in message
 
 
 def test_seqxfile_from_fs(forged_sequence):

--- a/qcodes/tests/drivers/test_tektronix_AWG70000A.py
+++ b/qcodes/tests/drivers/test_tektronix_AWG70000A.py
@@ -60,8 +60,8 @@ def random_wfm_m1_m2_package():
     return make
 
 
-@pytest.fixture(scope='module')
-def forged_sequence():
+@pytest.fixture(scope='module', name="forged_sequence")
+def _make_forged_sequence():
     """
     Return an example forged sequence containing a
     subsequence
@@ -187,7 +187,7 @@ def test_seqxfilefromfs_warns(forged_sequence, caplog):
     max_elem = forged_sequence[1]['content'][1]['data'][1]['wfm'].max()
     amplitude = max_elem/2
     with caplog.at_level(logging.WARNING):
-        seqx = make_seqx(forged_sequence, [amplitude, amplitude, amplitude], 'myseq')
+        make_seqx(forged_sequence, [amplitude, amplitude, amplitude], 'myseq')
     assert len(caplog.messages) > 0
     for message in caplog.messages:
         assert "Waveform exceeds specified channel range" in message


### PR DESCRIPTION
This line is intermittently covered by tests as is causing coverage failures such as https://codecov.io/gh/QCoDeS/Qcodes/pull/2584/changes in non related CI runs. This adds a test that explicitly covers this line. The line is intermittently covered since the data generated in the forged sequence is sampled from a normal distribution that may or may not clip the output. 