### PR TITLE
Do not preserve gh pages branch history

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -92,6 +92,7 @@ jobs:
         branch: gh-pages
         folder: ${{ github.workspace }}/docs/_build/html
         clean: true
+        single-commit: true
         git-config-email: "bot"
         git-config-name: "Documentation Bot"
       if: ${{ fromJSON(env.UPLOAD_TO_GHPAGES) }}


### PR DESCRIPTION
This will hopefully go some of the way in fixing https://github.com/QCoDeS/Qcodes/issues/3109 since the
gh-pages branch is fairly heavy and grows with every commit