### PR TITLE
Fix power and frequency ranges of Keysight N51x1 and N51x3 signal generators

### DIFF
--- a/docs/changes/newsfragments/3555.improved_driver
+++ b/docs/changes/newsfragments/3555.improved_driver
@@ -1,0 +1,5 @@
+Improved the drivers for Keysight N51x1 and N51x3 signal generators by:
+
+- Adding explicit support for N5173B
+- Fixing the power range of N5183B
+- Fixing the frequency range options for N51x1

--- a/qcodes/instrument_drivers/Keysight/Keysight_N5173B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N5173B.py
@@ -1,0 +1,4 @@
+
+from qcodes.instrument_drivers.Keysight.Keysight_N5183B import N5183B as N5173B
+# N5173B has the same interface as N5183B.
+# This file is to allow for improved device labeling.

--- a/qcodes/instrument_drivers/Keysight/Keysight_N5173B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N5173B.py
@@ -1,4 +1,5 @@
-from qcodes.instrument_drivers.Keysight.Keysight_N5183B import N5183B as N5173B
+from qcodes.instrument_drivers.Keysight.Keysight_N5183B import N5183B
 
-# N5173B has the same interface as N5183B.
-# This file is to allow for improved device labeling.
+
+class N5173B(N5183B):
+    pass  # N5173B has the same interface as N5183B

--- a/qcodes/instrument_drivers/Keysight/Keysight_N5183B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N5183B.py
@@ -1,6 +1,8 @@
+from typing import Any
+
 from qcodes.instrument_drivers.Keysight.N51x1 import N51x1
 
 
 class N5183B(N51x1):
-    def __init__(self, name: str, address: str, **kwargs):
+    def __init__(self, name: str, address: str, **kwargs: Any):
         super().__init__(name, address, min_power=-20, max_power=19, **kwargs)

--- a/qcodes/instrument_drivers/Keysight/Keysight_N5183B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N5183B.py
@@ -1,3 +1,6 @@
-from qcodes.instrument_drivers.Keysight.N51x1 import N51x1 as N5183B
-# N5183B has the same interface as N51x1 devices
-# This file is to allow for improved device labeling.
+from qcodes.instrument_drivers.Keysight.N51x1 import N51x1
+
+
+class N5183B(N51x1):
+    def __init__(self, name: str, address: str, **kwargs):
+        super().__init__(name, address, min_power=-20, max_power=19, **kwargs)

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -7,10 +7,10 @@ from qcodes.utils.validators import Numbers
 class N51x1(VisaInstrument):
     """
     This is the qcodes driver for Keysight/Agilent scalar RF sources.
-    It has been tested with N5171B, N5181A, N5171B, N5183B
+    It has been tested with N5171B, N5181A, N5173B, N5183B
     """
 
-    def __init__(self, name: str, address: str, **kwargs: Any):
+    def __init__(self, name: str, address: str, min_power=-144, max_power=19, **kwargs: Any):
         super().__init__(name, address, terminator='\n', **kwargs)
 
         self.add_parameter('power',
@@ -19,12 +19,12 @@ class N51x1(VisaInstrument):
                            get_parser=float,
                            set_cmd='SOUR:POW {:.2f}',
                            unit='dBm',
-                           vals=Numbers(min_value=-144,max_value=19))
+                           vals=Numbers(min_value=min_power,max_value=max_power))
 
         # Query the instrument to see what frequency range was purchased
-        freq_dict = {'501':1e9, '503':3e9, '505':6e9, '520':20e9}
+        freq_dict = {'501':1e9, '503':3e9, '506':6e9, '513': 13e9, '520':20e9, '532': 31.8e9, '540': 40e9}
 
-        max_freq = freq_dict[self.ask('*OPT?')]
+        max_freq = freq_dict[self.ask('*OPT?')]  # TODO: use .split(',') to detect other options
         self.add_parameter('frequency',
                            label='Frequency',
                            get_cmd='SOUR:FREQ?',

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -10,7 +10,7 @@ class N51x1(VisaInstrument):
     It has been tested with N5171B, N5181A, N5173B, N5183B
     """
 
-    def __init__(self, name: str, address: str, min_power=-144, max_power=19, **kwargs: Any):
+    def __init__(self, name: str, address: str, min_power: int = -144, max_power: int = 19, **kwargs: Any):
         super().__init__(name, address, terminator='\n', **kwargs)
 
         self.add_parameter('power',


### PR DESCRIPTION
This PR improves the drivers for Keysight N51x1 and N51x3 signal generators by:

- Adding explicit support for N5173B
- Fixing the power range of N5183B
- Fixing the frequency range options for N51x1

@jenshnielsen