### PR TITLE
move pytest related config to pyproject.toml

### DIFF
--- a/.github/workflows/pytest-non-local.yaml
+++ b/.github/workflows/pytest-non-local.yaml
@@ -55,5 +55,5 @@ jobs:
         cd ..
         mkdir empty
         cd empty
-        cp ../Qcodes/setup.cfg .
+        cp ../Qcodes/pyproject.toml .
         python -c "import sys; import qcodes; ec = qcodes.test(); sys.exit(ec)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,21 @@ build-backend = 'setuptools.build_meta'
 profile = "black"
 [tool.darker]
 isort = true
+[tool.pytest.ini_options]
+minversion = "6.0"
+junit_family = "legacy"
+
+addopts = "-n auto --dist=loadfile"
+
+markers = "serial"
+
+# warnings triggered by xarray and hdf5netcdf using deprecated apis
+filterwarnings = [
+    "ignore:The distutils package is deprecated and slated for removal in Python 3.12:DeprecationWarning",
+    "ignore:distutils Version classes are deprecated:DeprecationWarning",
+    "ignore:SelectableGroups dict interface is deprecated:DeprecationWarning"
+]
+
 [tool.towncrier]
 package = "qcodes"
 name = "QCoDeS"

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,24 +87,6 @@ test =
 console_scripts =
     qcodes-monitor = qcodes.monitor.monitor:main
 
-[tool:pytest]
-testpaths = "qcodes/tests"
-
-junit_family = legacy
-
-addopts =
-    -n auto
-    --dist=loadfile
-
-markers = serial
-
-;warnings triggered by xarray and hdf5netcdf using deprecated apis
-filterwarnings =
-    ignore:The distutils package is deprecated and slated for removal in Python 3.12:DeprecationWarning
-    ignore:distutils Version classes are deprecated:DeprecationWarning
-    ignore:SelectableGroups dict interface is deprecated:DeprecationWarning
-
-
 [mypy]
 strict_optional = True
 disallow_untyped_decorators = True


### PR DESCRIPTION
This was added in pytest 6.0 which is anyway the oldest version that we support. 
Pytest recommends against using setup.cfg for config now https://docs.pytest.org/en/6.2.x/customize.html#setup-cfg