### PR TITLE
Decouple measurement name from dataset results table name 

### DIFF
--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -511,7 +511,7 @@ class Runner:
         self.station = station
         self._interdependencies = interdeps
         self._shapes: Shapes = shapes
-        self.name = name
+        self.name = name if name else 'results'
         self._parent_datasets = parent_datasets
         self._extra_log_info = extra_log_info
         self._write_in_background = write_in_background
@@ -556,7 +556,7 @@ class Runner:
         if self._dataset_class is DataSet:
             dataset_class = cast(Type[DataSet], self._dataset_class)
             self.ds = dataset_class(
-                name='results',
+                name=self.name,
                 exp_id=exp_id,
                 conn=conn,
                 in_memory_cache=self._in_memory_cache,
@@ -573,9 +573,6 @@ class Runner:
             snapshot = station.snapshot()
         else:
             snapshot = {}
-
-        if len(self.name) != 0:
-            snapshot['measurement_name'] = self.name
 
         self.ds.prepare(
             snapshot=snapshot,
@@ -666,9 +663,9 @@ class Measurement:
             is the latest one created.
         station: The QCoDeS station to snapshot. If not given, the
             default one is used.
-        name: Name of the measurement. It is added to the snapshot in the
-            dataset.  If not given, no measurement name gets appended to the
-            snapshot is dataset.
+        name: Name of the measurement. This will be passed down to the dataset
+            produced by the measurement. If not given, a default value of
+            'results' is used for the dataset.
     """
 
     def __init__(self, exp: Optional[Experiment] = None,

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -511,7 +511,7 @@ class Runner:
         self.station = station
         self._interdependencies = interdeps
         self._shapes: Shapes = shapes
-        self.name = name if name else 'results'
+        self.name = name
         self._parent_datasets = parent_datasets
         self._extra_log_info = extra_log_info
         self._write_in_background = write_in_background
@@ -556,7 +556,7 @@ class Runner:
         if self._dataset_class is DataSet:
             dataset_class = cast(Type[DataSet], self._dataset_class)
             self.ds = dataset_class(
-                name=self.name,
+                name='results',
                 exp_id=exp_id,
                 conn=conn,
                 in_memory_cache=self._in_memory_cache,
@@ -573,6 +573,9 @@ class Runner:
             snapshot = station.snapshot()
         else:
             snapshot = {}
+
+        if len(self.name) != 0:
+            snapshot['measurement_name'] = self.name
 
         self.ds.prepare(
             snapshot=snapshot,
@@ -663,9 +666,9 @@ class Measurement:
             is the latest one created.
         station: The QCoDeS station to snapshot. If not given, the
             default one is used.
-        name: Name of the measurement. This will be passed down to the dataset
-            produced by the measurement. If not given, a default value of
-            'results' is used for the dataset.
+        name: Name of the measurement. It is added to the snapshot in the
+            dataset.  If not given, no measurement name gets appended to the
+            snapshot is dataset.
     """
 
     def __init__(self, exp: Optional[Experiment] = None,

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1155,7 +1155,7 @@ def _insert_run(conn: ConnectionPlus, exp_id: int, name: str,
                 captured_counter = existing_captured_counter + 1
             else:
                 captured_counter = run_counter
-    formatted_name = format_table_name(format_string, name, exp_id,
+    formatted_name = format_table_name(format_string, 'results', exp_id,
                                        run_counter)
     table = "runs"
 

--- a/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
@@ -265,10 +265,7 @@ def test_measurement_name_changed_via_attribute(experiment, DAC, DMM):
         run_id = datasaver.run_id
         expected_name = fmt.format('results', exp_id, run_id)
         assert datasaver.dataset.table_name == expected_name
-        assert datasaver.dataset.name == 'results'
-        assert datasaver.dataset.snapshot.get(
-            'station'
-        )['measurement_name'] == name
+        assert datasaver.dataset.name == name
 
 
 def test_measurement_name_set_as_argument(experiment, DAC, DMM):
@@ -286,10 +283,7 @@ def test_measurement_name_set_as_argument(experiment, DAC, DMM):
         run_id = datasaver.run_id
         expected_name = fmt.format('results', exp_id, run_id)
         assert datasaver.dataset.table_name == expected_name
-        assert datasaver.dataset.name == 'results'
-        assert datasaver.dataset.snapshot.get(
-            'station'
-        )['measurement_name'] == name
+        assert datasaver.dataset.name == name
 
 
 @settings(deadline=None)

--- a/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
@@ -263,9 +263,12 @@ def test_measurement_name_changed_via_attribute(experiment, DAC, DMM):
 
     with meas.run() as datasaver:
         run_id = datasaver.run_id
-        expected_name = fmt.format(name, exp_id, run_id)
+        expected_name = fmt.format('results', exp_id, run_id)
         assert datasaver.dataset.table_name == expected_name
-        assert datasaver.dataset.name == name
+        assert datasaver.dataset.name == 'results'
+        assert datasaver.dataset.snapshot.get(
+            'station'
+        )['measurement_name'] == name
 
 
 def test_measurement_name_set_as_argument(experiment, DAC, DMM):
@@ -281,9 +284,12 @@ def test_measurement_name_set_as_argument(experiment, DAC, DMM):
 
     with meas.run() as datasaver:
         run_id = datasaver.run_id
-        expected_name = fmt.format(name, exp_id, run_id)
+        expected_name = fmt.format('results', exp_id, run_id)
         assert datasaver.dataset.table_name == expected_name
-        assert datasaver.dataset.name == name
+        assert datasaver.dataset.name == 'results'
+        assert datasaver.dataset.snapshot.get(
+            'station'
+        )['measurement_name'] == name
 
 
 @settings(deadline=None)

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -389,11 +389,12 @@ def test_result_table_naming_and_run_id(two_empty_temp_db_connections,
 
     extract_runs_into_db(source_path, target_path, source_ds_2_2.run_id)
 
-    # The target ds ought to have a runs table "customname-1-1"
+    # The target ds ought to have a runs table "results-1-1"
     # and ought to be the same dataset as its "ancestor"
     target_ds = DataSet(conn=target_conn, run_id=1)
 
-    assert target_ds.table_name == "customname-1-1"
+    assert target_ds.name == "customname"
+    assert target_ds.table_name == "results-1-1"
     assert target_ds.the_same_dataset_as(source_ds_2_2)
 
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -271,7 +271,7 @@ def test_add_experiments(experiment_name,
     expected_ds_counter = 1
     assert loaded_dataset.name == dataset_name
     assert loaded_dataset.counter == expected_ds_counter
-    assert loaded_dataset.table_name == "{}-{}-{}".format(dataset_name,
+    assert loaded_dataset.table_name == "{}-{}-{}".format("results",
                                                           exp.exp_id,
                                                           loaded_dataset.counter)
     expected_ds_counter += 1
@@ -280,7 +280,7 @@ def test_add_experiments(experiment_name,
     loaded_dataset = load_by_id(dsid)
     assert loaded_dataset.name == dataset_name
     assert loaded_dataset.counter == expected_ds_counter
-    assert loaded_dataset.table_name == "{}-{}-{}".format(dataset_name,
+    assert loaded_dataset.table_name == "{}-{}-{}".format("results",
                                                           exp.exp_id,
                                                           loaded_dataset.counter)
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Decouple measurement name from dataset results table name to allow special characters in the measurement name
- Update failing tests


@jenshnielsen @astafan8 
