### PR TITLE
Use threaded setting from config in dond functions, and make process_params_meas public

### DIFF
--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -66,7 +66,7 @@
     "dataset": {
         "write_in_background": false,
         "write_period": 5.0,
-        "use_threaded": false,
+        "use_threads": false,
         "dond_plot": false,
         "dond_show_progress": false,
         "export_automatic": false,

--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -66,6 +66,7 @@
     "dataset": {
         "write_in_background": false,
         "write_period": 5.0,
+        "use_threaded": false,
         "dond_plot": false,
         "dond_show_progress": false,
         "export_automatic": false,

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -306,7 +306,7 @@
                     "default": 5.0,
                     "description": "How often should data be written to disk (s)"
                 },
-                "use_threaded": {
+                "use_threads": {
                         "type": "boolean",
                         "default": false,
                         "description": "Should instruments be addresesed in parallel for process_params_meas() in doNd measurement"

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -307,6 +307,11 @@
                     "default": 5.0,
                     "description": "How often should data be written to disk (s)"
                 },
+                "use_threaded": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Should instruments be addresesed in parallel for process_params_meas() in doNd measurement"
+                },
                 "dond_plot": {
                     "type": "boolean",
                     "default": false,

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -214,6 +214,7 @@
                             "description": "Upper and lower percentage of datapoints that may maximally be discarded by the auto color scale. For example for [1,1] the auto color scale will in a set of 10 0000 points not clip more than the 100 points of lowest and highest value.",
                             "type": "array",
                             "items": {
+                                "type": "number",
                                 "type": "number"
                             },
                             "default": [0.5, 0.5]

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -214,7 +214,6 @@
                             "description": "Upper and lower percentage of datapoints that may maximally be discarded by the auto color scale. For example for [1,1] the auto color scale will in a set of 10 0000 points not clip more than the 100 points of lowest and highest value.",
                             "type": "array",
                             "items": {
-                                "type": "number",
                                 "type": "number"
                             },
                             "default": [0.5, 0.5]

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -115,8 +115,8 @@ def _call_params(param_meas: Sequence[ParamMeasT]) -> OutType:
 
 def process_params_meas(
     param_meas: Sequence[ParamMeasT],
-        use_threads: Optional[bool] = None
-    ) -> OutType:
+    use_threads: Optional[bool] = None
+) -> OutType:
 
     if use_threads is None:
         use_threads = config.dataset.use_threads

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -115,8 +115,11 @@ def _call_params(param_meas: Sequence[ParamMeasT]) -> OutType:
 
 def _process_params_meas(
     param_meas: Sequence[ParamMeasT],
-        use_threads: bool = False
+        use_threads: Optional[bool] = None
     ) -> OutType:
+
+    if use_threads is None:
+        use_threads = config.dataset.use_threads
 
     if use_threads:
         return _call_params_threaded(param_meas)
@@ -177,7 +180,7 @@ def do0d(
         measurement_name: str = "",
         exp: Optional[Experiment] = None,
         do_plot: Optional[bool] = None,
-        use_threads: bool = False,
+        use_threads: Optional[bool] = None,
         ) -> AxesTupleListWithDataSet:
     """
     Perform a measurement of a single parameter. This is probably most
@@ -245,7 +248,7 @@ def do1d(
         measurement_name: str = "",
         exp: Optional[Experiment] = None,
         do_plot: Optional[bool] = None,
-        use_threads: bool = False,
+        use_threads: Optional[bool] = None,
         additional_setpoints: Sequence[ParamMeasT] = tuple(),
         show_progress: Optional[None] = None,
         ) -> AxesTupleListWithDataSet:
@@ -362,7 +365,7 @@ def do2d(
         exp: Optional[Experiment] = None,
         flush_columns: bool = False,
         do_plot: Optional[bool] = None,
-        use_threads: bool = False,
+        use_threads: Optional[bool] = None,
         additional_setpoints: Sequence[ParamMeasT] = tuple(),
         show_progress: Optional[None] = None,
         ) -> AxesTupleListWithDataSet:
@@ -636,7 +639,7 @@ def dond(
     exit_actions: ActionsT = (),
     do_plot: Optional[bool] = None,
     show_progress: Optional[bool] = None,
-    use_threads: bool = False,
+    use_threads: Optional[bool] = None,
     additional_setpoints: Sequence[ParamMeasT] = tuple(),
 ) -> AxesTupleListWithDataSet:
     """

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -748,6 +748,7 @@ def dond(
 
     try:
         with _catch_keyboard_interrupts() as interrupted, meas.run() as datasaver:
+            dataset = datasaver.dataset
             additional_setpoints_data = process_params_meas(additional_setpoints)
             for setpoints in tqdm(nested_setpoints, disable=not show_progress):
                 param_set_list = []
@@ -760,7 +761,6 @@ def dond(
                     *process_params_meas(params_meas, use_threads=use_threads),
                     *additional_setpoints_data,
                 )
-            dataset = datasaver.dataset
     finally:
         for parameter, original_delay in original_delays.items():
             parameter.post_delay = original_delay

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -228,7 +228,7 @@ def do0d(
 
     with meas.run() as datasaver:
         datasaver.add_result(
-            *_process_params_meas(
+            *process_params_meas(
                 param_meas,
                 use_threads=use_threads
             )
@@ -328,7 +328,7 @@ def do1d(
     # reimplemented from scratch
     with _catch_keyboard_interrupts() as interrupted, meas.run() as datasaver:
         dataset = datasaver.dataset
-        additional_setpoints_data = _process_params_meas(additional_setpoints)
+        additional_setpoints_data = process_params_meas(additional_setpoints)
         setpoints = np.linspace(start, stop, num_points)
 
         # flush to prevent unflushed print's to visually interrupt tqdm bar
@@ -340,7 +340,7 @@ def do1d(
             param_set.set(set_point)
             datasaver.add_result(
                 (param_set, set_point),
-                *_process_params_meas(param_meas, use_threads=use_threads),
+                *process_params_meas(param_meas, use_threads=use_threads),
                 *additional_setpoints_data
             )
 
@@ -459,7 +459,7 @@ def do2d(
 
     with _catch_keyboard_interrupts() as interrupted, meas.run() as datasaver:
         dataset = datasaver.dataset
-        additional_setpoints_data = _process_params_meas(additional_setpoints)
+        additional_setpoints_data = process_params_meas(additional_setpoints)
         setpoints1 = np.linspace(start1, stop1, num_points1)
         for set_point1 in tqdm(setpoints1, disable=not show_progress):
             if set_before_sweep:
@@ -487,7 +487,7 @@ def do2d(
 
                 datasaver.add_result((param_set1, set_point1),
                                      (param_set2, set_point2),
-                                     *_process_params_meas(param_meas, use_threads=use_threads),
+                                     *process_params_meas(param_meas, use_threads=use_threads),
                                      *additional_setpoints_data)
 
             for action in after_inner_actions:
@@ -748,7 +748,7 @@ def dond(
 
     try:
         with _catch_keyboard_interrupts() as interrupted, meas.run() as datasaver:
-            additional_setpoints_data = _process_params_meas(additional_setpoints)
+            additional_setpoints_data = process_params_meas(additional_setpoints)
             for setpoints in tqdm(nested_setpoints, disable=not show_progress):
                 param_set_list = []
                 param_value_pairs = zip(params_set[::-1], setpoints[::-1])
@@ -757,7 +757,7 @@ def dond(
                     param_set_list.append((setpoint_param, setpoint))
                 datasaver.add_result(
                     *param_set_list,
-                    *_process_params_meas(params_meas, use_threads=use_threads),
+                    *process_params_meas(params_meas, use_threads=use_threads),
                     *additional_setpoints_data,
                 )
             dataset = datasaver.dataset

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -113,7 +113,7 @@ def _call_params(param_meas: Sequence[ParamMeasT]) -> OutType:
     return output
 
 
-def _process_params_meas(
+def process_params_meas(
     param_meas: Sequence[ParamMeasT],
         use_threads: Optional[bool] = None
     ) -> OutType:

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -485,10 +485,12 @@ def do2d(
                 else:
                     param_set2.set(set_point2)
 
-                datasaver.add_result((param_set1, set_point1),
-                                     (param_set2, set_point2),
-                                     *process_params_meas(param_meas, use_threads=use_threads),
-                                     *additional_setpoints_data)
+                datasaver.add_result(
+                    (param_set1, set_point1),
+                    (param_set2, set_point2),
+                    *process_params_meas(param_meas, use_threads=use_threads),
+                    *additional_setpoints_data
+                )
 
             for action in after_inner_actions:
                 action()


### PR DESCRIPTION
Create a setting for use_threads in the config to be used in `process_params_meas` for doNd functions. Allows control of the setting in the config file rather than a required input at runtime. 
Additionally makes the measure function public for external use of threaded parameter calls. This could be split out to a separate PR but included here in case there are no objections/concerns with this change.

Bug fix: moved dataset reference up in new dond to handle keyboardinterrupts similar to other functions in file.