### PR TITLE
Speedup avoid loading pkg_resources at startup

### DIFF
--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -3,11 +3,11 @@ import copy
 import json
 import logging
 import os
-import pkg_resources as pkgr
 from os.path import expanduser
 from pathlib import Path
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
+
 import jsonschema
-from typing import Dict, Tuple, Optional, Any, Mapping, Union
 
 logger = logging.getLogger(__name__)
 
@@ -39,15 +39,14 @@ class Config:
     schema_file_name = "qcodesrc_schema.json"
     """Name of schema file"""
     # get abs path of packge config file
-    default_file_name = pkgr.resource_filename(__name__, config_file_name)
+    default_file_name = str(Path(__file__).parent / config_file_name)
     """Filename of default config"""
     current_config_path = default_file_name
     """Path of the last loaded config file"""
     _loaded_config_files = [default_file_name]
 
     # get abs path of schema  file
-    schema_default_file_name = pkgr.resource_filename(__name__,
-                                                      schema_file_name)
+    schema_default_file_name = str(Path(__file__).parent / schema_file_name)
     """Filename of default schema"""
 
     # home dir, os independent

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -9,8 +9,6 @@ import subprocess
 import sys
 from typing import Dict, List, Optional
 
-import requirements
-
 if sys.version_info >= (3, 8):
     from importlib.metadata import PackageNotFoundError, distribution, version
 else:
@@ -56,6 +54,7 @@ def get_qcodes_requirements() -> List[str]:
     """
     Return a list of the names of the packages that QCoDeS requires
     """
+    import requirements
     qc_pkg = distribution('qcodes').requires
     if qc_pkg is None:
         return []

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 from typing import Dict, List, Optional
 
-import pkg_resources
 import requirements
 
 if sys.version_info >= (3, 8):
@@ -89,6 +88,7 @@ def get_all_installed_package_versions() -> Dict[str, str]:
     """
     Return a dictionary of the currently installed packages and their versions.
     """
+    import pkg_resources
     packages = pkg_resources.working_set
     return {i.key: i.version for i in packages}
 


### PR DESCRIPTION
Avoid an import time dependency on pkg_resources. This takes 0.3-4 s to import

To do this 

* Make import lazy in two instances where it is only used for logging
* Dont use this to generate absolute paths to config files. This does in principle mean that these are no longer zip safe. However QCoDeS is currently not marked as zip safe and running from a zip file is not really something we want to support 
