### PR TITLE
remove wrongly named news fragment

### DIFF
--- a/docs/changes/newsfragments/3644.Underthehood
+++ b/docs/changes/newsfragments/3644.Underthehood
@@ -1,2 +1,0 @@
-Relax type assertions for DataSet timestamps so that if in the database they
-are written as integers, as opposed to floats, a DataSet can still be loaded


### PR DESCRIPTION
The format is nnnn.underthehood not nnnn.Underthehood so this was never included (and deleted). Remove now to avoid this being imitated
