### PR TITLE
fetch full git history when building docs so tag can be included in docs build info

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,9 +33,9 @@ jobs:
         fetch-depth: '0'
         # if we upload to ghpages we need the full
         # history to generate correct version info
-      if: ${{ UPLOAD_TO_GHPAGES }}
+      if: ${{ env.UPLOAD_TO_GHPAGES }}
     - uses: actions/checkout@v2
-      if: ${{ !UPLOAD_TO_GHPAGES }}
+      if: ${{ !env.UPLOAD_TO_GHPAGES }}
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
       if: runner.os == 'Linux'
@@ -95,4 +95,4 @@ jobs:
         clean: true
         git-config-email: "bot"
         git-config-name: "Documentation Bot"
-      if: ${{ UPLOAD_TO_GHPAGES }}
+      if: ${{ env.UPLOAD_TO_GHPAGES }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,6 +31,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
+        # if we upload to ghpages we need the full
+        # history to generate correct version info
       if: ${{ $UPLOAD_TO_GHPAGES }}
     - uses: actions/checkout@v2
       if: ${{ !$UPLOAD_TO_GHPAGES }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,11 +25,15 @@ jobs:
     env:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
+      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' && github.event_name == 'push' && github.ref == 'refs/heads/master'}}
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
+      if: ${{ $UPLOAD_TO_GHPAGES }}
+    - uses: actions/checkout@v2
+      if: ${{ !$UPLOAD_TO_GHPAGES }}
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
       if: runner.os == 'Linux'
@@ -89,4 +93,4 @@ jobs:
         clean: true
         git-config-email: "bot"
         git-config-name: "Documentation Bot"
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' && github.event_name == 'push' && github.ref == 'refs/heads/master'}}
+      if: ${{ $UPLOAD_TO_GHPAGES }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,9 +33,9 @@ jobs:
         fetch-depth: '0'
         # if we upload to ghpages we need the full
         # history to generate correct version info
-      if: ${{ $UPLOAD_TO_GHPAGES }}
+      if: ${{ UPLOAD_TO_GHPAGES }}
     - uses: actions/checkout@v2
-      if: ${{ !$UPLOAD_TO_GHPAGES }}
+      if: ${{ !UPLOAD_TO_GHPAGES }}
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
       if: runner.os == 'Linux'
@@ -95,4 +95,4 @@ jobs:
         clean: true
         git-config-email: "bot"
         git-config-name: "Documentation Bot"
-      if: ${{ $UPLOAD_TO_GHPAGES }}
+      if: ${{ UPLOAD_TO_GHPAGES }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,17 +25,16 @@ jobs:
     env:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
-      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' && github.event_name == 'push' && github.ref == 'refs/heads/master'}}
-
+      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.7' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
         # if we upload to ghpages we need the full
         # history to generate correct version info
-      if: ${{ env.UPLOAD_TO_GHPAGES }}
+      if: ${{ fromJSON(env.UPLOAD_TO_GHPAGES) }}
     - uses: actions/checkout@v2
-      if: ${{ !env.UPLOAD_TO_GHPAGES }}
+      if: ${{ !fromJSON(env.UPLOAD_TO_GHPAGES) }}
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
       if: runner.os == 'Linux'
@@ -95,4 +94,4 @@ jobs:
         clean: true
         git-config-email: "bot"
         git-config-name: "Documentation Bot"
-      if: ${{ env.UPLOAD_TO_GHPAGES }}
+      if: ${{ fromJSON(env.UPLOAD_TO_GHPAGES) }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
       if: runner.os == 'Linux'


### PR DESCRIPTION
Currently the docs renders the version number as 0+unknown. This is a quick fix to get the right version number back. 
It may be worth investigating using a tree or a blob less clone to speed this up. https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/

@astafan8 