### PR TITLE
Fix invalid array syntax in json schema 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,8 @@ repos:
     - id: trailing-whitespace
     - id: end-of-file-fixer
     - id: check-yaml
+    - id: check-json
+      exclude: asv.conf.json
     - id: debug-statements
     - id: check-ast
     - id: mixed-line-ending

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -213,10 +213,10 @@
                         "cutoff_percentile":{
                             "description": "Upper and lower percentage of datapoints that may maximally be discarded by the auto color scale. For example for [1,1] the auto color scale will in a set of 10 0000 points not clip more than the 100 points of lowest and highest value.",
                             "type": "array",
-                            "items": {
-                                "type": "number",
-                                "type": "number"
-                            },
+                            "items": [
+                                {"type": "number"},
+                                {"type": "number"}
+                            ],
                             "default": [0.5, 0.5]
                         },
                         "color_over":{


### PR DESCRIPTION
The current format is invalid. It should either be just a single item type or like this pr suggest a list of item types which defines exactly the type of each element

Since cutoff_percentile always has two numbers this seems like the correct format.

See https://json-schema.org/understanding-json-schema/reference/array.html for some details 

This also adds a pre-commit hook that check that json is valid which would have caught this. I had to exclude asv.conf.json since it contains comments which is not valid json