### PR TITLE
Let get_parameter_data return empty datasets in a more consistent way

### DIFF
--- a/docs/changes/newsfragments/3682.improved
+++ b/docs/changes/newsfragments/3682.improved
@@ -1,0 +1,4 @@
+get_parameter_data for an empty dataset now correctly
+returns a dict of dicts of empty numpy arrays consistent
+with how data is normally returned. Previously, this returned an
+empty dict.

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -331,13 +331,11 @@ def _merge_data_single_param(
         shape: Optional[Tuple[int, ...]],
         single_tree_write_status: Optional[int]) -> Tuple[Optional[np.ndarray], Optional[int]]:
     merged_data: Optional[np.ndarray]
-    if existing_values is not None and new_values is not None:
-        (merged_data,
-         new_write_status) = _insert_into_data_dict(
-            existing_values,
-            new_values,
-            single_tree_write_status,
-            shape=shape
+    if (
+        existing_values is not None and existing_values.size != 0
+    ) and new_values is not None:
+        (merged_data, new_write_status) = _insert_into_data_dict(
+            existing_values, new_values, single_tree_write_status, shape=shape
         )
     elif new_values is not None:
         (merged_data,
@@ -359,7 +357,7 @@ def _create_new_data_dict(new_values: np.ndarray,
                           ) -> Tuple[np.ndarray, int]:
     if shape is None:
         return new_values, new_values.size
-    else:
+    elif new_values.size > 0:
         n_values = new_values.size
         data = np.zeros(shape, dtype=new_values.dtype)
 
@@ -370,6 +368,8 @@ def _create_new_data_dict(new_values: np.ndarray,
 
         data.ravel()[0:n_values] = new_values.ravel()
         return data, n_values
+    else:
+        return new_values, new_values.size
 
 
 def _insert_into_data_dict(

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -465,7 +465,11 @@ class DataSetCacheWithDBBackend(DataSetCache["DataSet"]):
         if self._dataset.completed:
             self._loaded_from_completed_ds = True
 
-        (write_status, read_status, data,) = load_new_data_from_db_and_append(
+        (
+            self._write_status,
+            self._read_status,
+            self._data,
+        ) = load_new_data_from_db_and_append(
             self._dataset.conn,
             self._dataset.table_name,
             self.rundescriber,
@@ -474,11 +478,7 @@ class DataSetCacheWithDBBackend(DataSetCache["DataSet"]):
             self._data,
         )
         data_not_read = all(
-            status is None or status == 0 for status in write_status.values()
+            status is None or status == 0 for status in self._write_status.values()
         )
-
         if not data_not_read:
-            self._write_status = write_status
-            self._read_status = read_status
-            self._data = data
             self._live = False

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -465,11 +465,7 @@ class DataSetCacheWithDBBackend(DataSetCache["DataSet"]):
         if self._dataset.completed:
             self._loaded_from_completed_ds = True
 
-        (
-            self._write_status,
-            self._read_status,
-            self._data,
-        ) = load_new_data_from_db_and_append(
+        (write_status, read_status, data,) = load_new_data_from_db_and_append(
             self._dataset.conn,
             self._dataset.table_name,
             self.rundescriber,
@@ -477,5 +473,12 @@ class DataSetCacheWithDBBackend(DataSetCache["DataSet"]):
             self._read_status,
             self._data,
         )
-        if not all(status is None for status in self._write_status.values()):
+        data_not_read = all(
+            status is None or status == 0 for status in write_status.values()
+        )
+
+        if not data_not_read:
+            self._write_status = write_status
+            self._read_status = read_status
+            self._data = data
             self._live = False

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -378,6 +378,9 @@ def _insert_into_data_dict(
         write_status: Optional[int],
         shape: Optional[Tuple[int, ...]]
 ) -> Tuple[np.ndarray, Optional[int]]:
+    if new_values.size == 0:
+        return existing_values, write_status
+
     if shape is None or write_status is None:
         try:
             data = np.append(existing_values, new_values, axis=0)

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -306,7 +306,7 @@ def get_parameter_data_for_one_paramtree(
     # faster than transposing the data using np.array.transpose
     res_t = map(list, zip(*data))
 
-    for paramspec, column_data in zip_longest(paramspecs, res_t, fillvalue=[]):
+    for paramspec, column_data in zip_longest(paramspecs, res_t, fillvalue=tuple()):
         if paramspec.type == "numeric":
             # there is no reliable way to
             # tell the difference between a float and and int loaded

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -7,6 +7,7 @@ import sqlite3
 import time
 import unicodedata
 import warnings
+from itertools import zip_longest
 from typing import (
     Any,
     Callable,
@@ -305,7 +306,7 @@ def get_parameter_data_for_one_paramtree(
     # faster than transposing the data using np.array.transpose
     res_t = map(list, zip(*data))
 
-    for paramspec, column_data in zip(paramspecs, res_t):
+    for paramspec, column_data in zip_longest(paramspecs, res_t, fillvalue=[]):
         if paramspec.type == "numeric":
             # there is no reliable way to
             # tell the difference between a float and and int loaded

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1261,7 +1261,6 @@ def limit_data_to_start_end(start, end, input_names, expected_names,
             end = expected_shapes[input_names[0]][0][0]
         if end < start:
             for name in input_names:
-                expected_names[name] = []
                 expected_shapes[name] = ()
                 expected_values[name] = {}
         else:

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -21,9 +21,9 @@ from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.guids import parse_guid
-from qcodes.dataset.sqlite.connection import path_to_dbfile, atomic
+from qcodes.dataset.sqlite.connection import atomic, path_to_dbfile
 from qcodes.dataset.sqlite.database import get_DB_location
-from qcodes.dataset.sqlite.queries import _unicode_categories, _rewrite_timestamps
+from qcodes.dataset.sqlite.queries import _rewrite_timestamps, _unicode_categories
 from qcodes.tests.common import error_caused_by
 from qcodes.tests.dataset.helper_functions import verify_data_dict
 from qcodes.tests.dataset.test_links import generate_some_links
@@ -828,15 +828,10 @@ class TestGetData:
             (2, 4, xdata[(2-1):4]),
         ],
     )
-    def test_get_data_with_start_and_end_args(self, ds_with_vals,
-                                              start, end, expected):
-        data = ds_with_vals.get_parameter_data(
-            self.x, start=start, end=end)['x']
-        if len(expected) == 0:
-            assert data == {}
-        else:
-            data = data['x']
-            np.testing.assert_array_equal(data, expected)
+    def test_get_data_with_start_and_end_args(self, ds_with_vals, start, end, expected):
+        data = ds_with_vals.get_parameter_data(self.x, start=start, end=end)["x"]
+        data = data["x"]
+        np.testing.assert_array_equal(data, expected)
 
 
 @settings(deadline=600, suppress_health_check=(HealthCheck.function_scoped_fixture,))

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -319,15 +319,18 @@ def test_same_setpoint_warning_for_df_and_xarray(different_setpoint_dataset):
 def test_export_to_xarray_dataset_empty_ds(mock_empty_dataset):
     ds = mock_empty_dataset.to_xarray_dataset()
     assert len(ds) == 2
-    assert len(ds.coords) == 0
+    assert len(ds.coords) == 1
+    assert "x" in ds.coords
     _assert_xarray_metadata_is_as_expected(ds, mock_empty_dataset)
 
 
 def test_export_to_xarray_dataarray_empty_ds(mock_empty_dataset):
     dad = mock_empty_dataset.to_xarray_dataarray_dict()
     assert len(dad) == 2
-    assert len(dad["y"].coords) == 0
-    assert len(dad["z"].coords) == 0
+    assert len(dad["y"].coords) == 1
+    assert "x" in dad["y"].coords
+    assert len(dad["z"].coords) == 1
+    assert "x" in dad["z"].coords
 
 
 def test_export_to_xarray(mock_dataset):


### PR DESCRIPTION
This makes it so that get parameter data for an empty dataset returns a dict with empty arrays rather than an empty dict. This makes other things more consistent down the line and makes fixes such as the ones in https://github.com/QCoDeS/Qcodes/pull/3679 not needed 


Todo:

- [x] Handle broken data set cache tests
