### PR TITLE
Avoid calculating version twice on startup

### DIFF
--- a/docs/changes/newsfragments/3762.breaking
+++ b/docs/changes/newsfragments/3762.breaking
@@ -1,0 +1,2 @@
+The ``qcodes.version`` module deprecated and no longer imported by default e.g. if you want to use it you will need
+to explicitly import ``qcodes.version``. It is recommended to use ``qcodes.__version__`` as an alternative.

--- a/qcodes/data/hdf5_format.py
+++ b/qcodes/data/hdf5_format.py
@@ -6,7 +6,8 @@ from typing import TYPE_CHECKING
 import h5py
 import numpy as np
 
-from ..version import __version__ as _qcodes_version
+import qcodes as qc
+
 from .data_array import DataArray
 from .format import Formatter
 
@@ -165,8 +166,8 @@ class HDF5Format(Formatter):
         # name. This is useful for saving e.g. images in the same folder
         # I think this is a sane default (MAR).
         data_set._h5_base_group = self._create_file(filepath)
-        data_set._h5_base_group.attrs['__qcodes_version'] = _qcodes_version
-        data_set._h5_base_group.attrs['__format_tag'] = self._format_tag
+        data_set._h5_base_group.attrs["__qcodes_version"] = qc.__version__
+        data_set._h5_base_group.attrs["__format_tag"] = self._format_tag
 
         return data_set._h5_base_group
 

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -6,7 +6,7 @@ import qcodes.utils.installation_info as ii
 
 
 def test_get_qcodes_version():
-    assert ii.get_qcodes_version() == qc.version.__version__
+    assert ii.get_qcodes_version() == qc.__version__
 
 
 def test_get_qcodes_requirements():

--- a/qcodes/version.py
+++ b/qcodes/version.py
@@ -1,3 +1,14 @@
+import warnings
+
+from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+
 from ._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions
+
+warnings.warn(
+    "The qcodes.version module is deprecated and will be removed, Please use `qcodes.__version__` to "
+    "get the QCoDeS version at runtime",
+    QCoDeSDeprecationWarning,
+)


### PR DESCRIPTION
this is already statically avaliable as ``qcodes.__version__``

This shaves of 0.3 sec or so from the start up time. 
It may be worthwile deprecating the version module. However https://github.com/QCoDeS/Qcodes/pull/3731 fixes this anyway in a way that ensures version is only calculated once per session 