### PR TITLE
Document Parameter attributes

### DIFF
--- a/.github/static/environment_forge_full.yml
+++ b/.github/static/environment_forge_full.yml
@@ -36,6 +36,7 @@ dependencies:
  - pytest-xdist>=2.0.0
  - pytest-mock>=3.0.0
  - lxml>=4.3.0
+ - sphinx
  # extra relevant requirements from setup.cfg
  - pyqtgraph>=0.11.0
  # for running mypy type checking

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,12 +41,22 @@ sys.path.insert(0, os.path.abspath('..'))
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['nbsphinx', 'sphinx.ext.autodoc', 'sphinx.ext.autosummary',
-              'sphinx.ext.napoleon', 'sphinx-jsonschema', 'sphinx.ext.doctest',
-              'sphinx.ext.intersphinx', 'sphinx.ext.todo',
-              'sphinx.ext.coverage', 'sphinx.ext.mathjax',
-              'sphinx.ext.viewcode', 'sphinx.ext.githubpages',
-              'sphinx.ext.todo']
+extensions = [
+    "nbsphinx",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx-jsonschema",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
+    "sphinx.ext.coverage",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
+    "sphinx.ext.todo",
+    "qcodes.sphinx_extensions.parse_parameter_attr",
+]
 
 # include special __xxx__ that DO have a docstring
 # it probably means something important

--- a/docs/examples/writing_drivers/Creating-Instrument-Drivers.ipynb
+++ b/docs/examples/writing_drivers/Creating-Instrument-Drivers.ipynb
@@ -18,13 +18,13 @@
      "text": [
       "Logging hadn't been started.\n",
       "Activating auto-logging. Current session state plus future input saved.\n",
-      "Filename       : C:\\Users\\Jens-work\\.qcodes\\logs\\command_history.log\n",
+      "Filename       : C:\\Users\\jenielse\\.qcodes\\logs\\command_history.log\n",
       "Mode           : append\n",
       "Output logging : True\n",
       "Raw input log  : False\n",
       "Timestamping   : True\n",
       "State          : active\n",
-      "Qcodes Logfile : C:\\Users\\Jens-work\\.qcodes\\logs\\210722-38688-qcodes.log\n"
+      "Qcodes Logfile : C:\\Users\\jenielse\\.qcodes\\logs\\210816-9804-qcodes.log\n"
      ]
     }
    ],
@@ -163,6 +163,11 @@
     "            get_parser=float,\n",
     "            instrument=self\n",
     "        )\n",
+    "        \"\"\"Control the attenuation\"\"\"\n",
+    "        # The docstring below the Parameter declaration makes Sphinx document the attribute and it is therefore \n",
+    "        # possible to see from the documentation that the instrument has this parameter. It is strongly encouraged to \n",
+    "        # add a short docstring like this.    \n",
+    "        \n",
     "\n",
     "        # it's a good idea to call connect_message at the end of your constructor.\n",
     "        # this calls the 'IDN' parameter that the base Instrument class creates for\n",
@@ -613,28 +618,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0\n",
-      "1\n",
-      "2\n",
-      "3\n",
-      "4\n",
-      "5\n",
-      "6\n",
-      "7\n",
-      "8\n",
-      "9\n",
-      "Loop completed\n",
-      "Executing code after context manager\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qcodes.utils.delaykeyboardinterrupt import DelayedKeyboardInterrupt\n",
     "import time\n",
@@ -705,7 +691,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.11"
   },
   "toc": {
    "base_numbering": 1,

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1292,6 +1292,12 @@ class Parameter(_BaseParameter):
                 '',
                 self.__doc__))
 
+    def __repr__(self) -> str:
+        return (
+            super().__repr__()
+            + f"name {self.name}, unit {self.unit}, label {self.label}"
+        )
+
     def __getitem__(self, keys: Any) -> 'SweepFixedValues':
         """
         Slice a Parameter to get a SweepValues object

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1292,12 +1292,6 @@ class Parameter(_BaseParameter):
                 '',
                 self.__doc__))
 
-    def __repr__(self) -> str:
-        return (
-            super().__repr__()
-            + f"name {self.name}, unit {self.unit}, label {self.label}"
-        )
-
     def __getitem__(self, keys: Any) -> 'SweepFixedValues':
         """
         Slice a Parameter to get a SweepValues object

