### PR TITLE
Add post sweep actions to doND sweeps

### DIFF
--- a/docs/examples/DataSet/Using_doNd_functions_in_comparison_to_Measurement_context_manager_for_performing_measurements.ipynb
+++ b/docs/examples/DataSet/Using_doNd_functions_in_comparison_to_Measurement_context_manager_for_performing_measurements.ipynb
@@ -1428,6 +1428,175 @@
     "dataset_v1 = result[0][0] # dataset for the first group\n",
     "dataset_v2 = result[0][1] # dataset for the second group"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Actions in dond"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All `doNd` functions except `do0d` support passing what we call them `action`s. These `action`s are `Callable`s, which can be used, for instance, if a user wants to perform some functions call before/ after setting a setpoint parameter. Here, we only demonstrate inner actions in `dond` because they are part of sweep classes rather than the `dond` function.\n",
+    "\n",
+    "We first define simple functions that only print some messages:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def action_1():\n",
+    "    print(\"dac channel 1 is set\")\n",
+    "    print(\"********************\")\n",
+    "\n",
+    "def action_2():\n",
+    "    print(\"dac channel 2 is set\")\n",
+    "    print(\"++++++++++++++++++++\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we pass these functions into two sweep instances (note that `action`s should always be placed in a sequence like a list, even if there is only one `Callable`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sweep_5 = LinSweep(dac.ch1, 0, 1, 2, 0.01, [action_1])\n",
+    "sweep_6 = LinSweep(dac.ch2, 0, 1, 2, 0.01, [action_2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We intentionally chose two setpoints for each sweep instance to not populate our notebook with too many prints. Every time the parameter of `sweep_5` and `sweep_6` are set to their setpoint values, `action_1` and `action_2` will be called, respectively. Let's run a `dond` with these sweeps (here, we are only interested in actions, so we do not show the progress bar and plots):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting experimental run with id: 14. Using 'qcodes.utils.dataset.doNd.dond'\n",
+      "dac channel 1 is set\n",
+      "********************\n",
+      "dac channel 2 is set\n",
+      "++++++++++++++++++++\n",
+      "dac channel 2 is set\n",
+      "++++++++++++++++++++\n",
+      "dac channel 1 is set\n",
+      "********************\n",
+      "dac channel 2 is set\n",
+      "++++++++++++++++++++\n",
+      "dac channel 2 is set\n",
+      "++++++++++++++++++++\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(results #14@C:\\Users\\a-fbonabi\\Qcodes\\docs\\examples\\DataSet\\tutorial_doNd.db\n",
+       " ----------------------------------------------\n",
+       " dac_ch1 - numeric\n",
+       " dac_ch2 - numeric\n",
+       " dmm_v1 - numeric,\n",
+       " [None],\n",
+       " [None])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dond(sweep_5, sweep_6, dmm.v1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If only inner actions between the outer loop and the inner loop are needed, then we only pass those actions into the outer-loop sweep object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def action_wait():\n",
+    "    print(\"wait after setting dac channel 1\")\n",
+    "    print(\"++++++++++++++++++++++++++++++++\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sweep_5 = LinSweep(dac.ch1, 0, 1, 2, 0.01, [action_1, action_wait])\n",
+    "sweep_6 = LinSweep(dac.ch2, 0, 1, 2, 0.01)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Starting experimental run with id: 15. Using 'qcodes.utils.dataset.doNd.dond'\n",
+      "dac channel 1 is set\n",
+      "********************\n",
+      "wait after setting dac channel 1\n",
+      "++++++++++++++++++++++++++++++++\n",
+      "dac channel 1 is set\n",
+      "********************\n",
+      "wait after setting dac channel 1\n",
+      "++++++++++++++++++++++++++++++++\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(results #15@C:\\Users\\a-fbonabi\\Qcodes\\docs\\examples\\DataSet\\tutorial_doNd.db\n",
+       " ----------------------------------------------\n",
+       " dac_ch1 - numeric\n",
+       " dac_ch2 - numeric\n",
+       " dmm_v1 - numeric,\n",
+       " [None],\n",
+       " [None])"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dond(sweep_5, sweep_6, dmm.v1)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/DataSet/Using_doNd_functions_in_comparison_to_Measurement_context_manager_for_performing_measurements.ipynb
+++ b/docs/examples/DataSet/Using_doNd_functions_in_comparison_to_Measurement_context_manager_for_performing_measurements.ipynb
@@ -1440,9 +1440,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All `doNd` functions except `do0d` support passing what we call them `action`s. These `action`s are `Callable`s, which can be used, for instance, if a user wants to perform some functions call before/ after setting a setpoint parameter. Here, we only demonstrate inner actions in `dond` because they are part of sweep classes rather than the `dond` function.\n",
+    "All `doNd` functions except `do0d` support passing what we call them `action`s. These `action`s are `Callable`s, which can be used, for instance, if a user wants to perform some functions call before/ after setting a setpoint parameter. Here, we only demonstrate post_actions in `dond` because they are part of sweep classes rather than the `dond` function.\n",
     "\n",
