### PR TITLE
Remove non needed html theme path

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -176,7 +176,7 @@ html_theme = "sphinx_rtd_theme"
 # html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.


### PR DESCRIPTION
This is no longer needed according to the install instructions https://sphinx-rtd-theme.readthedocs.io/en/stable/
