### PR TITLE
use new version of sphinx json schema with string escape

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -65,10 +65,7 @@ Send2Trash==1.5.0
 six==1.15.0
 snowballstemmer==2.1.0
 Sphinx==3.5.3
-git+https://github.com/jenshnielsen/sphinx-jsonschema.git
-# as a workaround for lack of escaping in sphinx json schema we install a
-# branch with a fix for now. Revert once https://github.com/lnoor/sphinx-jsonschema/pull/57
-# or another solution is merged
+sphinx-jsonschema==1.16.8
 sphinx-rtd-theme==0.5.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2


### PR DESCRIPTION
as my fix has made it into an upstream release we can revert back to that
