### PR TITLE
cache lookup of editable package

### DIFF
--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -39,7 +39,7 @@ def is_package_installed_editably(package: str) -> Optional[bool]:
                                  check=True,
                                  stdout=subprocess.PIPE)
         e_pkgs = json.loads(pipproc.stdout.decode('utf-8'))
-        answer = any([d["name"] == package for d in e_pkgs])
+        answer = any(d["name"] == package for d in e_pkgs)
     except Exception as e:  # we actually do want a catch-all here
         log.warning(f'{type(e)}: {str(e)}')
         answer = None


### PR DESCRIPTION
Since this function is rather slow it makes sense to cache the lookup. My local benchmark indicates that this takes ~1.5 s but a cached version should evaluate in ns.

Also refactor the code a bit such that one can lookup editable status by name.
