### PR TITLE
Speedup import: disable ipython magic by default

### DIFF
--- a/docs/changes/newsfragments/3764.breaking
+++ b/docs/changes/newsfragments/3764.breaking
@@ -1,0 +1,3 @@
+IPython measurement magic (Special command staring with % for use in IPython) using the legacy
+loop is no longer enabled by default.
+To enable it set the corresponding config value (`core.register_magic`) in your ``qcodesrc.json`` config file to true.

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -104,11 +104,15 @@ from qcodes.utils import validators
 try:
     _register_magic = config.core.get('register_magic', False)
     if _register_magic is not False:
-        # Check if we are in iPython
-        get_ipython()  # type: ignore[name-defined]
-        from qcodes.utils.magic import register_magic_class
-        register_magic_class(magic_commands=_register_magic)
-except NameError:
+        from IPython import get_ipython
+
+        # Check if we are in IPython
+        ip = get_ipython()
+        if ip is not None:
+            from qcodes.utils.magic import register_magic_class
+
+            register_magic_class(magic_commands=_register_magic)
+except ImportError:
     pass
 except RuntimeError as e:
     print(e)

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -102,11 +102,11 @@ from qcodes.instrument_drivers.test import test_instrument, test_instruments
 from qcodes.utils import validators
 
 try:
-    # Check if we are in iPython
-    get_ipython()  # type: ignore[name-defined]
-    from qcodes.utils.magic import register_magic_class
     _register_magic = config.core.get('register_magic', False)
     if _register_magic is not False:
+        # Check if we are in iPython
+        get_ipython()  # type: ignore[name-defined]
+        from qcodes.utils.magic import register_magic_class
         register_magic_class(magic_commands=_register_magic)
 except NameError:
     pass

--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -1,7 +1,7 @@
 {
     "core":{
         "default_fmt": "data/{date}/#{counter}_{name}_{time}",
-        "register_magic": true,
+        "register_magic": false,
         "import_legacy_api": false,
         "db_location": "~/experiments.db",
         "db_debug": false,

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -43,7 +43,7 @@
                         {"type": "boolean"},
                         {"type": "array"}
                     ],
-                    "default": true
+                    "default": false
                 },
                 "import_legacy_api" : {
                     "description": "Import the legacy api in main qcodes namespace",

--- a/qcodes/utils/magic.py
+++ b/qcodes/utils/magic.py
@@ -1,4 +1,5 @@
-from IPython.core.magic import Magics, magics_class, line_cell_magic
+from IPython.core.magic import Magics, line_cell_magic, magics_class
+
 
 @magics_class
 class QCoDeSMagic(Magics):
@@ -153,7 +154,7 @@ def register_magic_class(cls=QCoDeSMagic, magic_commands=True):
 
     ip = get_ipython()
     if ip is None:
-        raise RuntimeError('No iPython shell found')
+        raise RuntimeError("No IPython shell found")
     else:
         if magic_commands is not True:
             # filter out any magic commands that are not in magic_commands

--- a/qcodes/utils/magic.py
+++ b/qcodes/utils/magic.py
@@ -1,3 +1,4 @@
+from IPython import get_ipython
 from IPython.core.magic import Magics, line_cell_magic, magics_class
 
 


### PR DESCRIPTION
This changes the configuration such that the legacy IPython magic becomes off by default. Avoiding to unconditionally import IPython on startup. This saves ~ 0.3/4 sec or so