### PR TITLE
Cleanup websockets test errors

### DIFF
--- a/qcodes/monitor/monitor.py
+++ b/qcodes/monitor/monitor.py
@@ -24,7 +24,6 @@ import json
 import logging
 import os
 import socketserver
-import sys
 import time
 import webbrowser
 from asyncio import CancelledError

--- a/qcodes/tests/test_monitor.py
+++ b/qcodes/tests/test_monitor.py
@@ -129,6 +129,7 @@ def test_parameter(request, inst_and_monitor):
         # Check parameter values
         old_timestamps = {}
         for local_param, mon in zip(monitor_parameters, metadata["parameters"]):
+            assert isinstance(local_param, Parameter)
             assert str(local_param.get_latest()) == mon["value"]
             assert local_param.label == mon["name"]
             old_timestamps[local_param.label] = float(mon["ts"])
@@ -141,6 +142,7 @@ def test_parameter(request, inst_and_monitor):
         metadata = data["parameters"][0]
         for local_param, mon in zip(monitor_parameters, metadata["parameters"]):
             assert str(local_param.get_latest()) == mon["value"]
+            assert isinstance(local_param, Parameter)
             assert local_param.label == mon["name"]
             assert float(mon["ts"]) > old_timestamps[local_param.label]
 

--- a/qcodes/tests/test_monitor.py
+++ b/qcodes/tests/test_monitor.py
@@ -91,9 +91,7 @@ def test_connection(request):
     asyncio.set_event_loop(loop)
 
     async def async_test_connection():
-        async with websockets.connect(
-            f"ws://localhost:{monitor.WEBSOCKET_PORT}"
-        ) as websocket:
+        async with websockets.connect(f"ws://localhost:{monitor.WEBSOCKET_PORT}"):
             pass
     loop.run_until_complete(async_test_connection())
 


### PR DESCRIPTION
test_parameter was not correctly closing the connection before closing the event loop. Using a async context manager makes it simpler to ensure this is the case