### PR TITLE
replace the use of Dict with Mapping for input args within instrument module

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -9,6 +9,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Mapping,
     Optional,
     Sequence,
     Type,
@@ -43,8 +44,8 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         metadata: additional static metadata to add to this
             instrument's JSON snapshot.
     """
-    def __init__(self, name: str,
-                 metadata: Optional[Dict[Any, Any]] = None) -> None:
+
+    def __init__(self, name: str, metadata: Optional[Mapping[Any, Any]] = None) -> None:
         self._name = str(name)
         self._short_name = str(name)
 
@@ -429,8 +430,7 @@ class Instrument(InstrumentBase, AbstractInstrument):
     _type = None
     _instances: "List[weakref.ref[Instrument]]" = []
 
-    def __init__(self, name: str,
-                 metadata: Optional[Dict[Any, Any]] = None) -> None:
+    def __init__(self, name: str, metadata: Optional[Mapping[Any, Any]] = None) -> None:
         self._t0 = time.time()
 
         super().__init__(name, metadata)

--- a/qcodes/instrument/delegate/delegate_channel_instrument.py
+++ b/qcodes/instrument/delegate/delegate_channel_instrument.py
@@ -1,6 +1,7 @@
-from typing import Dict, Sequence, Any, Optional
-from qcodes.station import Station
+from typing import Any, Mapping, Optional, Sequence
+
 from qcodes.instrument.delegate.delegate_instrument import DelegateInstrument
+from qcodes.station import Station
 
 
 class DelegateChannelInstrument(DelegateInstrument):
@@ -63,8 +64,8 @@ class DelegateChannelInstrument(DelegateInstrument):
         name: str,
         station: Station,
         channels: str,
-        parameters: Dict[str, Sequence[str]],
-        initial_values: Optional[Dict[str, Any]] = None,
+        parameters: Mapping[str, Sequence[str]],
+        initial_values: Optional[Mapping[str, Any]] = None,
         set_initial_values_on_load: bool = False,
         **kwargs: Any):
         _channels = self.parse_instrument_path(parent=station, path=channels)

--- a/qcodes/instrument/delegate/delegate_instrument.py
+++ b/qcodes/instrument/delegate/delegate_instrument.py
@@ -4,7 +4,6 @@ from functools import partial
 from typing import (
     Any,
     Callable,
-    Dict,
     List,
     Mapping,
     MutableMapping,
@@ -101,7 +100,7 @@ class DelegateInstrument(InstrumentBase):
         set_initial_values_on_load: bool = False,
         setters: Optional[Mapping[str, MutableMapping[str, Any]]] = None,
         units: Optional[Mapping[str, str]] = None,
-        metadata: Optional[Dict[Any, Any]] = None
+        metadata: Optional[Mapping[Any, Any]] = None,
     ):
         super().__init__(name=name, metadata=metadata)
         self._create_and_add_parameters(

--- a/qcodes/instrument/delegate/grouped_parameter.py
+++ b/qcodes/instrument/delegate/grouped_parameter.py
@@ -1,22 +1,24 @@
-from qcodes.instrument.group_parameter import Group, GroupParameter
+from collections import OrderedDict, namedtuple
 from typing import (
+    TYPE_CHECKING,
     Any,
+    Callable,
     Dict,
     Iterable,
+    Mapping,
     Optional,
+    Sequence,
     Tuple,
     Union,
-    Sequence,
-    Callable,
-    TYPE_CHECKING
 )
-from collections import namedtuple, OrderedDict
+
+from qcodes.instrument.group_parameter import Group, GroupParameter
 from qcodes.instrument.parameter import (
     DelegateParameter,
     ParamDataType,
-    ParamRawDataType,
     Parameter,
-    _BaseParameter
+    ParamRawDataType,
+    _BaseParameter,
 )
 
 if TYPE_CHECKING:
@@ -122,10 +124,7 @@ class DelegateGroup(Group):
     def _namedtuple(self, *args: Any, **kwargs: Any) -> Tuple[Any, ...]:
         return namedtuple(self.name, self._parameter_names)(*args, **kwargs)
 
-    def set(
-        self,
-        value: Union[ParamDataType, Dict[str, ParamDataType]]
-    ) -> None:
+    def set(self, value: Union[ParamDataType, Mapping[str, ParamDataType]]) -> None:
         if self._set_fn is not None:
             self._set_fn(value)
         else:
@@ -144,7 +143,7 @@ class DelegateGroup(Group):
     def get_parameters(self) -> Any:
         return self._formatter(*[_p.get() for _p in self.parameters.values()])
 
-    def _set_from_dict(self, calling_dict: Dict[str, ParamRawDataType]) -> None:
+    def _set_from_dict(self, calling_dict: Mapping[str, ParamRawDataType]) -> None:
         for name, p in list(self.parameters.items()):
             p.set(calling_dict[name])
 
@@ -209,11 +208,11 @@ class GroupedParameter(_BaseParameter):
         """Get source parameters of each DelegateParameter"""
         return self.group.source_parameters
 
-    def get_raw(self) -> Union[ParamDataType, Dict[str, ParamDataType]]:
+    def get_raw(self) -> Union[ParamDataType, Mapping[str, ParamDataType]]:
         """Get parameter raw value"""
         return self.group.get_parameters()
 
-    def set_raw(self, value: Union[ParamDataType, Dict[str, ParamDataType]]) -> None:
+    def set_raw(self, value: Union[ParamDataType, Mapping[str, ParamDataType]]) -> None:
         """Set parameter raw value
 
         Args:

