### PR TITLE
Allow getting an uninitialized DelegateParameter with offset or scale

### DIFF
--- a/docs/changes/newsfragments/3662.improved
+++ b/docs/changes/newsfragments/3662.improved
@@ -1,0 +1,3 @@
+Do not apply offset or scale when getting a DelegateParameter and source is
+uninitialized (its value is None) to prevent a TypeError being raised. Closes
+#3653

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -579,7 +579,7 @@ class _BaseParameter(Metadatable):
             value = raw_value
 
         # apply offset first (native scale)
-        if self.offset is not None:
+        if self.offset is not None and value is not None:
             # offset values
             try:
                 value = value - self.offset
@@ -595,7 +595,7 @@ class _BaseParameter(Metadatable):
                     raise
 
         # scale second
-        if self.scale is not None:
+        if self.scale is not None and value is not None:
             # Scale values
             try:
                 value = value / self.scale

--- a/qcodes/tests/parameter/test_delegate_parameter.py
+++ b/qcodes/tests/parameter/test_delegate_parameter.py
@@ -250,21 +250,24 @@ def test_delegate_get_updates_cache(make_observable_parameter, numeric_val):
     assert t.get_instr_val() == initial_value
 
 
-def test_delegate_parameter_get_and_snapshot_raises_with_none():
+def test_delegate_parameter_get_and_snapshot_with_none_source():
     """
-    Test that a delegate parameter raises on get and snapshot if
-    the source has a value of None and a scale is used.
-    But works correctly if the source is remapped to a real parameter.
-
+    Test that a delegate parameter returns None on get and snapshot if
+    the source has a value of None and an offset or scale is used.
+    And returns a value if the source is remapped to a real parameter.
     """
     none_param = Parameter("None")
     source_param = Parameter('source', get_cmd=None, set_cmd=None, initial_value=2)
     delegate_param = DelegateParameter(name='delegate', source=none_param)
+    delegate_param.offset = 4
+    assert delegate_param.get() is None
+    assert delegate_param.snapshot()['value'] is None
+
+    delegate_param.offset = None
     delegate_param.scale = 2
-    with pytest.raises(TypeError):
-        delegate_param.get()
-    with pytest.raises(TypeError):
-        delegate_param.snapshot()
+    assert delegate_param.get() is None
+    assert delegate_param.snapshot()['value'] is None
+
     assert delegate_param.cache._parameter.source.cache is none_param.cache
     delegate_param.source = source_param
     assert delegate_param.get() == 1

--- a/qcodes/tests/parameter/test_parameter_scale_offset.py
+++ b/qcodes/tests/parameter/test_parameter_scale_offset.py
@@ -205,25 +205,3 @@ def test_setting_numpy_array_valued_param_if_scale_and_offset_are_not_none():
     param(values)
 
     assert isinstance(param.raw_value, np.ndarray)
-
-
-def test_getting_uninitialized_delegate_parameter_with_offset_returns_none():
-    param = Parameter(name='test_param',
-                      set_cmd=None,
-                      get_cmd=None)
-
-    d_with_offset = DelegateParameter(name='deleg_param_with_offset',
-                                      source=param, offset=2)
-
-    assert d_with_offset.get() is None
-
-
-def test_getting_uninitialized_delegate_parameter_with_scale_returns_none():
-    param = Parameter(name='test_param',
-                      set_cmd=None,
-                      get_cmd=None)
-
-    d_with_scale = DelegateParameter(name='deleg_param_with_scale',
-                                     source=param, scale=2)
-
-    assert d_with_scale.get() is None

--- a/qcodes/tests/parameter/test_parameter_scale_offset.py
+++ b/qcodes/tests/parameter/test_parameter_scale_offset.py
@@ -4,7 +4,7 @@ import hypothesis.strategies as hst
 from hypothesis import given, event, settings
 import numpy as np
 
-from qcodes.instrument.parameter import Parameter, DelegateParameter
+from qcodes.instrument.parameter import Parameter
 
 
 def test_scale_raw_value():

--- a/qcodes/tests/parameter/test_parameter_scale_offset.py
+++ b/qcodes/tests/parameter/test_parameter_scale_offset.py
@@ -4,7 +4,7 @@ import hypothesis.strategies as hst
 from hypothesis import given, event, settings
 import numpy as np
 
-from qcodes.instrument.parameter import Parameter
+from qcodes.instrument.parameter import Parameter, DelegateParameter
 
 
 def test_scale_raw_value():
@@ -205,3 +205,25 @@ def test_setting_numpy_array_valued_param_if_scale_and_offset_are_not_none():
     param(values)
 
     assert isinstance(param.raw_value, np.ndarray)
+
+
+def test_getting_uninitialized_delegate_parameter_with_offset_returns_none():
+    param = Parameter(name='test_param',
+                      set_cmd=None,
+                      get_cmd=None)
+
+    d_with_offset = DelegateParameter(name='deleg_param_with_offset',
+                                      source=param, offset=2)
+
+    assert d_with_offset.get() is None
+
+
+def test_getting_uninitialized_delegate_parameter_with_scale_returns_none():
+    param = Parameter(name='test_param',
+                      set_cmd=None,
+                      get_cmd=None)
+
+    d_with_scale = DelegateParameter(name='deleg_param_with_scale',
+                                     source=param, scale=2)
+
+    assert d_with_scale.get() is None


### PR DESCRIPTION
- [x] do not apply offset or scale when getting delegate parameter and source is None (in `_from_raw_value_to_value`)
- [x] added two tests

Fixes #3653 

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
