### PR TITLE
Fix delegate test

### DIFF
--- a/qcodes/tests/delegate/test_device.py
+++ b/qcodes/tests/delegate/test_device.py
@@ -4,7 +4,8 @@ import numpy as np
 import pytest
 
 from qcodes import Measurement
-from qcodes.tests.instrument_mocks import MockCustomChannel, DummyChannel
+from qcodes.tests.dataset.conftest import empty_temp_db, experiment
+from qcodes.tests.instrument_mocks import DummyChannel, MockCustomChannel
 
 
 def test_device(station, chip_config, dac, lockin):
@@ -25,6 +26,7 @@ def test_device(station, chip_config, dac, lockin):
     )
 
 
+@pytest.mark.usefixtures("experiment")
 def test_device_meas(station, chip):
     meas = Measurement(station=station)
     device = chip.device1

--- a/qcodes/tests/delegate/test_device.py
+++ b/qcodes/tests/delegate/test_device.py
@@ -32,7 +32,8 @@ def test_device_meas(station, chip):
     device = chip.device1
     meas.register_parameter(device.gate)
     meas.register_parameter(device.drain, setpoints=(device.gate,))
-
+    device.gate.inter_delay = 0
+    device.gate.step = 1
     with meas.run() as datasaver:
         for set_v in np.linspace(0, 1.5, 10):
             device.gate.set(set_v)


### PR DESCRIPTION
* Test needs an experiment to add data to otherwise it cannot run standalone.
* Test was setting v on a device with non zero post delay and a small step size making it much slower than needed
