### PR TITLE
Set signal mode and snapshot_exclude attributes of volt and curr level params when needed (Keysight E4980A)

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
@@ -413,6 +413,9 @@ class KeysightE4980A(VisaInstrument):
         Sets voltage level
         """
         self.signal_mode("Voltage")
+        self.voltage_level.snapshot_exclude = False
+        self.current_level.snapshot_exclude = True
+
         self.write(f":VOLTage:LEVel {val}")
 
     def _set_current_level(self, val: str) -> None:
@@ -420,6 +423,9 @@ class KeysightE4980A(VisaInstrument):
         Sets current level
         """
         self.signal_mode("Current")
+        self.voltage_level.snapshot_exclude = True
+        self.current_level.snapshot_exclude = False
+
         self.write(f":CURRent:LEVel {val}")
 
     def _get_current_level(self) -> float:


### PR DESCRIPTION
Changes proposed in this pull request:
- Set signal mode at driver initialization
- Set snapshot_exclude attribute of volt and curr level params


@jenshnielsen 
