### PR TITLE
Support numpy 1.22

### DIFF
--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -37,7 +37,8 @@ nbformat==5.1.3
 nbsphinx==0.8.8
 nest-asyncio==1.5.4
 notebook==6.4.6
-numpy==1.21.5
+numpy~=1.21.5; python_version<'3.8'
+numpy~=1.22.0; python_version>='3.8'
 packaging==21.3
 pandas==1.3.5
 pandocfilters==1.5.0

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -97,7 +97,7 @@ def is_run_id_in_database(conn: ConnectionPlus,
         a dict with the run_ids as keys and bools as values. True means that
         the run_id DOES exist in the database
     """
-    run_ids = np.unique(run_ids)
+    run_ids = tuple(np.unique(run_ids))
     placeholders = sql_placeholder_string(len(run_ids))
 
     query = f"""

--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -735,14 +735,6 @@ class Buffer:
         self.size_bytes = size_bytes
         self.buffer: np.ndarray
 
-        npSampleType = {
-            ctypes.c_uint8: np.uint8,
-            ctypes.c_uint16: np.uint16,
-            ctypes.c_uint32: np.uint32,
-            ctypes.c_int32: np.int32,
-            ctypes.c_float: np.float32
-        }.get(c_sample_type, 0)
-
         bytes_per_sample = {
             ctypes.c_uint8:  1,
             ctypes.c_uint16: 2,
@@ -765,7 +757,7 @@ class Buffer:
 
         ctypes_array = (c_sample_type *
                         (size_bytes // bytes_per_sample)).from_address(self.addr)
-        self.buffer = np.frombuffer(ctypes_array, dtype=npSampleType)
+        self.buffer = np.ctypeslib.as_array(ctypes_array)
         self.ctypes_buffer = ctypes_array
 
     def free_mem(self) -> None:

--- a/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS_acquisition_controllers.py
@@ -1,8 +1,9 @@
-from typing import Any, Optional, Dict, Tuple
+import math
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
 
 from .ATS import AcquisitionController, OutputType
-import math
-import numpy as np
 
 
 # DFT AcquisitionController
@@ -37,8 +38,8 @@ class Demodulation_AcquisitionController(AcquisitionController[float]):
         self.records_per_buffer = 0
         self.buffers_per_acquisition = 0
         self.number_of_channels = 2
-        self.cos_list = None
-        self.sin_list = None
+        self.cos_list: Optional[np.ndarray] = None
+        self.sin_list: Optional[np.ndarray] = None
         self.buffer: Optional[np.ndarray] = None
         # make a call to the parent class and by extension, create the parameter
         # structure of this class
@@ -146,6 +147,8 @@ class Demodulation_AcquisitionController(AcquisitionController[float]):
         :return: return amplitude and phase of the resulted transform
         """
         # Discrete Fourier Transform
+        assert self.cos_list is not None
+        assert self.sin_list is not None
         RePart = np.dot(buf - 127.5, self.cos_list) / self.samples_per_record
         ImPart = np.dot(buf - 127.5, self.sin_list) / self.samples_per_record
 

--- a/qcodes/instrument_drivers/Galil/dmc_41x3.py
+++ b/qcodes/instrument_drivers/Galil/dmc_41x3.py
@@ -714,15 +714,15 @@ class Arm:
         a = np.asarray(self._right_top_position) - np.asarray(
             self._left_bottom_position
         )
-        self.norm_a = np.linalg.norm(a)
+        self.norm_a = float(np.linalg.norm(a))
         self._a = a / self.norm_a
 
         b = np.asarray(self._left_top_position) - np.asarray(self._left_bottom_position)
-        self.norm_b = np.linalg.norm(b)
+        self.norm_b = float(np.linalg.norm(b))
         self._b = b / self.norm_b
 
         c = np.asarray(self._right_top_position) - np.asarray(self._left_top_position)
-        self.norm_c = np.linalg.norm(c)
+        self.norm_c = float(np.linalg.norm(c))
         self._c = c / self.norm_c
 
         n = np.cross(self._a, self._b)
@@ -958,7 +958,7 @@ class Arm:
             raise RuntimeError("Cannot move further")
 
         motion_vec = -1 * self._b * self.norm_b + self._c * self.inter_pad_distance
-        norm = np.linalg.norm(motion_vec)
+        norm = float(np.linalg.norm(motion_vec))
         motion_vec_cap = motion_vec / norm
 
         self._pick_up()

--- a/qcodes/instrument_drivers/HP/HP8753D.py
+++ b/qcodes/instrument_drivers/HP/HP8753D.py
@@ -103,7 +103,7 @@ class HP8753DTrace(ArrayParameter):
             first_points += raw_resp[4:][2*n*4:(2*n+1)*4]
 
         dt = np.dtype('>f')
-        trace1 = np.fromstring(first_points, dtype=dt)
+        trace1 = np.frombuffer(first_points, dtype=dt)
 
         return trace1
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -1,23 +1,42 @@
 import re
 import textwrap
-from typing import Optional, Dict, Any, Union, TYPE_CHECKING, List, Tuple, \
-    cast, Sequence
-from typing_extensions import TypedDict, Literal, overload
-import numpy as np
-import qcodes.utils.validators as vals
-from qcodes.instrument.parameter import Parameter, ParamRawDataType
-from qcodes.instrument.channel import InstrumentChannel
-from qcodes.instrument.group_parameter import GroupParameter, Group
-from qcodes.utils.validators import Arrays
-from qcodes.utils.deprecate import deprecate
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
 
-from .KeysightB1500_sampling_measurement import SamplingMeasurement
-from .KeysightB1500_module import B1500Module, \
-    parse_spot_measurement_response
-from .message_builder import MessageBuilder
+import numpy as np
+from typing_extensions import Literal, TypedDict, overload
+
+import qcodes.utils.validators as vals
+from qcodes.instrument.channel import InstrumentChannel
+from qcodes.instrument.group_parameter import Group, GroupParameter
+from qcodes.instrument.parameter import Parameter, ParamRawDataType
+from qcodes.utils.deprecate import deprecate
+from qcodes.utils.validators import Arrays
+
 from . import constants
-from .constants import ModuleKind, ChNr, AAD, MM, MeasurementStatus, \
-    VMeasRange, IMeasRange, VOutputRange, IOutputRange
+from .constants import (
+    AAD,
+    MM,
+    ChNr,
+    IMeasRange,
+    IOutputRange,
+    MeasurementStatus,
+    ModuleKind,
+    VMeasRange,
+    VOutputRange,
+)
+from .KeysightB1500_module import B1500Module, parse_spot_measurement_response
+from .KeysightB1500_sampling_measurement import SamplingMeasurement
+from .message_builder import MessageBuilder
 
 if TYPE_CHECKING:
     from .KeysightB1500_base import KeysightB1500
@@ -796,7 +815,7 @@ class B1517A(B1500Module):
     def _get_time_axis(self) -> np.ndarray:
         sample_rate = self._timing_parameters['interval']
         total_time = self._total_measurement_time()
-        time_xaxis = np.arange(0, total_time, sample_rate)
+        time_xaxis: np.ndarray = np.arange(0, total_time, sample_rate)
         return time_xaxis
 
     def _total_measurement_time(self) -> float:

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -887,7 +887,7 @@ class AMI430_3D(Instrument):
             setpoint_values: Tuple[float, float, float]
     ) -> bool:
         if isinstance(self._field_limit, (int, float)):
-            return np.linalg.norm(setpoint_values) < self._field_limit
+            return bool(np.linalg.norm(setpoint_values) < self._field_limit)
 
         answer = any([limit_function(*setpoint_values) for
                       limit_function in self._field_limit])

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -122,10 +122,9 @@ class ScopeTrace(ArrayParameter):
         dataformat = instr.dataformat.get_latest()
 
         if dataformat == 'INT,8':
-            int_vals = np.fromstring(raw_vals, dtype=np.int8, count=no_points)
+            int_vals = np.frombuffer(raw_vals, dtype=np.int8, count=no_points)
         else:
-            int_vals = np.fromstring(raw_vals, dtype=np.int16,
-                                     count=no_points//2)
+            int_vals = np.frombuffer(raw_vals, dtype=np.int16, count=no_points // 2)
 
         # now the integer values must be converted to physical
         # values

--- a/qcodes/instrument_drivers/stanford_research/SR830.py
+++ b/qcodes/instrument_drivers/stanford_research/SR830.py
@@ -69,8 +69,8 @@ class ChannelTrace(ParameterWithSetpoints):
         rawdata = self.root_instrument.visa_handle.read_raw()
 
         # parse it
-        realdata = np.fromstring(rawdata, dtype='<i2')
-        numbers = realdata[::2]*2.0**(realdata[1::2]-124)
+        realdata = np.frombuffer(rawdata, dtype="<i2")
+        numbers = realdata[::2] * 2.0 ** (realdata[1::2] - 124)
 
         return numbers
 
@@ -178,8 +178,8 @@ class ChannelBuffer(ArrayParameter):
         rawdata = self.instrument.visa_handle.read_raw()
 
         # parse it
-        realdata = np.fromstring(rawdata, dtype='<i2')
-        numbers = realdata[::2]*2.0**(realdata[1::2]-124)
+        realdata = np.frombuffer(rawdata, dtype="<i2")
+        numbers = realdata[::2] * 2.0 ** (realdata[1::2] - 124)
         if self.shape[0] != N:
             raise RuntimeError(
                 f"SR830 got {N} points in buffer expected {self.shape[0]}"

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -377,7 +377,7 @@ class SR86xBuffer(InstrumentChannel):
                              f"is larger than current capture length of the "
                              f"buffer ({current_capture_length}kB).")
 
-        values = np.array([])
+        values: np.ndarray = np.array([])
         data_size_to_read_in_kb = size_in_kb
         n_readings = 0
 

--- a/qcodes/math_utils/field_vector.py
+++ b/qcodes/math_utils/field_vector.py
@@ -7,9 +7,10 @@ coordinate systems.
 from typing import Any, List, Optional, Sequence, Type, TypeVar, Union
 
 import numpy as np
+from typing_extensions import Literal
 
-NormOrder = Union[str, float]
-T = TypeVar('T', bound='FieldVector')
+NormOrder = Union[None, float, Literal["fro"], Literal["nuc"]]
+T = TypeVar("T", bound="FieldVector")
 
 
 class FieldVector:
@@ -315,7 +316,11 @@ class FieldVector:
         Returns the norm of this field vector. See ``np.norm``
         for the definition of the ord keyword argument.
         """
-        return np.linalg.norm([self.x, self.y, self.z], ord=ord)
+        assert self.x is not None
+        assert self.y is not None
+        assert self.z is not None
+
+        return float(np.linalg.norm([self.x, self.y, self.z], ord=ord))
 
     def distance(self, other,
                  ord: NormOrder = 2  # pylint: disable=redefined-builtin

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -756,7 +756,7 @@ class Arrays(Validator[np.ndarray]):
         if self.shape is None:
             return (np.array([self._min_value], dtype=valid_type),)
         else:
-            val_arr = np.empty(self.shape, dtype=valid_type)
+            val_arr: np.ndarray = np.empty(self.shape, dtype=valid_type)
             val_arr.fill(self._min_value)
             return (val_arr,)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,8 @@ nbconvert~=6.4.0
 nbformat~=5.1.3
 nest-asyncio~=1.5.4
 notebook~=6.4.6
-numpy~=1.21.5
+numpy~=1.21.5; python_version<'3.8'
+numpy~=1.22.0; python_version>='3.8'
 opencensus~=0.8.0
 opencensus-context~=0.1.2
 opencensus-ext-azure~=1.1.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -14,7 +14,8 @@ iniconfig==1.1.1
 lxml==4.7.1
 mypy==0.930
 mypy-extensions==0.4.3
-numpy==1.21.5
+numpy~=1.21.5; python_version<'3.8'
+numpy~=1.22.0; python_version>='3.8'
 ordered-set==4.0.2
 packaging==21.3
 pluggy==1.0.0


### PR DESCRIPTION
Numpy 1.22 adds a fair amount of types so there are a few tweaks to get it correct. 

The most important ones are probably the changes around fromstring / frombuffer. 
* fromstring is effectively deprecated in the format that we use it and it is recommended to use frombuffer as done here
* using from buffer with a ctypes array seems to be not recommended so we use the numpy ctypes api here. This results in a simplifications since we no longer have to manually map between ctypes and numpy types 
