### PR TITLE
Only record instrument instances when successfully created

### DIFF
--- a/docs/changes/newsfragments/3696.improved
+++ b/docs/changes/newsfragments/3696.improved
@@ -1,0 +1,3 @@
+Only register an Instrument in the list of connected instruments if the connection
+was successful. This change allows connections to be retried with the same name
+if the first attempt fails.

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -443,7 +443,8 @@ class AbstractInstrumentMeta(ABCMeta):
 
     Instead we use the fact that `__new__` and `__init__` are called inside
     `type.__call__`
-    (https://github.com/python/cpython/blob/main/Objects/typeobject.c#L1077)
+    (https://github.com/python/cpython/blob/main/Objects/typeobject.c#L1077,
+    https://github.com/python/typeshed/blob/master/stdlib/builtins.pyi#L156)
     which we will overload to insert our own custom code AFTER `__init__` is
     complete. Note this is part of the spec and will work in alternate python
     implementations like pypy too.

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -453,7 +453,7 @@ class AbstractInstrumentMeta(ABCMeta):
     `ABCMeta` instead of `type`.
     """
 
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
         """
         Overloads `type.__call__` to add code that runs only if __init__ completes
         successfully.

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -137,7 +137,7 @@ class DummyInstrument(Instrument):
 
 
 class DummyFailingInstrument(Instrument):
-    def __init__(self, name: str = "dummy", **kwargs):
+    def __init__(self, name: str = "dummy", fail: bool = True, **kwargs):
 
         """
         Create a dummy instrument that fails on initialization
@@ -150,7 +150,8 @@ class DummyFailingInstrument(Instrument):
         """
         super().__init__(name, **kwargs)
 
-        raise RuntimeError("Failed to create instrument")
+        if fail:
+            raise RuntimeError("Failed to create instrument")
 
 
 class DummyAttrInstrument(Instrument):

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -136,6 +136,23 @@ class DummyInstrument(Instrument):
             )
 
 
+class DummyFailingInstrument(Instrument):
+    def __init__(self, name: str = "dummy", **kwargs):
+
+        """
+        Create a dummy instrument that fails on initialization
+        that can be used for testing
+
+        Args:
+            name: name for the instrument
+            gates: list of names that is used to create parameters for
+                            the instrument
+        """
+        super().__init__(name, **kwargs)
+
+        raise RuntimeError("Failed to create instrument")
+
+
 class DummyAttrInstrument(Instrument):
     def __init__(self, name: str = "dummy", **kwargs: Any):
 

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -145,8 +145,7 @@ class DummyFailingInstrument(Instrument):
 
         Args:
             name: name for the instrument
-            gates: list of names that is used to create parameters for
-                            the instrument
+            fail: if true, instrument will throw a runtime error on creation.
         """
         super().__init__(name, **kwargs)
 

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -75,6 +75,17 @@ def test_instrument_fail(close_before_and_after):
     assert Instrument._all_instruments == {}
 
 
+def test_instrument_retry_with_same_name(close_before_and_after):
+    with pytest.raises(RuntimeError):
+        instr = DummyFailingInstrument(name="failinginstrument")
+    instr = DummyFailingInstrument(name="failinginstrument", fail=False)
+
+    # Check that the instrument is successfully registered after failing first
+    assert Instrument.instances() == []
+    assert DummyFailingInstrument.instances() == [instr]
+    assert Instrument._all_instruments == {"failinginstrument": weakref.ref(instr)}
+
+
 def test_attr_access(testdummy):
 
     # test the instrument works

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -12,7 +12,12 @@ from qcodes.instrument.base import Instrument, InstrumentBase, find_or_create_in
 from qcodes.instrument.function import Function
 from qcodes.instrument.parameter import Parameter
 
-from .instrument_mocks import DummyInstrument, MockMetaParabola, MockParabola
+from .instrument_mocks import (
+    DummyFailingInstrument,
+    DummyInstrument,
+    MockMetaParabola,
+    MockParabola,
+)
 
 
 @pytest.fixture(name='testdummy', scope='function')
@@ -59,6 +64,15 @@ def test_check_instances(testdummy):
     assert Instrument.instances() == []
     assert DummyInstrument.instances() == [testdummy]
     assert testdummy.instances() == [testdummy]
+
+
+def test_instrument_fail(close_before_and_after):
+    with pytest.raises(RuntimeError):
+        instr = DummyFailingInstrument(name="failinginstrument")
+
+    assert Instrument.instances() == []
+    assert DummyFailingInstrument.instances() == []
+    assert Instrument._all_instruments == {}
 
 
 def test_attr_access(testdummy):

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -67,8 +67,8 @@ def test_check_instances(testdummy):
 
 
 def test_instrument_fail(close_before_and_after):
-    with pytest.raises(RuntimeError):
-        instr = DummyFailingInstrument(name="failinginstrument")
+    with pytest.raises(RuntimeError, match="Failed to create instrument"):
+        DummyFailingInstrument(name="failinginstrument")
 
     assert Instrument.instances() == []
     assert DummyFailingInstrument.instances() == []
@@ -76,8 +76,8 @@ def test_instrument_fail(close_before_and_after):
 
 
 def test_instrument_retry_with_same_name(close_before_and_after):
-    with pytest.raises(RuntimeError):
-        instr = DummyFailingInstrument(name="failinginstrument")
+    with pytest.raises(RuntimeError, match="Failed to create instrument"):
+        DummyFailingInstrument(name="failinginstrument")
     instr = DummyFailingInstrument(name="failinginstrument", fail=False)
 
     # Check that the instrument is successfully registered after failing first


### PR DESCRIPTION
This commit fixes the issue of an instrument instance being registered in the instance dictionary even if the instrument creation failed. This will allow users to retry instrument connection when the first attempt fails without having to restart the interpreter or modify private variables in the Instrument class.

It certainly resolves a source of frustration when trying to debug failing instrument connections 😆 

This partially closes #1882, and should also allow us to be smarter about logging successful connections or cleaning up gracefully on failure.

@jenshnielsen @astafan8 What do you think?