### PR TITLE
Bump importlib metadata

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -15,7 +15,7 @@ docutils==0.16
 entrypoints==0.3
 idna==3.2
 imagesize==1.2.0
-importlib-metadata==3.10.1; python_version<'3.8'
+importlib-metadata==4.6.3; python_version<'3.8'
 ipykernel==6.1.0
 ipython==7.26.0
 ipython-genutils==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ googleapis-common-protos~=1.53.0
 h5netcdf~=0.11.0
 h5py~=3.3.0
 idna~=3.2
-importlib-metadata==3.10.1; python_version<'3.8'
+importlib-metadata==4.6.3; python_version<'3.8'
 ipykernel~=6.1.0
 ipython~=7.26.0
 ipython-genutils~=0.2.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,7 +10,7 @@ deepdiff==5.5.0
 execnet==1.9.0
 hypothesis==6.14.6
 idna==3.2
-importlib-metadata==3.10.1; python_version<'3.8'
+importlib-metadata==4.6.3; python_version<'3.8'
 iniconfig==1.1.1
 lxml==4.6.3
 mypy==0.910


### PR DESCRIPTION
Now that ipykernel supports importlib meatadata we can upgrade this again. dependabot does not do this automatically due to the env marker (a bug in dependabot)