### PR TITLE
add type packages discovered by mypy --install-types

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -38,9 +38,19 @@ stringparser==0.5
 toml==0.10.2
 typed-ast==1.4.3; python_version<'3.8'
 typing-extensions==3.10.0.2
-types_requests==2.25.7
+types-atomicwrites==1.4.0
+types-backports==0.1.3
+types-cryptography==3.3.5
+types-docutils==0.17.0
+types-ipaddress==1.0.0
+types-pyOpenSSL==20.0.6
+types-pytz==2021.1.2
+types-requests==2.25.7
 types-setuptools==57.4.0
+types-six==1.16.1
 types-tabulate==0.8.2
+types-toml==0.10.0
+types-typed-ast==1.4.4
 urllib3==1.26.6
 wincertstore==0.2
 wrapt==1.12.1


### PR DESCRIPTION
I have manually removed types-enum34 since that is a backport package that we do not use. it seems like mypy cannot tell this apart from the stdlib module of the same name

@astafan8 
