### PR TITLE
Added ramping_state to set_field Exception

### DIFF
--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -319,7 +319,8 @@ class AMI430(IPInstrument):
 
         # Check we can ramp
         if not self._can_start_ramping():
-            raise AMI430Exception("Cannot ramp in current state")
+            raise AMI430Exception(f"Cannot ramp in current state: "
+                                  f"state is {self.ramping_state()}")
 
         # Then, do the actual ramp
         self.pause()


### PR DESCRIPTION
This adds the ramping_state to the Exception message to get to know which state the magnet is, when it is not ramping.