### PR TITLE
Make it possible to set parameters as attribues and document these using a parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,12 +41,22 @@ sys.path.insert(0, os.path.abspath('..'))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['nbsphinx', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary',
-              'sphinx.ext.napoleon', 'sphinx-jsonschema', 'sphinx.ext.doctest',
-              'sphinx.ext.intersphinx', 'sphinx.ext.todo',
-              'sphinx.ext.coverage', 'sphinx.ext.mathjax',
-              'sphinx.ext.viewcode', 'sphinx.ext.githubpages',
-              'sphinx.ext.todo']
+extensions = [
+    "nbsphinx",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx-jsonschema",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.todo",
+    "qcodes.sphinx_extensions.parse_parameter_attr",
+]
 
 # include special __xxx__ that DO have a docstring
 # it probably means something important

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1292,6 +1292,12 @@ class Parameter(_BaseParameter):
                 '',
                 self.__doc__))
 
+    def __repr__(self) -> str:
+        return (
+            super().__repr__()
+            + f"name {self.name}, unit {self.unit}, label {self.label}"
+        )
+
     def __getitem__(self, keys: Any) -> 'SweepFixedValues':
         """
         Slice a Parameter to get a SweepValues object

--- a/qcodes/instrument_drivers/agilent/Agilent_34400A.py
+++ b/qcodes/instrument_drivers/agilent/Agilent_34400A.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from qcodes import VisaInstrument
+from qcodes import Parameter, VisaInstrument
 from qcodes.utils.validators import Enum, Strings
 
 
@@ -9,7 +9,6 @@ class Agilent_34400A(VisaInstrument):
     This is the QCoDeS driver for the Agilent_34400A DMM Series,
     tested with Agilent_34401A, Agilent_34410A, and Agilent_34411A.
     """
-
     def __init__(self, name: str, address: str, **kwargs: Any) -> None:
         super().__init__(name, address, terminator='\n', **kwargs)
 
@@ -30,12 +29,15 @@ class Agilent_34400A(VisaInstrument):
                                               1e-07, 3e-08]
                                    }[self.model]
 
-        self.add_parameter('resolution',
-                           get_cmd='VOLT:DC:RES?',
-                           get_parser=float,
-                           set_cmd=self._set_resolution,
-                           label='Resolution',
-                           unit='V')
+        self.resolution = Parameter(
+            "resolution",
+            get_cmd="VOLT:DC:RES?",
+            get_parser=float,
+            set_cmd=self._set_resolution,
+            label="Resolution",
+            unit="V",
+        )
+        """Resolution """
 
         self.add_parameter('volt',
                            get_cmd='READ?',

--- a/qcodes/instrument_drivers/weinschel/Weinschel_8320.py
+++ b/qcodes/instrument_drivers/weinschel/Weinschel_8320.py
@@ -24,5 +24,6 @@ class Weinschel_8320(VisaInstrument):
             instrument=self,
             get_parser=float,
         )
