### PR TITLE
Add changelog link to docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ project_urls =
     Documentation = https://qcodes.github.io/Qcodes/
     Source = https://github.com/qcodes/qcodes
     Tracker = https://github.com/QCoDeS/Qcodes/issues
+    Changelog = https://qcodes.github.io/Qcodes/changes/index.html
 
 [options]
 zip_safe = False


### PR DESCRIPTION
This will add a handy changelog link to the sidebar of https://pypi.org/project/qcodes/ (under project links)