-    "We first define simple functions that only print some messages:"
+    "Let's walk through an example. We first define simple functions that only print some messages:"
    ]
   },
   {
@@ -1596,6 +1596,13 @@
    ],
    "source": [
     "dond(sweep_5, sweep_6, dmm.v1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These actions can be extremely useful in actual measurements that utilize `dond`. For example, If a user wants to run syncing the oscillator of two MFLI lockins after setting a frequency setpoint or starting an arbitrary waveform generator (AWG) upon sweeping a parameter, these functions can be triggered on instruments using the mentioned actions. "
    ]
   }
  ],

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -503,7 +503,7 @@ class AbstractSweep(ABC):
 
     @property
     @abstractmethod
-    def action(self) -> ActionsT:
+    def post_actions(self) -> ActionsT:
         """
         actions to be performed after setting param to its setpoint.
         """
@@ -529,14 +529,14 @@ class LinSweep(AbstractSweep):
         stop: float,
         num_points: int,
         delay: float = 0,
-        action: ActionsT = (),
+        post_actions: ActionsT = (),
     ):
         self._param = param
         self._start = start
         self._stop = stop
         self._num_points = num_points
         self._delay = delay
-        self._action = action
+        self._post_actions = post_actions
 
     def get_setpoints(self) -> np.ndarray:
         """
@@ -558,8 +558,8 @@ class LinSweep(AbstractSweep):
         return self._num_points
 
     @property
-    def action(self) -> ActionsT:
-        return self._action
+    def post_actions(self) -> ActionsT:
+        return self._post_actions
 
 
 class LogSweep(AbstractSweep):
@@ -581,14 +581,14 @@ class LogSweep(AbstractSweep):
         stop: float,
         num_points: int,
         delay: float = 0,
-        action: ActionsT = (),
+        post_actions: ActionsT = (),
     ):
         self._param = param
         self._start = start
         self._stop = stop
         self._num_points = num_points
         self._delay = delay
-        self._action = action
+        self._post_actions = post_actions
 
     def get_setpoints(self) -> np.ndarray:
         """
@@ -610,8 +610,8 @@ class LogSweep(AbstractSweep):
         return self._num_points
 
     @property
