### PR TITLE
Improve xarray metadata export

### DIFF
--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -101,14 +101,19 @@ def load_to_xarray_dataset(dataset: DataSetProtocol, data: ParameterData) -> xr.
     xrdataset = xr.Dataset(
         cast(Dict[Hashable, xr.DataArray], data_xrdarray_dict))
 
-    for dim in xrdataset.dims:
-        if "index" != dim:
-            paramspec_dict = _paramspec_dict_with_extras(dataset, str(dim))
-            xrdataset.coords[str(dim)].attrs.update(paramspec_dict.items())
-
+    _add_param_spec_to_xarray_coords(dataset, xrdataset)
     _add_metadata_to_xarray(dataset, xrdataset)
 
     return xrdataset
+
+
+def _add_param_spec_to_xarray_coords(
+    dataset: DataSetProtocol, xrdataset: Union[xr.Dataset, xr.DataArray]
+) -> None:
+    for coord in xrdataset.coords:
+        if coord != "index":
+            paramspec_dict = _paramspec_dict_with_extras(dataset, str(coord))
+            xrdataset.coords[str(coord)].attrs.update(paramspec_dict.items())
 
 
 def _paramspec_dict_with_extras(

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -124,7 +124,9 @@ def _paramspec_dict_with_extras(
     dataset: DataSetProtocol, dim_name: str
 ) -> Dict[str, object]:
     paramspec_dict = dict(dataset.paramspecs[str(dim_name)]._to_dict())
-
+    # units and long_name have special meaning in xarray that closely
+    # matches how qcodes uses unit and label so we copy these attributes
+    # https://xarray.pydata.org/en/stable/getting-started-guide/quick-overview.html#attributes
     paramspec_dict["units"] = paramspec_dict.get("unit", "")
     paramspec_dict["long_name"] = paramspec_dict.get("label", "")
     return paramspec_dict

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Any, Dict, Hashable, Mapping, Union, cast
+from typing import TYPE_CHECKING, Dict, Hashable, Mapping, Union, cast
 
 import numpy as np
 
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
 
     from qcodes.dataset.data_set import ParameterData
     from qcodes.dataset.data_set_protocol import DataSetProtocol
-
 
 
 def _load_to_xarray_dataarray_dict_no_metadata(

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Dict, Hashable, Mapping, Union, cast
 
 import numpy as np
 
+from qcodes.dataset.linked_datasets.links import links_to_str
+
 from ..descriptions.versioning import serialization as serial
 from .export_to_pandas import (
     _data_to_dataframe,
@@ -72,6 +74,7 @@ def _add_metadata_to_xarray(
             "captured_counter": dataset.captured_counter,
             "run_id": dataset.run_id,
             "run_description": serial.to_json_for_storage(dataset.description),
+            "parent_dataset_links": links_to_str(dataset.parent_dataset_links),
         }
     )
     if dataset.run_timestamp_raw is not None:

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -103,7 +103,9 @@ def load_to_xarray_dataset(dataset: DataSetProtocol, data: ParameterData) -> xr.
 
     for dim in xrdataset.dims:
         if "index" != dim:
-            paramspec_dict = dataset.paramspecs[str(dim)]._to_dict()
+            paramspec_dict = dict(dataset.paramspecs[str(dim)]._to_dict())
+            paramspec_dict["units"] = paramspec_dict.get("unit", "")
+            paramspec_dict["long_name"] = paramspec_dict.get("label", "")
             xrdataset.coords[str(dim)].attrs.update(paramspec_dict.items())
 
     _add_metadata_to_xarray(dataset, xrdataset)

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -51,7 +51,9 @@ def load_to_xarray_dataarray_dict(
     dataarrays = _load_to_xarray_dataarray_dict_no_metadata(dataset, datadict)
 
     for dataarray in dataarrays.values():
+        _add_param_spec_to_xarray_coords(dataset, dataarray)
         _add_metadata_to_xarray(dataset, dataarray)
+
     return dataarrays
 
 

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -8,8 +8,9 @@ import qcodes
 from qcodes import new_data_set
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
-from qcodes.dataset.export_config import DataExportType
 from qcodes.dataset.descriptions.versioning import serialization as serial
+from qcodes.dataset.export_config import DataExportType
+from qcodes.dataset.linked_datasets.links import links_to_str
 
 
 @pytest.mark.usefixtures('experiment')
@@ -271,4 +272,9 @@ def _assert_xarray_metadata_is_as_expected(xarray_ds, qc_dataset):
     assert xarray_ds.captured_run_id == qc_dataset.captured_run_id
     assert xarray_ds.captured_counter == qc_dataset.captured_counter
     assert xarray_ds.run_id == qc_dataset.run_id
-    assert xarray_ds.run_description == serial.to_json_for_storage(qc_dataset.description)
+    assert xarray_ds.run_description == serial.to_json_for_storage(
+        qc_dataset.description
+    )
+    assert xarray_ds.parent_dataset_links == links_to_str(
+        qc_dataset.parent_dataset_links
+    )


### PR DESCRIPTION
- [X] Add units and long_name to match default xarray usage https://xarray.pydata.org/en/stable/getting-started-guide/quick-overview.html#attributes
- [x] Ensure that the per array metadata is also exported to dataarrays (and not just datasets)
- [x] Export parent dataset links
- [x] Tests for all above
- [x] Refactor logic to make the handling of data_vars attrs more clear 