### PR TITLE
Coverage cleanup

### DIFF
--- a/.github/workflows/pytest-min-versions.yaml
+++ b/.github/workflows/pytest-min-versions.yaml
@@ -55,5 +55,4 @@ jobs:
       run: pip install .
     - name: Run tests
       run: |
-        cd qcodes
-        py.test --hypothesis-profile ci
+        pytest --hypothesis-profile ci qcodes

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -56,10 +56,9 @@ jobs:
       run: mypy qcodes
     - name: Run tests
       run: |
-        cd qcodes
-        py.test --cov=qcodes --cov-report xml --cov-config=.coveragerc --hypothesis-profile ci
+        pytest --cov=qcodes --cov-report xml --cov-config=setup.cfg --hypothesis-profile ci qcodes
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        file: ./qcodes/coverage.xml
+        file: ./coverage.xml
         env_vars: OS,PYTHON

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,30 +95,28 @@ jobs:
         condition: succeededOrFailed()
       - bash: |
           source activate qcodes &&
-          cd qcodes &&
-          pytest -m "not serial" --junitxml=test-parallel-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc --hypothesis-profile ci &&
-          pytest -n 0 --dist no -m serial --junitxml=test-serial-results.xml --cov-append --cov=qcodes --cov-report=xml --cov-config=.coveragerc --hypothesis-profile ci
+          pytest -m "not serial" --junitxml=test-parallel-results.xml --cov=qcodes --cov-report=xml --cov-config=setup.cfg --hypothesis-profile ci qcodes &&
+          pytest -n 0 --dist no -m serial --junitxml=test-serial-results.xml --cov-append --cov=qcodes --cov-report=xml--cov-config=setup.cfg --hypothesis-profile ci qcodes
         displayName: "Pytest on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))
       - bash: |
           source activate qcodes &&
-          cd qcodes &&
           xvfb-run --server-args="-screen 0 1024x768x24" \
-            pytest --junitxml=test-parallel-results.xml --cov=qcodes --cov-report=xml --cov-config=.coveragerc --hypothesis-profile ci
+            pytest --junitxml=test-parallel-results.xml --cov=qcodes --cov-report=xml --cov-config=setup.cfg --hypothesis-profile ci qcodes
         displayName: "Pytest on Linux"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Linux' ))
       - task: PublishTestResults@2
         displayName: "Publish test results"
         condition: succeededOrFailed()
         inputs:
-          testResultsFiles: '**/test-*.xml'
+          testResultsFiles: 'test-*.xml'
           testRunTitle: 'Publish test results'
       - task: PublishCodeCoverageResults@1
         displayName: "Publish code coverage results"
         condition: succeededOrFailed()
         inputs:
           codeCoverageTool: Cobertura
-          summaryFileLocation: '$(System.DefaultWorkingDirectory)/qcodes/coverage.xml'
+          summaryFileLocation: '$(System.DefaultWorkingDirectory)/coverage.xml'
       - script: |
           CALL C:\Miniconda\condabin\conda_hook.bat && ^
           CALL conda activate qcodes && ^

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
       - bash: |
           source activate qcodes &&
           pytest -m "not serial" --junitxml=test-parallel-results.xml --cov=qcodes --cov-report=xml --cov-config=setup.cfg --hypothesis-profile ci qcodes &&
-          pytest -n 0 --dist no -m serial --junitxml=test-serial-results.xml --cov-append --cov=qcodes --cov-report=xml--cov-config=setup.cfg --hypothesis-profile ci qcodes
+          pytest -n 0 --dist no -m serial --junitxml=test-serial-results.xml --cov-append --cov=qcodes --cov-report=xml --cov-config=setup.cfg --hypothesis-profile ci qcodes
         displayName: "Pytest on Windows"
         condition: and(succeededOrFailed(), eq( variables['Agent.OS'], 'Windows_NT' ))
       - bash: |

--- a/qcodes/.coveragerc
+++ b/qcodes/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-omit =
-    __init__.py
-    */__init__.py
-    _version.py
-    test.py
-    tests/*
-    instrument_drivers/test.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,9 +96,8 @@ parentdir_prefix = qcodes-
 
 [coverage:run]
 omit =
-    __init__.py
+    qcodes/__init__.py
     */__init__.py
-    _version.py
-    test.py
-    tests/*
-    instrument_drivers/test.py
+    qcodes/_version.py
+    qcodes/tests/*
+    qcodes/instrument_drivers/test.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,3 +92,13 @@ versionfile_source = qcodes/_version.py
 versionfile_build = qcodes/_version.py
 tag_prefix = v
 parentdir_prefix = qcodes-
+
+
+[coverage:run]
+omit =
+    __init__.py
+    */__init__.py
+    _version.py
+    test.py
+    tests/*
+    instrument_drivers/test.py


### PR DESCRIPTION
* Move coverage config to setup.cfg
* Simplify logic by running tests from toplevel dir
* Hopefully silence warning about module qcodes not being covered