### PR TITLE
Keithley 2600: support returning both voltage and current compliance limit errors

### DIFF
--- a/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
@@ -208,6 +208,7 @@ class MeasurementStatus(StrEnum):
     VOLTAGE_COMPLIANCE_ERROR = 'Reached voltage compliance limit.'
     VOLTAGE_AND_CURRENT_COMPLIANCE_ERROR = 'Reached both voltage and current compliance limits.'
     NORMAL = 'No error occured.'
+    COMPLIANCE_ERROR = 'Reached compliance limit.'  # deprecated, dont use it. It exists only for backwards compatibility
 
 
 _from_bits_tuple_to_status = {

--- a/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
@@ -236,7 +236,7 @@ class _ParameterWithStatus(Parameter):
             int(float(meas_status))
         ).replace('0b', '').zfill(16)[::-1]]
 
-        status = _from_bits_tuple_to_status[tuple(status_bits[0:2])]
+        status = _from_bits_tuple_to_status[(status_bits[0], status_bits[1])]
 
         return float(value), status
 

--- a/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
@@ -204,7 +204,9 @@ class MeasurementStatus(StrEnum):
     """
     Keeps track of measurement status.
     """
-    COMPLIANCE_ERROR = 'Reached compliance limit.'
+    CURRENT_COMPLIANCE_ERROR = 'Reached current compliance limit.'
+    VOLTAGE_COMPLIANCE_ERROR = 'Reached voltage compliance limit.'
+    VOLTAGE_AND_CURRENT_COMPLIANCE_ERROR = 'Reached both voltage and current compliance limits.'
     NORMAL = 'No error occured.'
 
 
@@ -218,19 +220,24 @@ class _ParameterWithStatus(Parameter):
     def measurement_status(self) -> Optional[MeasurementStatus]:
         return self._measurement_status
 
+    _from_bits_tuple_to_status = {
+        (0, 0): MeasurementStatus.NORMAL,
+        (1, 0): MeasurementStatus.VOLTAGE_COMPLIANCE_ERROR,
+        (0, 1): MeasurementStatus.CURRENT_COMPLIANCE_ERROR,
+        (1, 1): MeasurementStatus.VOLTAGE_AND_CURRENT_COMPLIANCE_ERROR,
+    }
+
     @staticmethod
     def _parse_response(data: str) -> Tuple[float, MeasurementStatus]:
-
         value, meas_status = data.split('\t')
 
         status_bits = [int(i) for i in bin(
             int(float(meas_status))
         ).replace('0b', '').zfill(16)[::-1]]
 
-        if status_bits[1]:
-            return float(value), MeasurementStatus.COMPLIANCE_ERROR
-        else:
-            return float(value), MeasurementStatus.NORMAL
+        status = _from_bits_tuple_to_status[tuple(status_bits[0:2])]
+
+        return float(value), status
 
     def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None

--- a/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
@@ -210,6 +210,14 @@ class MeasurementStatus(StrEnum):
     NORMAL = 'No error occured.'
 
 
+_from_bits_tuple_to_status = {
+    (0, 0): MeasurementStatus.NORMAL,
+    (1, 0): MeasurementStatus.VOLTAGE_COMPLIANCE_ERROR,
+    (0, 1): MeasurementStatus.CURRENT_COMPLIANCE_ERROR,
+    (1, 1): MeasurementStatus.VOLTAGE_AND_CURRENT_COMPLIANCE_ERROR,
+}
+
+
 class _ParameterWithStatus(Parameter):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
@@ -219,13 +227,6 @@ class _ParameterWithStatus(Parameter):
     @property
     def measurement_status(self) -> Optional[MeasurementStatus]:
         return self._measurement_status
-
-    _from_bits_tuple_to_status = {
-        (0, 0): MeasurementStatus.NORMAL,
-        (1, 0): MeasurementStatus.VOLTAGE_COMPLIANCE_ERROR,
-        (0, 1): MeasurementStatus.CURRENT_COMPLIANCE_ERROR,
-        (1, 1): MeasurementStatus.VOLTAGE_AND_CURRENT_COMPLIANCE_ERROR,
-    }
 
     @staticmethod
     def _parse_response(data: str) -> Tuple[float, MeasurementStatus]:


### PR DESCRIPTION
otherwise when in the SMU is used in current sourcing mode and the voltage hits the voltage compliance limit, the measurement_status property of the current/voltage parameters did not reflect that.