-    def action(self) -> ActionsT:
-        return self._action
+    def post_actions(self) -> ActionsT:
+        return self._post_actions
 
 
 def dond(
@@ -748,12 +748,12 @@ def dond(
 
     original_delays: Dict[_BaseParameter, float] = {}
     params_set: List[_BaseParameter] = []
-    actions: List[ActionsT] = []
+    post_actions: List[ActionsT] = []
     for sweep in sweep_instances:
         original_delays[sweep.param] = sweep.param.post_delay
         sweep.param.post_delay = sweep.delay
         params_set.append(sweep.param)
-        actions.append(sweep.action)
+        post_actions.append(sweep.post_actions)
 
     datasets = []
     plots_axes = []
@@ -775,7 +775,7 @@ def dond(
             for setpoints in tqdm(nested_setpoints, disable=not show_progress):
 
                 active_actions = _select_active_actions(
-                    actions, setpoints, previous_setpoints
+                    post_actions, setpoints, previous_setpoints
                 )
                 previous_setpoints = setpoints
 
@@ -822,7 +822,7 @@ def _select_active_actions(
     actions: Sequence[ActionsT], setpoints: np.ndarray, previous_setpoints: np.ndarray
 ) -> List[ActionsT]:
     """
-    Select ActionT (Sequence[Callable]) from a Sequence of ActionsT  if
+    Select ActionT (Sequence[Callable]) from a Sequence of ActionsT if
     the corresponding setpoint has changed. Otherwise select an empty Sequence.
     """
     actions_list: List[ActionsT] = [()] * len(setpoints)

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -821,6 +821,10 @@ def dond(
 def _select_active_actions(
     actions: Sequence[ActionsT], setpoints: np.ndarray, previous_setpoints: np.ndarray
 ) -> List[ActionsT]:
+    """
+    Select ActionT (Sequence[Callable]) from a Sequence of ActionsT  if
+    the corresponding setpoint has changed. Otherwise select an empty Sequence.
+    """
     actions_list: List[ActionsT] = [()] * len(setpoints)
     for ind, (new_setpoint, old_setpoint) in enumerate(
         zip(setpoints, previous_setpoints)

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -501,6 +501,14 @@ class AbstractSweep(ABC):
         """
         pass
 
+    @property
+    @abstractmethod
+    def action(self) -> ActionsT:
+        """
+        actions to be performed after setting param to its setpoint.
+        """
+        pass
+
 
 class LinSweep(AbstractSweep):
     """
@@ -521,12 +529,14 @@ class LinSweep(AbstractSweep):
         stop: float,
         num_points: int,
         delay: float = 0,
+        action: ActionsT = (),
     ):
         self._param = param
         self._start = start
         self._stop = stop
         self._num_points = num_points
         self._delay = delay
+        self._action = action
 
     def get_setpoints(self) -> np.ndarray:
         """
@@ -546,6 +556,10 @@ class LinSweep(AbstractSweep):
     @property
     def num_points(self) -> int:
         return self._num_points
+
+    @property
+    def action(self) -> ActionsT:
+        return self._action
 
 
 class LogSweep(AbstractSweep):
@@ -567,12 +581,14 @@ class LogSweep(AbstractSweep):
         stop: float,
         num_points: int,
         delay: float = 0,
+        action: ActionsT = (),
     ):
         self._param = param
         self._start = start
         self._stop = stop
         self._num_points = num_points
         self._delay = delay
+        self._action = action
 
     def get_setpoints(self) -> np.ndarray:
         """
@@ -592,6 +608,10 @@ class LogSweep(AbstractSweep):
     @property
     def num_points(self) -> int:
         return self._num_points
+
+    @property
+    def action(self) -> ActionsT:
+        return self._action
 
 
 def dond(
@@ -728,10 +748,12 @@ def dond(
 
     original_delays: Dict[_BaseParameter, float] = {}
     params_set: List[_BaseParameter] = []
+    actions: List[ActionsT] = []
     for sweep in sweep_instances:
         original_delays[sweep.param] = sweep.param.post_delay
         sweep.param.post_delay = sweep.delay
         params_set.append(sweep.param)
+        actions.append(sweep.action)
 
     datasets = []
     plots_axes = []
@@ -749,12 +771,22 @@ def dond(
         with _catch_keyboard_interrupts() as interrupted, ExitStack() as stack, params_meas_caller as call_params_meas:
             datasavers = [stack.enter_context(measure.run()) for measure in meas_list]
             additional_setpoints_data = process_params_meas(additional_setpoints)
+            temp_setpoints = ['temp'] * len(sweep_instances)
             for setpoints in tqdm(nested_setpoints, disable=not show_progress):
+
+                actions_list: List[ActionsT] = [()] * len(sweep_instances)
+                for ind, (new_setpoint, old_setpoint) in enumerate(zip(setpoints, temp_setpoints)):
+                    if new_setpoint != old_setpoint:
+                        actions_list[ind] = actions[ind]
+                temp_setpoints = setpoints
+
                 param_set_list = []
-                param_value_pairs = zip(params_set[::-1], setpoints[::-1])
-                for setpoint_param, setpoint in param_value_pairs:
+                param_value_action = zip(params_set, setpoints, actions_list)
+                for setpoint_param, setpoint, action in param_value_action:
                     setpoint_param(setpoint)
                     param_set_list.append((setpoint_param, setpoint))
+                    for act in action:
+                        act()
 
                 meas_value_pair = call_params_meas()
                 for group in grouped_parameters.values():

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -771,11 +771,13 @@ def dond(
         with _catch_keyboard_interrupts() as interrupted, ExitStack() as stack, params_meas_caller as call_params_meas:
             datasavers = [stack.enter_context(measure.run()) for measure in meas_list]
             additional_setpoints_data = process_params_meas(additional_setpoints)
-            temp_setpoints = ['temp'] * len(sweep_instances)
+            temp_setpoints = ["temp"] * len(sweep_instances)
             for setpoints in tqdm(nested_setpoints, disable=not show_progress):
 
                 actions_list: List[ActionsT] = [()] * len(sweep_instances)
-                for ind, (new_setpoint, old_setpoint) in enumerate(zip(setpoints, temp_setpoints)):
+                for ind, (new_setpoint, old_setpoint) in enumerate(
+                    zip(setpoints, temp_setpoints)
+                ):
                     if new_setpoint != old_setpoint:
                         actions_list[ind] = actions[ind]
                 temp_setpoints = setpoints


### PR DESCRIPTION
This PR enables dond to take inner actions. The actions are passed in the Sweep instances.
The logic is as follows: actions for a sweep parameter will be called when the set value of that parameter is changed. I didn't put comments in the code, but I think it would be nice to add a few comments.

I couldn't find a a good way to unit test actions, so it is still missing if we want to have the test.

- [x] Update doNd notebook about the usage of actions in dond.

@jenshnielsen 