### PR TITLE
Log all installed packages

### DIFF
--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -6,6 +6,7 @@ the default configuration.
 """
 
 import io
+import json
 import logging
 
 # logging.handlers is not imported by logging. This extra import is necessary
@@ -332,16 +333,19 @@ def log_qcodes_versions(logger: logging.Logger) -> None:
     """
     Log the version information relevant to QCoDeS. This function logs
     the currently installed qcodes version, whether QCoDeS is installed in
-    editable mode, and the installed versions of QCoDeS' requirements.
+    editable mode, the installed versions of QCoDeS' requirements, and the
+    versions of all installed packages.
     """
 
     qc_version = ii.get_qcodes_version()
     qc_e_inst = ii.is_qcodes_installed_editably()
     qc_req_vs = ii.get_qcodes_requirements_versions()
+    ipvs = ii.get_all_installed_package_versions()
 
-    logger.info(f'QCoDeS version: {qc_version}')
-    logger.info(f'QCoDeS installed in editable mode: {qc_e_inst}')
-    logger.info(f'QCoDeS requirements versions: {qc_req_vs}')
+    logger.info(f"QCoDeS version: {qc_version}")
+    logger.info(f"QCoDeS installed in editable mode: {qc_e_inst}")
+    logger.info(f"QCoDeS requirements versions: {qc_req_vs}")
+    logger.info(f"All installed package versions: {json.dumps(ipvs)}")
 
 
 def start_all_logging() -> None:

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -1,6 +1,5 @@
-import qcodes.utils.installation_info as ii
 import qcodes as qc
-
+import qcodes.utils.installation_info as ii
 
 # The get_* functions from installation_info are hard to meaningfully test,
 # but we can at least test that they execute without errors
@@ -28,3 +27,14 @@ def test_is_qcodes_installed_editably():
     answer = ii.is_qcodes_installed_editably()
 
     assert isinstance(answer, bool)
+
+
+def test_get_all_installed_package_versions():
+    ipvs = ii.get_all_installed_package_versions()
+
+    assert isinstance(ipvs, dict)
+    assert len(ipvs) > 0
+
+    for k, v in ipvs.items():
+        assert isinstance(k, str)
+        assert isinstance(v, str)

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -37,8 +37,8 @@ def remove_root_handlers():
 @pytest.fixture
 def awg5208():
 
-    from qcodes.instrument_drivers.tektronix.AWG5208 import AWG5208
     import qcodes.instrument.sims as sims
+    from qcodes.instrument_drivers.tektronix.AWG5208 import AWG5208
     visalib = sims.__file__.replace('__init__.py',
                                     'Tektronix_AWG5208.yaml@sim')
 
@@ -78,10 +78,11 @@ def model372():
 
 @pytest.fixture()
 def AMI430_3D():
+    import numpy as np
+
+    import qcodes.instrument.sims as sims
     from qcodes.instrument.ip_to_visa import AMI430_VISA
     from qcodes.instrument_drivers.american_magnetics.AMI430 import AMI430_3D
-    import qcodes.instrument.sims as sims
-    import numpy as np
     visalib = sims.__file__.replace('__init__.py', 'AMI430.yaml@sim')
     mag_x = AMI430_VISA('x', address='GPIB::1::INSTR', visalib=visalib,
                         terminator='\n', port=1)
@@ -308,6 +309,7 @@ def test_installation_info_logging():
     with open(logger.get_log_file_name()) as f:
         lines = f.readlines()
 
-    assert 'QCoDeS version:' in lines[-3]
-    assert 'QCoDeS installed in editable mode:' in lines[-2]
-    assert 'QCoDeS requirements versions:' in lines[-1]
+    assert "QCoDeS version:" in lines[-4]
+    assert "QCoDeS installed in editable mode:" in lines[-3]
+    assert "QCoDeS requirements versions:" in lines[-2]
+    assert "All installed package versions:" in lines[-1]

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -3,20 +3,22 @@ This module contains helper functions that provide information about how
 QCoDeS is installed and about what other packages are installed along with
 QCoDeS
 """
-import sys
-from typing import Dict, List, Optional
-import subprocess
 import json
 import logging
+import subprocess
+import sys
+from typing import Dict, List, Optional
+
+import pkg_resources
 import requirements
 
 if sys.version_info >= (3, 8):
-    from importlib.metadata import distribution, version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, distribution, version
 else:
     # 3.7 and earlier
     from importlib_metadata import distribution, version, PackageNotFoundError
-import qcodes
 
+import qcodes
 
 log = logging.getLogger(__name__)
 
@@ -81,3 +83,11 @@ def get_qcodes_requirements_versions() -> Dict[str, str]:
             req_versions[req] = "Not installed"
 
     return req_versions
+
+
+def get_all_installed_package_versions() -> Dict[str, str]:
+    """
+    Return a dictionary of the currently installed packages and their versions.
+    """
+    packages = pkg_resources.working_set
+    return {i.key: i.version for i in packages}


### PR DESCRIPTION
Towards reproducible experiments! A small step is that we log the versions of installed packages in the environment where QCoDeS runs. 

Changes proposed in this pull request:
- Add function to get a list (well, dict) of all installed packages and their versions
- Log this information upon import

I did a quick and dirty comparison of import times before and after these changes, and there is no significant overhead.

@QCoDeS/core 
