### PR TITLE
Reimplement abstract instrument

### DIFF
--- a/docs/changes/newsfragments/3718.new
+++ b/docs/changes/newsfragments/3718.new
@@ -1,0 +1,5 @@
+An abstract instrument (An instrument with one or more abstract parameters) will now raise at
+instrument creation time preventing such an instrument from being created.
+This makes it easier to define interfaces that multiple instruments must implement.
+See `here <../examples/writing_drivers/abstract_instruments.ipynb>`__ for examples of how to use
+this.

--- a/docs/examples/writing_drivers/abstract_instruments.ipynb
+++ b/docs/examples/writing_drivers/abstract_instruments.ipynb
@@ -17,23 +17,7 @@
    "execution_count": 1,
    "id": "32244de2",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Logging hadn't been started.\n",
-      "Activating auto-logging. Current session state plus future input saved.\n",
-      "Filename       : C:\\Users\\Jens-work\\.qcodes\\logs\\command_history.log\n",
-      "Mode           : append\n",
-      "Output logging : True\n",
-      "Raw input log  : False\n",
-      "Timestamping   : True\n",
-      "State          : active\n",
-      "Qcodes Logfile : C:\\Users\\Jens-work\\.qcodes\\logs\\210719-37156-qcodes.log\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from qcodes import Instrument"
    ]
@@ -45,28 +29,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class BaseVoltageSource(Instrument): \n",
+    "class BaseVoltageSource(Instrument):\n",
     "    \"\"\"\n",
-    "    All abstract parameters *must* be implemented \n",
-    "    before this class can be initialized. This \n",
-    "    allows us to enforce an interface. \n",
+    "    All abstract parameters *must* be implemented\n",
+    "    before this class can be initialized. This\n",
+    "    allows us to enforce an interface.\n",
     "    \"\"\"\n",
-    "    \n",
-    "    def __init__(self, name: str): \n",
+    "\n",
+    "    def __init__(self, name: str):\n",
     "        super().__init__(name)\n",
