### PR TITLE
Fix intermittend (hypothesis) failure by bumping min supported numpy version to 1.16.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ zip_safe = False
 packages = find:
 python_requires = >=3.7
 install_requires =
-   numpy>=1.16
+   numpy>=1.16.3
    pyvisa>=1.11.0, <1.12.0
    h5py>=2.10.0
    websockets>=7.0


### PR DESCRIPTION
as can be seen from running testAggregator

the following code will fail

```
import numpy as np
npoints=1
z_start_stop=[-9223372036854775809, -9223372036854775809]
np.linspace(z_start_stop[0], z_start_stop[1], npoints).reshape(npoints, 1)
```

with
```
AttributeError: 'float' object has no attribute 'ndim'
```
for numpy 1.16.0, 1.16.1 and 1.16.2. This has been fixed in 1.16.3

An example of this can be seen in https://github.com/QCoDeS/Qcodes/pull/2849

This is intermittent since the values in z_start_stop are generated by hypothesis and this only happens for sufficiently large numbers probably due to an overflow or something similar