### PR TITLE
fix(logger): Disable conditionally start logging for Sphinx documenta…

### DIFF
--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -356,7 +356,7 @@ def conditionally_start_all_logging() -> None:
         tools = (
             'pytest.py',
             'pytest',
-            'sphinx\__main__.py',    # Sphinx docs building
+            r'sphinx\__main__.py',    # Sphinx docs building
             '_jb_pytest_runner.py',  # Jetbrains Pycharm
             'testlauncher.py'        # VSCode
         )

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -356,12 +356,13 @@ def conditionally_start_all_logging() -> None:
         tools = (
             'pytest.py',
             'pytest',
+            'sphinx\__main__.py',    # Sphinx docs building
             '_jb_pytest_runner.py',  # Jetbrains Pycharm
             'testlauncher.py'        # VSCode
         )
         return any(sys.argv[0].endswith(tool) for tool in tools)
-
-    if start_logging_on_import() and not running_in_test_or_tool():
+    
+    if not running_in_test_or_tool() and start_logging_on_import():
         start_all_logging()
 
 

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -361,7 +361,7 @@ def conditionally_start_all_logging() -> None:
             'testlauncher.py'        # VSCode
         )
         return any(sys.argv[0].endswith(tool) for tool in tools)
-    
+
     if not running_in_test_or_tool() and start_logging_on_import():
         start_all_logging()
 


### PR DESCRIPTION
Disable conditionally start logging for Sphinx documentation. Solves #2908


Fixes #2908.

Changes proposed in this pull request:
- Swapped `start_logging_on_import` and `running_in_test_or_tool` so that the tools are evaluated before starting logging on import.
- Added sphinx main to the list of tools.

**Edit** This is not really a proper fix for the issue that seems to be lying elsewhere but a work around that should enable users to build documentation in certain configurations.