### PR TITLE
Fix some tests that depends on shared state

### DIFF
--- a/qcodes/tests/delegate/conftest.py
+++ b/qcodes/tests/delegate/conftest.py
@@ -27,7 +27,7 @@ def lockin():
     return _lockin
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def station(dac, lockin, field_x):
     _station = qc.Station()
     _station.add_component(dac)


### PR DESCRIPTION
This is discovered using pytest-randomly https://github.com/pytest-dev/pytest-randomly
which randomly reorders the tests. 

* station fixture was being modified in tests so its not safe to reuse at session scope
* Stahl drivers tests were sensitive to what was in the logger before test started executing. Rewrite using caplog from pytest

There failures can be systematically reproduced using 

```
pytest.exe --randomly-seed=3202135262
```

Note that there are more ordering issues not yet fixed here 
