### PR TITLE
make qcodes install mostly pep517/518 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = [
+    "setuptools >= 48",
+    "wheel >= 0.29.0",
+]
+build-backend = 'setuptools.build_meta'
 [tool.isort]
 profile = "black"
 [tool.darker]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ import versioneer
 
 sys.path.pop()
 
-setup(
-    version=versioneer.get_version(),
-    cmdclass=versioneer.get_cmdclass(),
-)
+
+if __name__ == "__main__":
+    setup(
+        version=versioneer.get_version(),
+        cmdclass=versioneer.get_cmdclass(),
+    )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,14 @@
+import os
+import sys
+
 from setuptools import setup
 
+# we need to import versioneer from the current dir
+# once versioneer is pep517/518 compliant this can be removed
+sys.path.append(os.path.dirname(__file__))
 import versioneer
+
+sys.path.pop()
 
 setup(
     version=versioneer.get_version(),


### PR DESCRIPTION
Versioneer is not pep518 compliant so to make this work I have added the local dir to path as suggested as a work around here https://snarky.ca/what-the-heck-is-pyproject-toml/