### PR TITLE
silence deprecation warning from uncertainties

### DIFF
--- a/qcodes/tests/helpers/test_json_encoder.py
+++ b/qcodes/tests/helpers/test_json_encoder.py
@@ -1,9 +1,15 @@
 import json
+import warnings
 from collections import OrderedDict, UserDict
 
 import numpy as np
 import pytest
-import uncertainties
+
+with warnings.catch_warnings():
+    # this context manager can be removed when uncertainties
+    # no longer triggers deprecation warnings
+    warnings.simplefilter("ignore", category=DeprecationWarning)
+    import uncertainties
 
 from qcodes.utils.helpers import NumpyJSONEncoder
 from qcodes.utils.types import numpy_complex, numpy_floats, numpy_ints
@@ -37,10 +43,12 @@ def test_complex_types():
         assert e.encode(complex_type(complex(1, 2))) == \
                '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
 
+
 def test_UFloat_type():
     e = NumpyJSONEncoder()
     assert e.encode(uncertainties.ufloat(1.0, 2.0)) == \
            '{"__dtype__": "UFloat", "nominal_value": 1.0, "std_dev": 2.0}'
+
 
 def test_numpy_int_types():
     e = NumpyJSONEncoder()
@@ -115,6 +123,7 @@ def test_object_with_serialization_method():
 
 class SomeUserDict(UserDict):
     pass
+
 
 EXAMPLEMETADATA = {
     'name': 'Rapunzel',

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -6,6 +6,7 @@ import math
 import numbers
 import os
 import time
+import warnings
 from asyncio import iscoroutinefunction
 from collections import OrderedDict, abc
 from contextlib import contextmanager
@@ -79,7 +80,11 @@ class NumpyJSONEncoder(json.JSONEncoder):
         * Other objects which cannot be serialized get converted to their
           string representation (using the ``str`` function).
         """
-        import uncertainties
+        with warnings.catch_warnings():
+            # this context manager can be removed when uncertainties
+            # no longer triggers deprecation warnings
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            import uncertainties
 
         if isinstance(obj, np.generic) \
                 and not isinstance(obj, np.complexfloating):


### PR DESCRIPTION
When importing uncertainties. Since this is a deprecation warning in a third party package there is not much we can do to fix it

