### PR TITLE
try changing formatting for env markers differently

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -15,7 +15,7 @@ docutils==0.16
 entrypoints==0.3
 idna==2.10
 imagesize==1.2.0
-importlib-metadata==4.0.0;python_version<'3.8'
+importlib-metadata==4.0.0; python_version<'3.8'
 ipykernel==5.5.3
 ipython==7.22.0
 ipython-genutils==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ google-auth~=1.30.0
 googleapis-common-protos~=1.53.0
 h5py~=3.2.1
 idna~=2.10
-importlib-metadata==4.0.0;python_version<'3.8'
+importlib-metadata==4.0.0; python_version<'3.8'
 ipykernel~=5.5.3
 ipython~=7.22.0
 ipython-genutils~=0.2.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,7 +10,7 @@ deepdiff==5.3.0
 execnet==1.8.0
 hypothesis==6.10.1
 idna==2.10
-importlib-metadata==4.0.0;python_version<'3.8'
+importlib-metadata==4.0.0; python_version<'3.8'
 iniconfig==1.1.1
 lxml==4.6.3
 mypy==0.812


### PR DESCRIPTION
Perhaps this will enable dependabot to parse them correctly?
Since it has no problem with the pywin32 related env markers