### PR TITLE
Add darker to precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,7 @@ repos:
     - id: pyupgrade
       args: ['--py37-plus']
       exclude: _version.py|versioneer.py
+  - repo: https://github.com/akaihola/darker
+    rev: 1.2.3
+    hooks:
+      -   id: darker

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,5 @@ repos:
     rev: 1.2.3
     hooks:
       -   id: darker
+          args: [-i]
+          additional_dependencies: [isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,4 @@
 [tool.isort]
 profile = "black"
+[tool.darker]
+isort = true


### PR DESCRIPTION
This adds darker https://github.com/akaihola/darker as a pre commit hook. Darker basically works as a incremental version of black that only reformat the code that has been changed in a given pr
