### PR TITLE
Drop use of Distutils LooseVersion

### DIFF
--- a/qcodes/dataset/sqlite/query_helpers.py
+++ b/qcodes/dataset/sqlite/query_helpers.py
@@ -203,7 +203,7 @@ def insert_many_values(conn: ConnectionPlus,
     # Version check cf.
     # "https://stackoverflow.com/questions/9527851/sqlite-error-
     #  too-many-terms-in-compound-select"
-    version_str = SQLiteSettings.settings['VERSION']
+    version_str = SQLiteSettings.settings["VERSION"]
 
     # According to the SQLite changelog, the version number
     # to check against below

--- a/qcodes/dataset/sqlite/query_helpers.py
+++ b/qcodes/dataset/sqlite/query_helpers.py
@@ -4,11 +4,11 @@ are useful for building more database-specific queries out of them.
 """
 import itertools
 import sqlite3
-from distutils.version import LooseVersion
 from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 import numpy as np
 from numpy import ndarray
+from packaging import version
 
 from qcodes.dataset.sqlite.connection import (
     ConnectionPlus,
@@ -203,13 +203,13 @@ def insert_many_values(conn: ConnectionPlus,
     # Version check cf.
     # "https://stackoverflow.com/questions/9527851/sqlite-error-
     #  too-many-terms-in-compound-select"
-    version = SQLiteSettings.settings['VERSION']
+    version_str = SQLiteSettings.settings['VERSION']
 
     # According to the SQLite changelog, the version number
     # to check against below
     # ought to be 3.7.11, but that fails on Travis
-    if LooseVersion(str(version)) <= LooseVersion('3.8.2'):
-        max_var = SQLiteSettings.limits['MAX_COMPOUND_SELECT']
+    if version.parse(str(version_str)) <= version.parse("3.8.2"):
+        max_var = SQLiteSettings.limits["MAX_COMPOUND_SELECT"]
     else:
         max_var = SQLiteSettings.limits['MAX_VARIABLE_NUMBER']
     rows_per_transaction = int(int(max_var)/no_of_columns)

--- a/qcodes/instrument_drivers/AlazarTech/ATS9360.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9360.py
@@ -1,7 +1,7 @@
-from distutils.version import LooseVersion
 from typing import Any
 
 import numpy as np
+from packaging import version
 
 from qcodes.utils import validators
 
@@ -326,8 +326,9 @@ class AlazarTech_ATS9360(AlazarTech_ATS):
     def _get_trigger_holdoff(self) -> bool:
         fwversion = self.get_idn()['firmware']
 
-        if not isinstance(fwversion, str) or LooseVersion(fwversion) < \
-                LooseVersion(self._trigger_holdoff_min_fw_version):
+        if not isinstance(fwversion, str) or version.parse(fwversion) < version.parse(
+            self._trigger_holdoff_min_fw_version
+        ):
             return False
 
         # we want to check if the 26h bit (zero indexed) is high or not
@@ -344,13 +345,16 @@ class AlazarTech_ATS9360(AlazarTech_ATS):
         return bool(bin(output)[-27])
 
     def _set_trigger_holdoff(self, value: bool) -> None:
-        fwversion = self.get_idn()['firmware']
-        if not isinstance(fwversion, str) or  LooseVersion(fwversion) < \
-                LooseVersion(self._trigger_holdoff_min_fw_version):
-            raise RuntimeError(f"Alazar 9360 requires at least firmware "
-                               f"version {self._trigger_holdoff_min_fw_version}"
-                               f" for trigger holdoff support. "
-                               f"You have version {fwversion}")
+        fwversion = self.get_idn()["firmware"]
+        if not isinstance(fwversion, str) or version.parse(fwversion) < version.parse(
+            self._trigger_holdoff_min_fw_version
+        ):
+            raise RuntimeError(
+                f"Alazar 9360 requires at least firmware "
+                f"version {self._trigger_holdoff_min_fw_version}"
+                f" for trigger holdoff support. "
+                f"You have version {fwversion}"
+            )
         current_value = self._read_register(58)
 
         if value is True:

--- a/qcodes/instrument_drivers/AlazarTech/ATS9373.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS9373.py
@@ -1,7 +1,7 @@
-from distutils.version import LooseVersion
 from typing import Any
 
 import numpy as np
+from packaging import version
 
 from qcodes.instrument_drivers.AlazarTech.ATS import AlazarTech_ATS
 from qcodes.instrument_drivers.AlazarTech.utils import TraceParameter
@@ -340,9 +340,10 @@ class AlazarTech_ATS9373(AlazarTech_ATS):
                             f" found '{str(model)}' instead.")
 
     def _get_trigger_holdoff(self) -> bool:
-        fwversion = self.get_idn()['firmware']
-        if not isinstance(fwversion, str) or LooseVersion(fwversion) < \
-                LooseVersion(self._trigger_holdoff_min_fw_version):
+        fwversion = self.get_idn()["firmware"]
+        if not isinstance(fwversion, str) or version.parse(fwversion) < version.parse(
+            self._trigger_holdoff_min_fw_version
+        ):
             return False
 
         # we want to check if the 26h bit (zero indexed) is high or not
@@ -359,13 +360,16 @@ class AlazarTech_ATS9373(AlazarTech_ATS):
         return bool(bin(output)[-27])
 
     def _set_trigger_holdoff(self, value: bool) -> None:
-        fwversion = self.get_idn()['firmware']
-        if not isinstance(fwversion, str) or LooseVersion(fwversion) < \
-                LooseVersion(self._trigger_holdoff_min_fw_version):
-            raise RuntimeError(f"Alazar 9373 requires at least firmware "
-                               f"version {self._trigger_holdoff_min_fw_version}"
-                               f" for trigger holdoff support. "
-                               f"You have version {fwversion}")
+        fwversion = self.get_idn()["firmware"]
+        if not isinstance(fwversion, str) or version.parse(fwversion) < version.parse(
+            self._trigger_holdoff_min_fw_version
+        ):
+            raise RuntimeError(
+                f"Alazar 9373 requires at least firmware "
+                f"version {self._trigger_holdoff_min_fw_version}"
+                f" for trigger holdoff support. "
+                f"You have version {fwversion}"
+            )
         current_value = self._read_register(58)
 
         if value is True:

--- a/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
@@ -1,6 +1,6 @@
-from distutils.version import LooseVersion
 from typing import Any, Sequence, Tuple, Union, cast
 
+from packaging import version
 from pyvisa.errors import VisaIOError
 
 from qcodes import InstrumentChannel, VisaInstrument
@@ -194,9 +194,9 @@ class KeysightE4980A(VisaInstrument):
 
         idn = self.IDN.get()
 
-        self.has_firmware_a_02_10_or_above = (
-                LooseVersion(idn["firmware"]) >= LooseVersion("A.02.10")
-        )
+        self.has_firmware_a_02_10_or_above = version.parse(
+            idn["firmware"]
+        ) >= version.parse("A.02.10")
 
         self.has_option_001 = '001' in self._options()
         self._dc_bias_v_level_range: Union[Numbers, Enum]

--- a/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
@@ -11,6 +11,7 @@ from qcodes.instrument.parameter import (
     ParamRawDataType,
 )
 from qcodes.utils.helpers import create_on_off_val_mapping
+from qcodes.utils.installation_info import convert_legacy_version_to_supported_version
 from qcodes.utils.validators import Bool, Enum, Ints, Numbers
 
 
@@ -195,8 +196,8 @@ class KeysightE4980A(VisaInstrument):
         idn = self.IDN.get()
 
         self.has_firmware_a_02_10_or_above = version.parse(
-            idn["firmware"]
-        ) >= version.parse("A.02.10")
+            convert_legacy_version_to_supported_version(idn["firmware"])
+        ) >= version.parse(convert_legacy_version_to_supported_version("A.02.10"))
 
         self.has_option_001 = '001' in self._options()
         self._dc_bias_v_level_range: Union[Numbers, Enum]

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -14,6 +14,7 @@ from qcodes.instrument.parameter import Parameter, ParameterWithSetpoints
 from qcodes.instrument_drivers.Keysight.private.error_handling import (
     KeysightErrorQueueMixin,
 )
+from qcodes.utils.installation_info import convert_legacy_version_to_supported_version
 
 
 class Trigger(InstrumentChannel):
@@ -465,7 +466,11 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
 
         options = self._options()
         self.has_DIG = self.is_34465A_34470A and (
-            "DIG" in options or version.parse("A.03") <= version.parse(idn["firmware"])
+            "DIG" in options
+            or version.parse(convert_legacy_version_to_supported_version("A.03"))
+            <= version.parse(
+                convert_legacy_version_to_supported_version(idn["firmware"])
+            )
         )
         # Note that the firmware version check is still needed because
         # ``_options`` (the ``*OPT?`` command) returns 'DIG' option for

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -1,18 +1,19 @@
 import textwrap
+from bisect import bisect_left
 from contextlib import ExitStack
 from functools import partial
-from typing import Sequence, Tuple, Any, Optional
-from distutils.version import LooseVersion
-from bisect import bisect_left
+from typing import Any, Optional, Sequence, Tuple
 
 import numpy as np
+from packaging import version
 
 import qcodes.utils.validators as vals
-from qcodes import VisaInstrument, InstrumentChannel
-from qcodes.instrument_drivers.Keysight.private.error_handling import \
-    KeysightErrorQueueMixin
-from qcodes.instrument.parameter import Parameter, ParameterWithSetpoints
+from qcodes import InstrumentChannel, VisaInstrument
 from qcodes.instrument.base import Instrument
+from qcodes.instrument.parameter import Parameter, ParameterWithSetpoints
+from qcodes.instrument_drivers.Keysight.private.error_handling import (
+    KeysightErrorQueueMixin,
+)
 
 
 class Trigger(InstrumentChannel):
@@ -464,8 +465,7 @@ class _Keysight_344xxA(KeysightErrorQueueMixin, VisaInstrument):
 
         options = self._options()
         self.has_DIG = self.is_34465A_34470A and (
-            'DIG' in options
-            or LooseVersion('A.03') <= LooseVersion(idn['firmware'])
+            "DIG" in options or version.parse("A.03") <= version.parse(idn["firmware"])
         )
         # Note that the firmware version check is still needed because
         # ``_options`` (the ``*OPT?`` command) returns 'DIG' option for

--- a/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
+++ b/qcodes/instrument_drivers/oxford/MercuryiPS_VISA.py
@@ -1,10 +1,10 @@
 import logging
 import time
-from distutils.version import LooseVersion
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 import numpy as np
+from packaging import version
 
 from qcodes.instrument.channel import InstrumentChannel
 from qcodes.instrument.visa import VisaInstrument
@@ -73,7 +73,7 @@ class MercuryWorkerPS(InstrumentChannel):
 
         # The firmware update from 2.5 -> 2.6 changed the command
         # syntax slightly
-        if LooseVersion(self.root_instrument.firmware) >= LooseVersion('2.6'):
+        if version.parse(self.root_instrument.firmware) >= version.parse("2.6"):
             self.psu_string = "SPSU"
         else:
             self.psu_string = "PSU"

--- a/qcodes/instrument_drivers/rigol/DS4000.py
+++ b/qcodes/instrument_drivers/rigol/DS4000.py
@@ -300,9 +300,7 @@ class DS4000(VisaInstrument):
         idn = self.get_idn()
         verstr = idn["firmware"]
         if verstr is None:
-            raise RuntimeError(
-                "Could not determine firmware version of DS4000."
-            )
+            raise RuntimeError("Could not determine firmware version of DS4000.")
         ver = version.parse(verstr)
         if ver < version.parse("00.02.03"):
             warnings.warn(

--- a/qcodes/instrument_drivers/rigol/DS4000.py
+++ b/qcodes/instrument_drivers/rigol/DS4000.py
@@ -3,10 +3,10 @@ import re
 import time
 import warnings
 from collections import namedtuple
-from distutils.version import LooseVersion
 from typing import Any
 
 import numpy as np
+from packaging import version
 
 from qcodes import VisaInstrument
 from qcodes import validators as vals
@@ -298,7 +298,14 @@ class DS4000(VisaInstrument):
         #Require version 00.02.03
 
         idn = self.get_idn()
-        ver = LooseVersion(idn['firmware'])
-        if ver < LooseVersion('00.02.03'):
-            warnings.warn('Firmware version should be at least 00.02.03,'
-                          'data transfer may not work correctly')
+        verstr = idn["firmware"]
+        if verstr is None:
+            raise RuntimeError(
+                "Could not determine firmware version of DS4000."
+            )
+        ver = version.parse(verstr)
+        if ver < version.parse("00.02.03"):
+            warnings.warn(
+                "Firmware version should be at least 00.02.03,"
+                "data transfer may not work correctly"
+            )

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -4,10 +4,10 @@
 import logging
 import time
 import warnings
-from distutils.version import LooseVersion
 from typing import Any, Optional
 
 import numpy as np
+from packaging import version
 
 from qcodes import Instrument
 from qcodes.instrument.channel import InstrumentChannel
@@ -467,13 +467,20 @@ class RTO1000(VisaInstrument):
         # model number can NOT be queried from the instrument
         # (at least fails with RTO1024, fw 2.52.1.1), so in that case
         # the user must provide the model manually.
-        firmware_version = self.get_idn()['firmware']
+        firmware_version_str = self.get_idn()['firmware']
+        if firmware_version_str is None:
+            raise RuntimeError(
+                "Could not determine firmware version of RTO1000."
+            )
+        firmware_version = version.parse(firmware_version_str)
 
-        if LooseVersion(firmware_version) < LooseVersion('3'):
-            log.warning('Old firmware version detected. This driver may '
-                        'not be compatible. Please upgrade your firmware.')
+        if firmware_version < version.parse("3"):
+            log.warning(
+                "Old firmware version detected. This driver may "
+                "not be compatible. Please upgrade your firmware."
+            )
 
-        if LooseVersion(firmware_version) >= LooseVersion('3.65'):
+        if firmware_version >= version.parse("3.65"):
             # strip just in case there is a newline character at the end
             self.model = self.ask('DIAGnostic:SERVice:WFAModel?').strip()
             if model is not None and model != self.model:

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -467,11 +467,9 @@ class RTO1000(VisaInstrument):
         # model number can NOT be queried from the instrument
         # (at least fails with RTO1024, fw 2.52.1.1), so in that case
         # the user must provide the model manually.
-        firmware_version_str = self.get_idn()['firmware']
+        firmware_version_str = self.get_idn()["firmware"]
         if firmware_version_str is None:
-            raise RuntimeError(
-                "Could not determine firmware version of RTO1000."
-            )
+            raise RuntimeError("Could not determine firmware version of RTO1000.")
         firmware_version = version.parse(firmware_version_str)
 
         if firmware_version < version.parse("3"):

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -38,3 +38,14 @@ def test_get_all_installed_package_versions():
     for k, v in ipvs.items():
         assert isinstance(k, str)
         assert isinstance(v, str)
+
+
+def test_convert_legacy_version_to_supported_version():
+    legacy_verstr = "a.1.4"
+    assert ii.convert_legacy_version_to_supported_version(legacy_verstr) == "65.1.4"
+
+    legacy_verstr = "10.4.7"
+    assert ii.convert_legacy_version_to_supported_version(legacy_verstr) == "10.4.7"
+
+    legacy_verstr = "C.2.1"
+    assert ii.convert_legacy_version_to_supported_version(legacy_verstr) == "67.2.1"

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -91,3 +91,20 @@ def get_all_installed_package_versions() -> Dict[str, str]:
     """
     packages = pkg_resources.working_set
     return {i.key: i.version for i in packages}
+
+
+def convert_legacy_version_to_supported_version(ver: str) -> str:
+    """
+    Convert a legacy version str containing single chars rather than
+    numbers to a regular version string. This is done by replacing a char
+    by its ASCII code (using ``ord``). This assumes that the version number
+    only uses at most a single char per level and only ASCII chars.
+    """
+
+    temp_list = []
+    for v in ver:
+        if v.isalpha():
+            temp_list.append(str(ord(v.upper())))
+        else:
+            temp_list.append(v)
+    return "".join(temp_list)

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,12 @@ addopts =
 
 markers = serial
 
+filterwarnings =
+    ignore:The distutils package is deprecated and slated for removal in Python 3.12:DeprecationWarning
+    ignore:distutils Version classes are deprecated:DeprecationWarning
+    ignore:SelectableGroups dict interface is deprecated:DeprecationWarning
+
+
 [mypy]
 strict_optional = True
 disallow_untyped_decorators = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,6 +98,7 @@ addopts =
 
 markers = serial
 
+;warnings triggered by xarray and hdf5netcdf using deprecated apis
 filterwarnings =
     ignore:The distutils package is deprecated and slated for removal in Python 3.12:DeprecationWarning
     ignore:distutils Version classes are deprecated:DeprecationWarning


### PR DESCRIPTION
All of distutils is deprecated in python 3.10 and the recommended alternative for LooseVersion is packaging.version.parse

This removes all use of distutils outside versioneer