### PR TITLE
move pytest assert rewrite to before import of the relevant module

### DIFF
--- a/qcodes/tests/dataset/__init__.py
+++ b/qcodes/tests/dataset/__init__.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite('qcodes.tests.dataset.helper_functions')

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -29,8 +29,6 @@ from qcodes.utils.types import numpy_ints, numpy_floats
 
 from qcodes.tests.dataset.helper_functions import verify_data_dict
 
-pytest.register_assert_rewrite('qcodes.tests.dataset.helper_functions')
-
 n_experiments = 0
 
 


### PR DESCRIPTION
To silence warning about it being imported before rewrite.
As recommended here https://docs.pytest.org/en/stable/writing_plugins.html#assertion-rewriting
