### PR TITLE
Use correct visa address for lakeshore pyvisa sim in station test

### DIFF
--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -275,7 +275,7 @@ instruments:
   lakeshore:
     type: qcodes.instrument_drivers.Lakeshore.Model_336.Model_336
     enable_forced_reconnect: true
-    address: GPIB::2::65535::INSTR
+    address: GPIB::2::INSTR
     init:
       visalib: '{sims_path}lakeshore_model336.yaml@sim'
   mock_dac:


### PR DESCRIPTION
otheriwse there will be a warning that a read meassge from instrument does not contain termination character.