### PR TITLE
forward instrument to parameter baseclass in rto driver

### DIFF
--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -2,18 +2,18 @@
 # for firmware 3.65, 2017
 
 import logging
-import warnings
 import time
-from typing import Optional, Any
+import warnings
+from distutils.version import LooseVersion
+from typing import Any, Optional
 
 import numpy as np
-from distutils.version import LooseVersion
 
 from qcodes import Instrument
-from qcodes.instrument.visa import VisaInstrument
 from qcodes.instrument.channel import InstrumentChannel
-from qcodes.utils import validators as vals
 from qcodes.instrument.parameter import ArrayParameter
+from qcodes.instrument.visa import VisaInstrument
+from qcodes.utils import validators as vals
 from qcodes.utils.helpers import create_on_off_val_mapping
 
 log = logging.getLogger(__name__)
@@ -28,14 +28,18 @@ class ScopeTrace(ArrayParameter):
 
         For now, we only support reading out the entire trace.
         """
-        super().__init__(name=name,
-                         shape=(1,),
-                         label='Voltage',  # TODO: Is this sometimes dbm?
-                         unit='V',
-                         setpoint_names=('Time',),
-                         setpoint_labels=('Time',),
-                         setpoint_units=('s',),
-                         docstring='Holds scope trace')
+        super().__init__(
+            name=name,
+            shape=(1,),
+            label="Voltage",  # TODO: Is this sometimes dbm?
+            unit="V",
+            setpoint_names=("Time",),
+            setpoint_labels=("Time",),
+            setpoint_units=("s",),
+            docstring="Holds scope trace",
+            snapshot_value=False,
+            instrument=instrument,
+        )
 
         self.channel = instrument
         self.channum = channum

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -49,6 +49,8 @@ class ScopeTrace(ArrayParameter):
         """
         Prepare the scope for returning data, calculate the setpoints
         """
+        assert self.root_instrument is not None
+
         # We always use 16 bit integers for the data format
         self.root_instrument.dataformat("INT,16")
         # ensure little-endianess
@@ -89,6 +91,7 @@ class ScopeTrace(ArrayParameter):
         """
 
         instr = self.root_instrument
+        assert instr is not None
 
         if not self._trace_ready:
             raise ValueError('Trace not ready! Please call '

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -43,25 +43,25 @@ class ScopeTrace(ArrayParameter):
 
         self.channel = instrument
         self.channum = channum
+        self._trace_ready = False
 
     def prepare_trace(self) -> None:
         """
         Prepare the scope for returning data, calculate the setpoints
         """
         # We always use 16 bit integers for the data format
-        self.channel._parent.dataformat('INT,16')
+        self.root_instrument.dataformat("INT,16")
         # ensure little-endianess
-        self.channel._parent.write('FORMat:BORder LSBFirst')
+        self.root_instrument.write("FORMat:BORder LSBFirst")
         # only export y-values
-        self.channel._parent.write('EXPort:WAVeform:INCXvalues OFF')
+        self.root_instrument.write("EXPort:WAVeform:INCXvalues OFF")
         # only export one channel
-        self.channel._parent.write('EXPort:WAVeform:MULTichannel OFF')
+        self.root_instrument.write("EXPort:WAVeform:MULTichannel OFF")
 
         # now get setpoints
 
-        hdr = self.channel._parent.ask(f'CHANnel{self.channum}:'
-                                       'DATA:HEADER?')
-        hdr_vals = list(map(float, hdr.split(',')))
+        hdr = self.root_instrument.ask(f"CHANnel{self.channum}:" "DATA:HEADER?")
+        hdr_vals = list(map(float, hdr.split(",")))
         t_start = hdr_vals[0]
         t_stop = hdr_vals[1]
         no_samples = int(hdr_vals[2])
@@ -81,14 +81,14 @@ class ScopeTrace(ArrayParameter):
 
         self._trace_ready = True
         # we must ensure that all this took effect before proceeding
-        self.channel._parent.ask('*OPC?')
+        self.root_instrument.ask("*OPC?")
 
     def get_raw(self) -> np.ndarray:
         """
         Returns a trace
         """
 
-        instr = self.channel._parent
+        instr = self.root_instrument
 
         if not self._trace_ready:
             raise ValueError('Trace not ready! Please call '


### PR DESCRIPTION
Bug fix taken from #3191

Not sure why this instrument uses channel instead of instrument but perhaps the intent was to avoid a snapshot so set snapshot_value to false as it makes no sense to snapshot this value.

Also sneaked in a few cleanups. 
Use public root instrument attr and make sure that trace_ready is always set
