### PR TITLE
add _repr_html_ for qcodes instruments

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -1,18 +1,31 @@
 """Instrument base class."""
+import logging
 import time
 import weakref
-import logging
 from abc import ABC, abstractmethod
-from typing import Sequence, Optional, Dict, Union, Callable, Any, List, \
-    TYPE_CHECKING, cast, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+    cast,
+)
 
 import numpy as np
-from qcodes.utils.helpers import DelegateAttributes, strip_attrs, full_class
+
+from qcodes.logger.instrument_logger import get_instrument_logger
+from qcodes.utils.helpers import DelegateAttributes, full_class, strip_attrs
 from qcodes.utils.metadata import Metadatable
 from qcodes.utils.validators import Anything
-from qcodes.logger.instrument_logger import get_instrument_logger
-from .parameter import Parameter, _BaseParameter
+
+from .base_representation import instrument_repr_html
 from .function import Function
+from .parameter import Parameter, _BaseParameter
 
 if TYPE_CHECKING:
     from qcodes.instrument.channel import ChannelList
@@ -497,6 +510,10 @@ class Instrument(InstrumentBase, AbstractInstrument):
     def __repr__(self) -> str:
         """Simplified repr giving just the class and name."""
         return '<{}: {}>'.format(type(self).__name__, self.name)
+
+    def _repr_html_(self) -> str:
+        """Fancy representation adding Parameters and Functions."""
+        return instrument_repr_html(self)
 
     def __del__(self) -> None:
         """Close the instrument and remove its instance record."""

--- a/qcodes/instrument/base_representation.py
+++ b/qcodes/instrument/base_representation.py
@@ -93,7 +93,7 @@ def instrument_repr_html(self: "qcodes.instrument.base.Instrument") -> str:
     }
 
     sections = [
-        parameter_section(section_data),  # type: ignore
+        parameter_section(section_data),
         functions_section(functions_section_data),
     ]
 

--- a/qcodes/instrument/base_representation.py
+++ b/qcodes/instrument/base_representation.py
@@ -93,7 +93,7 @@ def instrument_repr_html(self: "qcodes.instrument.base.Instrument") -> str:
     }
 
     sections = [
-        parameter_section(section_data),
+        parameter_section(section_data),  # type: ignore
         functions_section(functions_section_data),
     ]
 

