### PR TITLE
Allow time stamps to be passed to set_run_timestamp and mark_run_completed. 

### DIFF
--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -806,7 +806,7 @@ def mark_run_complete(
         conn: database connection
         run_id: id of the run to mark complete
         timestamp: time stamp for completion. If None the function will
-            automatically get the time.
+            automatically get the current time.
     """
     query = """
     UPDATE
@@ -1417,6 +1417,12 @@ def set_run_timestamp(
     """
     Set the run_timestamp for the run with the given run_id. If the
     run_timestamp has already been set, a RuntimeError is raised.
+
+    Args:
+        conn: database connection
+        run_id: id of the run to mark complete
+        timestamp: time stamp for completion. If None the function will
+            automatically get the current time.
     """
 
     query = """

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -797,12 +797,16 @@ def new_experiment(conn: ConnectionPlus,
 
 # TODO(WilliamHPNielsen): we should remove the redundant
 # is_completed
-def mark_run_complete(conn: ConnectionPlus, run_id: int) -> None:
-    """ Mark run complete
+def mark_run_complete(
+    conn: ConnectionPlus, run_id: int, timestamp: Optional[float] = None
+) -> None:
+    """Mark run complete
 
     Args:
         conn: database connection
         run_id: id of the run to mark complete
+        timestamp: time stamp for completion. If None the function will
+            automatically get the time.
     """
     query = """
     UPDATE
@@ -812,7 +816,9 @@ def mark_run_complete(conn: ConnectionPlus, run_id: int) -> None:
         is_completed=?
     WHERE run_id=?;
     """
-    atomic_transaction(conn, query, time.time(), True, run_id)
+    if timestamp is None:
+        timestamp = time.time()
+    atomic_transaction(conn, query, timestamp, True, run_id)
 
 
 def completed(conn: ConnectionPlus, run_id: int) -> bool:
@@ -1405,7 +1411,9 @@ def update_parent_datasets(conn: ConnectionPlus,
         conn.cursor().execute(sql, (links_str, run_id))
 
 
-def set_run_timestamp(conn: ConnectionPlus, run_id: int) -> None:
+def set_run_timestamp(
+    conn: ConnectionPlus, run_id: int, timestamp: Optional[float] = None
+) -> None:
     """
     Set the run_timestamp for the run with the given run_id. If the
     run_timestamp has already been set, a RuntimeError is raised.
@@ -1424,15 +1432,17 @@ def set_run_timestamp(conn: ConnectionPlus, run_id: int) -> None:
 
     with atomic(conn) as conn:
         c = conn.cursor()
-        timestamp = one(c.execute(query, (run_id,)), 'run_timestamp')
-        if timestamp is not None:
-            raise RuntimeError('Can not set run_timestamp; it has already '
-                               f'been set to: {timestamp}')
+        old_timestamp = one(c.execute(query, (run_id,)), "run_timestamp")
+        if old_timestamp is not None:
+            raise RuntimeError(
+                "Can not set run_timestamp; it has already "
+                f"been set to: {old_timestamp}"
+            )
         else:
-            current_time = time.time()
-            c.execute(cmd, (current_time, run_id))
-            log.info(f"Set the run_timestamp of run_id {run_id} to "
-                     f"{current_time}")
+            if timestamp is None:
+                timestamp = time.time()
+            c.execute(cmd, (timestamp, run_id))
+            log.info(f"Set the run_timestamp of run_id {run_id} to " f"{timestamp}")
 
 
 def add_parameter(conn: ConnectionPlus,

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -366,3 +366,21 @@ def test_set_run_timestamp(dataset):
 
     assert error_caused_by(ei, ("Can not set run_timestamp; it has already "
                                 "been set"))
+
+
+def test_set_run_timestamp_explicit(dataset):
+
+    assert dataset.run_timestamp_raw is None
+
+    time_now = time.time()
+    time.sleep(1)  # for slower test platforms
+    mut_queries.set_run_timestamp(dataset.conn, dataset.run_id, time_now)
+
+    assert dataset.run_timestamp_raw == time_now
+
+    with pytest.raises(
+        RuntimeError, match="Rolling back due to unhandled " "exception"
+    ) as ei:
+        mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
+
+    assert error_caused_by(ei, "Can not set run_timestamp; it has already " "been set")

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -1,35 +1,34 @@
 # Since all other tests of data_set and measurements will inevitably also
 # test the sqlite module, we mainly test exceptions and small helper
 # functions here
-from sqlite3 import OperationalError
-from contextlib import contextmanager
 import time
-
-import pytest
-import hypothesis.strategies as hst
-from hypothesis import given
 import unicodedata
-import numpy as np
+from contextlib import contextmanager
+from sqlite3 import OperationalError
 from unittest.mock import patch
 
+import hypothesis.strategies as hst
+import numpy as np
+import pytest
+from hypothesis import given
+
+import qcodes.dataset.descriptions.versioning.serialization as serial
+from qcodes.dataset.data_set import DataSet
+from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpec
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
-from qcodes.dataset.descriptions.dependencies import InterDependencies_
-import qcodes.dataset.descriptions.versioning.serialization as serial
+from qcodes.dataset.guids import generate_guid
+
+# mut: module under test
+from qcodes.dataset.sqlite import connection as mut_conn
+from qcodes.dataset.sqlite import database as mut_db
+from qcodes.dataset.sqlite import queries as mut_queries
+from qcodes.dataset.sqlite import query_helpers as mut_help
 from qcodes.dataset.sqlite.connection import path_to_dbfile
 from qcodes.dataset.sqlite.database import get_DB_location
-from qcodes.dataset.guids import generate_guid
-from qcodes.dataset.data_set import DataSet
 from qcodes.tests.common import error_caused_by
 
 from .helper_functions import verify_data_dict
-
-# mut: module under test
-from qcodes.dataset.sqlite import queries as mut_queries
-from qcodes.dataset.sqlite import query_helpers as mut_help
-from qcodes.dataset.sqlite import connection as mut_conn
-from qcodes.dataset.sqlite import database as mut_db
-
 
 _unicode_categories = ('Lu', 'Ll', 'Lt', 'Lm', 'Lo', 'Nd', 'Pc', 'Pd', 'Zs')
 
@@ -351,23 +350,19 @@ def test_atomic_creation(experiment):
         assert len(runs) == 1
 
 
-def test_set_run_timestamp(experiment):
+def test_set_run_timestamp(dataset):
 
-    ds = DataSet()
-
-    assert ds.run_timestamp_raw is None
+    assert dataset.run_timestamp_raw is None
 
     time_now = time.time()
     time.sleep(1)  # for slower test platforms
-    mut_queries.set_run_timestamp(ds.conn, ds.run_id)
+    mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
 
-    assert ds.run_timestamp_raw > time_now
+    assert dataset.run_timestamp_raw > time_now
 
     with pytest.raises(RuntimeError, match="Rolling back due to unhandled "
                                            "exception") as ei:
-        mut_queries.set_run_timestamp(ds.conn, ds.run_id)
+        mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
 
     assert error_caused_by(ei, ("Can not set run_timestamp; it has already "
                                 "been set"))
-
-    ds.conn.close()

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -353,12 +353,14 @@ def test_atomic_creation(experiment):
 def test_set_run_timestamp(dataset):
 
     assert dataset.run_timestamp_raw is None
+    assert dataset.completed_timestamp_raw is None
 
     time_now = time.time()
     time.sleep(1)  # for slower test platforms
     mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
 
     assert dataset.run_timestamp_raw > time_now
+    assert dataset.completed_timestamp_raw is None
 
     with pytest.raises(RuntimeError, match="Rolling back due to unhandled "
                                            "exception") as ei:
@@ -371,12 +373,14 @@ def test_set_run_timestamp(dataset):
 def test_set_run_timestamp_explicit(dataset):
 
     assert dataset.run_timestamp_raw is None
+    assert dataset.completed_timestamp_raw is None
 
     time_now = time.time()
     time.sleep(1)  # for slower test platforms
     mut_queries.set_run_timestamp(dataset.conn, dataset.run_id, time_now)
 
     assert dataset.run_timestamp_raw == time_now
+    assert dataset.completed_timestamp_raw is None
 
     with pytest.raises(
         RuntimeError, match="Rolling back due to unhandled " "exception"
@@ -389,6 +393,7 @@ def test_set_run_timestamp_explicit(dataset):
 def test_mark_run_complete(dataset):
 
     assert dataset.run_timestamp_raw is None
+    assert dataset.completed_timestamp_raw is None
 
     time_now = time.time()
     mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
@@ -401,6 +406,7 @@ def test_mark_run_complete(dataset):
 def test_mark_run_complete_explicit_time(dataset):
 
     assert dataset.run_timestamp_raw is None
+    assert dataset.completed_timestamp_raw is None
 
     mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
     time_now = time.time()

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -384,3 +384,29 @@ def test_set_run_timestamp_explicit(dataset):
         mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
 
     assert error_caused_by(ei, "Can not set run_timestamp; it has already " "been set")
+
+
+def test_mark_run_complete(dataset):
+
+    assert dataset.run_timestamp_raw is None
+
+    time_now = time.time()
+    mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
+    time.sleep(1)  # for slower test platforms
+    mut_queries.mark_run_complete(dataset.conn, dataset.run_id)
+
+    assert dataset.completed_timestamp_raw > time_now
+
+
+def test_mark_run_complete_explicit_time(dataset):
+
+    assert dataset.run_timestamp_raw is None
+
+    mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
+    time_now = time.time()
+    time.sleep(1)  # for slower test platforms
+    mut_queries.mark_run_complete(dataset.conn, dataset.run_id, time_now)
+
+    assert dataset.completed_timestamp_raw == time_now
+
+    mut_queries.mark_run_complete(dataset.conn, dataset.run_id)


### PR DESCRIPTION
This will help decouple the sqlite backend from the dataset implementation