### PR TITLE
Make doNd reset original post_delay values + fix to keyboard interrupt

### DIFF
--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -313,6 +313,8 @@ def do1d(
                          shapes=shapes)
     _set_write_period(meas, write_period)
     _register_actions(meas, enter_actions, exit_actions)
+
+    original_delay = param_set.post_delay
     param_set.post_delay = delay
 
     # do1D enforces a simple relationship between measured parameters
@@ -335,6 +337,9 @@ def do1d(
                 *_process_params_meas(param_meas, use_threads=use_threads),
                 *additional_setpoints_data
             )
+
+    param_set.post_delay = original_delay
+
     return _handle_plotting(dataset, do_plot, interrupted())
 
 
@@ -440,6 +445,9 @@ def do2d(
     _set_write_period(meas, write_period)
     _register_actions(meas, enter_actions, exit_actions)
 
+    original_delay1 = param_set1.post_delay
+    original_delay2 = param_set2.post_delay
+
     param_set1.post_delay = delay1
     param_set2.post_delay = delay2
 
@@ -480,6 +488,10 @@ def do2d(
                 action()
             if flush_columns:
                 datasaver.flush_data_to_database()
+
+    param_set1.post_delay = original_delay1
+    param_set2.post_delay = original_delay2
+
     return _handle_plotting(dataset, do_plot, interrupted())
 
 

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -319,6 +319,7 @@ def do1d(
     # and set parameters. For anything more complicated this should be
     # reimplemented from scratch
     with _catch_keyboard_interrupts() as interrupted, meas.run() as datasaver:
+        dataset = datasaver.dataset
         additional_setpoints_data = _process_params_meas(additional_setpoints)
         setpoints = np.linspace(start, stop, num_points)
 
@@ -334,7 +335,6 @@ def do1d(
                 *_process_params_meas(param_meas, use_threads=use_threads),
                 *additional_setpoints_data
             )
-        dataset = datasaver.dataset
     return _handle_plotting(dataset, do_plot, interrupted())
 
 
@@ -444,6 +444,7 @@ def do2d(
     param_set2.post_delay = delay2
 
     with _catch_keyboard_interrupts() as interrupted, meas.run() as datasaver:
+        dataset = datasaver.dataset
         additional_setpoints_data = _process_params_meas(additional_setpoints)
         setpoints1 = np.linspace(start1, stop1, num_points1)
         for set_point1 in tqdm(setpoints1, disable=not show_progress):
@@ -479,7 +480,6 @@ def do2d(
                 action()
             if flush_columns:
                 datasaver.flush_data_to_database()
-        dataset = datasaver.dataset
     return _handle_plotting(dataset, do_plot, interrupted())
 
 


### PR DESCRIPTION
doNd functions will currently modify post_delay values on swept parameters that will propagate outside of the doNd function. This will modify sweep rates of the parameter if post_delay/step values are used to limit sweep rates in qcodes.
Ideally this would also be added to the interrupt handle context but didnt include it there as I am not too familiar with python contexts.

Also moved dataset definition up to before the context starts as a keyboard interrupt throws an error due to dataset not being defined.

PR has been tested on offline computer but not actual measurements for now.