### PR TITLE
Use qcodes config to have active experiment

### DIFF
--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -72,7 +72,8 @@
         "export_automatic": false,
         "export_type": null,
         "export_prefix": "qcodes_",
-        "export_path": "~"
+        "export_path": "~",
+        "active_experiment": null
     },
     "telemetry":
     {

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -342,6 +342,11 @@
                     "type": "string",
                     "default": "qcodes_",
                     "description": "Prefix to add to filename for exporting datasets to disk after a measurement finishes. Only activated if export_type is set"
+                },
+                "active_experiment": {
+                    "type": ["integer", "null"],
+                    "default": null,
+                    "description": "Active experiment's exp_id. Default is None means no active experiment by default."
                 }
             },
             "description": "Settings related to the DataSet and Measurement Context manager",

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -288,7 +288,10 @@ class DataSet(Sized):
             # with no parameters; they are written to disk when the dataset
             # is marked as started
             if exp_id is None:
-                exp_id = get_last_experiment(self.conn)
+                exp_id = qcodes.config["dataset"]["active_experiment"]
+                if exp_id is None:
+                    exp_id = get_last_experiment(self.conn)
+                    qcodes.config["dataset"]["active_experiment"] = exp_id
                 if exp_id is None:  # if it's still None, then...
                     raise ValueError("No experiments found."
                                      "You can start a new one with:"

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -217,6 +217,7 @@ def initialise_database(journal_mode: Optional[str] = 'WAL') -> None:
     # calling connect performs all the needed actions to create and upgrade
     # the db to the latest version.
     conn = connect(get_DB_location(), get_DB_debug())
+    qcodes.config['dataset']['active_experiment'] = None
     if journal_mode is not None:
         set_journal_mode(conn, journal_mode)
     conn.close()
@@ -259,6 +260,7 @@ def initialise_or_create_database_at(db_file_with_abs_path: str,
     """
     qcodes.config.core.db_location = db_file_with_abs_path
     initialise_database(journal_mode)
+    qcodes.config['dataset']['active_experiment'] = None
 
 
 @contextmanager
@@ -277,6 +279,7 @@ def initialised_database_at(db_file_with_abs_path: str) -> Iterator[None]:
         yield
     finally:
         qcodes.config["core"]["db_location"] = db_location
+        qcodes.config['dataset']['active_experiment'] = None
 
 
 def conn_from_dbpath_or_conn(conn: Optional[ConnectionPlus],


### PR DESCRIPTION
This PR :

- Adds a setting in qcodes config file with the active_experiment key to hold the active_experiment exp_id.
- It adds set_active_experiment function to change the config and runs this function inside every create/ load of experiment related functions. There is also a get_active_experiment function to read the config.
- DataSet creation now reads the active_experiment setting first to assign that dataset to the active_experiment, if active_experiment is None, it reads the last experiment as before.
- Resets the active_experiment config setting upon creating/ loading a database

**The PR is on-hold and will remain as draft **