-    "        \n",
-    "        self.add_parameter(\n",
-    "            \"voltage\", \n",
-    "            unit=\"V\", \n",
-    "            abstract=True\n",
-    "        )\n",
-    "        \n",
-    "        self.add_parameter(\n",
-    "            \"current\", \n",
-    "            unit=\"A\", \n",
-    "            get_cmd=None, \n",
-    "            set_cmd=None \n",
-    "        )"
+    "\n",
+    "        self.add_parameter(\"voltage\", unit=\"V\", abstract=True)\n",
+    "\n",
+    "        self.add_parameter(\"current\", unit=\"A\", get_cmd=None, set_cmd=None)"
    ]
   },
   {
@@ -74,7 +49,7 @@
    "id": "a3d0714c",
    "metadata": {},
    "source": [
-    "### We cannot get or set abstract paramters. "
+    "### We cannot instantiate a Instrument with abstract parameters."
    ]
   },
   {
@@ -87,17 +62,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Error: Trying to get an abstract parameter: name_voltage\n"
+      "Error: Class 'BaseVoltageSource' has un-implemented Abstract Parameter(s): 'voltage'\n"
      ]
     }
    ],
    "source": [
-    "try: \n",
+    "try:\n",
     "    bv = BaseVoltageSource(\"name\")\n",
-    "    bv.voltage.get()\n",
     "except NotImplementedError as error:\n",
-    "    print(f\"Error: {error}\")\n",
-    "bv.close()"
+    "    print(f\"Error: {error}\")"
    ]
   },
   {
@@ -105,7 +78,28 @@
    "id": "c322bd66",
    "metadata": {},
    "source": [
-    "Instruments which fail to initialize are not registered"
+    "Instruments which fail to initialize are not registered:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0576d8e6-f335-4344-9e2f-f74dfa63a86d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "BaseVoltageSource.instances()"
    ]
   },
   {
@@ -118,28 +112,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "90720c97",
    "metadata": {},
    "outputs": [],
    "source": [
-    "class WrongSource2(BaseVoltageSource): \n",
+    "class WrongSource2(BaseVoltageSource):\n",
     "    \"\"\"\n",
-    "    We implement the voltage paramter with the wrong unit \n",
+    "    We implement the voltage paramter with the wrong unit\n",
     "    \"\"\"\n",
-    "    \n",
-    "    def __init__(self, name: str, *args, **kwargs): \n",
+    "\n",
+    "    def __init__(self, name: str, *args, **kwargs):\n",
     "        super().__init__(name, *args, **kwargs)\n",
-    "        \n",
-    "        self.add_parameter(\n",
-    "           \"voltage\", \n",
-    "           unit=\"mV\"\n",
-    "        )   "
+    "\n",
+    "        self.add_parameter(\"voltage\", unit=\"mV\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "890aec75",
    "metadata": {},
    "outputs": [
@@ -153,9 +144,136 @@
    ],
    "source": [
     "try:\n",
-    "    WrongSource2(\"name4\")  \n",
-    "except ValueError as error: \n",
+    "    WrongSource2(\"name4\")\n",
+    "except ValueError as error:\n",
     "    print(f\"Error: {error}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e23bed0-2d60-4e26-9e52-5fc9c61256f2",
+   "metadata": {},
+   "source": [
+    "Instruments which fail to initialize due to the wrong unit are also not registered:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8bd10672-e6fa-4efb-a5f2-f5459ff26c6f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "BaseVoltageSource.instances()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a43888a9-65f2-410b-ba20-46920c63408a",
+   "metadata": {},
+   "source": [
+    "# Working subclass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1a954275-aed8-4e4d-a961-d6cf28070308",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class VoltageSource(BaseVoltageSource):\n",
+    "    \"\"\"\n",
+    "    We implement the voltage paramter with the correct unit.\n",
+    "    Here we just implement it as a manual parameter but in a\n",
+    "    real instrument we would probably not do that.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, name: str, *args, **kwargs):\n",
+    "        super().__init__(name, *args, **kwargs)\n",
+    "\n",
+    "        self.add_parameter(\"voltage\", unit=\"V\", set_cmd=None, get_cmd=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ae7ed4a7-4d58-471d-8775-5581a4874757",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vs = VoltageSource(\"name\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cdb66d15-066c-427a-b6f0-51d159f0b2ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vs.voltage(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fad3fda4-cb6b-46ec-b17c-490bacb99cdc",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "vs.voltage()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5175c314-2ea7-4139-bb41-12b88f2fdcff",
+   "metadata": {},
+   "source": [
+    "This instrument is registered as expected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "f40bfff7-8329-41bd-8632-5f22c69d8eeb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<VoltageSource: name>]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "VoltageSource.instances()"
    ]
   }
  ],
@@ -175,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -359,12 +359,10 @@ class InstrumentBase(Metadatable, DelegateAttributes):
 
     def _raise_if_abstract(self) -> None:
         """
-        This method is run after the initialization of a subclass of
-        `InstrumentBase`. If we have a chain of base classes like so:
-        InstrumentBase -> Instrument -> VisaInstrument -> Driver
-        This method is run after the instantiation of the class `Driver`.
-        Please see the docstring of `InstrumentBase.__init_subclass__`
-        for details about the mechanism which makes this possible.
+        This method is run after the initialization of an instrument but
+        before the instrument is registered. It recursively checks that there are
+        no abstract parameters defined on the instrument or any instrument channels.
+        If a non overwritten abstract parameter is found it raises a ``NotImplementedError``
         """
         abstract_parameters = [
             parameter.name

--- a/qcodes/tests/test_abstract_instrument.py
+++ b/qcodes/tests/test_abstract_instrument.py
@@ -67,23 +67,6 @@ class VoltageSourceInitException(Instrument):
             assert False
 
 
-class VoltageSourceSubSub(VoltageSource):
-    """
-    This is a sub-sub class of the example base voltage
-    source. The post init function should be called
-    only once
-    """
-
-    call_count = 0
-
-    def __init__(self, name: str):
-        super().__init__(name)
-
-    def __post_init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__post_init__()  # type: ignore[misc]
-        self.call_count += 1
-
-
 class VoltageChannelBase(InstrumentChannel):
     """
     Create a channel with an abstract parameter
@@ -106,6 +89,37 @@ class VoltageChannel(VoltageChannelBase):
         self.add_parameter("voltage", unit="V", get_cmd=None, set_cmd=None)
 
 
+class VoltageAbstractChannelSource(Instrument):
+    """
+    A channel instrument with an abstract parameter on the channel.
+    This should raise.
+    """
+
+    def __init__(
+        self,
+        name: str,
+    ):
+        super().__init__(name)
+        channel = VoltageChannelBase(self, "voltage")
+        self.add_submodule("voltage", channel)
+
+
+class VoltageChannelSource(Instrument):
+    """
+    A channel instrument with an implementation of the
+    abstract parameter on the channel.
+    This should not raise.
+    """
+
+    def __init__(
+        self,
+        name: str,
+    ):
+        super().__init__(name)
+        channel = VoltageChannel(self, "voltage")
+        self.add_submodule("voltage", channel)
+
+
 @pytest.fixture(name="driver", scope="module")
 def _driver():
     drvr = VoltageSource("abstract_instrument_driver")
@@ -122,7 +136,6 @@ def test_sanity(driver):
     assert driver.voltage() == 0.1
 
 
-@pytest.mark.skip("tests unimplemented feature")
 def test_not_implemented_error():
     """
     If not all abstract parameters are implemented, we should see
@@ -135,30 +148,12 @@ def test_not_implemented_error():
     assert not VoltageSourceNotImplemented.instances()
 
 
-def test_get_set_raises(request):
-    """
-    If not all abstract parameters are implemented, we should see
-    an exception
-    """
-    vs = VoltageSourceNotImplemented("abstract_instrument_driver_3")
-    request.addfinalizer(vs.close)
-    with pytest.raises(
-        NotImplementedError, match="Trying to get an abstract parameter"
-    ):
-        vs.voltage.get()
-
-    with pytest.raises(
-        NotImplementedError, match="Trying to set an abstract parameter"
-    ):
-        vs.voltage.set(0)
-
-
 def test_unit_value_error():
     """
     Units should match between subclasses and base classes
     """
     with pytest.raises(ValueError, match="This is inconsistent with the unit defined"):
-        VoltageSourceBadUnit("abstract_instrument_driver_4")
+        VoltageSourceBadUnit("abstract_instrument_driver_3")
 
 
 def test_unit_value_error_does_not_register_instrument():
@@ -166,19 +161,13 @@ def test_unit_value_error_does_not_register_instrument():
     Units should match between subclasses and base classes
     """
     with pytest.raises(ValueError, match="This is inconsistent with the unit defined"):
-        VoltageSourceBadUnit("abstract_instrument_driver_5")
+        VoltageSourceBadUnit("abstract_instrument_driver_4")
     assert not VoltageSourceBadUnit.instances()
 
 
 def test_exception_in_init():
     """
-    In previous versions of QCoDeS, if an error occurred in
-    the instrument init method, we could not attempt to retry
-    the instantiation with the same instrument name. This is
-    because the driver instance was recorded at the end of
-    the init method in the base class. In current versions
-    the instance is recorded in the __post_init__ method,
-    which should eliminate this problem
+    Verify that if the instrument raises in init it is not registered as an instance
     """
     name = "abstract_instrument_driver_6"
     try:
@@ -191,25 +180,19 @@ def test_exception_in_init():
     instance.close()
 
 
-@pytest.mark.skip("tests unimplemented feature")
-def test_subsub():
+def test_abstract_channel_raises(driver):
     """
-    Verify that the post init method is only called once, even
-    for sub-sub classes. This should work for arbitrary levels
-    of subclassing.
+    Creating an instrument with a channel with abstract parameters should raise
     """
-    instance = VoltageSourceSubSub("abstract_instrument_driver_7")
-    assert instance.call_count == 1
-
-
-@pytest.mark.skip("tests unimplemented feature")
-def test_channel(driver):
-    """
-    This should work without exceptions
-    """
-    VoltageChannel(driver, "abstract_instrument_driver_8")
-
     with pytest.raises(
         NotImplementedError, match="has un-implemented Abstract Parameter"
     ):
-        VoltageChannelBase(driver, "driver6")
+        VoltageAbstractChannelSource("abstract_instrument_driver_7")
+
+
+def test_non_abstract_channel_does_not_raises(request, driver):
+    """
+    Creating an instrument with a channel that implements concrete interface should not raise
+    """
+    source = VoltageChannelSource("abstract_instrument_driver_8")
+    request.addfinalizer(source.close)

--- a/qcodes/tests/test_abstract_instrument.py
+++ b/qcodes/tests/test_abstract_instrument.py
@@ -192,7 +192,8 @@ def test_abstract_channel_raises(driver):
 
 def test_non_abstract_channel_does_not_raises(request, driver):
     """
-    Creating an instrument with a channel that implements concrete interface should not raise
+    Creating an instrument with a channel that implements concrete
+    interface should not raise
     """
     source = VoltageChannelSource("abstract_instrument_driver_8")
     request.addfinalizer(source.close)


### PR DESCRIPTION
This is a start of re implementing the abstract parameter interface reverted in https://github.com/QCoDeS/Qcodes/pull/3197 and https://github.com/QCoDeS/Qcodes/pull/3217 based on top of https://github.com/QCoDeS/Qcodes/pull/3696

Compared to the solution based on init subclass this works a bit differently. The metaclass in use is only implemented for the Instrument class but not for the InstrumentChannel. Changing this would require metaclass inheritance which is a bad idea. 
This meas that it is not an error to create an InstrumentChannel with abstract parameters but it is an error to attach such a thing to an instrument at instrument creation time. I don't think this is a big issue since that is how most instruments are created. 

Still need to update docs again and verify if there are other reverted changes to bring over 

