### PR TITLE
add license to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include versioneer.py
 include qcodes/_version.py
+include LICENSE
+include LICENSE.rst


### PR DESCRIPTION
Avoids manually having to include it in Conda build from pypi