### PR TITLE
Move private dataset export functions to their own module

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -52,12 +52,15 @@ from .data_set_cache import DataSetCache
 from .descriptions.versioning import serialization as serial
 from .subscriber import _Subscriber
 
-from .exporters.export_to_pandas_xarray import (
+from .exporters.export_to_pandas import (
     load_to_dataframe_dict,
-    load_to_concatenated_dataframe,
+    load_to_concatenated_dataframe
+)
+from .exporters.export_to_xarray import (
     load_to_xarray_dataset,
     load_to_xarray_dataarray_dict
 )
+
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -10,12 +10,15 @@ from qcodes.dataset.sqlite.queries import (
 from qcodes.dataset.sqlite.connection import ConnectionPlus
 from qcodes.utils.deprecate import deprecate
 
-from .exporters.export_to_pandas_xarray import (
+from .exporters.export_to_pandas import (
     load_to_dataframe_dict,
-    load_to_xarray_dataarray_dict,
     load_to_concatenated_dataframe,
+)
+from .exporters.export_to_xarray import (
+    load_to_xarray_dataarray_dict,
     load_to_xarray_dataset
 )
+
 
 if TYPE_CHECKING:
     import pandas as pd

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -10,6 +10,8 @@ from qcodes.dataset.sqlite.queries import (
 from qcodes.dataset.sqlite.connection import ConnectionPlus
 from qcodes.utils.deprecate import deprecate
 
+from .exporters.export_to_pandas_xarray import _load_to_dataframe_dict, _load_to_xarray_dataarray_dict
+
 if TYPE_CHECKING:
     import pandas as pd
     import xarray as xr
@@ -142,7 +144,7 @@ class DataSetCache:
             represents one parameter tree.
         """
         data = self.data()
-        return self._dataset._load_to_dataframe_dict(data)
+        return _load_to_dataframe_dict(data)
 
     def to_pandas_dataframe(self) -> "pd.DataFrame":
         """
@@ -190,7 +192,7 @@ class DataSetCache:
 
         """
         data = self.data()
-        return self._dataset._load_to_xarray_dataarray_dict(data)
+        return _load_to_xarray_dataarray_dict(self._dataset, data)
 
     def to_xarray_dataset(self) -> "xr.Dataset":
         """

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -10,7 +10,12 @@ from qcodes.dataset.sqlite.queries import (
 from qcodes.dataset.sqlite.connection import ConnectionPlus
 from qcodes.utils.deprecate import deprecate
 
-from .exporters.export_to_pandas_xarray import _load_to_dataframe_dict, _load_to_xarray_dataarray_dict
+from .exporters.export_to_pandas_xarray import (
+    load_to_dataframe_dict,
+    load_to_xarray_dataarray_dict,
+    load_to_concatenated_dataframe,
+    load_to_xarray_dataset
+)
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -144,7 +149,7 @@ class DataSetCache:
             represents one parameter tree.
         """
         data = self.data()
-        return _load_to_dataframe_dict(data)
+        return load_to_dataframe_dict(data)
 
     def to_pandas_dataframe(self) -> "pd.DataFrame":
         """
@@ -156,7 +161,7 @@ class DataSetCache:
             represents one parameter tree.
         """
         data = self.data()
-        return self._dataset._load_to_concatenated_dataframe(data)
+        return load_to_concatenated_dataframe(data)
 
     @deprecate(alternative="to_pandas_dataframe or to_pandas_dataframe_dict")
     def to_pandas(self) -> Dict[str, "pd.DataFrame"]:
@@ -192,7 +197,7 @@ class DataSetCache:
 
         """
         data = self.data()
-        return _load_to_xarray_dataarray_dict(self._dataset, data)
+        return load_to_xarray_dataarray_dict(self._dataset, data)
 
     def to_xarray_dataset(self) -> "xr.Dataset":
         """
@@ -209,7 +214,7 @@ class DataSetCache:
 
         """
         data = self.data()
-        return self._dataset._load_to_xarray_dataset(data)
+        return load_to_xarray_dataset(self._dataset, data)
 
 
 def load_new_data_from_db_and_append(

--- a/qcodes/dataset/exporters/__init__.py
+++ b/qcodes/dataset/exporters/__init__.py
@@ -1,0 +1,4 @@
+"""
+Functions for exporting data within a dataset or its cache to Pandas and Xarray formats.
+These functions are not considered part of the public api and may change and any time.
+"""

--- a/qcodes/dataset/exporters/export_to_pandas.py
+++ b/qcodes/dataset/exporters/export_to_pandas.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import warnings
 
-from typing import Dict, TYPE_CHECKING, Union, Iterator, cast, Hashable
+from typing import Dict, TYPE_CHECKING, Union, Iterator
 
 import numpy as np
 
 
 if TYPE_CHECKING:
     import pandas as pd
-    from qcodes.dataset.data_set import DataSet, ParameterData
+    from qcodes.dataset.data_set import ParameterData
 
 
 def load_to_dataframe_dict(datadict: ParameterData) -> Dict[str, pd.DataFrame]:

--- a/qcodes/dataset/exporters/export_to_pandas.py
+++ b/qcodes/dataset/exporters/export_to_pandas.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import warnings
+
+from typing import Dict, TYPE_CHECKING, Union, Iterator, cast, Hashable
+
+import numpy as np
+
+
+if TYPE_CHECKING:
+    import pandas as pd
+    from qcodes.dataset.data_set import DataSet, ParameterData
+
+
+def load_to_dataframe_dict(datadict: ParameterData) -> Dict[str, pd.DataFrame]:
+    dfs = {}
+    for name, subdict in datadict.items():
+        index = _generate_pandas_index(subdict)
+        dfs[name] = _data_to_dataframe(subdict, index)
+    return dfs
+
+
+def load_to_concatenated_dataframe(
+        datadict: ParameterData
+) -> "pd.DataFrame":
+    import pandas as pd
+
+    if not _same_setpoints(datadict):
+        warnings.warn(
+            "Independent parameter setpoints are not equal. "
+            "Check concatenated output carefully. Please "
+            "consider using `to_pandas_dataframe_dict` to export each "
+            "independent parameter to its own dataframe."
+        )
+
+    dfs_dict = load_to_dataframe_dict(datadict)
+    df = pd.concat(list(dfs_dict.values()), axis=1)
+
+    return df
+
+
+def _data_to_dataframe(data: Dict[str, np.ndarray], index: Union[pd.Index, pd.MultiIndex]) -> pd.DataFrame:
+    import pandas as pd
+    if len(data) == 0:
+        return pd.DataFrame()
+    dependent_col_name = list(data.keys())[0]
+    dependent_data = data[dependent_col_name]
+    if dependent_data.dtype == np.dtype('O'):
+        # ravel will not fully unpack a numpy array of arrays
+        # which are of "object" dtype. This can happen if a variable
+        # length array is stored in the db. We use concatenate to
+        # flatten these
+        mydata = np.concatenate(dependent_data)
+    else:
+        mydata = dependent_data.ravel()
+    df = pd.DataFrame(mydata, index=index,
+                      columns=[dependent_col_name])
+    return df
+
+
+def _generate_pandas_index(data: Dict[str, np.ndarray]) -> Union[pd.Index, pd.MultiIndex]:
+    # the first element in the dict given by parameter_tree is always the dependent
+    # parameter and the index is therefore formed from the rest
+    import pandas as pd
+    keys = list(data.keys())
+    if len(data) <= 1:
+        index = None
+    elif len(data) == 2:
+        index = pd.Index(data[keys[1]].ravel(), name=keys[1])
+    else:
+        index_data = tuple(np.concatenate(data[key])
+                           if data[key].dtype == np.dtype('O')
+                           else data[key].ravel()
+                           for key in keys[1:])
+        index = pd.MultiIndex.from_arrays(
+            index_data,
+            names=keys[1:])
+    return index
+
+
+def _parameter_data_identical(param_dict_a: Dict[str, np.ndarray],
+                              param_dict_b: Dict[str, np.ndarray]) -> bool:
+
+    try:
+        np.testing.assert_equal(param_dict_a, param_dict_b)
+    except AssertionError:
+        return False
+
+    return True
+
+
+def _same_setpoints(datadict: ParameterData) -> bool:
+
+    def _get_setpoints(dd: ParameterData) -> Iterator[Dict[str, np.ndarray]]:
+
+        for dep_name, param_dict in dd.items():
+            out = {
+                name: vals for name, vals in param_dict.items() if name != dep_name
+            }
+            yield out
+
+    sp_iterator = _get_setpoints(datadict)
+
+    try:
+        first = next(sp_iterator)
+    except StopIteration:
+        return True
+
+    return all(_parameter_data_identical(first, rest) for rest in sp_iterator)

--- a/qcodes/dataset/exporters/export_to_pandas_xarray.py
+++ b/qcodes/dataset/exporters/export_to_pandas_xarray.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import warnings
+
+from typing import Dict, TYPE_CHECKING, Union, Iterator
+
+import numpy as np
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import xarray as xr
+    from qcodes.dataset.data_set import DataSet, ParameterData
+
+
+def _load_to_xarray_dataarray_dict(dataset: DataSet,
+                                   datadict: Dict[str, Dict[str, np.ndarray]]) -> \
+        Dict[str, xr.DataArray]:
+    import xarray as xr
+
+    data_xrdarray_dict: Dict[str, xr.DataArray] = {}
+
+    for name, subdict in datadict.items():
+        index = _generate_pandas_index(subdict)
+        if index is not None and len(index.unique()) != len(index):
+            for _name in subdict:
+                data_xrdarray_dict[_name] = _data_to_dataframe(
+                    subdict, index).reset_index().to_xarray()[_name]
+                paramspec_dict = dataset.paramspecs[_name]._to_dict()
+                data_xrdarray_dict[_name].attrs.update(paramspec_dict.items())
+        else:
+            xrdarray: xr.DataArray = _data_to_dataframe(
+                subdict, index).to_xarray()[name]
+            data_xrdarray_dict[name] = xrdarray
+            paramspec_dict = dataset.paramspecs[name]._to_dict()
+            xrdarray.attrs.update(paramspec_dict.items())
+
+    return data_xrdarray_dict
+
+
+def _data_to_dataframe(data: Dict[str, np.ndarray], index: Union[pd.Index, pd.MultiIndex]) -> pd.DataFrame:
+    import pandas as pd
+    if len(data) == 0:
+        return pd.DataFrame()
+    dependent_col_name = list(data.keys())[0]
+    dependent_data = data[dependent_col_name]
+    if dependent_data.dtype == np.dtype('O'):
+        # ravel will not fully unpack a numpy array of arrays
+        # which are of "object" dtype. This can happen if a variable
+        # length array is stored in the db. We use concatenate to
+        # flatten these
+        mydata = np.concatenate(dependent_data)
+    else:
+        mydata = dependent_data.ravel()
+    df = pd.DataFrame(mydata, index=index,
+                      columns=[dependent_col_name])
+    return df
+
+
+def _generate_pandas_index(data: Dict[str, np.ndarray]) -> Union[pd.Index, pd.MultiIndex]:
+    # the first element in the dict given by parameter_tree is always the dependent
+    # parameter and the index is therefore formed from the rest
+    import pandas as pd
+    keys = list(data.keys())
+    if len(data) <= 1:
+        index = None
+    elif len(data) == 2:
+        index = pd.Index(data[keys[1]].ravel(), name=keys[1])
+    else:
+        index_data = tuple(np.concatenate(data[key])
+                           if data[key].dtype == np.dtype('O')
+                           else data[key].ravel()
+                           for key in keys[1:])
+        index = pd.MultiIndex.from_arrays(
+            index_data,
+            names=keys[1:])
+    return index
+
+
+def _load_to_dataframe_dict(datadict: ParameterData) -> Dict[str, pd.DataFrame]:
+    dfs = {}
+    for name, subdict in datadict.items():
+        index = _generate_pandas_index(subdict)
+        dfs[name] = _data_to_dataframe(subdict, index)
+    return dfs
+
+
+def _parameter_data_identical(param_dict_a: Dict[str, np.ndarray],
+                              param_dict_b: Dict[str, np.ndarray]) -> bool:
+
+    try:
+        np.testing.assert_equal(param_dict_a, param_dict_b)
+    except AssertionError:
+        return False
+
+    return True
+
+
+def _same_setpoints(datadict: ParameterData) -> bool:
+
+    def _get_setpoints(dd: ParameterData) -> Iterator[Dict[str, np.ndarray]]:
+
+        for dep_name, param_dict in dd.items():
+            out = {
+                name: vals for name, vals in param_dict.items() if name != dep_name
+            }
+            yield out
+
+    sp_iterator = _get_setpoints(datadict)
+
+    try:
+        first = next(sp_iterator)
+    except StopIteration:
+        return True
+
+    return all(_parameter_data_identical(first, rest) for rest in sp_iterator)
+
+
+def _load_to_concatenated_dataframe(
+        datadict: ParameterData
+) -> "pd.DataFrame":
+    import pandas as pd
+
+    if not _same_setpoints(datadict):
+        warnings.warn(
+            "Independent parameter setpoints are not equal. "
+            "Check concatenated output carefully. Please "
+            "consider using `to_pandas_dataframe_dict` to export each "
+            "independent parameter to its own dataframe."
+        )
+
+    dfs_dict = _load_to_dataframe_dict(datadict)
+    df = pd.concat(list(dfs_dict.values()), axis=1)
+
+    return df

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import warnings
 
-from typing import Dict, TYPE_CHECKING, Union, Iterator, cast, Hashable
+from typing import Dict, TYPE_CHECKING, Union, cast, Hashable
 
 import numpy as np
 
 from ..descriptions.versioning import serialization as serial
+from .export_to_pandas import _generate_pandas_index, _data_to_dataframe, _same_setpoints
 
 if TYPE_CHECKING:
-    import pandas as pd
     import xarray as xr
     from qcodes.dataset.data_set import DataSet, ParameterData
 
@@ -49,103 +49,6 @@ def load_to_xarray_dataarray_dict(
     for dataarray in dataarrays.values():
         _add_metadata_to_xarray(dataset, dataarray)
     return dataarrays
-
-
-def _data_to_dataframe(data: Dict[str, np.ndarray], index: Union[pd.Index, pd.MultiIndex]) -> pd.DataFrame:
-    import pandas as pd
-    if len(data) == 0:
-        return pd.DataFrame()
-    dependent_col_name = list(data.keys())[0]
-    dependent_data = data[dependent_col_name]
-    if dependent_data.dtype == np.dtype('O'):
-        # ravel will not fully unpack a numpy array of arrays
-        # which are of "object" dtype. This can happen if a variable
-        # length array is stored in the db. We use concatenate to
-        # flatten these
-        mydata = np.concatenate(dependent_data)
-    else:
-        mydata = dependent_data.ravel()
-    df = pd.DataFrame(mydata, index=index,
-                      columns=[dependent_col_name])
-    return df
-
-
-def _generate_pandas_index(data: Dict[str, np.ndarray]) -> Union[pd.Index, pd.MultiIndex]:
-    # the first element in the dict given by parameter_tree is always the dependent
-    # parameter and the index is therefore formed from the rest
-    import pandas as pd
-    keys = list(data.keys())
-    if len(data) <= 1:
-        index = None
-    elif len(data) == 2:
-        index = pd.Index(data[keys[1]].ravel(), name=keys[1])
-    else:
-        index_data = tuple(np.concatenate(data[key])
-                           if data[key].dtype == np.dtype('O')
-                           else data[key].ravel()
-                           for key in keys[1:])
-        index = pd.MultiIndex.from_arrays(
-            index_data,
-            names=keys[1:])
-    return index
-
-
-def load_to_dataframe_dict(datadict: ParameterData) -> Dict[str, pd.DataFrame]:
-    dfs = {}
-    for name, subdict in datadict.items():
-        index = _generate_pandas_index(subdict)
-        dfs[name] = _data_to_dataframe(subdict, index)
-    return dfs
-
-
-def _parameter_data_identical(param_dict_a: Dict[str, np.ndarray],
-                              param_dict_b: Dict[str, np.ndarray]) -> bool:
-
-    try:
-        np.testing.assert_equal(param_dict_a, param_dict_b)
-    except AssertionError:
-        return False
-
-    return True
-
-
-def _same_setpoints(datadict: ParameterData) -> bool:
-
-    def _get_setpoints(dd: ParameterData) -> Iterator[Dict[str, np.ndarray]]:
-
-        for dep_name, param_dict in dd.items():
-            out = {
-                name: vals for name, vals in param_dict.items() if name != dep_name
-            }
-            yield out
-
-    sp_iterator = _get_setpoints(datadict)
-
-    try:
-        first = next(sp_iterator)
-    except StopIteration:
-        return True
-
-    return all(_parameter_data_identical(first, rest) for rest in sp_iterator)
-
-
-def load_to_concatenated_dataframe(
-        datadict: ParameterData
-) -> "pd.DataFrame":
-    import pandas as pd
-
-    if not _same_setpoints(datadict):
-        warnings.warn(
-            "Independent parameter setpoints are not equal. "
-            "Check concatenated output carefully. Please "
-            "consider using `to_pandas_dataframe_dict` to export each "
-            "independent parameter to its own dataframe."
-        )
-
-    dfs_dict = load_to_dataframe_dict(datadict)
-    df = pd.concat(list(dfs_dict.values()), axis=1)
-
-    return df
 
 
 def _add_metadata_to_xarray(

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -103,4 +103,6 @@ def load_to_xarray_dataset(dataset: DataSet, data: ParameterData) -> xr.Dataset:
             paramspec_dict = dataset.paramspecs[str(dim)]._to_dict()
             xrdataset.coords[str(dim)].attrs.update(paramspec_dict.items())
 
+    _add_metadata_to_xarray(dataset, xrdataset)
+
     return xrdataset


### PR DESCRIPTION
This will eventually enable us to reuse these in other dataset implementations. 
This could also have been achieved by making a base class but since the coupling to the dataset is not very strong
and they are also used from the cache I think it makes more sense to move them into their own module

