### PR TITLE
Don't allow metadata tags that are not valid python identifiers

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -622,7 +622,9 @@ class DataSet(Sized):
     def add_metadata(self, tag: str, metadata: Any) -> None:
         """
         Adds metadata to the :class:`.DataSet`. The metadata is stored under the
-        provided tag. Note that None is not allowed as a metadata value.
+        provided tag. Note that None is not allowed as a metadata value, and the
+        tag has to be a valid python identified (e.g. containing alphanumeric
+        characters and underscores).
 
         Args:
             tag: represents the key in the metadata dictionary

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1726,7 +1726,8 @@ def insert_meta_data(conn: ConnectionPlus, row_id: int, table_name: str,
                      metadata: Mapping[str, Any]) -> None:
     """
     Insert new metadata column and add values. Note that None is not a valid
-    metadata value
+    metadata value, and keys should be valid SQLite column names
+    (i.e. contain only alphanumeric characters and underscores).
 
     Args:
         - conn: the connection to the sqlite database
@@ -1735,9 +1736,12 @@ def insert_meta_data(conn: ConnectionPlus, row_id: int, table_name: str,
         - metadata: the metadata to add
     """
     for tag, val in metadata.items():
+        if not tag.isidentifier():
+            raise KeyError(f'Tag {tag} is not a valid tag. '
+                            'Use only alphanumeric characters and underscores!')
         if val is None:
             raise ValueError(f'Tag {tag} has value None. '
-                             ' That is not a valid metadata value!')
+                              'That is not a valid metadata value!')
     for key in metadata.keys():
         insert_column(conn, table_name, key)
     update_meta_data(conn, row_id, table_name, metadata)
@@ -1763,7 +1767,9 @@ def add_meta_data(conn: ConnectionPlus,
                   table_name: str = "runs") -> None:
     """
     Add metadata data (updates if exists, create otherwise).
-    Note that None is not a valid metadata value.
+    Note that None is not a valid metadata value, and keys
+    should be valid SQLite column names (i.e. contain only
+    alphanumeric characters and underscores).
 
     Args:
         - conn: the connection to the sqlite database

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1722,6 +1722,24 @@ def get_metadata_from_run_id(
     return metadata
 
 
+def validate_meta_data(metadata: Mapping[str, Any]) -> None:
+    """
+    Validate metadata tags and values. Note that None is not a valid
+    metadata value, and keys should be valid SQLite column names
+    (i.e. contain only alphanumeric characters and underscores).
+
+    Args:
+        metadata: the metadata mapping (tags to values)
+    """
+    for tag, val in metadata.items():
+        if not tag.isidentifier():
+            raise KeyError(f'Tag {tag} is not a valid tag. '
+                            'Use only alphanumeric characters and underscores!')
+        if val is None:
+            raise ValueError(f'Tag {tag} has value None. '
+                              'That is not a valid metadata value!')
+
+
 def insert_meta_data(conn: ConnectionPlus, row_id: int, table_name: str,
                      metadata: Mapping[str, Any]) -> None:
     """
@@ -1735,13 +1753,7 @@ def insert_meta_data(conn: ConnectionPlus, row_id: int, table_name: str,
         - table_name: the table to add to, defaults to runs
         - metadata: the metadata to add
     """
-    for tag, val in metadata.items():
-        if not tag.isidentifier():
-            raise KeyError(f'Tag {tag} is not a valid tag. '
-                            'Use only alphanumeric characters and underscores!')
-        if val is None:
-            raise ValueError(f'Tag {tag} has value None. '
-                              'That is not a valid metadata value!')
+    validate_meta_data(metadata)
     for key in metadata.keys():
         insert_column(conn, table_name, key)
     update_meta_data(conn, row_id, table_name, metadata)
@@ -1758,6 +1770,7 @@ def update_meta_data(conn: ConnectionPlus, row_id: int, table_name: str,
         - table_name: the table to add to, defaults to runs
         - metadata: the metadata to add
     """
+    validate_meta_data(metadata)
     update_where(conn, table_name, 'rowid', row_id, **metadata)
 
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -680,8 +680,7 @@ def test_metadata(experiment, request):
     )
     with pytest.raises(RuntimeError,
                        match="Rolling back due to unhandled exception") as e2:
-        for tag, value in sorry_metadata.items():
-            ds1.add_metadata(good_tag, None)
+        ds1.add_metadata(good_tag, None)
     assert error_caused_by(e2, none_value_msg)
 
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -663,18 +663,26 @@ def test_metadata(experiment, request):
     request.addfinalizer(loaded_ds2.conn.close)
     assert loaded_ds2.metadata == metadata2
 
-    badtag = 'lex luthor'
-    sorry_metadata = {'superman': 1, badtag: None, 'spiderman': 'two'}
-
-    bad_tag_msg = (f'Tag {badtag} has value None. '
-                   ' That is not a valid metadata value!')
-
+    bad_tag = "lex luthor"
+    bad_tag_msg = (
+      f"Tag {bad_tag} is not a valid tag. "
+      "Use only alphanumeric characters and underscores!"
+    )
     with pytest.raises(RuntimeError,
-                       match='Rolling back due to unhandled exception') as e:
-        for tag, value in sorry_metadata.items():
-            ds1.add_metadata(tag, value)
+                       match="Rolling back due to unhandled exception") as e1:
+        ds1.add_metadata(bad_tag, "value")
+    assert error_caused_by(e1, bad_tag_msg)
 
-    assert error_caused_by(e, bad_tag_msg)
+    good_tag = "tag"
+    none_value_msg = (
+      f"Tag {good_tag} has value None. "
+      "That is not a valid metadata value!"
+    )
+    with pytest.raises(RuntimeError,
+                       match="Rolling back due to unhandled exception") as e2:
+        for tag, value in sorry_metadata.items():
+            ds1.add_metadata(good_tag, None)
+    assert error_caused_by(e2, none_value_msg)
 
 
 def test_the_same_dataset_as(some_interdeps, experiment):


### PR DESCRIPTION
otherwise there will be a confusing error message from sqlite