### PR TITLE
use python -m pip to upgrade pip in github actions

### DIFF
--- a/.github/actions/prepare-cache-pip/action.yml
+++ b/.github/actions/prepare-cache-pip/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: upgrade pip setuptools wheel
-      run: pip install --upgrade pip setuptools wheel
+      run: python -m pip install --upgrade pip setuptools wheel
       shell: bash
     - name: Get pip cache dir
       id: get-pip-cache-dir


### PR DESCRIPTION
This will hopefully avoid a permission error when pip tries to replace pip on windows

