### PR TITLE
Support dataset export to NetCDF after measurement ends

### DIFF
--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -68,7 +68,7 @@
         "write_period": 5.0,
         "dond_plot": false,
         "dond_show_progress": false,
-        "export_type": null,
+        "export_type": "",
         "export_prefix": "qcodes_",
         "export_path": "~"
     },

--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -67,7 +67,10 @@
         "write_in_background": false,
         "write_period": 5.0,
         "dond_plot": false,
-        "dond_show_progress": false
+        "dond_show_progress": false,
+        "export_type": null,
+        "export_prefix": "qcodes_",
+        "export_path": "~"
     },
     "telemetry":
     {

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -316,6 +316,21 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Should dond functions show a progress bar during the measurement"
+                },
+                "export_type": {
+                    "type": "string",
+                    "default": null,
+                    "description": "Data export type for exporting datasets to disk after a measurement finishes. Does not export if set to null (default). Currently supported type(s): netcdf"
+                },
+                "export_path": {
+                    "type": "string",
+                    "default": "~",
+                    "description": "Data export path for exporting datasets to disk after a measurement finishes. Only activated if export_type is set"
+                },
+                "export_prefix": {
+                    "type": "string",
+                    "default": "qcodes_",
+                    "description": "Prefix to add to filename for exporting datasets to disk after a measurement finishes. Only activated if export_type is set"
                 }
             },
             "description": "Settings related to the DataSet and Measurement Context manager",

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -319,8 +319,8 @@
                 },
                 "export_type": {
                     "type": "string",
-                    "default": null,
-                    "description": "Data export type for exporting datasets to disk after a measurement finishes. Does not export if set to null (default). Currently supported type(s): netcdf"
+                    "default": "",
+                    "description": "Data export type for exporting datasets to disk after a measurement finishes. Does not export if set to empty string (default). Currently supported type(s): netcdf"
                 },
                 "export_path": {
                     "type": "string",

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -320,7 +320,7 @@
                 "export_type": {
                     "type": "string",
                     "default": "",
-                    "description": "Data export type for exporting datasets to disk after a measurement finishes. Does not export if set to empty string (default). Currently supported type(s): netcdf"
+                    "description": "Data export type for exporting datasets to disk after a measurement finishes. Does not export if set to empty string (default). Currently supported type(s): netcdf, csv"
                 },
                 "export_path": {
                     "type": "string",

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -1,62 +1,13 @@
 from typing import List, Any, Sequence, Tuple, Dict, Union, cast
-from os.path import normpath, expanduser
+
 import logging
-import enum
 
 import numpy as np
 
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.data_set import load_by_id
-from qcodes import config
 
 log = logging.getLogger(__name__)
-
-
-DATASET_CONFIG_SECTION = "dataset"
-EXPORT_TYPE = "export_type"
-EXPORT_PATH = "export_path"
-EXPORT_PREFIX = "export_prefix"
-
-
-class DataExportType(enum.Enum):
-    """File extensions for supported data types to export data"""
-    NETCDF = "nc"
-
-
-def set_data_export_type(export_type: str) -> None:
-    if hasattr(DataExportType, export_type.upper()):
-        config[DATASET_CONFIG_SECTION][EXPORT_TYPE] = export_type.upper()
-
-
-def set_data_export_path(export_path: str) -> None:
-    if not os.path.exists(export_path):
-        raise ValueError(f"Cannot set export path to '{export_path}' because it does not exist.")
-    config[DATASET_CONFIG_SECTION][EXPORT_PATH] = export_path
-
-
-def get_data_export_type() -> Union[DataExportType, None]:
-    export_type = config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
-
-    if export_type:
-        if not hasattr(DataExportType, export_type):
-            raise ValueError(f"Unknown export data type: {export_type}")
-        export_type = getattr(DataExportType, export_type)
-    else:
-        return None
-
-    return export_type
-
-
-def get_data_export_path() -> str:
-    return normpath(expanduser(config[DATASET_CONFIG_SECTION][EXPORT_PATH]))
-
-
-def set_data_export_prefix(export_prefix: str) -> None:
-    config[DATASET_CONFIG_SECTION][EXPORT_PREFIX] = export_prefix
-
-
-def get_data_export_prefix() -> str:
-    return config[DATASET_CONFIG_SECTION][EXPORT_PREFIX]
 
 
 def flatten_1D_data_for_plot(rawdata: Union[Sequence[Sequence[Any]],

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -1,12 +1,62 @@
 from typing import List, Any, Sequence, Tuple, Dict, Union, cast
+from os.path import normpath, expanduser
 import logging
+import enum
 
 import numpy as np
 
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.data_set import load_by_id
+from qcodes import config
 
 log = logging.getLogger(__name__)
+
+
+DATASET_CONFIG_SECTION = "dataset"
+EXPORT_TYPE = "export_type"
+EXPORT_PATH = "export_path"
+EXPORT_PREFIX = "export_prefix"
+
+
+class DataExportType(enum.Enum):
+    """File extensions for supported data types to export data"""
+    NETCDF = "nc"
+
+
+def set_data_export_type(export_type: str) -> None:
+    if hasattr(DataExportType, export_type.upper()):
+        config[DATASET_CONFIG_SECTION][EXPORT_TYPE] = export_type.upper()
+
+
+def set_data_export_path(export_path: str) -> None:
+    if not os.path.exists(export_path):
+        raise ValueError(f"Cannot set export path to '{export_path}' because it does not exist.")
+    config[DATASET_CONFIG_SECTION][EXPORT_PATH] = export_path
+
+
+def get_data_export_type() -> Union[DataExportType, None]:
+    export_type = config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
+
+    if export_type:
+        if not hasattr(DataExportType, export_type):
+            raise ValueError(f"Unknown export data type: {export_type}")
+        export_type = getattr(DataExportType, export_type)
+    else:
+        return None
+
+    return export_type
+
+
+def get_data_export_path() -> str:
+    return normpath(expanduser(config[DATASET_CONFIG_SECTION][EXPORT_PATH]))
+
+
+def set_data_export_prefix(export_prefix: str) -> None:
+    config[DATASET_CONFIG_SECTION][EXPORT_PREFIX] = export_prefix
+
+
+def get_data_export_prefix() -> str:
+    return config[DATASET_CONFIG_SECTION][EXPORT_PREFIX]
 
 
 def flatten_1D_data_for_plot(rawdata: Union[Sequence[Sequence[Any]],

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1707,14 +1707,14 @@ class DataSet(Sized):
         """Export data to disk with file name {prefix}{run_id}.{ext}.
         Values for the export type, path and prefix are set in the qcodes "dataset" config.
 
-        :param export_type: Data export type, e.g. "netcdf" or DataExportType.NETCDF,
-            defaults to value set config
-        :type export_type: DataExportType, optional
-        :param path: Export path, defaults to value set in config
-        :type path: str, optional
-        :param prefix: File prefix, e.g. "qcodes_", defaults to value set in config
-        :type prefix: str, optional
-        :raises ValueError: If the export data type is not specified, raise an error
+        Args:
+            export_type (Union[DataExportType, str], optional): Data export type, e.g. "netcdf" or DataExportType.NETCDF,
+            defaults to value set config. Defaults to None.
+            path (str, optional): Export path, defaults to value set in config. Defaults to None.
+            prefix (str, optional): File prefix, e.g. "qcodes_", defaults to value set in config. Defaults to None.
+
+        Raises:
+            ValueError: If the export data type is not specified, raise an error
         """
         # Set defaults to values in config if the value was not set (defaults to None)
         export_type = get_data_export_type(export_type)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1703,29 +1703,40 @@ class DataSet(Sized):
         xarr_dataset = self.to_xarray_dataset()
         xarr_dataset.to_netcdf(path=path)
 
-    def export(self, export_type: Union[DataExportType, str] = None, path: str = None, prefix: str = None) -> None:
+    def export(
+        self,
+        export_type: Union[DataExportType, str] = None,
+        path: str = None,
+        prefix: str = None) -> None:
         """Export data to disk with file name {prefix}{run_id}.{ext}.
-        Values for the export type, path and prefix are set in the qcodes "dataset" config.
+        Values for the export type, path and prefix are set in the qcodes
+        "dataset" config.
 
         Args:
-            export_type (Union[DataExportType, str], optional): Data export type, e.g. "netcdf" or DataExportType.NETCDF,
-            defaults to value set config. Defaults to None.
-            path (str, optional): Export path, defaults to value set in config. Defaults to None.
-            prefix (str, optional): File prefix, e.g. "qcodes_", defaults to value set in config. Defaults to None.
+            # export_type (Union[DataExportType, str], optional): Data
+            export type, e.g. "netcdf" or DataExportType.NETCDF,
+            defaults to value set config
+            path (str, optional): Export path, defaults to value set in
+            config
+            prefix (str, optional): File prefix, e.g. "qcodes_",
+            defaults to value set in config.
 
         Raises:
             ValueError: If the export data type is not specified, raise an error
         """
-        # Set defaults to values in config if the value was not set (defaults to None)
+        # Set defaults to values in config if the value was not set
+        # (defaults to None)
         export_type = get_data_export_type(export_type)
         path = path or get_data_export_path()
         prefix = prefix or get_data_export_prefix()
 
         if DataExportType.NETCDF == export_type:
             self._export_as_netcdf(path=path, prefix=prefix)
-        
+
         else:
-            raise ValueError("No data export type specified. Please set the export data type by using `qcodes.dataset.data_export.set_data_export_type(path)`.")
+            raise ValueError("No data export type specified. Please set the \
+            export data type by using \
+            `qcodes.dataset.data_export.set_data_export_type(path)`.")
 
 
 # public api

--- a/qcodes/dataset/export_config.py
+++ b/qcodes/dataset/export_config.py
@@ -20,9 +20,9 @@ class DataExportType(enum.Enum):
 def set_data_export_type(export_type: str) -> None:
     """Set data export type
 
-    :param export_type: Export type to use
+    Args:
+        export_type (str): Export type to use
         Currently supported values: "netcdf".
-    :type export_type: str
     """
     if hasattr(DataExportType, export_type.upper()):
         config[DATASET_CONFIG_SECTION][EXPORT_TYPE] = export_type.upper()
@@ -31,9 +31,11 @@ def set_data_export_type(export_type: str) -> None:
 def set_data_export_path(export_path: str) -> None:
     """Set path to export data to at the end of a measurement
 
-    :param export_path: An existing file path on disk
-    :type export_path: str
-    :raises ValueError: If the path does not exist, this raises an error
+    Args:
+        export_path (str): An existing file path on disk
+
+    Raises:
+        ValueError: If the path does not exist, this raises an error
     """
     if not exists(export_path):
         raise ValueError(f"Cannot set export path to '{export_path}' \
@@ -46,9 +48,15 @@ def get_data_export_type(
     """Get the file type for exporting data to disk at the end of
     a measurement from config
 
-    :raises ValueError: If the type is not supported, this raises an error
-    :return: Data export type or None
-    :rtype: Union[DataExportType, None]
+    Args:
+        export_type (Union[str, None], optional): Export type string format
+        to convert to DataExportType. Defaults to None.
+
+    Raises:
+        ValueError: If the type is not supported, this raises an error
+
+    Returns:
+        Union[DataExportType, None]: Data export type
     """
     # If export_type is None, get value from config
     export_type = export_type or config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
@@ -66,8 +74,8 @@ def get_data_export_type(
 def get_data_export_path() -> str:
     """Get the path to export data to at the end of a measurement from config
 
-    :return: Path
-    :rtype: str
+    Returns:
+        str: Path
     """
     return normpath(expanduser(config[DATASET_CONFIG_SECTION][EXPORT_PATH]))
 
@@ -76,8 +84,8 @@ def set_data_export_prefix(export_prefix: str) -> None:
     """Set the data export file name prefix to export data to at the end of 
     a measurement
 
-    :param export_prefix: Prefix, e.g. "qcodes_"
-    :type export_prefix: str
+    Args:
+        export_prefix (str): Prefix, e.g. "qcodes_"
     """
     config[DATASET_CONFIG_SECTION][EXPORT_PREFIX] = export_prefix
 
@@ -86,7 +94,7 @@ def get_data_export_prefix() -> str:
     """Get the data export file name prefix to export data to at the end of 
     a measurement from config
 
-    :return: Prefix, e.g. "qcodes_"
-    :rtype: str
+    Returns:
+        str: Prefix, e.g. "qcodes_"
     """
     return config[DATASET_CONFIG_SECTION][EXPORT_PREFIX]

--- a/qcodes/dataset/export_config.py
+++ b/qcodes/dataset/export_config.py
@@ -15,6 +15,7 @@ EXPORT_PREFIX = "export_prefix"
 class DataExportType(enum.Enum):
     """File extensions for supported data types to export data"""
     NETCDF = "nc"
+    CSV = "csv"
 
 
 def set_data_export_type(export_type: str) -> None:
@@ -22,7 +23,7 @@ def set_data_export_type(export_type: str) -> None:
 
     Args:
         export_type (str): Export type to use
-        Currently supported values: "netcdf".
+        Currently supported values: netcdf, csv.
     """
     if hasattr(DataExportType, export_type.upper()):
         config[DATASET_CONFIG_SECTION][EXPORT_TYPE] = export_type.upper()
@@ -58,16 +59,15 @@ def get_data_export_type(
     Returns:
         Union[DataExportType, None]: Data export type
     """
-    if not isinstance(export_type, DataExportType):
-        # If export_type is None, get value from config
-        export_type = export_type or config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
+    if isinstance(export_type, DataExportType):
+        return export_type
 
-        if export_type:
-            if not hasattr(DataExportType, export_type):
-                return
-            export_type = getattr(DataExportType, export_type)
+    # If export_type is None, get value from config
+    export_type = export_type or config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
 
-    return export_type
+    if export_type:
+        if hasattr(DataExportType, export_type.upper()):
+            return getattr(DataExportType, export_type.upper())
 
 
 def get_data_export_path() -> str:

--- a/qcodes/dataset/export_config.py
+++ b/qcodes/dataset/export_config.py
@@ -1,0 +1,92 @@
+import enum
+
+from os.path import normpath, expanduser, exists
+from typing import Union
+
+from qcodes import config
+
+
+DATASET_CONFIG_SECTION = "dataset"
+EXPORT_TYPE = "export_type"
+EXPORT_PATH = "export_path"
+EXPORT_PREFIX = "export_prefix"
+
+
+class DataExportType(enum.Enum):
+    """File extensions for supported data types to export data"""
+    NETCDF = "nc"
+
+
+def set_data_export_type(export_type: str) -> None:
+    """Set data export type
+
+    :param export_type: Export type to use
+        Currently supported values: "netcdf".
+    :type export_type: str
+    """
+    if hasattr(DataExportType, export_type.upper()):
+        config[DATASET_CONFIG_SECTION][EXPORT_TYPE] = export_type.upper()
+
+
+def set_data_export_path(export_path: str) -> None:
+    """Set path to export data to at the end of a measurement
+
+    :param export_path: An existing file path on disk
+    :type export_path: str
+    :raises ValueError: If the path does not exist, this raises an error
+    """
+    if not exists(export_path):
+        raise ValueError(f"Cannot set export path to '{export_path}' \
+        because it does not exist.")
+    config[DATASET_CONFIG_SECTION][EXPORT_PATH] = export_path
+
+
+def get_data_export_type(
+    export_type: Union[str, None] = None) -> Union[DataExportType, None]:
+    """Get the file type for exporting data to disk at the end of
+    a measurement from config
+
+    :raises ValueError: If the type is not supported, this raises an error
+    :return: Data export type or None
+    :rtype: Union[DataExportType, None]
+    """
+    # If export_type is None, get value from config
+    export_type = export_type or config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
+
+    if export_type:
+        if not hasattr(DataExportType, export_type):
+            raise ValueError(f"Unknown export data type: {export_type}")
+        export_type = getattr(DataExportType, export_type)
+    else:
+        return None
+
+    return export_type
+
+
+def get_data_export_path() -> str:
+    """Get the path to export data to at the end of a measurement from config
+
+    :return: Path
+    :rtype: str
+    """
+    return normpath(expanduser(config[DATASET_CONFIG_SECTION][EXPORT_PATH]))
+
+
+def set_data_export_prefix(export_prefix: str) -> None:
+    """Set the data export file name prefix to export data to at the end of 
+    a measurement
+
+    :param export_prefix: Prefix, e.g. "qcodes_"
+    :type export_prefix: str
+    """
+    config[DATASET_CONFIG_SECTION][EXPORT_PREFIX] = export_prefix
+
+
+def get_data_export_prefix() -> str:
+    """Get the data export file name prefix to export data to at the end of 
+    a measurement from config
+
+    :return: Prefix, e.g. "qcodes_"
+    :rtype: str
+    """
+    return config[DATASET_CONFIG_SECTION][EXPORT_PREFIX]

--- a/qcodes/dataset/export_config.py
+++ b/qcodes/dataset/export_config.py
@@ -58,15 +58,14 @@ def get_data_export_type(
     Returns:
         Union[DataExportType, None]: Data export type
     """
-    # If export_type is None, get value from config
-    export_type = export_type or config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
+    if not isinstance(export_type, DataExportType):
+        # If export_type is None, get value from config
+        export_type = export_type or config[DATASET_CONFIG_SECTION][EXPORT_TYPE]
 
-    if export_type:
-        if not hasattr(DataExportType, export_type):
-            raise ValueError(f"Unknown export data type: {export_type}")
-        export_type = getattr(DataExportType, export_type)
-    else:
-        return None
+        if export_type:
+            if not hasattr(DataExportType, export_type):
+                return
+            export_type = getattr(DataExportType, export_type)
 
     return export_type
 

--- a/qcodes/dataset/export_config.py
+++ b/qcodes/dataset/export_config.py
@@ -25,6 +25,10 @@ def set_data_export_type(export_type: str) -> None:
         export_type (str): Export type to use
         Currently supported values: netcdf, csv.
     """
+    # disable file export
+    if export_type is None:
+        config[DATASET_CONFIG_SECTION][EXPORT_TYPE] = None
+
     if hasattr(DataExportType, export_type.upper()):
         config[DATASET_CONFIG_SECTION][EXPORT_TYPE] = export_type.upper()
 

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -40,6 +40,7 @@ from qcodes.instrument.parameter import (ArrayParameter, MultiParameter,
                                          expand_setpoints_helper)
 from qcodes.utils.delaykeyboardinterrupt import DelayedKeyboardInterrupt
 from qcodes.utils.helpers import NumpyJSONEncoder
+from qcodes.dataset.export_config import get_data_export_type
 
 log = logging.getLogger(__name__)
 
@@ -412,6 +413,17 @@ class DataSaver:
         """
         self.dataset._flush_data_to_database(block=block)
 
+    def export_data(self) -> bool:
+        """Export data at end of measurement if export_type
+        is specified in "dataset" config
+
+        Returns:
+            bool: Flag to export data
+        """
+        export_type = get_data_export_type()
+        if export_type is not None:
+            self.dataset.export(export_type=export_type)
+
     @property
     def run_id(self) -> int:
         return self._dataset.run_id
@@ -560,6 +572,7 @@ class Runner:
                  ) -> None:
         with DelayedKeyboardInterrupt():
             self.datasaver.flush_data_to_database(block=True)
+            self.datasaver.export_data()
 
             # perform the "teardown" events
             for func, args in self.exitactions:


### PR DESCRIPTION
Fixes #2775.

Changes proposed in this pull request:
- Add an `export_data` method to `DataSet` that allows users to export data to a supported file format. The goal is not to save data "live" (i.e. per row) but only at the end of a measurement. I am open to a different name for this method if that makes more sense.
- Addition of "export_type", "export_prefix" and "export_path variables in the qcodes config under "dataset". These variables contain respectively the data type to export in (if this is set to `null`, export is disabled), the prefix to add to the file and the path to export the file to.

Parts of this PR were already reviewed in draft on PR #2774. I've opened a new PR in order to make the branch name compliant with [contribution guidelines](https://qcodes.github.io/Qcodes/community/contributing.html).

@jenshnielsen 
