### PR TITLE
bump importlib-metadata to 3.4.0

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -15,7 +15,7 @@ docutils==0.16
 entrypoints==0.3
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.3.0;python_version<'3.8'
+importlib-metadata==3.4.0;python_version<'3.8'
 ipykernel==5.4.3
 ipython==7.19.0
 ipython-genutils==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ google-auth~=1.24.0
 googleapis-common-protos~=1.52.0
 h5py~=3.1.0
 idna~=2.10
-importlib-metadata==3.3.0;python_version<'3.8'
+importlib-metadata==3.4.0;python_version<'3.8'
 ipykernel~=5.4.3
 ipython~=7.19.0
 ipython-genutils~=0.2.0

--- a/science_requirements.txt
+++ b/science_requirements.txt
@@ -25,7 +25,7 @@ flake8==3.8.4
 helpdev==0.7.1
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==3.3.0;python_version<'3.8'
+importlib-metadata==3.4.0;python_version<'3.8'
 intervaltree==3.1.0
 ipykernel==5.4.3
 ipython==7.19.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,7 +12,7 @@ gitdb==4.0.5
 GitPython==3.1.12
 hypothesis==6.0.0
 idna==2.10
-importlib-metadata==3.3.0;python_version<'3.8'
+importlib-metadata==3.4.0;python_version<'3.8'
 iniconfig==1.1.1
 lxml==4.6.2
 mypy==0.790


### PR DESCRIPTION
Seems like dependabot does not do this correctly when using an environmental marker. 
