### PR TITLE
remove incorrect news fragment

### DIFF
--- a/docs/changes/newsfragments/3484.Underthehood
+++ b/docs/changes/newsfragments/3484.Underthehood
@@ -1,1 +1,0 @@
-Update installation document to mention Python 3.9 as the default version for installing qcodes.


### PR DESCRIPTION
This fragment should have been included in 0.30.0 but was not since it was incorrectly formatted (the file name should be underthehood not Underthehood) 