### PR TITLE
Give threads time to start in tests

### DIFF
--- a/qcodes/tests/test_threading.py
+++ b/qcodes/tests/test_threading.py
@@ -64,6 +64,7 @@ def test_call_params_threaded(dummy_1, dummy_2):
 
     params_per_thread_id = defaultdict(set)
     for param, thread_id in params_output:
+        assert thread_id is not None
         params_per_thread_id[thread_id].add(param)
     assert len(params_per_thread_id) == 2
     expected_params_per_thread = {

--- a/qcodes/tests/test_threading.py
+++ b/qcodes/tests/test_threading.py
@@ -2,6 +2,7 @@
 Test suite for utils.threading.*
 """
 import threading
+import time
 from collections import defaultdict
 from typing import Any
 
@@ -18,6 +19,7 @@ class ParameterWithThreadKnowledge(Parameter):
         super().__init__(*args, **kwargs)
 
     def get_raw(self) -> ParamRawDataType:
+        time.sleep(0.1)
         return threading.get_ident()
 
 


### PR DESCRIPTION
Trying to debug a failed test on the master branch. This will hopefully make sure that all threads have started before any of them end and therefor does end up with a reused id.