### PR TITLE
Compare shapes in RunDescriber equality method

### DIFF
--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -125,6 +125,8 @@ class RunDescriber:
             return False
         if self.interdeps != other.interdeps:
             return False
+        if self.shapes != other.shapes:
+            return False
         return True
 
     def __repr__(self) -> str:


### PR DESCRIPTION
@jenshnielsen what do you think, should this be happening or not?

for latest version of the class, this seems very fair, but i'm not sure what should happen for the case where RunDescriber from V2 data (without shapes, because there were no notion of shapes back then) is compared with RunDescriber from V3 data (that has the shapes or has None as the shape) and the interdependencies part is equal. or am i overthinking this too much?