--- a/qcodes/instrument_drivers/agilent/Agilent_34400A.py
+++ b/qcodes/instrument_drivers/agilent/Agilent_34400A.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from qcodes import VisaInstrument
+from qcodes import Parameter, VisaInstrument
 from qcodes.utils.validators import Enum, Strings
 
 
@@ -9,7 +9,6 @@ class Agilent_34400A(VisaInstrument):
     This is the QCoDeS driver for the Agilent_34400A DMM Series,
     tested with Agilent_34401A, Agilent_34410A, and Agilent_34411A.
     """
-
     def __init__(self, name: str, address: str, **kwargs: Any) -> None:
         super().__init__(name, address, terminator='\n', **kwargs)
 
@@ -30,12 +29,15 @@ class Agilent_34400A(VisaInstrument):
                                               1e-07, 3e-08]
                                    }[self.model]
 
-        self.add_parameter('resolution',
-                           get_cmd='VOLT:DC:RES?',
-                           get_parser=float,
-                           set_cmd=self._set_resolution,
-                           label='Resolution',
-                           unit='V')
+        self.resolution = Parameter(
+            "resolution",
+            get_cmd="VOLT:DC:RES?",
+            get_parser=float,
+            set_cmd=self._set_resolution,
+            label="Resolution",
+            unit="V",
+        )
+        """Resolution """
 
         self.add_parameter('volt',
                            get_cmd='READ?',

--- a/qcodes/instrument_drivers/weinschel/Weinschel_8320.py
+++ b/qcodes/instrument_drivers/weinschel/Weinschel_8320.py
@@ -24,5 +24,6 @@ class Weinschel_8320(VisaInstrument):
             instrument=self,
             get_parser=float,
         )
+        """Control the attenuation"""
 
         self.connect_message()

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -29,11 +29,11 @@ class ParameterProxy:
 
 
 def find_class(
-    nodeorleaf: parso.tree.BaseNode, classname: str
+    node: parso.tree.BaseNode, classname: str
 ) -> Tuple[parso.python.tree.Class, ...]:
     """Find all classes in a given Parso node named ``classname``."""
     nodes = []
-    for child in nodeorleaf.children:
+    for child in node.children:
         if isinstance(child, parso.python.tree.Class) and child.name.value == classname:
             nodes.append(child)
         elif isinstance(child, parso.python.tree.Node):
@@ -42,11 +42,11 @@ def find_class(
 
 
 def find_init_func(
-    nodeorleaf: parso.tree.BaseNode,
+    node: parso.tree.BaseNode,
 ) -> Tuple[parso.python.tree.Function, ...]:
     """Find all ``__init__`` functions in the supplied Parso node."""
     nodes = []
-    for child in nodeorleaf.children:
+    for child in node.children:
         if (
             isinstance(child, parso.python.tree.Function)
             and child.name.value == "__init__"

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -38,7 +38,9 @@ def parse_init_function_from_str(
     )
     if len(classes) != 1:
 
-        LOGGER.warning(f"Could not find exactly one class for {classname}")
+        LOGGER.warning(
+            f"Could not find exactly one class for {classname}: Found {classes}"
+        )
         return None
     assert len(classes) == 1
     myclass = classes[0]

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -48,6 +48,8 @@ def parse_init_function_from_str(
         if isinstance(child, parso.python.tree.PythonNode)
     )
     node = nodes[-1]
+    # todo this does not correctly handle a node in a decorated init functions
+    # since that is nested one level further down
     init_funcs = tuple(
         child
         for child in node.children

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -117,7 +117,8 @@ def extract_code_as_repr(
     rhs = stm.get_rhs()
     if len(lhs.children) == 2 and lhs.children[0].value == "self":
         name = lhs.children[1].children[1].value
-        pp = ParameterProxy(rhs.get_code().strip())
+        code = " ".join(rhs.get_code().strip().split())
+        pp = ParameterProxy(code)
         return name, pp
     else:
         return None

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -47,10 +47,7 @@ def parse_init_function_from_str(
         for child in myclass.children
         if isinstance(child, parso.python.tree.PythonNode)
     )
-    if len(nodes) != 1:
-        LOGGER.warning(f"Could not find a single node from {classname}")
-        return None
-    node = nodes[0]
+    node = nodes[-1]
     init_funcs = tuple(
         child
         for child in node.children

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -55,7 +55,7 @@ def parse_init_function_from_str(
         and child.name.value == "__init__"
     )
     if len(init_funcs) != 1:
-        LOGGER.warning(
+        LOGGER.debug(
             f"Did not find an init func or found more than one for {classname}: Found {init_funcs}"
         )
         return None

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -30,6 +30,7 @@ class ParameterProxy:
 def find_class(
     nodeorleaf: parso.tree.BaseNode, classname: str
 ) -> Tuple[parso.python.tree.Class, ...]:
+    """Find all classes in a given Parso node named ``classname``"""
     nodes = []
     for child in nodeorleaf.children:
         if isinstance(child, parso.python.tree.Class) and child.name.value == classname:
@@ -42,6 +43,7 @@ def find_class(
 def find_init_func(
     nodeorleaf: parso.tree.BaseNode,
 ) -> Tuple[parso.python.tree.Function, ...]:
+    """Find all ``__init__`` functions in the supplied Parso node."""
     nodes = []
     for child in nodeorleaf.children:
         if (
@@ -146,6 +148,22 @@ def extract_code_as_repr(
 def qcodes_parameter_attr_getter(
     object_to_document_attr_on: Type[object], name: str, *default: Any
 ) -> Any:
+    """
+    Try to extract an attribute as a proxy object with a repr containing the code
+    if the class the attribute is bound to is a subclass of ``InstrumentBase``
+    and the attribute is not private.
+
+    Args:
+        object_to_document_attr_on: The type (not instance of the object to detect the
+            attribute on.
+        name: Name of the attribute to look for.
+        *default: Default obejct to use as a replacement if the attribute could not be
+            found.
+
+    Returns:
+        Attribute looked up, proxy object containing the code of the attribute as a
+        repr or a default object.
+    """
     if (
         inspect.isclass(object_to_document_attr_on)
         and issubclass(object_to_document_attr_on, InstrumentBase)

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -105,6 +105,7 @@ def eval_params_from_code(code: str, classname: str) -> Dict[str, ParameterProxy
         try:
             name_code = extract_code_as_repr(stm)
         except Exception:
+            LOGGER.warning(f"Error while trying to parse attribute from {classname}")
             continue
         if name_code is not None:
             name, proxy_param = name_code

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -131,9 +131,9 @@ def qcodes_parameter_attr_getter(
         and not name.startswith("_")
     ):
         try:
-            return safe_getattr(object_to_document_attr_on, name)
-        except AttributeError:
-            print(f"Parsing attribute {name} on {object_to_document_attr_on}")
+            attr = safe_getattr(object_to_document_attr_on, name)
+        except AttributeError as e:
+            print(f"Parsing attribute {name} on {object_to_document_attr_on} after {e}")
             obj_name = object_to_document_attr_on.__name__
             with open(
                 inspect.getfile(object_to_document_attr_on), encoding="utf8"
@@ -141,13 +141,13 @@ def qcodes_parameter_attr_getter(
                 code = file.read()
             param_dict = eval_params_from_code(code, obj_name)
             if param_dict.get(name) is not None:
-                return param_dict[name]
+                attr = param_dict[name]
             else:
                 print("fall back to default")
-                return safe_getattr(object_to_document_attr_on, name, default)
+                attr = safe_getattr(object_to_document_attr_on, name, default)
     else:
-
-        return safe_getattr(object_to_document_attr_on, name, default)
+        attr = safe_getattr(object_to_document_attr_on, name, default)
+    return attr
 
 
 def setup(app: Any) -> Dict[str, Union[str, bool]]:

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -52,7 +52,7 @@ def parse_init_function_from_str(
 
 def extract_statements_from_func_node(
     parso_func: parso.python.tree.Function,
-) -> Tuple[Any, ...]:
+) -> Tuple[parso.python.tree.ExprStmt, ...]:
     function_bodys = tuple(
         child
         for child in parso_func.children

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -140,12 +140,15 @@ def qcodes_parameter_attr_getter(
             mro = inspect.getmro(object_to_document_attr_on)
             attr = None
             for classobj in mro:
-                param_dict = eval_params_from_code(
-                    inspect.getsource(classobj), classobj.__name__
-                )
-                if param_dict.get(name) is not None:
-                    attr = param_dict[name]
-                    break
+                try:
+                    param_dict = eval_params_from_code(
+                        inspect.getsource(classobj), classobj.__name__
+                    )
+                    if param_dict.get(name) is not None:
+                        attr = param_dict[name]
+                        break
+                except TypeError:
+                    continue
             if attr is None:
                 LOGGER.debug(
                     f"fall back to default for {name} on {object_to_document_attr_on}"

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -11,6 +11,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ParameterProxy:
+
     """
     An object that acts as a proxy for documenting containing
     a repr that can be set from a string.
@@ -30,7 +31,7 @@ class ParameterProxy:
 def find_class(
     nodeorleaf: parso.tree.BaseNode, classname: str
 ) -> Tuple[parso.python.tree.Class, ...]:
-    """Find all classes in a given Parso node named ``classname``"""
+    """Find all classes in a given Parso node named ``classname``."""
     nodes = []
     for child in nodeorleaf.children:
         if isinstance(child, parso.python.tree.Class) and child.name.value == classname:
@@ -164,7 +165,7 @@ def qcodes_parameter_attr_getter(
     ):
         try:
             attr = safe_getattr(object_to_document_attr_on, name)
-        except AttributeError as e:
+        except AttributeError:
             LOGGER.debug(
                 f"Attempting to load attribute {name} on "
                 f"{object_to_document_attr_on} via parsing"

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -31,6 +31,7 @@ def parse_init_function_from_str(
     code: str, classname: str
 ) -> Optional[parso.python.tree.Function]:
     module = parso.parse(code)
+    # todo this fails if the class is decorated since its nested one more level
     classes = tuple(
         child
         for child in module.children

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -56,7 +56,7 @@ def parse_init_function_from_str(
     )
     if len(init_funcs) != 1:
         LOGGER.warning(
-            f"Did not find an init func or found more than one from {init_funcs}"
+            f"Did not find an init func or found more than one for {classname}: Found {init_funcs}"
         )
         return None
     return init_funcs[0]

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -11,8 +11,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ParameterProxy:
-
     """
+
     An object that acts as a proxy for documenting containing
     a repr that can be set from a string.
 

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -4,6 +4,7 @@ attribute. This enables better documentation of instance attributes.
 Especially QCoDeS Parameters.  Note that this is for the moment limited to
 attributes on QCoDeS instruments."""
 
+import functools
 import inspect
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
@@ -101,6 +102,7 @@ def extract_statements_from_node(
     return tuple(nodes)
 
 
+@functools.lru_cache(maxsize=None, typed=True)
 def eval_params_from_code(code: str, classname: str) -> Dict[str, ParameterProxy]:
     init_func_tree = parse_init_function_from_str(code, classname)
     if init_func_tree is None:

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -1,15 +1,10 @@
 import inspect
 from typing import Any, Dict, Optional, Tuple
 
-import numpy as np
 import parso
 from sphinx.util.inspect import safe_getattr
 
-# adhock imports required to run eval below
-# this should be parsed out rather
-import qcodes.utils.validators as vals
 from qcodes.instrument.base import InstrumentBase
-from qcodes.instrument.parameter import Parameter
 
 
 class ParameterProxy:

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -28,7 +28,7 @@ class ParameterProxy:
 
 
 def find_class(
-    nodeorleaf: parso.tree.NodeOrLeaf, classname: str
+    nodeorleaf: parso.tree.BaseNode, classname: str
 ) -> Tuple[parso.python.tree.Class, ...]:
     nodes = []
     for child in nodeorleaf.children:
@@ -40,7 +40,7 @@ def find_class(
 
 
 def find_init_func(
-    nodeorleaf: parso.tree.NodeOrLeaf,
+    nodeorleaf: parso.tree.BaseNode,
 ) -> Tuple[parso.python.tree.Function, ...]:
     nodes = []
     for child in nodeorleaf.children:
@@ -80,8 +80,8 @@ def parse_init_function_from_str(
     return init_funcs[0]
 
 
-def extract_statements_from_func_node(
-    parso_func: parso.python.tree.Function,
+def extract_statements_from_node(
+    parso_node: parso.tree.BaseNode,
 ) -> Tuple[parso.python.tree.ExprStmt, ...]:
     function_bodys = tuple(
         child

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -1,3 +1,9 @@
+"""A Sphinx extension that uses Parso to extract the code of a
+instance attribute as a proxy object with a repr containing the code defining the
+attribute. This enables better documentation of instance attributes.
+Especially QCoDeS Parameters.  Note that this is for the moment limited to
+attributes on QCoDeS instruments."""
+
 import inspect
 from typing import Any, Dict, Optional, Tuple, Type, Union
 

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -1,0 +1,163 @@
+import inspect
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import parso
+from sphinx.util.inspect import safe_getattr
+
+# adhock imports required to run eval below
+# this should be parsed out rather
+import qcodes.utils.validators as vals
+from qcodes.instrument.base import InstrumentBase
+from qcodes.instrument.parameter import Parameter
+
+
+def parse_init_function_from_str(
+    code: str, classname
+) -> Optional[parso.python.tree.Function]:
+    module = parso.parse(code)
+    classes = tuple(
+        child
+        for child in module.children
+        if isinstance(child, parso.python.tree.Class) and child.name.value == classname
+    )
+    if len(classes) != 1:
+        print(f"Could not find exactly one class for {classname}")
+        return None
+    assert len(classes) == 1
+    myclass = classes[0]
+    nodes = tuple(
+        child
+        for child in myclass.children
+        if isinstance(child, parso.python.tree.PythonNode)
+    )
+    if len(nodes) != 1:
+        print(f"Could not find a single node from {classname}")
+        return None
+    node = nodes[0]
+    init_funcs = tuple(
+        child
+        for child in node.children
+        if isinstance(child, parso.python.tree.Function)
+        and child.name.value == "__init__"
+    )
+    if len(init_funcs) != 1:
+        print(f"Did not find an init func or found more than one from {init_funcs}")
+        return None
+    return init_funcs[0]
+
+
+def extract_statements_from_func_node(parso_func: parso.python.tree.Function):
+    function_bodys = tuple(
+        child
+        for child in parso_func.children
+        if isinstance(child, parso.python.tree.PythonNode) and child.type == "suite"
+    )
+    assert len(function_bodys) == 1
+    function_body = function_bodys[0]
+    statement_lines = tuple(
+        child.children[0]
+        for child in function_body.children
+        if isinstance(child, parso.python.tree.PythonNode)
+        and isinstance(child.children[0], parso.python.tree.ExprStmt)
+    )
+
+    return statement_lines
+
+
+def eval_params_from_code(code: str, classname: str) -> Dict[str, Parameter]:
+    init_func_tree = parse_init_function_from_str(code, classname)
+    if init_func_tree is None:
+        return {}
+    stms = extract_statements_from_func_node(init_func_tree)
+    param_dict = {}
+
+    for stm in stms:
+        try:
+            name_code = extract_code_without_self_from_statement(stm)
+        except:
+            continue
+        if name_code is not None:
+            name, code = name_code
+            try:
+                param_dict[name] = eval(code)
+            except Exception as e:
+                param_dict[name] = None
+    return param_dict
+
+
+def parse_string_or_node(stm):
+    skip = False
+    if isinstance(stm, parso.python.tree.PythonNode):
+        for child in stm.children:
+            if not isinstance(child, parso.python.tree.PythonNode):
+                # todo more robust parsing of recursive nodes
+                if child.value == "self":
+                    skip = True
+            if isinstance(child, parso.python.tree.PythonNode):
+                maybeskip = parse_string_or_node(child)
+                if maybeskip:
+                    skip = True
+    else:
+        if stm.value == "self":
+            skip = True
+
+    return skip
+
+
+def extract_code_without_self_from_statement(
+    stm: parso.python.tree.ExprStmt,
+) -> Optional[Tuple[str, str]]:
+    lhs = stm.children[0]
+    rhs = stm.get_rhs()
+    if len(lhs.children) == 2 and lhs.children[0].value == "self":
+        name = lhs.children[1].children[1].value
+        arglist = rhs.children[1].children[1]
+        to_remove = []
+        for i, arg in enumerate(arglist.children):
+            if parse_string_or_node(arg):
+                to_remove.append(i)
+                to_remove.append(i + 1)
+        to_remove.sort(reverse=True)
+        for j in to_remove:
+            arglist.children.pop(j)
+        return name, rhs.get_code().strip()
+    else:
+        return None
+
+
+def qcodes_parameter_attr_getter(object: Any, name: str, *default: Any) -> Any:
+    if (
+        inspect.isclass(object)
+        and issubclass(object, InstrumentBase)
+        and not name.startswith("_")
+    ):
+        try:
+            return safe_getattr(object, name)
+        except AttributeError:
+            print(f"Parsing attribute {name} on {object}")
+            obj_name = object.__name__
+            with open(inspect.getfile(object), encoding="utf8") as file:
+                code = file.read()
+            param_dict = eval_params_from_code(code, obj_name)
+            if param_dict.get(name) is not None:
+                return param_dict[name]
+            else:
+                print("fall back to default")
+                return safe_getattr(object, name, default)
+    else:
+
+        return safe_getattr(object, name, default)
+
+
+def setup(app):
+    """Called by sphinx to setup the extension."""
+    app.setup_extension("sphinx.ext.autodoc")  # Require autodoc extension
+
+    app.add_autodoc_attrgetter(object, qcodes_parameter_attr_getter)
+
+    return {
+        "version": "0.1",
+        "parallel_read_safe": True,  # Not tested, should not be an issue
+        "parallel_write_safe": True,  # Not tested, should not be an issue
+    }

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -86,25 +86,6 @@ def eval_params_from_code(code: str, classname: str) -> Dict[str, ParameterProxy
     return param_dict
 
 
-def parse_string_or_node(stm):
-    skip = False
-    if isinstance(stm, parso.python.tree.PythonNode):
-        for child in stm.children:
-            if not isinstance(child, parso.python.tree.PythonNode):
-                # todo more robust parsing of recursive nodes
-                if child.value == "self":
-                    skip = True
-            if isinstance(child, parso.python.tree.PythonNode):
-                maybeskip = parse_string_or_node(child)
-                if maybeskip:
-                    skip = True
-    else:
-        if stm.value == "self":
-            skip = True
-
-    return skip
-
-
 def extract_code_as_repr(
     stm: parso.python.tree.ExprStmt,
 ) -> Optional[Tuple[str, ParameterProxy]]:

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -1,7 +1,8 @@
-"""A Sphinx extension that uses Parso to extract the code of a
-instance attribute as a proxy object with a repr containing the code defining the
+"""A Sphinx extension that uses Parso to extract the code of a instance attribute.
+
+The code is used to produce a proxy object with a repr containing the code defining the
 attribute. This enables better documentation of instance attributes.
-Especially QCoDeS Parameters.  Note that this is for the moment limited to
+Especially QCoDeS Parameters. Note that this is for the moment limited to
 attributes on QCoDeS instruments."""
 
 import functools
@@ -18,8 +19,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ParameterProxy:
-    """
 
+    """
     An object that acts as a proxy for documenting containing
     a repr that can be set from a string.
 

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -33,7 +33,7 @@ class DummyNoInitClass(InstrumentBase):
     A class attribute
     """
 
-    def foo(self) -> str:
+    def somefunction(self) -> str:
         return self.myattr
 
 
@@ -113,7 +113,7 @@ def test_decorated_class():
 
 
 def test_no_init():
-    """Test that attribute can be found from a class without an init function"""
+    """Test that attribute can be found from a class without an init function."""
     attr = qcodes_parameter_attr_getter(DummyNoInitClass, "parameters")
     assert isinstance(attr, ParameterProxy)
     assert repr(attr) == "{}"

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -2,6 +2,7 @@ import pytest
 from sphinx.util.inspect import safe_getattr
 
 from qcodes.instrument.base import InstrumentBase
+from qcodes.instrument.visa import VisaInstrument
 from qcodes.sphinx_extensions.parse_parameter_attr import (
     ParameterProxy,
     qcodes_parameter_attr_getter,
@@ -39,3 +40,15 @@ def test_extract_instance_attr():
     b = qcodes_parameter_attr_getter(DummyTestClass, "other_attr")
     assert isinstance(b, ParameterProxy)
     assert repr(b) == '"InstanceAttribute"'
+
+
+def test_instrument_base_get_attr():
+    parameters = qcodes_parameter_attr_getter(InstrumentBase, "parameters")
+    assert isinstance(parameters, ParameterProxy)
+    assert repr(parameters) == "{}"
+
+
+def test_visa_instr_get_attr():
+    parameters = qcodes_parameter_attr_getter(VisaInstrument, "parameters")
+    assert isinstance(parameters, ParameterProxy)
+    assert repr(parameters) == "{}"

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -26,6 +26,17 @@ class DummyTestClass(InstrumentBase):
         """
 
 
+class DummyNoInitClass(InstrumentBase):
+
+    myattr: str = "ClassAttribute"
+    """
+    A class attribute
+    """
+
+    def foo(self) -> str:
+        return self.myattr
+
+
 class DummyDecoratedInitTestClass(InstrumentBase):
 
     myattr: str = "ClassAttribute"
@@ -99,3 +110,12 @@ def test_decorated_class():
     attr = qcodes_parameter_attr_getter(DummyDecoratedClassTestClass, "other_attr")
     assert isinstance(attr, ParameterProxy)
     assert repr(attr) == '"InstanceAttribute"'
+
+
+def test_no_init():
+    """
+    Test that attribute can be found from a class without an init function
+    """
+    attr = qcodes_parameter_attr_getter(DummyNoInitClass, "parameters")
+    assert isinstance(attr, ParameterProxy)
+    assert repr(attr) == "{}"

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -26,10 +26,10 @@ class DummyTestClass(InstrumentBase):
 
 def test_extract_class_attr():
     a = safe_getattr(DummyTestClass, "myattr")
-    assert a == "SomeAttribute"
+    assert a == "ClassAttribute"
 
     b = qcodes_parameter_attr_getter(DummyTestClass, "myattr")
-    assert b == "SomeAttribute"
+    assert b == "ClassAttribute"
 
 
 def test_extract_instance_attr():

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -1,0 +1,41 @@
+import pytest
+from sphinx.util.inspect import safe_getattr
+
+from qcodes.instrument.base import InstrumentBase
+from qcodes.sphinx_extensions.parse_parameter_attr import (
+    ParameterProxy,
+    qcodes_parameter_attr_getter,
+)
+
+
+class DummyTestClass(InstrumentBase):
+
+    myattr: str = "ClassAttribute"
+    """
+    A class attribute
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.other_attr = "InstanceAttribute"
+        """
+        An instance attribute
+        """
+
+
+def test_extract_class_attr():
+    a = safe_getattr(DummyTestClass, "myattr")
+    assert a == "SomeAttribute"
+
+    b = qcodes_parameter_attr_getter(DummyTestClass, "myattr")
+    assert b == "SomeAttribute"
+
+
+def test_extract_instance_attr():
+    with pytest.raises(AttributeError):
+        safe_getattr(DummyTestClass, "other_attr")
+
+    b = qcodes_parameter_attr_getter(DummyTestClass, "other_attr")
+    assert isinstance(b, ParameterProxy)
+    assert repr(b) == '"InstanceAttribute"'

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -113,9 +113,7 @@ def test_decorated_class():
 
 
 def test_no_init():
-    """
-    Test that attribute can be found from a class without an init function
-    """
+    """Test that attribute can be found from a class without an init function"""
     attr = qcodes_parameter_attr_getter(DummyNoInitClass, "parameters")
     assert isinstance(attr, ParameterProxy)
     assert repr(attr) == "{}"

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -26,7 +26,7 @@ class DummyTestClass(InstrumentBase):
         """
 
 
-class DummyDeprecatedTestClass(InstrumentBase):
+class DummyDecoratedInitTestClass(InstrumentBase):
 
     myattr: str = "ClassAttribute"
     """
@@ -34,6 +34,23 @@ class DummyDeprecatedTestClass(InstrumentBase):
     """
 
     @deprecate("Deprecate to test that decorated init is handled correctly")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.other_attr = "InstanceAttribute"
+        """
+        An instance attribute
+        """
+
+
+@deprecate("Deprecate to test that decorated class is handled correctly")
+class DummyDecoratedClassTestClass(InstrumentBase):
+
+    myattr: str = "ClassAttribute"
+    """
+    A class attribute
+    """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -72,6 +89,13 @@ def test_visa_instr_get_attr():
     assert repr(parameters) == "{}"
 
 
-def test_zi():
-    scope = qcodes_parameter_attr_getter(DummyDeprecatedTestClass, "other_attr")
-    # not currently correctly resolved since init is decorated
+def test_decorated_init_func():
+    attr = qcodes_parameter_attr_getter(DummyDecoratedInitTestClass, "other_attr")
+    assert isinstance(attr, ParameterProxy)
+    assert repr(attr) == '"InstanceAttribute"'
+
+
+def test_decorated_class():
+    attr = qcodes_parameter_attr_getter(DummyDecoratedClassTestClass, "other_attr")
+    assert isinstance(attr, ParameterProxy)
+    assert repr(attr) == '"InstanceAttribute"'

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -3,6 +3,7 @@ from sphinx.util.inspect import safe_getattr
 
 from qcodes.instrument.base import InstrumentBase
 from qcodes.instrument.visa import VisaInstrument
+from qcodes.instrument_drivers.ZI.ZIUHFLI import ZIUHFLI
 from qcodes.sphinx_extensions.parse_parameter_attr import (
     ParameterProxy,
     qcodes_parameter_attr_getter,
@@ -52,3 +53,8 @@ def test_visa_instr_get_attr():
     parameters = qcodes_parameter_attr_getter(VisaInstrument, "parameters")
     assert isinstance(parameters, ParameterProxy)
     assert repr(parameters) == "{}"
+
+
+def test_zi():
+    scope = qcodes_parameter_attr_getter(ZIUHFLI, "scope")
+    # not currently correctly resolved since init is decorated

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -3,11 +3,11 @@ from sphinx.util.inspect import safe_getattr
 
 from qcodes.instrument.base import InstrumentBase
 from qcodes.instrument.visa import VisaInstrument
-from qcodes.instrument_drivers.ZI.ZIUHFLI import ZIUHFLI
 from qcodes.sphinx_extensions.parse_parameter_attr import (
     ParameterProxy,
     qcodes_parameter_attr_getter,
 )
+from qcodes.utils.deprecate import deprecate
 
 
 class DummyTestClass(InstrumentBase):
@@ -17,6 +17,23 @@ class DummyTestClass(InstrumentBase):
     A class attribute
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.other_attr = "InstanceAttribute"
+        """
+        An instance attribute
+        """
+
+
+class DummyDeprecatedTestClass(InstrumentBase):
+
+    myattr: str = "ClassAttribute"
+    """
+    A class attribute
+    """
+
+    @deprecate("Deprecate to test that decorated init is handled correctly")
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -56,5 +73,5 @@ def test_visa_instr_get_attr():
 
 
 def test_zi():
-    scope = qcodes_parameter_attr_getter(ZIUHFLI, "scope")
+    scope = qcodes_parameter_attr_getter(DummyDeprecatedTestClass, "other_attr")
     # not currently correctly resolved since init is decorated

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,6 +79,7 @@ test =
     types_requests>=0.1.8
     types-setuptools>=57.0.0
     types-tabulate>=0.1.0
+    Sphinx>=4.1.2
 
 [tool:pytest]
 testpaths = "qcodes/tests"

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -33,6 +33,7 @@ PyYAML==5.4.1
 requests==2.26.0
 six==1.16.0
 sortedcontainers==2.4.0
+Sphinx==4.1.2
 stringparser==0.5
 toml==0.10.2
 typed-ast==1.4.3; python_version<'3.8'


### PR DESCRIPTION
This adds a Sphinx extension that documents parameter attributes on instrument classes. There are documented using a proxy object that contains a `__repr__` that contains the code to construct the parameter class. 

As an example this is how the Wenishel looks on this class 

![Screenshot 2021-07-23 140750](https://user-images.githubusercontent.com/548266/126779521-590413d3-29ea-4d2a-8b6c-93da6af38b33.png)

In the longer term this can be improved to more nicely format the repr using `autodoc-process-docstring` or `autodoc-process-signature`

This pr replaces #3188