### PR TITLE
add snapshot and other relevant metadata to xarray export

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1246,6 +1246,7 @@ class DataSet(Sized):
                 paramspec_dict = self.paramspecs[str(dim)]._to_dict()
                 xrdataset.coords[str(dim)].attrs.update(paramspec_dict.items())
 
+        xrdataset.attrs["name"] = self.name
         xrdataset.attrs["sample_name"] = self.sample_name
         xrdataset.attrs["exp_name"] = self.exp_name
         xrdataset.attrs["guid"] = self.guid

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1253,7 +1253,7 @@ class DataSet(Sized):
         xrdataset.attrs["run_timestamp"] = self.run_timestamp_raw
         xrdataset.attrs["completed_timestamp"] = self.completed_timestamp_raw
         xrdataset.attrs["parameters"] = self.parameters
-        xrdataset.attrs["run_description"] = self.description
+        xrdataset.attrs["run_description"] = serial.to_json_for_storage(self.description)
         xrdataset.attrs["snapshot"] = self.snapshot
         xrdataset.attrs["captured_run_id"] = self.captured_run_id
         xrdataset.attrs["captured_counter"] = self.captured_counter

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1248,6 +1248,17 @@ class DataSet(Sized):
 
         xrdataset.attrs["sample_name"] = self.sample_name
         xrdataset.attrs["exp_name"] = self.exp_name
+        xrdataset.attrs["guid"] = self.guid
+        xrdataset.attrs["run_timestamp"] = self.run_timestamp_raw
+        xrdataset.attrs["completed_timestamp"] = self.completed_timestamp_raw
+        xrdataset.attrs["parameters"] = self.parameters
+        xrdataset.attrs["run_description"] = self.description
+        xrdataset.attrs["snapshot"] = self.snapshot
+        xrdataset.attrs["captured_run_id"] = self.captured_run_id
+        xrdataset.attrs["captured_counter"] = self.captured_counter
+
+        for metadata_tag, metadata in self._metadata.keys():
+            xrdataset.attrs[metadata_tag] = metadata
 
         return xrdataset
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1257,7 +1257,7 @@ class DataSet(Sized):
         xrdataset.attrs["captured_run_id"] = self.captured_run_id
         xrdataset.attrs["captured_counter"] = self.captured_counter
 
-        for metadata_tag, metadata in self._metadata.keys():
+        for metadata_tag, metadata in self._metadata.items():
             xrdataset.attrs[metadata_tag] = metadata
 
         return xrdataset

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1254,7 +1254,7 @@ class DataSet(Sized):
         xrdataset.attrs["completed_timestamp"] = self.completed_timestamp_raw
         xrdataset.attrs["parameters"] = self.parameters
         xrdataset.attrs["run_description"] = serial.to_json_for_storage(self.description)
-        xrdataset.attrs["snapshot"] = self.snapshot
+        xrdataset.attrs["snapshot"] = self.snapshot_raw
         xrdataset.attrs["captured_run_id"] = self.captured_run_id
         xrdataset.attrs["captured_counter"] = self.captured_counter
 


### PR DESCRIPTION
@astafan8 

In principle this means that the qcodes dataset should be reconstructable from the exported data. 

Note that I have left out a few things on purpose.

The `run_id` since this is anyway not conserved when exporting
completed flag since this can be constructed from the completed time stamp 
exp_id since this is really specific to the specific db

- [ ] Add some tests