--- a/qcodes/instrument/delegate/instrument_group.py
+++ b/qcodes/instrument/delegate/instrument_group.py
@@ -1,6 +1,5 @@
 import importlib
-
-from typing import List, Dict, Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, List, Mapping
 
 from qcodes.instrument.base import InstrumentBase
 
@@ -31,8 +30,8 @@ class InstrumentGroup(InstrumentBase):
         name: str,
         station: "Station",
         submodules_type: str,
-        submodules: Dict[str, Dict[str, List[str]]],
-        initial_values: Dict[str, Dict[str, Any]],
+        submodules: Mapping[str, Mapping[str, List[str]]],
+        initial_values: Mapping[str, Mapping[str, Any]],
         set_initial_values_on_load: bool = False,
         **kwargs: Any
     ):

--- a/qcodes/instrument/group_parameter.py
+++ b/qcodes/instrument/group_parameter.py
@@ -6,12 +6,10 @@ should be of type :class:`GroupParameter`
 
 
 from collections import OrderedDict
-from typing import Union, Callable, Dict, Any, Optional, Sequence
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Union
 
-from qcodes.instrument.parameter import (DelegateParameter, Parameter,
-                                         ParamRawDataType,
-                                         ParamDataType)
 from qcodes.instrument.base import InstrumentBase
+from qcodes.instrument.parameter import ParamDataType, Parameter, ParamRawDataType
 
 
 class GroupParameter(Parameter):
@@ -158,15 +156,16 @@ class Group:
         single_instrument: A flag to indicate that all parameters belong to a
         single instrument, which in turn does additional checks. Defaults to True.
     """
-    def __init__(self,
-                 parameters: Sequence[GroupParameter],
-                 set_cmd: Optional[str] = None,
-                 get_cmd: Optional[str] = None,
-                 get_parser: Union[Callable[[str],
-                                            Dict[str, Any]], None] = None,
-                 separator: str = ',',
-                 single_instrument: bool = True
-                 ) -> None:
+
+    def __init__(
+        self,
+        parameters: Sequence[GroupParameter],
+        set_cmd: Optional[str] = None,
+        get_cmd: Optional[str] = None,
+        get_parser: Union[Callable[[str], Mapping[str, Any]], None] = None,
+        separator: str = ",",
+        single_instrument: bool = True,
+    ) -> None:
         self._parameters = OrderedDict((p.name, p) for p in parameters)
 
         for p in parameters:
@@ -221,8 +220,7 @@ class Group:
 
         return parser
 
-    def set_parameters(self,
-                       parameters_dict: Dict[str, ParamDataType]) -> None:
+    def set_parameters(self, parameters_dict: Mapping[str, ParamDataType]) -> None:
         """
         Sets the value of one or more parameters within a group to the given
         values by calling the ``set_cmd`` while updating rest.
@@ -264,7 +262,7 @@ class Group:
 
         self._set_from_dict(calling_dict)
 
