### PR TITLE
Fix numpy deprecation for ragged arrays

### DIFF
--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -7,6 +7,7 @@ from typing_extensions import TypedDict
 from qcodes.dataset.data_set import load_by_id
 from qcodes.dataset.data_set_protocol import DataSetProtocol
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
+from qcodes.dataset.sqlite.queries import list_of_data_to_maybe_ragged_nd_array
 from qcodes.utils.deprecate import deprecate
 
 log = logging.getLogger(__name__)
@@ -180,7 +181,7 @@ def _rows_from_datapoints(inputsetpoints: np.ndarray) -> np.ndarray:
         rows.append(temp)
         setpoints = np.delete(setpoints, inds)
 
-    return np.array(rows)
+    return list_of_data_to_maybe_ragged_nd_array(rows)
 
 
 def _all_in_group_or_subgroup(rows: np.ndarray) -> bool:

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -7,8 +7,8 @@ from typing_extensions import TypedDict
 from qcodes.dataset.data_set import load_by_id
 from qcodes.dataset.data_set_protocol import DataSetProtocol
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
-from qcodes.dataset.sqlite.queries import list_of_data_to_maybe_ragged_nd_array
 from qcodes.utils.deprecate import deprecate
+from qcodes.utils.numpy_utils import list_of_data_to_maybe_ragged_nd_array
 
 log = logging.getLogger(__name__)
 

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -307,14 +307,14 @@ def get_parameter_data_for_one_paramtree(
     res_t = map(list, zip(*data))
 
     for paramspec, column_data in zip(paramspecs, res_t):
+        if paramspec.type == "numeric":
+            # there is no reliable way to
+            # tell the difference between a float and and int loaded
+            # from sqlite numeric columns so always fall back to float
+            dtype: Optional[type] = np.float64
+        else:
+            dtype = None
         try:
-            if paramspec.type == "numeric":
-                # there is no reliable way to
-                # tell the difference between a float and and int loaded
-                # from sqlite numeric columns so always fall back to float
-                dtype: Optional[type] = np.float64
-            else:
-                dtype = None
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -23,7 +23,6 @@ from typing import (
 )
 
 import numpy as np
-from numpy import VisibleDeprecationWarning
 
 import qcodes as qc
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
@@ -54,6 +53,7 @@ from qcodes.dataset.sqlite.query_helpers import (
     update_where,
 )
 from qcodes.utils.deprecate import deprecate
+from qcodes.utils.numpy_utils import list_of_data_to_maybe_ragged_nd_array
 
 log = logging.getLogger(__name__)
 
@@ -317,38 +317,6 @@ def get_parameter_data_for_one_paramtree(
             column_data, dtype
         )
     return param_data, n_rows
-
-
-def list_of_data_to_maybe_ragged_nd_array(
-    column_data: Sequence[Any],
-    dtype: Optional[type] = None,
-) -> np.ndarray:
-    """
-    Convert a (nested) Sequence of data to numpy arrays. Handle that
-    the elements of the sequence may not have the same length in which
-    case the returned array will be of dtype object.
-
-    """
-    try:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                category=VisibleDeprecationWarning,
-                message="Creating an ndarray from ragged nested sequences",
-            )
-            # numpy warns here and coming versions
-            # will eventually raise
-            # for ragged arrays if you don't explicitly set
-            # dtype=object
-            # It is time consuming to detect ragged arrays here
-            # and it is expected to be a relatively rare situation
-            # so fallback to object if the regular dtype fail
-            data = np.array(column_data, dtype=dtype)
-    except:
-        # Not clear which error to catch here. This will only be clarified
-        # once numpy actually starts to raise here.
-        data = np.array(column_data, dtype=object)
-    return data
 
 
 def _expand_data_to_arrays(data: List[List[Any]], paramspecs: Sequence[ParamSpecBase]) -> None:

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -321,7 +321,7 @@ def get_parameter_data_for_one_paramtree(
 
 def list_of_data_to_maybe_ragged_nd_array(
     column_data: Sequence[Any],
-    dtype,
+    dtype: Optional[type] = None,
 ) -> np.ndarray:
     """
     Convert a (nested) Sequence of data to numpy arrays. Handle that

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -7,7 +7,6 @@ import sqlite3
 import time
 import unicodedata
 import warnings
-from copy import copy
 from pathlib import Path
 from typing import (
     Any,

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -313,26 +313,42 @@ def get_parameter_data_for_one_paramtree(
             dtype: Optional[type] = np.float64
         else:
             dtype = None
-        try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore",
-                    category=VisibleDeprecationWarning,
-                    message="Creating an ndarray from ragged nested sequences"
-                )
-                # numpy warns here and coming versions
-                # will eventually raise
-                # for ragged arrays if you don't explicitly set
-                # dtype=object
-                # It is time consuming to detect ragged arrays here
-                # and it is expected to be a relatively rare situation
-                # so fallback to object if the regular dtype fail
-                param_data[paramspec.name] = np.array(column_data, dtype=dtype)
-        except:
-            # Not clear which error to catch here. This will only be clarified
-            # once numpy actually starts to raise here.
-            param_data[paramspec.name] = np.array(column_data, dtype=object)
+        param_data[paramspec.name] = list_of_data_to_maybe_ragged_nd_array(
+            column_data, dtype
+        )
     return param_data, n_rows
+
+
+def list_of_data_to_maybe_ragged_nd_array(
+    column_data: Sequence[Any],
+    dtype,
+) -> np.ndarray:
+    """
+    Convert a (nested) Sequence of data to numpy arrays. Handle that
+    the elements of the sequence may not have the same length in which
+    case the returned array will be of dtype object.
+
+    """
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=VisibleDeprecationWarning,
+                message="Creating an ndarray from ragged nested sequences",
+            )
+            # numpy warns here and coming versions
+            # will eventually raise
+            # for ragged arrays if you don't explicitly set
+            # dtype=object
+            # It is time consuming to detect ragged arrays here
+            # and it is expected to be a relatively rare situation
+            # so fallback to object if the regular dtype fail
+            data = np.array(column_data, dtype=dtype)
+    except:
+        # Not clear which error to catch here. This will only be clarified
+        # once numpy actually starts to raise here.
+        data = np.array(column_data, dtype=object)
+    return data
 
 
 def _expand_data_to_arrays(data: List[List[Any]], paramspecs: Sequence[ParamSpecBase]) -> None:

--- a/qcodes/utils/numpy_utils.py
+++ b/qcodes/utils/numpy_utils.py
@@ -1,0 +1,37 @@
+import warnings
+from typing import Any, Optional, Sequence
+
+import numpy as np
+from numpy import VisibleDeprecationWarning
+
+
+def list_of_data_to_maybe_ragged_nd_array(
+    column_data: Sequence[Any],
+    dtype: Optional[type] = None,
+) -> np.ndarray:
+    """
+    Convert a (nested) Sequence of data to numpy arrays. Handle that
+    the elements of the sequence may not have the same length in which
+    case the returned array will be of dtype object.
+
+    """
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=VisibleDeprecationWarning,
+                message="Creating an ndarray from ragged nested sequences",
+            )
+            # numpy warns here and coming versions
+            # will eventually raise
+            # for ragged arrays if you don't explicitly set
+            # dtype=object
+            # It is time consuming to detect ragged arrays here
+            # and it is expected to be a relatively rare situation
+            # so fallback to object if the regular dtype fail
+            data = np.array(column_data, dtype=dtype)
+    except:
+        # Not clear which error to catch here. This will only be clarified
+        # once numpy actually starts to raise here.
+        data = np.array(column_data, dtype=object)
+    return data


### PR DESCRIPTION
Extract method from where this was already fixed and reuse it.

Perhaps we should think of another location for this method. 
