### PR TITLE
Name legacy test datasets

### DIFF
--- a/qcodes/tests/legacy/test_data.py
+++ b/qcodes/tests/legacy/test_data.py
@@ -288,7 +288,7 @@ class TestDataArray(TestCase):
         xarray_dataarray = data.to_xarray()
 
     def test_xarray_conversions(self):
-        da = DataSet1D().x_set
+        da = DataSet1D(name="TestDataArray_test_xarray_conversions").x_set
 
         xarray_dictionary = data_array_to_xarray_dictionary(da)
 
@@ -599,7 +599,7 @@ class TestDataSet(TestCase):
         self.assertFalse('z' in m.arrays)
 
     def test_xarray_conversions(self):
-        qd = DataSet1D()
+        qd = DataSet1D(name="TestNewData_test_xarray_conversions")
         xarray_data_set = qcodes_dataset_to_xarray_dataset(qd)
         qd_transformed = xarray_dataset_to_qcodes_dataset(xarray_data_set)
         m = qd.default_parameter_array()
@@ -607,7 +607,7 @@ class TestDataSet(TestCase):
 
         for key in ["name", "unit"]:
             self.assertEqual(getattr(m, key), getattr(mt, key))
-        qd2 = DataSet2D()
+        qd2 = DataSet2D(name="TestNewData_test_xarray_conversions")
         xarray_data_set = qcodes_dataset_to_xarray_dataset(qd2)
         qd2_transformed = xarray_dataset_to_qcodes_dataset(xarray_data_set)
 

--- a/qcodes/tests/legacy/test_generic_formatter.py
+++ b/qcodes/tests/legacy/test_generic_formatter.py
@@ -47,4 +47,4 @@ class TestNoSorting(TestCase):
                              )
 
     def test_can_measure(self):
-        qcodes.measure.Measure(self.param).run()
+        qcodes.measure.Measure(self.param).run(name="test_no_sorting")

--- a/qcodes/tests/legacy/test_loop.py
+++ b/qcodes/tests/legacy/test_loop.py
@@ -115,7 +115,7 @@ class TestLoop(TestCase):
     def test_measurement_with_many_nans(self):
         loop = Loop(self.p1.sweep(0, 1, num=10),
                     delay=0.05).each(self.p4_crazy)
-        ds = loop.get_data_set()
+        ds = loop.get_data_set(name="test_measurement_with_many_nans")
         loop.run()
 
         # assert that both the snapshot and the datafile are there


### PR DESCRIPTION
Otherwise there is a risk of race condition when multiple datasets are created at the same time by tests executing in parallel. 
An example of that can be seen here https://github.com/QCoDeS/Qcodes/pull/2894/checks?check_run_id=2401386164