### PR TITLE
Add support for Mypy 0.800

### DIFF
--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from .KeysightB1500_base import KeysightB1500
 
 
-_FMTResponse = namedtuple('FMTResponse', 'value status channel type')
+_FMTResponse = namedtuple('_FMTResponse', 'value status channel type')
 
 
 class MeasurementNotTaken(Exception):

--- a/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
+++ b/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
@@ -21,7 +21,7 @@ from collections import namedtuple
 LOG = logging.getLogger(__name__)
 
 
-_ModeTuple = namedtuple('Mode', 'v i')
+_ModeTuple = namedtuple('_ModeTuple', 'v i')
 
 
 class Mode(Enum):

--- a/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/commandhandler.py
+++ b/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/commandhandler.py
@@ -16,7 +16,7 @@ except ImportError as e:
     raise ImportError(message)
 
 
-CmdArgs = namedtuple('cmd_and_args', 'cmd args')
+CmdArgs = namedtuple('CmdArgs', 'cmd args')
 
 # The length of a command header, aka a command keyword
 # Every command sent from the driver via the server must have a
@@ -38,8 +38,7 @@ class CommandHandler:
     _variants = {'double': win32com.client.VARIANT(VT_BYREF | VT_R8, 0.0),
                  'long': win32com.client.VARIANT(VT_BYREF | VT_I4, 0)}
 
-
-    def __init__(self, inst_type: str='dynacool') -> None:
+    def __init__(self, inst_type: str = 'dynacool') -> None:
         self.inst_type = inst_type
         pythoncom.CoInitialize()
         client_id = f'QD.MULTIVU.{inst_type.upper()}.1'
@@ -120,7 +119,7 @@ class CommandHandler:
             args = list(float(arg) for arg in cmd_str[5:].split(', '))
             is_query = False
 
-        return (CmdArgs(cmd=cmd, args=args), is_query)
+        return CmdArgs(cmd=cmd, args=args), is_query
 
     @staticmethod
     def postparser(error_code: int, vals: List[Any]) -> str:

--- a/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
+++ b/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
@@ -1,7 +1,11 @@
-import socket
-import select
-from msvcrt import kbhit, getch
 import logging
+import select
+import socket
+import sys
+if sys.platform == "win32":
+    from msvcrt import kbhit, getch
+else:
+    raise RuntimeError("Dynacool server only supported on Windows")
 
 from qcodes.instrument_drivers.QuantumDesign.\
     DynaCoolPPMS.private.commandhandler import CommandHandler

--- a/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
+++ b/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
@@ -1,6 +1,6 @@
 import socket
 import select
-from msvcrt import kbhit, getch  # type: ignore[attr-defined]
+from msvcrt import kbhit, getch
 import logging
 
 from qcodes.instrument_drivers.QuantumDesign.\

--- a/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
+++ b/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
@@ -10,6 +10,8 @@ else:
 from qcodes.instrument_drivers.QuantumDesign.\
     DynaCoolPPMS.private.commandhandler import CommandHandler
 
+assert sys.platform == 'win32'
+
 command_handler = CommandHandler()
 
 log = logging.getLogger(__name__)

--- a/qcodes/instrument_drivers/rigol/DS4000.py
+++ b/qcodes/instrument_drivers/rigol/DS4000.py
@@ -162,7 +162,7 @@ class ScopeArray(ArrayParameter):
 
     def get_preamble(self) -> None:
         assert isinstance(self.instrument, RigolDS4000Channel)
-        preamble_nt = namedtuple('preamble', ["format", "mode", "points", "count", "xincrement", "xorigin",
+        preamble_nt = namedtuple('preamble_nt', ["format", "mode", "points", "count", "xincrement", "xorigin",
                                               "xreference", "yincrement", "yorigin", "yreference"])
         conv = lambda x: int(x) if x.isdigit() else float(x)
 
@@ -201,6 +201,7 @@ class RigolDS4000Channel(InstrumentChannel):
                            parameter_class=ScopeArray,
                            raw=True
                            )
+
 
 class DS4000(VisaInstrument):
     """

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -15,7 +15,7 @@ idna==2.10
 importlib-metadata==3.4.0;python_version<'3.8'
 iniconfig==1.1.1
 lxml==4.6.2
-mypy==0.790
+mypy==0.800
 mypy-extensions==0.4.3
 numpy==1.19.5
 ordered-set==4.0.2


### PR DESCRIPTION
Replaces https://github.com/QCoDeS/Qcodes/pull/2645

* Mypy now requires that you use the same name for a named tuple variable and its name. Apparently that has 
always been recommended. 
* Handle that `msvcrt` module is now correctly detected on Windows but missing on other platforms 