### PR TITLE
remove typo in paramcaller

### DIFF
--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -48,7 +48,6 @@ class _ParamCaller:
         output = []
         for param in self._parameters:
             output.append(param.get())
-            output.append(param.get())
         return tuple(output)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
Not sure how this happened but get was being called twice on the same parameter
