### PR TITLE
fix IPython deprecation warning

### DIFF
--- a/qcodes/interactive_widget.py
+++ b/qcodes/interactive_widget.py
@@ -11,8 +11,7 @@ from functools import partial, reduce
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Sequence
 
 import matplotlib.pyplot as plt
-from IPython.core.display import display
-from IPython.display import clear_output
+from IPython.display import clear_output, display
 from ipywidgets import (
     HTML,
     Box,


### PR DESCRIPTION
Fixes 

<ipython-input-1-71c4ab7913f1>:1: DeprecationWarning: Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython display
  from IPython.core.display import display
