### PR TITLE
add pristine and running properties to protocol

### DIFF
--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -48,6 +48,14 @@ class DataSetProtocol(Protocol, Sized):
         pass
 
     @property
+    def pristine(self) -> bool:
+        pass
+
+    @property
+    def running(self) -> bool:
+        pass
+
+    @property
     def completed(self) -> bool:
         pass
 


### PR DESCRIPTION
Since they seem to logically belong together with the completed property. Note that I have left out the started property since that is really just Either running or completed. 