### PR TITLE
Logging: explicitly set encoding for file handler

### DIFF
--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -283,8 +283,9 @@ def start_logger() -> None:
     filename = get_log_file_name()
     os.makedirs(os.path.dirname(filename), exist_ok=True)
 
-    file_handler = logging.handlers.TimedRotatingFileHandler(filename,
-                                                             when='midnight')
+    file_handler = logging.handlers.TimedRotatingFileHandler(
+        filename, when="midnight", encoding="utf-8"
+    )
 
     file_handler.setLevel(qc.config.logger.file_level)
     file_handler.setFormatter(get_formatter())

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -283,7 +283,7 @@ def test_instrument_connect_message():
     code, but it is more conveniently written here
     """
 
-    with open(logger.get_log_file_name()) as f:
+    with open(logger.get_log_file_name(), encoding="utf-8") as f:
         lines = f.readlines()
 
     con_mssg_log_line = lines[-1]


### PR DESCRIPTION
This prevents issues where the broken pipe character (used for delimiting messages) cannot be written to the log file if the file has a different encoding. Reading the documentation it is not clear to which extend this may also be an issue for the stream handler used for the console logging. This writes to stderr. According to https://docs.python.org/3/library/sys.html#sys.stderr the encoding of stderr should be defined by local on oses other than windows so this probably works without issues on windows (but there are some limitations as noted in the stderr documentation) On most other platforms I would expect local encoding to be utf8 anyway. 