### PR TITLE
Fix flaky test

### DIFF
--- a/qcodes/tests/delegate/test_delegate_instrument.py
+++ b/qcodes/tests/delegate/test_delegate_instrument.py
@@ -1,4 +1,7 @@
 from unittest.mock import patch
+
+from numpy.testing import assert_almost_equal
+
 from qcodes.tests.instrument_mocks import MockField
 
 
@@ -22,7 +25,7 @@ def test_mock_field_delegate(station, field_x, chip_config):
         # Test group delegate parameters
         field_x.set_field(0.001)
         ramp = field.ramp_X()
-        assert ramp.field == 0.001
+        assert_almost_equal(ramp.field, 0.001)
         assert ramp.ramp_rate == 0.02
 
         field.ramp_X(dict(field=0.0, ramp_rate=10.0))


### PR DESCRIPTION
This for instance fails here https://github.com/QCoDeS/Qcodes/runs/4073011897?check_suite_focus=true
The field is calculated from ramp time and rate so the value may not be exact

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
