### PR TITLE
Explicitly depend on setuptools

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
    broadbean>=0.9.1
    uncertainties>=3.0.2
    h5netcdf>=0.8.0
+   setuptools>=48
 
 [options.package_data]
 qcodes =


### PR DESCRIPTION
Since we are using pkg_resources which is part of setuptools at runtime.
This was previously effectively an implicit dependency. This was not an issue since almost all python envs comes with a version of setuptools