### PR TITLE
Remove manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include LICENSE
-include LICENSE.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 48",
+    "setuptools >= 56.0",
     "wheel >= 0.29.0",
     "versioningit ~= 0.3.0",
 ]


### PR DESCRIPTION
With setuptools 56 the licence is automatically included and there is no need to specify it in the manifest. 
This means that we have one less file to clutter the main source dir 