+        """Control the attenuation"""
 
         self.connect_message()

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -1,0 +1,163 @@
+import inspect
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import parso
+from sphinx.util.inspect import safe_getattr
+
+# adhock imports required to run eval below
+# this should be parsed out rather
+import qcodes.utils.validators as vals
+from qcodes.instrument.base import InstrumentBase
+from qcodes.instrument.parameter import Parameter
+
+
+def parse_init_function_from_str(
+    code: str, classname
+) -> Optional[parso.python.tree.Function]:
+    module = parso.parse(code)
+    classes = tuple(
+        child
+        for child in module.children
+        if isinstance(child, parso.python.tree.Class) and child.name.value == classname
+    )
+    if len(classes) != 1:
+        print(f"Could not find exactly one class for {classname}")
+        return None
+    assert len(classes) == 1
+    myclass = classes[0]
+    nodes = tuple(
+        child
+        for child in myclass.children
+        if isinstance(child, parso.python.tree.PythonNode)
+    )
+    if len(nodes) != 1:
+        print(f"Could not find a single node from {classname}")
+        return None
+    node = nodes[0]
+    init_funcs = tuple(
+        child
+        for child in node.children
+        if isinstance(child, parso.python.tree.Function)
+        and child.name.value == "__init__"
+    )
+    if len(init_funcs) != 1:
+        print(f"Did not find an init func or found more than one from {init_funcs}")
+        return None
+    return init_funcs[0]
+
+
+def extract_statements_from_func_node(parso_func: parso.python.tree.Function):
+    function_bodys = tuple(
+        child
+        for child in parso_func.children
+        if isinstance(child, parso.python.tree.PythonNode) and child.type == "suite"
+    )
+    assert len(function_bodys) == 1
+    function_body = function_bodys[0]
+    statement_lines = tuple(
+        child.children[0]
+        for child in function_body.children
+        if isinstance(child, parso.python.tree.PythonNode)
+        and isinstance(child.children[0], parso.python.tree.ExprStmt)
+    )
+
+    return statement_lines
+
+
+def eval_params_from_code(code: str, classname: str) -> Dict[str, Parameter]:
+    init_func_tree = parse_init_function_from_str(code, classname)
+    if init_func_tree is None:
+        return {}
+    stms = extract_statements_from_func_node(init_func_tree)
+    param_dict = {}
+
+    for stm in stms:
+        try:
+            name_code = extract_code_without_self_from_statement(stm)
+        except:
+            continue
+        if name_code is not None:
+            name, code = name_code
+            try:
+                param_dict[name] = eval(code)
+            except Exception as e:
+                param_dict[name] = None
+    return param_dict
+
+
+def parse_string_or_node(stm):
+    skip = False
+    if isinstance(stm, parso.python.tree.PythonNode):
+        for child in stm.children:
+            if not isinstance(child, parso.python.tree.PythonNode):
+                # todo more robust parsing of recursive nodes
+                if child.value == "self":
+                    skip = True
+            if isinstance(child, parso.python.tree.PythonNode):
+                maybeskip = parse_string_or_node(child)
+                if maybeskip:
+                    skip = True
+    else:
+        if stm.value == "self":
+            skip = True
+
+    return skip
+
+
+def extract_code_without_self_from_statement(
+    stm: parso.python.tree.ExprStmt,
+) -> Optional[Tuple[str, str]]:
+    lhs = stm.children[0]
+    rhs = stm.get_rhs()
+    if len(lhs.children) == 2 and lhs.children[0].value == "self":
+        name = lhs.children[1].children[1].value
+        arglist = rhs.children[1].children[1]
+        to_remove = []
+        for i, arg in enumerate(arglist.children):
+            if parse_string_or_node(arg):
+                to_remove.append(i)
+                to_remove.append(i + 1)
+        to_remove.sort(reverse=True)
+        for j in to_remove:
+            arglist.children.pop(j)
+        return name, rhs.get_code().strip()
+    else:
+        return None
+
+
+def qcodes_parameter_attr_getter(object: Any, name: str, *default: Any) -> Any:
+    if (
+        inspect.isclass(object)
+        and issubclass(object, InstrumentBase)
+        and not name.startswith("_")
+    ):
+        try:
+            return safe_getattr(object, name)
+        except AttributeError:
+            print(f"Parsing attribute {name} on {object}")
+            obj_name = object.__name__
+            with open(inspect.getfile(object), encoding="utf8") as file:
+                code = file.read()
+            param_dict = eval_params_from_code(code, obj_name)
+            if param_dict.get(name) is not None:
+                return param_dict[name]
+            else:
+                print("fall back to default")
+                return safe_getattr(object, name, default)
+    else:
+
+        return safe_getattr(object, name, default)
+
+
+def setup(app):
+    """Called by sphinx to setup the extension."""
+    app.setup_extension("sphinx.ext.autodoc")  # Require autodoc extension
+
+    app.add_autodoc_attrgetter(object, qcodes_parameter_attr_getter)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,  # Not tested, should not be an issue
+        "parallel_write_safe": True,  # Not tested, should not be an issue
+    }


### PR DESCRIPTION
This is an alternative suggestion to #3098. Since #32 was solved by #3125 I consider that out of scope for both these prs.

This enables parameters to be expressed as attributes on the instrument directly without having to call add_parameter. This has the advantage that the code exactly matches what one would expect a parameter to be namely an attribute on the instrument. 

Sphinx automatically documents attributes if they have a docstring enabling this to fix #1151 However the documentation for instance attributes is less than ideal by default. This therefor also includes a very early proof of concept sphinx extension that instantiates parameter attributes when calling getattr on an instrument. It does this by parsing the code and extracting any argument that contains self (since the instrument class cannot be instantiated) and then instantiating the parameter without these. 

The attributes are documented via their `__repr__` which has been overwritten here to prove the concept. 
This parser would need significant further work. One could either do

* Use autodoc-process-docstring/signature as in #3098 to provide a better formatting than the repr
* Rather than instantiating the object we could create a proxy object that only contains a repr as we want it. 

Compared to the old way of add_parameter this has a few disadvantages.

* One must explicitly pass self as instrument to the parameter. 
* Name is repeated both as the attribute name and as the name passed to the parameter. 

I do however feel that the added clarity of the code more that out ways these issues. 


Note that some tests fail due to the change in repr.
If we go down this route we should probably do the same for qcodes functions and submodules eventually. 