-    def _set_from_dict(self, calling_dict: Dict[str, ParamRawDataType]) -> None:
+    def _set_from_dict(self, calling_dict: Mapping[str, ParamRawDataType]) -> None:
         """
         Use ``set_cmd`` to parse a dict that maps parameter names to parameter
         raw values, and actually perform setting the values.

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -72,33 +72,53 @@ more specialized ones:
 # create an ABC for Parameter and MultiParameter - or just remove this statement
 # if everyone is happy to use these classes.
 
-from datetime import datetime, timedelta
-from copy import copy
-from operator import xor
-import time
+import collections
+import enum
 import logging
 import os
-import collections
+import time
 import warnings
-import enum
-from typing import Optional, Sequence, TYPE_CHECKING, Union, Callable, List, \
-    Dict, Any, Sized, Iterable, cast, Type, Tuple, Iterator
-from typing_extensions import Protocol
-from types import TracebackType
+from copy import copy
+from datetime import datetime, timedelta
 from functools import wraps
+from operator import xor
+from types import TracebackType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Sized,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 import numpy
+from typing_extensions import Protocol
 
-from qcodes.utils.deprecate import deprecate, issue_deprecation_warning
-from qcodes.utils.helpers import abstractmethod
-from qcodes.utils.helpers import (permissive_range, is_sequence_of,
-                                  DelegateAttributes, full_class, named_repr,
-                                  warn_units)
-from qcodes.utils.metadata import Metadatable
-from qcodes.utils.command import Command
-from qcodes.utils.validators import Validator, Ints, Strings, Enum, Arrays
-from qcodes.instrument.sweep_values import SweepFixedValues
 from qcodes.data.data_array import DataArray
+from qcodes.instrument.sweep_values import SweepFixedValues
+from qcodes.utils.command import Command
+from qcodes.utils.deprecate import deprecate, issue_deprecation_warning
+from qcodes.utils.helpers import (
+    DelegateAttributes,
+    abstractmethod,
+    full_class,
+    is_sequence_of,
+    named_repr,
+    permissive_range,
+    warn_units,
+)
+from qcodes.utils.metadata import Metadatable
+from qcodes.utils.validators import Arrays, Enum, Ints, Strings, Validator
 
 if TYPE_CHECKING:
     from .base import Instrument, InstrumentBase
@@ -156,7 +176,7 @@ class _SetParamContext:
             self._parameter.set(self._original_value)
 
 
-def invert_val_mapping(val_mapping: Dict[Any, Any]) -> Dict[Any, Any]:
+def invert_val_mapping(val_mapping: Mapping[Any, Any]) -> Dict[Any, Any]:
     """Inverts the value mapping dictionary for allowed parameter values"""
     return {v: k for k, v in val_mapping.items()}
 
@@ -243,22 +263,25 @@ class _BaseParameter(Metadatable):
             JSON snapshot of the parameter
     """
 
