### PR TITLE
Fix ami430 tests

### DIFF
--- a/qcodes/instrument/sims/AMI430.yaml
+++ b/qcodes/instrument/sims/AMI430.yaml
@@ -54,7 +54,7 @@ devices:
           q: 'CONF:RAMP:RATE:SEG {}'
 
       ramp rate field first segment:
-        default: '25, 25, 25'
+        default: '0.11, 0.11, 0.11'
         getter:
           q: 'RAMP:RATE:FIELD:1?'
           r: '{}'

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -74,8 +74,8 @@ def current_driver(magnet_axes_instances):
     driver.close()
 
 
-@pytest.fixture(scope='function')
-def ami430():
+@pytest.fixture(scope="function", name="ami430")
+def _make_ami430():
     mag = AMI430_VISA('ami430', address='GPIB::1::INSTR', visalib=visalib,
                       terminator='\n', port=1)
     yield mag

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -733,7 +733,8 @@ def test_current_and_field_params_interlink__change_field_ramp_limit(
 
 
 def test_current_and_field_params_interlink__change_coil_constant(
-        ami430, factor=3):
+    ami430, factor: float = 3
+):
     """
     Test that after changing ``change_coil_constant``, the values of the
     ``current_*`` parameters remain the same while the values of the

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -486,16 +486,12 @@ def test_ramp_rate_exception(current_driver):
     Test that an exception is raised if we try to set the ramp rate
     to a higher value than is allowed
     """
-    max_ramp_rate = AMI430_VISA._DEFAULT_CURRENT_RAMP_LIMIT
-    target_ramp_rate = max_ramp_rate + 0.01
     ix = current_driver._instrument_x
+    max_ramp_rate = ix.field_ramp_limit()
+    target_ramp_rate = max_ramp_rate + 0.01
 
-    with pytest.raises(Exception) as excinfo:
+    with pytest.raises(ValueError, match="is above the ramp rate limit of"):
         ix.ramp_rate(target_ramp_rate)
-
-        errmsg = f"must be between 0 and {max_ramp_rate} inclusive"
-
-        assert errmsg in excinfo.value.args[0]
 
 
 def test_reducing_field_ramp_limit_reduces_a_higher_ramp_rate(ami430):


### PR DESCRIPTION
This test was broken in several ways.

1) The test compares the field rate limit in T/S against the current
rate limits in A/s. This means that ix.ramp_rate(target_ramp_rate)
did not actually raise the error tested for.
2) The test only asserted that any Exception was raised not checking
for a specific type of exception.
3) excinfo.value.args inside the context manager raises a AttributeError
which is then in turn caught by the pytest.raises context manager.
This makes the test pass incorrectly.
4) This in turn causes pytest to leave the tests in an inconsistent state
which results in other tests passing asserts that they should not. 
This means the tests pass if running after this one but don't if they are executed before this test (or independently).

For now I have commented out the failing assertions. It is not clear if these should be changed or the code in the driver should be changed. They test the relationship between the ramp rate in [T/S] on one side and the current ramp rate [A/S] and coilconstant on the other side. However the default values are not compatible since the field ramp rate default is set to 25 in the AMI430.yaml file and _DEFAULT_CURRENT_RAMP_LIMIT = 0.06 and the coil constant to 2.0 in the yaml file