--- a/qcodes/instrument/base_representation.py
+++ b/qcodes/instrument/base_representation.py
@@ -47,11 +47,14 @@ def create_entries(variables: Dict[str, Entry]) -> str:
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 
+from xarray.core.options import DISPLAY_EXPAND_ATTRS
+
 parameter_section = partial(
     _mapping_section,
     name="Parameters",
     details_func=create_entries,
     max_items_collapse=10,
+    expand_option_name=DISPLAY_EXPAND_ATTRS,
 )
 
 functions_section = partial(
@@ -59,6 +62,7 @@ functions_section = partial(
     name="Functions",
     details_func=create_entries,
     max_items_collapse=10,
+    expand_option_name=DISPLAY_EXPAND_ATTRS,
 )
 
 

--- a/qcodes/instrument/base_representation.py
+++ b/qcodes/instrument/base_representation.py
@@ -1,0 +1,95 @@
+""" Representation methods for instruments """
+import logging
+import uuid
+from collections import namedtuple
+from functools import partial
+from html import escape
+
+import numpy as np
+from xarray.core.formatting_html import _icon, _mapping_section, _obj_repr
+
+
+def create_entry(ed, preview=None):
+    name = ed.name
+    preview = ed.short
+    long = ed.long
+
+    data_id = "data-" + str(uuid.uuid4())
+    data_icon = _icon("icon-database")
+    data_repr = f"{long}"
+    cssclass_idx = " class='xr-has-index'"
+
+    logging.debug(f"create_entry: {name} {preview}")
+
+    disabled = "" if long is not None else "disabled"
+
+    return (
+        f"<div class='xr-var-name'><span{cssclass_idx}>{name}</span></div>"
+        f"<div class='xr-var-preview xr-preview'>{preview}</div>"
+        f"<input id='{data_id}' class='xr-var-data-in' type='checkbox' {disabled}>"
+        f"<label for='{data_id}' title='Show/Hide data repr'>"
+        f"{data_icon}</label>"
+        f"<div class='xr-var-data'>{data_repr}</div>"
+    )
+
+
+def create_entries(variables):
+    logging.debug(f"create_entries: {variables}")
+    vars_li = "".join(
+        f"<li class='xr-var-item'>{create_entry(entry)}</li>"
+        for name, entry in variables.items()
+    )
+
+    return f"<ul class='xr-var-list'>{vars_li}</ul>"
+
+
+parameter_section = partial(
+    _mapping_section,
+    name="Parameters",
+    details_func=create_entries,
+    max_items_collapse=10,
+)
+
+functions_section = partial(
+    _mapping_section,
+    name="Functions",
+    details_func=create_entries,
+    max_items_collapse=10,
+)
+
+
+def instrument_repr_html(self):
+    obj_type = "{}".format(type(self).__name__)
+
+    name = self.name
+    header_components = [f"<div class='xr-obj-type'>{escape(obj_type)}: {name}</div>"]
+
+    Entry = namedtuple("SectionEntry", ["name", "short", "long"])
+
+    dd = []
+    parameters = list(self.parameters.keys())
+    for ii, parameter_name in enumerate(sorted(parameters)):
+        parameter = self.parameters[parameter_name]
+        try:
+            short = f"{parameter()} [{parameter.unit}]"
+        except:
+            short = None
+        timestamp = parameter.cache.timestamp
+
+        def hcolor(txt):
+            return f'<span style="color:#777777">{txt}</span>'
+
+        long = f"unit: {hcolor(parameter.unit)}, label: {hcolor(parameter.label)}, timestamp: {hcolor(timestamp)}"
+        dd.append(Entry(parameter_name, short=short, long=long))
+    section_data = {ed.name: ed for ed in dd}
+
+    functions_section_data = {
+        key: Entry(key, str(function), None) for key, function in self.functions.items()
+    }
+
+    sections = [
+        parameter_section(section_data),
+        functions_section(functions_section_data),
+    ]
+
+    return _obj_repr(self, header_components, sections)

--- a/qcodes/instrument/base_representation.py
+++ b/qcodes/instrument/base_representation.py
@@ -7,6 +7,7 @@ from html import escape
 from typing import Any, Dict, Optional
 
 from xarray.core.formatting_html import _icon, _mapping_section, _obj_repr
+from xarray.core.options import DISPLAY_EXPAND_ATTRS
 
 import qcodes
 
@@ -47,7 +48,6 @@ def create_entries(variables: Dict[str, Entry]) -> str:
     return f"<ul class='xr-var-list'>{vars_li}</ul>"
 
 
-from xarray.core.options import DISPLAY_EXPAND_ATTRS
 
 parameter_section = partial(
     _mapping_section,

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -1,17 +1,18 @@
 """
 Test suite for instument.base.*
 """
-import pytest
-import weakref
-import io
 import contextlib
+import io
 import re
+import weakref
+
+import pytest
 
 from qcodes.instrument.base import Instrument, InstrumentBase, find_or_create_instrument
-from qcodes.instrument.parameter import Parameter
 from qcodes.instrument.function import Function
+from qcodes.instrument.parameter import Parameter
 
-from .instrument_mocks import DummyInstrument, MockParabola, MockMetaParabola
+from .instrument_mocks import DummyInstrument, MockMetaParabola, MockParabola
 
 
 @pytest.fixture(name='testdummy', scope='function')
@@ -273,6 +274,10 @@ def test_instrumentbase_metadata():
     instrument = InstrumentBase('instr', metadata=metadatadict)
     assert instrument.metadata == metadatadict
 
+
+def test_instrument_repr_html():
+    html_repr = DummyInstrument("test")._repr_html_()
+    assert isinstance(html_repr, str)
 
 def test_snapshot_and_meta_attrs():
     """Test snapshot of InstrumentBase contains _meta_attrs attributes"""


### PR DESCRIPTION

Changes proposed in this pull request:
- Add `_repr_html_` for all qcodes instruments. This gives a nice representation in tools like jupyter notebook.

New representation:

![image](https://user-images.githubusercontent.com/17724047/117361081-dd4e2180-aeb9-11eb-905d-e836d443868f.png)

Old representation: 

![image](https://user-images.githubusercontent.com/17724047/117361400-46ce3000-aeba-11eb-9b60-c2bde64ac533.png)

@jenshnielsen 
