### PR TITLE
add dataset.export_data to save as netcdf file

### DIFF
--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -67,7 +67,10 @@
         "write_in_background": false,
         "write_period": 5.0,
         "dond_plot": false,
-        "dond_show_progress": false
+        "dond_show_progress": false,
+        "export_type": null,
+        "export_prefix": "qcodes_",
+        "export_path": "~"
     },
     "telemetry":
     {

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -1,12 +1,62 @@
 from typing import List, Any, Sequence, Tuple, Dict, Union, cast
+from os.path import normpath, expanduser
 import logging
+import enum
 
 import numpy as np
 
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.data_set import load_by_id
+from qcodes import config
 
 log = logging.getLogger(__name__)
+
+
+DATASET_CONFIG_SECTION = "dataset"
+EXPORT_TYPE = "export_type"
+EXPORT_PATH = "export_path"
+EXPORT_PREFIX = "export_prefix"
+
+
+class DataExportType(enum.Enum):
+    """File extensions for supported data types to export data"""
+    NETCDF = "nc"
+
+
+def set_data_export_type(export_type: str) -> None:
+    if hasattr(DataExportType, export_type.upper()):
+        config[DATASET_CONFIG_SECTION][EXPORT_TYPE] = export_type.upper()
+
+
+def set_data_export_path(export_path: str) -> None:
+    if not os.path.exists(export_path):
+        raise ValueError(f"Cannot set export path to '{export_path}' because it does not exist.")
+    config[DATASET_CONFIG_SECTION][EXPORT_PATH] = export_path
+
+
+def get_data_export_type() -> Union[DataExportType, None]:
+    export_type = config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
+
+    if export_type:
+        if not hasattr(DataExportType, export_type):
+            raise ValueError(f"Unknown export data type: {export_type}")
+        export_type = getattr(DataExportType, export_type)
+    else:
+        return None
+
+    return export_type
+
+
+def get_data_export_path() -> str:
+    return normpath(expanduser(config[DATASET_CONFIG_SECTION][EXPORT_PATH]))
+
+
+def set_data_export_prefix(export_prefix: str) -> None:
+    config[DATASET_CONFIG_SECTION][EXPORT_PREFIX] = export_prefix
+
+
+def get_data_export_prefix() -> str:
+    return config[DATASET_CONFIG_SECTION][EXPORT_PREFIX]
 
 
 def flatten_1D_data_for_plot(rawdata: Union[Sequence[Sequence[Any]],


### PR DESCRIPTION
Fixes #issuenumber.

Changes proposed in this pull request:
- Add an `export_data` method to `DataSet` that allows users to export data to a supported file format. The goal is not to save data "live" (i.e. per row) but only at the end of a measurement. I am open to a different name for this method if that makes more sense.
- Addition of "export_type", "export_prefix" and "export_path variables in the qcodes config under "dataset". These variables contain respectively the data type to export in (if this is set to `null`, export is disabled), the prefix to add to the file and the path to export the file to.

@jenshnielsen 
