### PR TITLE
support export to xarray for data with non unique indices

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1248,6 +1248,7 @@ class DataSet(Sized):
 
         xrdataset.attrs["sample_name"] = self.sample_name
         xrdataset.attrs["exp_name"] = self.exp_name
+        xrdataset.attrs["snapshot"] = json.dumps(self.snapshot)
 
         return xrdataset
 
@@ -1306,11 +1307,17 @@ class DataSet(Sized):
 
         for name, subdict in datadict.items():
             index = self._generate_pandas_index(subdict)
-            xrdarray: xr.DataArray = self._data_to_dataframe(
-                subdict, index).to_xarray()[name]
+            if len(index.unique()) != len(index):
+                for _name in subdict:
+                    xrdarray: xr.DataArray = self._data_to_dataframe(
+                        subdict, index).reset_index().to_xarray()[_name]
+                    data_xrdarray_dict[_name] = xrdarray
+            else:
+                xrdarray: xr.DataArray = self._data_to_dataframe(
+                    subdict, index).to_xarray()[name]
+                data_xrdarray_dict[name] = xrdarray
             paramspec_dict = self.paramspecs[name]._to_dict()
             xrdarray.attrs.update(paramspec_dict.items())
-            data_xrdarray_dict[name] = xrdarray
 
         return data_xrdarray_dict
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1350,6 +1350,8 @@ class DataSet(Sized):
             single_file: If true, merges the data of same length of multiple
                          dependent parameters to a single file.
             single_file_name: User defined name for the data to be concatenated.
+                              If no extension is passed (.dat, .csv or .txt),
+                              .dat is automatically appended.
 
         Raises:
             DataLengthException: If the data of multiple parameters have not same

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1246,10 +1246,15 @@ class DataSet(Sized):
                 paramspec_dict = self.paramspecs[str(dim)]._to_dict()
                 xrdataset.coords[str(dim)].attrs.update(paramspec_dict.items())
 
-        xrdataset.attrs["sample_name"] = self.sample_name
-        xrdataset.attrs["exp_name"] = self.exp_name
-        xrdataset.attrs["snapshot"] = json.dumps(self.snapshot)
-        xrdataset.attrs["guid"] = self.guid
+        xrdataset.attrs.update({
+            "sample_name": self.sample_name,
+            "exp_name": self.exp_name,
+            "snapshot": json.dumps(self.snapshot),
+            "guid": self.guid,
+            "run_timestamp": self.run_timestamp(),
+            "completed_timestamp": self.completed_timestamp(),
+            "run_id": self.run_id
+        })
 
         return xrdataset
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1307,7 +1307,7 @@ class DataSet(Sized):
 
         for name, subdict in datadict.items():
             index = self._generate_pandas_index(subdict)
-            if len(index.unique()) != len(index):
+            if index is not None and len(index.unique()) != len(index):
                 for _name in subdict:
                     data_xrdarray_dict[_name] = self._data_to_dataframe(
                         subdict, index).reset_index().to_xarray()[_name]

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1249,6 +1249,7 @@ class DataSet(Sized):
         xrdataset.attrs["sample_name"] = self.sample_name
         xrdataset.attrs["exp_name"] = self.exp_name
         xrdataset.attrs["snapshot"] = json.dumps(self.snapshot)
+        xrdataset.attrs["guid"] = self.guid
 
         return xrdataset
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1309,15 +1309,16 @@ class DataSet(Sized):
             index = self._generate_pandas_index(subdict)
             if len(index.unique()) != len(index):
                 for _name in subdict:
-                    xrdarray: xr.DataArray = self._data_to_dataframe(
+                    data_xrdarray_dict[_name] = self._data_to_dataframe(
                         subdict, index).reset_index().to_xarray()[_name]
-                    data_xrdarray_dict[_name] = xrdarray
+                    paramspec_dict = self.paramspecs[_name]._to_dict()
+                    data_xrdarray_dict[_name].attrs.update(paramspec_dict.items())
             else:
                 xrdarray: xr.DataArray = self._data_to_dataframe(
                     subdict, index).to_xarray()[name]
                 data_xrdarray_dict[name] = xrdarray
-            paramspec_dict = self.paramspecs[name]._to_dict()
-            xrdarray.attrs.update(paramspec_dict.items())
+                paramspec_dict = self.paramspecs[name]._to_dict()
+                xrdarray.attrs.update(paramspec_dict.items())
 
         return data_xrdarray_dict
 

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1251,8 +1251,8 @@ class DataSet(Sized):
             "exp_name": self.exp_name,
             "snapshot": json.dumps(self.snapshot),
             "guid": self.guid,
-            "run_timestamp": self.run_timestamp(),
-            "completed_timestamp": self.completed_timestamp(),
+            "run_timestamp": self.run_timestamp() or "",
+            "completed_timestamp": self.completed_timestamp() or "",
             "run_id": self.run_id
         })
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1451,8 +1451,10 @@ def test_export_to_xarray(mock_dataset, mock_dataset_nonunique):
     assert len(ds) == 2
     assert "index" not in ds.coords
     assert "x" in ds.coords
+    assert ds.guid == mock_dataset.guid
 
     ds = mock_dataset_nonunique.to_xarray_dataset()
     assert len(ds) == 3
     assert "index" in ds.coords
     assert "x" not in ds.coords
+    assert ds.guid == mock_dataset_nonunique.guid

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -4,6 +4,7 @@ import re
 from copy import copy
 from typing import Dict, List, Optional, Sequence, Tuple
 from unittest.mock import patch
+import json
 
 import hypothesis.strategies as hst
 import numpy as np
@@ -1452,9 +1453,21 @@ def test_export_to_xarray(mock_dataset, mock_dataset_nonunique):
     assert "index" not in ds.coords
     assert "x" in ds.coords
     assert ds.guid == mock_dataset.guid
+    assert ds.sample_name == mock_dataset.sample_name
+    assert ds.exp_name == mock_dataset.exp_name
+    assert ds.snapshot == json.dumps(mock_dataset.snapshot)
+    assert ds.run_timestamp == mock_dataset.run_timestamp()
+    assert ds.completed_timestamp == mock_dataset.completed_timestamp()
+    assert ds.run_id == mock_dataset.run_id
 
     ds = mock_dataset_nonunique.to_xarray_dataset()
     assert len(ds) == 3
     assert "index" in ds.coords
     assert "x" not in ds.coords
     assert ds.guid == mock_dataset_nonunique.guid
+    assert ds.sample_name == mock_dataset_nonunique.sample_name
+    assert ds.exp_name == mock_dataset_nonunique.exp_name
+    assert ds.snapshot == json.dumps(mock_dataset_nonunique.snapshot)
+    assert ds.run_timestamp == mock_dataset_nonunique.run_timestamp()
+    assert ds.completed_timestamp == mock_dataset_nonunique.completed_timestamp()
+    assert ds.run_id == mock_dataset_nonunique.run_id


### PR DESCRIPTION
Fixes #2847.

Changes proposed in this pull request:
- support exporting dataset with multiindex with non-unique entries to xarray
- add station snapshot to xarray attributes
- update docstring


@jenshnielsen 
