### PR TITLE
Alazar ATS drivers: Fix buffer size for mode='TS' and buffers_per_acquisition > 1

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -386,6 +386,10 @@ class AlazarTech_ATS(Instrument):
         internal_buffer_size_requested = (bits_per_sample * samples_per_record *
                                           records_per_buffer) // 8
 
+        if mode == 'TS':
+            transfer_buffer_size //= buffers_per_acquisition
+            internal_buffer_size_requested //= buffers_per_acquisition
+
         if internal_buffer_size_requested > max_buffer_size:
             raise RuntimeError(f"Requested a buffer of size: "
                                f"{internal_buffer_size_requested / 1024 ** 2}"


### PR DESCRIPTION
Fixes #3117

Changes proposed in this pull request:
- in mode 'TS' the buffer size = reccord size / nr of buffers

