### PR TITLE
Remove websockets import wrapper

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -23,16 +23,6 @@ conditionally_start_all_logging()
 add_to_spyder_UMR_excludelist('qcodes')
 
 
-from qcodes.station import Station
-
-haswebsockets = True
-try:
-    import websockets
-except ImportError:
-    haswebsockets = False
-if haswebsockets:
-    from qcodes.monitor.monitor import Monitor
-
 # ensure to close all instruments when interpreter is closed
 import atexit
 
@@ -76,6 +66,8 @@ from qcodes.instrument.parameter import (
 from qcodes.instrument.sweep_values import SweepFixedValues, SweepValues
 from qcodes.instrument.visa import VisaInstrument
 from qcodes.instrument_drivers.test import test_instrument, test_instruments
+from qcodes.monitor.monitor import Monitor
+from qcodes.station import Station
 from qcodes.utils import validators
 
 atexit.register(Instrument.close_all)

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -23,7 +23,6 @@ conditionally_start_all_logging()
 add_to_spyder_UMR_excludelist('qcodes')
 
 
-# ensure to close all instruments when interpreter is closed
 import atexit
 
 from qcodes.dataset.data_set import (
@@ -70,6 +69,7 @@ from qcodes.monitor.monitor import Monitor
 from qcodes.station import Station
 from qcodes.utils import validators
 
+# ensure to close all instruments when interpreter is closed
 atexit.register(Instrument.close_all)
 
 if config.core.import_legacy_api:

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -589,7 +589,7 @@ class Runner:
 
         # .. and give the dataset a snapshot as metadata
         if self.station is None:
-            station = qc.Station.default
+            station = Station.default
         else:
             station = self.station
 
@@ -692,9 +692,12 @@ class Measurement:
             'results' is used for the dataset.
     """
 
-    def __init__(self, exp: Optional[Experiment] = None,
-                 station: Optional[qc.Station] = None,
-                 name: str = '') -> None:
+    def __init__(
+        self,
+        exp: Optional[Experiment] = None,
+        station: Optional[Station] = None,
+        name: str = "",
+    ) -> None:
         self.exitactions: List[ActionType] = []
         self.enteractions: List[ActionType] = []
         self.subscribers: List[SubscriberType] = []


### PR DESCRIPTION
Websockets is a hard dependency at the moment so this does not make a lot of sense to wrap the import logic like this.

This is done on top of https://github.com/QCoDeS/Qcodes/pull/3781 which should be merged first

The reordering of imports done by darker here triggered another circular import which is fixed by correcting the measurement module to not use station from the top level