-    def __init__(self, name: str,
-                 instrument: Optional['InstrumentBase'],
-                 snapshot_get: bool = True,
-                 metadata: Optional[Dict[Any, Any]] = None,
-                 step: Optional[float] = None,
-                 scale: Optional[Union[float, Iterable[float]]] = None,
-                 offset: Optional[Union[float, Iterable[float]]] = None,
-                 inter_delay: float = 0,
-                 post_delay: float = 0,
-                 val_mapping: Optional[Dict[Any, Any]] = None,
-                 get_parser: Optional[Callable[..., Any]] = None,
-                 set_parser: Optional[Callable[..., Any]] = None,
-                 snapshot_value: bool = True,
-                 snapshot_exclude: bool = False,
-                 max_val_age: Optional[float] = None,
-                 vals: Optional[Validator[Any]] = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        instrument: Optional["InstrumentBase"],
+        snapshot_get: bool = True,
+        metadata: Optional[Mapping[Any, Any]] = None,
+        step: Optional[float] = None,
+        scale: Optional[Union[float, Iterable[float]]] = None,
+        offset: Optional[Union[float, Iterable[float]]] = None,
+        inter_delay: float = 0,
+        post_delay: float = 0,
+        val_mapping: Optional[Mapping[Any, Any]] = None,
+        get_parser: Optional[Callable[..., Any]] = None,
+        set_parser: Optional[Callable[..., Any]] = None,
+        snapshot_value: bool = True,
+        snapshot_exclude: bool = False,
+        max_val_age: Optional[float] = None,
+        vals: Optional[Validator[Any]] = None,
+    ) -> None:
         super().__init__(metadata)
         if not str(name).isidentifier():
             raise ValueError(f"Parameter name must be a valid identifier "
@@ -1632,24 +1655,31 @@ class ArrayParameter(_BaseParameter):
             JSON snapshot of the parameter.
     """
 
-    def __init__(self,
-                 name: str,
-                 shape: Sequence[int],
-                 instrument: Optional['InstrumentBase'] = None,
-                 label: Optional[str] = None,
-                 unit: Optional[str] = None,
-                 setpoints: Optional[Sequence[Any]] = None,
-                 setpoint_names: Optional[Sequence[str]] = None,
-                 setpoint_labels: Optional[Sequence[str]] = None,
-                 setpoint_units: Optional[Sequence[str]] = None,
-                 docstring: Optional[str] = None,
-                 snapshot_get: bool = True,
-                 snapshot_value: bool = False,
-                 snapshot_exclude: bool = False,
-                 metadata: Optional[Dict[Any, Any]] = None) -> None:
-        super().__init__(name, instrument, snapshot_get, metadata,
-                         snapshot_value=snapshot_value,
-                         snapshot_exclude=snapshot_exclude)
+    def __init__(
+        self,
+        name: str,
+        shape: Sequence[int],
+        instrument: Optional["InstrumentBase"] = None,
+        label: Optional[str] = None,
+        unit: Optional[str] = None,
+        setpoints: Optional[Sequence[Any]] = None,
+        setpoint_names: Optional[Sequence[str]] = None,
+        setpoint_labels: Optional[Sequence[str]] = None,
+        setpoint_units: Optional[Sequence[str]] = None,
+        docstring: Optional[str] = None,
+        snapshot_get: bool = True,
+        snapshot_value: bool = False,
+        snapshot_exclude: bool = False,
+        metadata: Optional[Mapping[Any, Any]] = None,
+    ) -> None:
+        super().__init__(
+            name,
+            instrument,
+            snapshot_get,
+            metadata,
+            snapshot_value=snapshot_value,
+            snapshot_exclude=snapshot_exclude,
+        )
 
         if self.settable:
             # TODO (alexcjohnson): can we support, ala Combine?
@@ -1838,25 +1868,32 @@ class MultiParameter(_BaseParameter):
             JSON snapshot of the parameter.
     """
 
-    def __init__(self,
-                 name: str,
-                 names: Sequence[str],
-                 shapes: Sequence[Sequence[int]],
-                 instrument: Optional['InstrumentBase'] = None,
-                 labels: Optional[Sequence[str]] = None,
-                 units: Optional[Sequence[str]] = None,
-                 setpoints: Optional[Sequence[Sequence[Any]]] = None,
-                 setpoint_names: Optional[Sequence[Sequence[str]]] = None,
-                 setpoint_labels: Optional[Sequence[Sequence[str]]] = None,
-                 setpoint_units: Optional[Sequence[Sequence[str]]] = None,
-                 docstring: Optional[str] = None,
-                 snapshot_get: bool = True,
-                 snapshot_value: bool = False,
-                 snapshot_exclude: bool = False,
-                 metadata: Optional[Dict[Any, Any]] = None) -> None:
-        super().__init__(name, instrument, snapshot_get, metadata,
-                         snapshot_value=snapshot_value,
-                         snapshot_exclude=snapshot_exclude)
+    def __init__(
+        self,
+        name: str,
+        names: Sequence[str],
+        shapes: Sequence[Sequence[int]],
+        instrument: Optional["InstrumentBase"] = None,
+        labels: Optional[Sequence[str]] = None,
+        units: Optional[Sequence[str]] = None,
+        setpoints: Optional[Sequence[Sequence[Any]]] = None,
+        setpoint_names: Optional[Sequence[Sequence[str]]] = None,
+        setpoint_labels: Optional[Sequence[Sequence[str]]] = None,
+        setpoint_units: Optional[Sequence[Sequence[str]]] = None,
+        docstring: Optional[str] = None,
+        snapshot_get: bool = True,
+        snapshot_value: bool = False,
+        snapshot_exclude: bool = False,
+        metadata: Optional[Mapping[Any, Any]] = None,
+    ) -> None:
+        super().__init__(
+            name,
+            instrument,
+            snapshot_get,
+            metadata,
+            snapshot_value=snapshot_value,
+            snapshot_exclude=snapshot_exclude,
+        )
 
         self._meta_attrs.extend(['setpoint_names', 'setpoint_labels',
                                  'setpoint_units', 'names', 'labels', 'units'])


### PR DESCRIPTION
This has the benefit of clarifying that the mappings are imitable and allows the functions to take other mappings with  the dict interface ordereddict etc