### PR TITLE
Register InstrumentModules separately from ChannelLists

### DIFF
--- a/docs/changes/newsfragments/3834.improved
+++ b/docs/changes/newsfragments/3834.improved
@@ -1,0 +1,3 @@
+Instances of ``InstrumentModule`` (and therfor their subclass ``InstrumentChannel``) are now accessible via
+the ``Instrument.instrument_modules`` dict on an instrument in addition to the ``Instrument.submodules`` dict
+which combines them with instances of ``ChannelList``.

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -80,6 +80,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         """
         All the ChannelLists of this instrument
         Usually populated via :py:meth:`add_submodule`.
+        This is private until the correct name has been decided.
         """
 
         super().__init__(metadata)
@@ -220,9 +221,9 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         self.submodules[name] = submodule
 
         if isinstance(submodule, collections.abc.Sequence):
-            # this is channel_list like
-            # We cannot check against channels to avoid circular imports
-            # This is private for now until we agree on the name
+            # this is channel_list like:
+            # We cannot check against ChannelsList itself since that
+            # would introduce a circular dependency.
             self._channel_lists[name] = submodule
         else:
             self.instrument_modules[name] = submodule

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -1,10 +1,10 @@
 """Instrument base class."""
+import collections.abc
 import logging
 import time
 import warnings
 import weakref
 from abc import ABC, ABCMeta, abstractmethod
-from collections.abc import Collection
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -220,13 +220,12 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             raise TypeError('Submodules must be metadatable.')
         self.submodules[name] = submodule
 
-        if isinstance(submodule, Collection):
+        if isinstance(submodule, collections.abc.Sequence):
             # this is channel_list like
             # We cannot check against channels to avoid circular imports
             self.channel_list_modules[name] = submodule  # type: ignore[assignment]
         else:
             self.channel_modules[name] = submodule  # type: ignore[assignment]
-
 
     def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -70,18 +70,17 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         such as channel lists or logical groupings of parameters.
         Usually populated via :py:meth:`add_submodule`.
         """
-        self.channel_modules: Dict[str, "ChannelList"] = {}
+        self.instrument_modules: Dict[str, "InstrumentModule"] = {}
         """
-        All the channels of this instrument
+        All the instrument_modules of this instrument
         Usually populated via :py:meth:`add_submodule`.
         """
 
-        self.channel_list_modules: Dict[str, "ChannelList"] = {}
+        self._channel_lists: Dict[str, "ChannelList"] = {}
         """
         All the ChannelLists of this instrument
         Usually populated via :py:meth:`add_submodule`.
         """
-
 
         super().__init__(metadata)
 
@@ -223,9 +222,10 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         if isinstance(submodule, collections.abc.Sequence):
             # this is channel_list like
             # We cannot check against channels to avoid circular imports
-            self.channel_list_modules[name] = submodule  # type: ignore[assignment]
+            # This is private for now until we agree on the name
+            self._channel_lists[name] = submodule
         else:
-            self.channel_modules[name] = submodule  # type: ignore[assignment]
+            self.instrument_modules[name] = submodule
 
     def snapshot_base(self, update: Optional[bool] = False,
                       params_to_skip_update: Optional[Sequence[str]] = None


### PR DESCRIPTION
- [x] Register channels and channel lists in two separate dicts. This is done on the basis of the ABC to avoid a circular import

Open questions 

- [ ] Deprecate submodules dict (yes but not now)
- [ ] Adapt snapshot etc to use the channels rather than (again not now)
- [x] Better names for the new dicts (channels is not an option since many instruments uses that as the name of the channel list)