### PR TITLE
Dond: Only set parameter if not already at setpoint.

### DIFF
--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -758,7 +758,7 @@ def dond(
                 param_set_list = []
                 param_value_action = zip(params_set, setpoints, active_actions)
                 for setpoint_param, setpoint, action in param_value_action:
-                    if setpoint != setpoint_param.chache():
+                    if setpoint != setpoint_param.cache():
                         setpoint_param(setpoint)
                     param_set_list.append((setpoint_param, setpoint))
                     for act in action:

--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -758,7 +758,8 @@ def dond(
                 param_set_list = []
                 param_value_action = zip(params_set, setpoints, active_actions)
                 for setpoint_param, setpoint, action in param_value_action:
-                    setpoint_param(setpoint)
+                    if setpoint != setpoint_param.chache():
+                        setpoint_param(setpoint)
                     param_set_list.append((setpoint_param, setpoint))
                     for act in action:
                         act()


### PR DESCRIPTION
Current implementation of `dond` will ask _every_ instrument to set the setpoint at _every_ measurement point. This leads to an excessive amount of instrument communication as well as adding up all `post_delay`s at every measurement point.
Especially for magnet parameters this becomes a huge issue as setting the parameter even to the current value can take several seconds due to internal PID loops in the magnet power supply.

Change behaviour to only set the parameter if it isn't already at the desired value as known by qcodes. This ensures we inly ping instruments that needs to get the setpoint updated during the run.