### PR TITLE
Precommit: Run darker relative to master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
     hooks:
     - id: pyupgrade
       args: ['--py37-plus', '--keep-runtime-typing']
-      exclude: _version.py|versioneer.py
   - repo: https://github.com/akaihola/darker
     rev: github-action-v1.3.2-2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,5 +20,5 @@ repos:
     rev: github-action-v1.3.2-2
     hooks:
       -   id: darker
-          args: [-i]
+          args: [-i, "-r master"]
           additional_dependencies: [isort]


### PR DESCRIPTION
As currently configured it would only run darker on the latest commit. That works greak if you have the pre commit installed locally but means that we miss cleanup when the formatter runs in ci.

Also remove an exclude that is no longer needed after we removed versioneer. 