### PR TITLE
Split ChannelList into a ChannelTuple and a ChannelList

### DIFF
--- a/docs/changes/newsfragments/3851.new
+++ b/docs/changes/newsfragments/3851.new
@@ -1,0 +1,10 @@
+The instrument channel container ``ChannelList`` has been split into a immutable ``ChannelTuple``
+and a mutable ``ChannelList``. The ``ChannelList`` class has gained a ``to_channel_tuple`` method.
+The ``lock`` method which locks a ``ChannelList`` has been retained but we do expect to deprecate
+this in the future.
+
+All drivers in QCoDeS have been updated to either use a ``ChannelTuple`` or a unlocked
+``ChannelList`` as it makes sense.
+
+Furthermore, the ``ChannelList`` class now implements the full
+``collections.abc.MutableSequence`` interface behaving like a python list.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ warn_redundant_casts = true
 no_implicit_optional = true
 plugins = "numpy.typing.mypy_plugin"
 disallow_untyped_defs = true
+show_error_codes = true
 
 [[tool.mypy.overrides]]
 module = [

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -47,7 +47,7 @@ from qcodes.dataset.sqlite.database import (
 )
 from qcodes.dataset.sqlite.settings import SQLiteSettings
 from qcodes.instrument.base import Instrument, find_or_create_instrument
-from qcodes.instrument.channel import ChannelList, InstrumentChannel
+from qcodes.instrument.channel import ChannelList, ChannelTuple, InstrumentChannel
 from qcodes.instrument.function import Function
 from qcodes.instrument.ip import IPInstrument
 from qcodes.instrument.parameter import (

--- a/qcodes/instrument/__init__.py
+++ b/qcodes/instrument/__init__.py
@@ -1,5 +1,5 @@
 from .base import Instrument, find_or_create_instrument
-from .channel import ChannelList, InstrumentChannel, InstrumentModule
+from .channel import ChannelList, ChannelTuple, InstrumentChannel, InstrumentModule
 from .function import Function
 from .ip import IPInstrument
 from .parameter import (

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -31,7 +31,7 @@ from .function import Function
 from .parameter import Parameter, _BaseParameter
 
 if TYPE_CHECKING:
-    from qcodes.instrument.channel import ChannelList, InstrumentModule
+    from qcodes.instrument.channel import ChannelTuple, InstrumentModule
     from qcodes.logger.instrument_logger import InstrumentLoggerAdapter
 
 from qcodes.utils.deprecate import QCoDeSDeprecationWarning
@@ -64,7 +64,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         All the functions supported by this
         instrument. Usually populated via :py:meth:`add_function`.
         """
-        self.submodules: Dict[str, Union["InstrumentModule", "ChannelList"]] = {}
+        self.submodules: Dict[str, Union["InstrumentModule", "ChannelTuple"]] = {}
         """
         All the submodules of this instrument
         such as channel lists or logical groupings of parameters.
@@ -76,9 +76,9 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         Usually populated via :py:meth:`add_submodule`.
         """
 
-        self._channel_lists: Dict[str, "ChannelList"] = {}
+        self._channel_lists: Dict[str, "ChannelTuple"] = {}
         """
-        All the ChannelLists of this instrument
+        All the ChannelTuples of this instrument
         Usually populated via :py:meth:`add_submodule`.
         This is private until the correct name has been decided.
         """
@@ -187,7 +187,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         self.functions[name] = func
 
     def add_submodule(
-        self, name: str, submodule: Union["InstrumentModule", "ChannelList"]
+        self, name: str, submodule: Union["InstrumentModule", "ChannelTuple"]
     ) -> None:
         """
         Bind one submodule to this instrument.
@@ -200,7 +200,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         snapshottable. For example, they can be used to either store
         logical groupings of parameters, which may or may not be
         repeated, or channel lists. They should either be an instance
-        of an ``InstrumentModule`` or a ``ChannelList``.
+        of an ``InstrumentModule`` or a ``ChannelTuple``.
 
         Args:
             name: How the submodule will be stored within

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -221,10 +221,8 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
         # channels. This will eventually become a locked tuple.
         self._channels: Sequence[InstrumentChannel]
         if chan_list is None:
-            self._locked = False
-            self._channels = []
+            self._channels = ()
         else:
-            self._locked = True
             self._channels = tuple(chan_list)
             if self._channels is None:
                 raise RuntimeError("Empty channel list")
@@ -509,6 +507,23 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
 # taking a tuple is not compatible with MutableSequence
 # for some reason this does not happen with Sequence
 class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ignore[misc]
+    def __init__(
+        self,
+        parent: InstrumentBase,
+        name: str,
+        chan_type: type,
+        chan_list: Optional[Sequence[InstrumentChannel]] = None,
+        snapshotable: bool = True,
+        multichan_paramclass: type = MultiChannelInstrumentParameter,
+    ):
+        super().__init__(
+            parent, name, chan_type, chan_list, snapshotable, multichan_paramclass
+        )
+        if len(self._channels) > 0:
+            self._locked = True
+        else:
+            self._channels = list(self._channels)
+            self._locked = False
 
     @overload
     def __delitem__(self, key: int) -> None:

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -725,7 +725,7 @@ class ChannelTupleValidator(Validator[InstrumentChannel]):
                 "object containing the "
                 "channels that should be validated"
             )
-        if not channel_list._locked:
+        if isinstance(channel_list, ChannelList) and not channel_list._locked:
             raise AttributeError(
                 "channel_list must be locked before it can "
                 "be used to create a validator"

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -249,7 +249,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
 
     def __getitem__(
         self: T, i: Union[int, slice, Tuple[int, ...]]
-    ) -> Union["InstrumentChannel", T]:
+    ) -> Union[InstrumentChannel, T]:
         """
         Return either a single channel, or a new :class:`ChannelTuple`
         containing only the specified channels
@@ -420,7 +420,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
         a function on the channel type contained in this container return a
         multi-channel function or parameter that we can use to get or
         set all items in a channel list simultaneously. If this is the
-        name of a channel return that channel.
+        name of a channel, return that channel.
 
         Params:
             name: The name of the parameter, function or channel that we want to
@@ -643,9 +643,9 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
         """
         # objects may be a generator but we need to iterate over it twice
         # below so copy it into a tuple just in case.
-        objects_tuple = tuple(objects)
         if self._locked:
             raise AttributeError("Cannot extend a locked channel list")
+        objects_tuple = tuple(objects)
         if not all(isinstance(obj, self._chan_type) for obj in objects_tuple):
             raise TypeError("All items in a channel list must be of the same type.")
         channels = cast(List[InstrumentChannel], self._channels)

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -154,7 +154,7 @@ class MultiChannelInstrumentParameter(MultiParameter):
 T = TypeVar("T", bound="ChannelTuple")
 
 
-class ChannelTuple(Metadatable, collections.abc.Sequence):
+class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
     """
     Container for channelized parameters that allows for sweeps over
     all channels, as well as addressing of individual channels.
@@ -320,7 +320,9 @@ class ChannelTuple(Metadatable, collections.abc.Sequence):
             list(self._channels) + list(other._channels),
         )
 
-    def index(self, obj: object, start: int = 0, stop: int = sys.maxsize) -> int:
+    def index(
+        self, obj: InstrumentChannel, start: int = 0, stop: int = sys.maxsize
+    ) -> int:
         """
         Return the index of the given object
 
@@ -331,7 +333,7 @@ class ChannelTuple(Metadatable, collections.abc.Sequence):
         """
         return self._channels.index(obj, start, stop)
 
-    def count(self, obj: object) -> int:
+    def count(self, obj: InstrumentChannel) -> int:
         """Returns number of instances of the given object in the list
 
         Args:

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -521,20 +521,27 @@ class ChannelList(ChannelTuple, collections.abc.MutableSequence):
         self._channels.__delitem__(key)
 
     @overload
-    def __setitem__(self, key: int, value: InstrumentChannel) -> None:
+    def __setitem__(self, index: int, value: InstrumentChannel) -> None:
         ...
 
     @overload
-    def __setitem__(self, key: slice, value: Iterable[InstrumentChannel]) -> None:
+    def __setitem__(self, index: slice, value: Iterable[InstrumentChannel]) -> None:
         ...
 
     def __setitem__(
         self,
-        key: Union[int, slice],
+        index: Union[int, slice],
         value: Union[InstrumentChannel, Iterable[InstrumentChannel]],
     ) -> None:
         # update mapping
-        self._channels[key] = value
+        self._channels = cast(List[InstrumentChannel], self._channels)
+        # asserts added to work around https://github.com/python/mypy/issues/7858
+        if isinstance(index, int):
+            assert isinstance(value, InstrumentChannel)
+            self._channels[index] = value
+        else:
+            assert not isinstance(value, InstrumentChannel)
+            self._channels[index] = value
 
     def append(self, obj: InstrumentChannel) -> None:
         """

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -191,12 +191,15 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
 
     """
 
-    def __init__(self, parent: InstrumentBase,
-                 name: str,
-                 chan_type: type,
-                 chan_list: Optional[Sequence[InstrumentChannel]] = None,
-                 snapshotable: bool = True,
-                 multichan_paramclass: type = MultiChannelInstrumentParameter):
+    def __init__(
+        self,
+        parent: InstrumentBase,
+        name: str,
+        chan_type: type,
+        chan_list: Optional[Sequence[InstrumentChannel]] = None,
+        snapshotable: bool = True,
+        multichan_paramclass: type = MultiChannelInstrumentParameter,
+    ):
         super().__init__()
 
         self._parent = parent
@@ -699,6 +702,7 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
             self._chan_type,
             self._channels,
             multichan_paramclass=self._paramclass,
+            snapshotable=self._snapshotable,
         )
 
 

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -287,7 +287,7 @@ class ChannelTuple(Metadatable, collections.abc.Sequence):
                                                     self._chan_type.__name__,
                                                     self._channels)
 
-    def __add__(self, other: 'ChannelList') -> 'ChannelList':
+    def __add__(self: T, other: T) -> T:
         """
         Return a new channel list containing the channels from both
         :class:`ChannelList` self and r.
@@ -297,11 +297,11 @@ class ChannelTuple(Metadatable, collections.abc.Sequence):
         Args:
             other: Right argument to add.
         """
-        if not isinstance(self, ChannelList) or not isinstance(other,
-                                                               ChannelList):
-            raise TypeError("Can't add objects of type"
-                            " {} and {} together".format(type(self).__name__,
-                                                         type(other).__name__))
+        if not isinstance(self, ChannelTuple) or not isinstance(other, ChannelTuple):
+            raise TypeError(
+                "Can't add objects of type"
+                " {} and {} together".format(type(self).__name__, type(other).__name__)
+            )
         if self._chan_type != other._chan_type:
             raise TypeError("Both l and r arguments to add must contain "
                             "channels of the same type."

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -232,7 +232,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
                                      for channel in self._channels}
             if not all(isinstance(chan, chan_type) for chan in self._channels):
                 raise TypeError(
-                    f"All items in this channel list must be of "
+                    f"All items in this ChannelTuple must be of "
                     f"type {chan_type.__name__}."
                 )
 

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -629,7 +629,7 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
         if self._locked:
             raise AttributeError("Cannot extend a locked channel list")
         if not all(isinstance(obj, self._chan_type) for obj in objects_tuple):
-            raise TypeError("All items in a channel list must be of the same " "type.")
+            raise TypeError("All items in a channel list must be of the same type.")
         channels = cast(List[InstrumentChannel], self._channels)
         channels.extend(objects_tuple)
         self._channel_mapping.update({obj.short_name: obj for obj in objects})

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    MutableSequence,
     Optional,
     Sequence,
     Tuple,
@@ -505,8 +506,11 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
                 channel.print_readable_snapshot(update=update,
                                                 max_chars=max_chars)
 
+# we ignore a mypy error here since the __getitem__ signature above
+# taking a tuple is not compatible with MutableSequence
+# for some reason this does not happen with Sequence
+class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ignore[misc]
 
-class ChannelList(ChannelTuple, collections.abc.MutableSequence):
     @overload
     def __delitem__(self, key: int) -> None:
         ...

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -613,6 +613,16 @@ class ChannelList(ChannelTuple):
         self._channels = tuple(self._channels)
         self._locked = True
 
+    def to_channel_tuple(self) -> ChannelTuple:
+        return ChannelTuple(
+            self._parent,
+            self._name,
+            self._chan_type,
+            self._channels,
+            multichan_paramclass=self._paramclass,
+        )
+
+
 
 class ChannelTupleValidator(Validator[InstrumentChannel]):
     """

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -265,6 +265,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
                 self._chan_type,
                 self._channels[i],
                 multichan_paramclass=self._paramclass,
+                snapshotable=self._snapshotable,
             )
         elif isinstance(i, tuple):
             return type(self)(
@@ -273,6 +274,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
                 self._chan_type,
                 [self._channels[j] for j in i],
                 multichan_paramclass=self._paramclass,
+                snapshotable=self._snapshotable,
             )
         return self._channels[i]
 
@@ -323,6 +325,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
             self._name,
             self._chan_type,
             list(self._channels) + list(other._channels),
+            snapshotable=self._snapshotable,
         )
 
     def index(

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -534,6 +534,8 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
         ...
 
     def __delitem__(self, key: Union[int, slice]) -> None:
+        if isinstance(self._channels, tuple) or self._locked:
+            raise AttributeError("Cannot delete from a locked channel list")
         self._channels = cast(List[InstrumentChannel], self._channels)
         # update mapping
         self._channels.__delitem__(key)
@@ -551,6 +553,8 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
         index: Union[int, slice],
         value: Union[InstrumentChannel, Iterable[InstrumentChannel]],
     ) -> None:
+        if isinstance(self._channels, tuple) or self._locked:
+            raise AttributeError("Cannot set item in a locked channel list")
         # update mapping
         self._channels = cast(List[InstrumentChannel], self._channels)
         # asserts added to work around https://github.com/python/mypy/issues/7858

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -288,7 +288,7 @@ class ChannelTuple(Metadatable, collections.abc.Sequence):
                                                     self._chan_type.__name__,
                                                     self._channels)
 
-    def __add__(self: T, other: T) -> T:
+    def __add__(self: T, other: "ChannelTuple") -> T:
         """
         Return a new channel list containing the channels from both
         :class:`ChannelList` self and r.

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -359,12 +359,12 @@ class ChannelTuple(Metadatable, collections.abc.Sequence):
             self._paramclass,
         )
 
-    def get_validator(self) -> 'ChannelListValidator':
+    def get_validator(self) -> "ChannelTupleValidator":
         """
         Returns a validator that checks that the returned object is a channel
         in this channel list
         """
-        return ChannelListValidator(self)
+        return ChannelTupleValidator(self)
 
     def snapshot_base(self, update: Optional[bool] = True,
                       params_to_skip_update: Optional[Sequence[str]] = None
@@ -591,7 +591,7 @@ class ChannelList(ChannelTuple):
         self._channels.insert(index, obj)
         self._channel_mapping[obj.short_name] = obj
 
-    def get_validator(self) -> "ChannelListValidator":
+    def get_validator(self) -> "ChannelTupleValidator":
         """
         Returns a validator that checks that the returned object is a channel
         in this channel list
@@ -613,7 +613,8 @@ class ChannelList(ChannelTuple):
         self._channels = tuple(self._channels)
         self._locked = True
 
-class ChannelListValidator(Validator[InstrumentChannel]):
+
+class ChannelTupleValidator(Validator[InstrumentChannel]):
     """
     A validator that checks that the returned object is a member of the
     channel list with which the validator was constructed.
@@ -653,6 +654,10 @@ class ChannelListValidator(Validator[InstrumentChannel]):
             raise ValueError(
                 '{} is not part of the expected channel list; {}'.format(
                     repr(value), context))
+
+
+class ChannelListValidator(ChannelTupleValidator):
+    pass
 
 
 class AutoLoadableInstrumentChannel(InstrumentChannel):

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -503,7 +503,37 @@ class ChannelTuple(Metadatable, collections.abc.Sequence):
                 channel.print_readable_snapshot(update=update,
                                                 max_chars=max_chars)
 
-class ChannelList(ChannelTuple):
+
+class ChannelList(ChannelTuple, collections.abc.MutableSequence):
+    @overload
+    def __delitem__(self, key: int) -> None:
+        ...
+
+    @overload
+    def __delitem__(self, key: slice) -> None:
+        ...
+
+    def __delitem__(self, key: Union[int, slice]) -> None:
+        self._channels = cast(List[InstrumentChannel], self._channels)
+        # update mapping
+        self._channels.__delitem__(key)
+
+    @overload
+    def __setitem__(self, key: int, value: InstrumentChannel) -> None:
+        ...
+
+    @overload
+    def __setitem__(self, key: slice, value: Iterable[InstrumentChannel]) -> None:
+        ...
+
+    def __setitem__(
+        self,
+        key: Union[int, slice],
+        value: Union[InstrumentChannel, Iterable[InstrumentChannel]],
+    ) -> None:
+        # update mapping
+        self._channels[key] = value
+
     def append(self, obj: InstrumentChannel) -> None:
         """
         Append a Channel to this list. Requires that the ChannelList is not

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -529,7 +529,7 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
     This behaves like a python list i.e. it implements the
     ``collections.abc.MutableSequence`` interface.
 
-    Note it may be useful to use the mutable ChannelList while construction it.
+    Note it may be useful to use the mutable ChannelList while constructing it.
     E.g. adding channels as they are created, but in most use cases it is recommended
     to convert this to a ``ChannelTuple`` before adding it to an instrument.
     This can be done using the ``to_channel_tuple`` method.
@@ -684,7 +684,7 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
         if not all(isinstance(obj, self._chan_type) for obj in objects_tuple):
             raise TypeError("All items in a channel list must be of the same type.")
         self._channels.extend(objects_tuple)
-        self._channel_mapping.update({obj.short_name: obj for obj in objects})
+        self._channel_mapping.update({obj.short_name: obj for obj in objects_tuple})
 
     def insert(self, index: int, obj: InstrumentChannel) -> None:
         """

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -663,7 +663,7 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
         """
         if not self._locked:
             raise AttributeError(
-                "Cannot create a validator for an unlocked " "channel list"
+                "Cannot create a validator for an unlocked channel list"
             )
         return super().get_validator()
 

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -159,6 +159,9 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
     Container for channelized parameters that allows for sweeps over
     all channels, as well as addressing of individual channels.
 
+    This behaves like a python tuple i.e. it implements the
+    ``collections.abc.Sequence`` interface.
+
     Args:
         parent: The instrument to which this ChannelTuple
             should be attached.
@@ -166,11 +169,10 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
         name: The name of the ChannelTuple.
 
         chan_type: The type of channel contained
-            within this list.
+            within this tuple.
 
         chan_list: An optional iterable of
-            channels of type ``chan_type``.  This will create a list and
-            immediately lock it is this is a :class:`ChannelList`.
+            channels of type ``chan_type``.
 
         snapshotable: Optionally disables taking of snapshots
             for a given ChannelTuple. This is used when objects
@@ -521,8 +523,47 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
 # for some reason this does not happen with Sequence
 class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ignore[misc]
     """
-    A Subclass of ChannelTuple that allows modifying the content. This implements
-    the MutableSequence abc and behaves like a regular python list.
+    Mutable Container for channelized parameters that allows for sweeps over
+    all channels, as well as addressing of individual channels.
+
+    This behaves like a python list i.e. it implements the
+    ``collections.abc.MutableSequence`` interface.
+
+    Note it may be useful to use the mutable ChannelList while construction it.
+    E.g. adding channels as they are created, but in most use cases it is recommended
+    to convert this to a ``ChannelTuple`` before adding it to an instrument.
+    This can be done using the ``to_channel_tuple`` method.
+
+    Args:
+        parent: The instrument to which this ChannelList
+            should be attached.
+
+        name: The name of the ChannelList.
+
+        chan_type: The type of channel contained
+            within this list.
+
+        chan_list: An optional iterable of
+            channels of type ``chan_type``.  This will create a list and
+            immediately lock the :class:`ChannelList`.
+
+        snapshotable: Optionally disables taking of snapshots
+            for a given ChannelList. This is used when objects
+            stored inside a ChannelList are accessible in multiple
+            ways and should not be repeated in an instrument snapshot.
+
+        multichan_paramclass: The class of
+            the object to be returned by the ``__getattr__``
+            method of :class:`ChannelList`.
+            Should be a subclass of :class:`MultiChannelInstrumentParameter`.
+
+    Raises:
+        ValueError: If ``chan_type`` is not a subclass of
+            :class:`InstrumentChannel`
+        ValueError: If ``multichan_paramclass`` is not a subclass of
+            :class:`MultiChannelInstrumentParameter` (note that a class is a
+            subclass of itself).
+
     """
 
     def __init__(

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -224,8 +224,6 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
             self._channels = ()
         else:
             self._channels = tuple(chan_list)
-            if self._channels is None:
-                raise RuntimeError("Empty channel list")
             self._channel_mapping = {channel.short_name: channel
                                      for channel in self._channels}
             if not all(isinstance(chan, chan_type) for chan in self._channels):

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -548,9 +549,7 @@ class ChannelList(ChannelTuple):
             self._channels.remove(obj)
             self._channel_mapping.pop(obj.short_name)
 
-    def extend(
-        self, objects: Union[Sequence[InstrumentChannel], "ChannelTuple"]
-    ) -> None:
+    def extend(self, objects: Iterable[InstrumentChannel]) -> None:
         """
         Insert an iterable of objects into the list of channels.
 

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -537,8 +537,10 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
         if isinstance(self._channels, tuple) or self._locked:
             raise AttributeError("Cannot delete from a locked channel list")
         self._channels = cast(List[InstrumentChannel], self._channels)
-        # update mapping
         self._channels.__delitem__(key)
+        self._channel_mapping = {
+            channel.short_name: channel for channel in self._channels
+        }
 
     @overload
     def __setitem__(self, index: int, value: InstrumentChannel) -> None:
@@ -564,6 +566,9 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
         else:
             assert not isinstance(value, InstrumentChannel)
             self._channels[index] = value
+        self._channel_mapping = {
+            channel.short_name: channel for channel in self._channels
+        }
 
     def append(self, obj: InstrumentChannel) -> None:
         """

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -1,5 +1,4 @@
 """ Base class for the channel of an instrument """
-import collections.abc
 import sys
 from typing import (
     Any,

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -173,7 +173,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
             immediately lock it is this is a :class:`ChannelList`.
 
         snapshotable: Optionally disables taking of snapshots
-            for a given ChannelTuple.  This is used when objects
+            for a given ChannelTuple. This is used when objects
             stored inside a ChannelTuple are accessible in multiple
             ways and should not be repeated in an instrument snapshot.
 
@@ -416,11 +416,14 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
                                               Callable[..., None],
                                               InstrumentChannel]:
         """
-        Return a multi-channel function or parameter that we can use to get or
-        set all items in a channel list simultaneously.
+        Look up an attribute by name. If this is the name of a parameter or
+        a function on the channel type contained in this container return a
+        multi-channel function or parameter that we can use to get or
+        set all items in a channel list simultaneously. If this is the
+        name of a channel return that channel.
 
         Params:
-            name: The name of the parameter or function that we want to
+            name: The name of the parameter, function or channel that we want to
             operate on.
         """
         # Check if this is a valid parameter
@@ -518,7 +521,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
 # for some reason this does not happen with Sequence
 class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ignore[misc]
     """
-    A Subclass of ChannelTuple that allows modifying the content. This implementes
+    A Subclass of ChannelTuple that allows modifying the content. This implements
     the MutableSequence abc and behaves like a regular python list.
     """
 
@@ -673,7 +676,10 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentChannel]):  # type: ig
     def get_validator(self) -> "ChannelTupleValidator":
         """
         Returns a validator that checks that the returned object is a channel
-        in this channel list
+        in this ChannelList.
+
+        Raises:
+            AttributeError: If the ChannelList is not locked.
         """
         if not self._locked:
             raise AttributeError(

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -420,7 +420,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
         """
         Look up an attribute by name. If this is the name of a parameter or
         a function on the channel type contained in this container return a
-        multi-channel function or parameter that we can use to get or
+        multi-channel function or parameter that can be used to get or
         set all items in a channel list simultaneously. If this is the
         name of a channel, return that channel.
 

--- a/qcodes/instrument_drivers/AimTTi/AimTTi_PL601P_channels.py
+++ b/qcodes/instrument_drivers/AimTTi/AimTTi_PL601P_channels.py
@@ -1,7 +1,7 @@
-from typing import Dict, Optional, Any
+from typing import Any, Dict, Optional
 
-from qcodes import VisaInstrument, validators as vals
-from qcodes import InstrumentChannel, ChannelList
+from qcodes import ChannelList, InstrumentChannel, VisaInstrument
+from qcodes import validators as vals
 from qcodes.instrument.base import Instrument
 from qcodes.utils.helpers import create_on_off_val_mapping
 
@@ -221,8 +221,7 @@ class AimTTi(VisaInstrument):
             channels.append(channel)
             self.add_submodule(f'ch{i}', channel)
 
-        channels.lock()
-        self.add_submodule('channels', channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
         self.connect_message()
 
     # Interface Management

--- a/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -463,10 +463,8 @@ class Decadac(VisaInstrument, DacReader):
             slot_channels = slots[i].channels
             slot_channels = cast(ChannelList, slot_channels)
             channels.extend(slot_channels)
-        slots.lock()
-        channels.lock()
-        self.add_submodule("slots", slots)
-        self.add_submodule("channels", channels)
+        self.add_submodule("slots", slots.to_channel_tuple())
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/Keysight/Infiniium.py
+++ b/qcodes/instrument_drivers/Keysight/Infiniium.py
@@ -492,24 +492,28 @@ class Infiniium(VisaInstrument):
 
         # this parameter gets used internally for data aquisition. For now it
         # should not be used manually
-        self.add_parameter('data_source',
-                           label='Waveform Data source',
-                           get_cmd=':WAVeform:SOURce?',
-                           set_cmd=':WAVeform:SOURce {}',
-                           vals = Enum( *(\
-                                [f'CHANnel{i}' for i in range(1, 4+1)]+\
-                                [f'CHAN{i}' for i in range(1, 4+1)]+\
-                                [f'DIFF{i}' for i in range(1, 2+1)]+\
-                                [f'COMMonmode{i}' for i in range(3, 4+1)]+\
-                                [f'COMM{i}' for i in range(3, 4+1)]+\
-                                [f'FUNCtion{i}' for i in range(1, 16+1)]+\
-                                [f'FUNC{i}' for i in range(1, 16+1)]+\
-                                [f'WMEMory{i}' for i in range(1, 4+1)]+\
-                                [f'WMEM{i}' for i in range(1, 4+1)]+\
-                                [f'BUS{i}' for i in range(1, 4+1)]+\
-                                ['HISTogram', 'HIST', 'CLOCK']+\
-                                ['MTRend', 'MTR']))
-                           )
+        self.add_parameter(
+            "data_source",
+            label="Waveform Data source",
+            get_cmd=":WAVeform:SOURce?",
+            set_cmd=":WAVeform:SOURce {}",
+            vals=Enum(
+                *(
+                    [f"CHANnel{i}" for i in range(1, 4 + 1)]
+                    + [f"CHAN{i}" for i in range(1, 4 + 1)]
+                    + [f"DIFF{i}" for i in range(1, 2 + 1)]
+                    + [f"COMMonmode{i}" for i in range(3, 4 + 1)]
+                    + [f"COMM{i}" for i in range(3, 4 + 1)]
+                    + [f"FUNCtion{i}" for i in range(1, 16 + 1)]
+                    + [f"FUNC{i}" for i in range(1, 16 + 1)]
+                    + [f"WMEMory{i}" for i in range(1, 4 + 1)]
+                    + [f"WMEM{i}" for i in range(1, 4 + 1)]
+                    + [f"BUS{i}" for i in range(1, 4 + 1)]
+                    + ["HISTogram", "HIST", "CLOCK"]
+                    + ["MTRend", "MTR"]
+                )
+            ),
+        )
 
         # TODO: implement as array parameter to allow for setting the other filter
         # ratios
@@ -557,9 +561,8 @@ class Infiniium(VisaInstrument):
         for i in range(1,5):
             channel = InfiniiumChannel(self, f'chan{i}', i)
             channels.append(channel)
-            self.add_submodule(f'ch{i}', channel)
-        channels.lock()
-        self.add_submodule('channels', channels)
+            self.add_submodule(f"ch{i}", channel)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         # Submodules
         meassubsys = MeasurementSubsystem(self, 'measure')

--- a/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -354,8 +354,7 @@ class PNABase(VisaInstrument):
                            min_power, max_power)
             ports.append(port)
             self.add_submodule(f"port{port_num}", port)
-        ports.lock()
-        self.add_submodule("ports", ports)
+        self.add_submodule("ports", ports.to_channel_tuple())
 
         # Drive power
         self.add_parameter('power',
@@ -639,11 +638,11 @@ class PNABase(VisaInstrument):
 
 class PNAxBase(PNABase):
     def _enable_fom(self) -> None:
-        '''
+        """
         PNA-x units with two sources have an enormous list of functions &
         configurations. In practice, most of this will be set up manually on
         the unit, with power and frequency varied in a sweep.
-        '''
+        """
         self.add_parameter('aux_frequency',
                            label='Aux Frequency',
                            get_cmd='SENS:FOM:RANG4:FREQ:CW?',

--- a/qcodes/instrument_drivers/Lakeshore/Model_325.py
+++ b/qcodes/instrument_drivers/Lakeshore/Model_325.py
@@ -480,8 +480,7 @@ class Model_325(VisaInstrument):
             sensors.append(sensor)
             self.add_submodule(f'sensor_{inp}', sensor)
 
-        sensors.lock()
-        self.add_submodule("sensor", sensors)
+        self.add_submodule("sensor", sensors.to_channel_tuple())
 
         heaters = ChannelList(
             self, "heater", Model_325_Heater, snapshotable=False)
@@ -491,8 +490,7 @@ class Model_325(VisaInstrument):
             heaters.append(heater)
             self.add_submodule(f'heater_{loop}', heater)
 
-        heaters.lock()
-        self.add_submodule("heater", heaters)
+        self.add_submodule("heater", heaters.to_channel_tuple())
 
         curves = ChannelList(
             self, "curve", Model_325_Curve, snapshotable=False

--- a/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
+++ b/qcodes/instrument_drivers/Lakeshore/lakeshore_base.py
@@ -504,7 +504,6 @@ class LakeshoreBase(VisaInstrument):
             channel = self.CHANNEL_CLASS(self, name, command)
             channels.append(channel)
             self.add_submodule(name, channel)
-        channels.lock()
-        self.add_submodule("channels", channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         self.connect_message()

--- a/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import warnings
-from typing import Dict, Optional, Type, Hashable, Any
+from typing import Any, Dict, Hashable, Optional, Type
 
 from qcodes.instrument.base import Instrument
 from qcodes.instrument.channel import ChannelList, InstrumentChannel
@@ -72,8 +72,7 @@ class SPDT_Base(Instrument):
             self.add_submodule(attribute_name, channel)
             self.add_submodule(c, channel)
             self._deprecated_attributes[attribute_name] = c
-        channels.lock()
-        self.add_submodule('channels', channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
     def all(self, switch_to: int) -> None:
         for c in self.channels:

--- a/qcodes/instrument_drivers/Minicircuits/RC_SP4T.py
+++ b/qcodes/instrument_drivers/Minicircuits/RC_SP4T.py
@@ -1,9 +1,9 @@
+import math
 from typing import Dict, Optional
 
 from qcodes import IPInstrument
+from qcodes.instrument.channel import ChannelList, InstrumentChannel
 from qcodes.utils import validators as vals
-from qcodes.instrument.channel import InstrumentChannel, ChannelList
-import math
 
 
 class MC_channel(InstrumentChannel):
@@ -81,9 +81,8 @@ class RC_SP4T(IPInstrument):
         for c in _chanlist:
             channel = MC_channel(self, f'channel_{c}', c)
             channels.append(channel)
-            self.add_submodule(f'channel_{c}', channel)
-        channels.lock()
-        self.add_submodule('channels', channels)
+            self.add_submodule(f"channel_{c}", channel)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/Minicircuits/RC_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/RC_SPDT.py
@@ -61,9 +61,8 @@ class RC_SPDT(IPInstrument):
         for c in _chanlist:
             channel = MC_channel(self, f'channel_{c}', c)
             channels.append(channel)
-            self.add_submodule(f'channel_{c}', channel)
-        channels.lock()
-        self.add_submodule('channels', channels)
+            self.add_submodule(f"channel_{c}", channel)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -234,9 +234,8 @@ class QDac(VisaInstrument):
             channel = QDacChannel(self, f'chan{i:02}', i)
             channels.append(channel)
             # Should raise valueerror if name is invalid (silently fails now)
-            self.add_submodule(f'ch{i:02}', channel)
-        channels.lock()
-        self.add_submodule('channels', channels)
+            self.add_submodule(f"ch{i:02}", channel)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         for board in range(6):
             for sensor in range(3):

--- a/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
+++ b/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
@@ -268,9 +268,8 @@ class QDac(VisaInstrument):
         for i in self._chan_range:
             channel = QDacChannel(self, f'chan{i:02}', i)
             channels.append(channel)
-            self.add_submodule(f'ch{i:02}', channel)
-        channels.lock()
-        self.add_submodule('channels', channels)
+            self.add_submodule(f"ch{i:02}", channel)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         # Updatechannel  sync port validator according to number of boards
         self._num_syns = max(num_boards-1, 1)

--- a/qcodes/instrument_drivers/ZI/ZIUHFLI.py
+++ b/qcodes/instrument_drivers/ZI/ZIUHFLI.py
@@ -1051,8 +1051,7 @@ class ZIUHFLI(Instrument):
             auxchannel = AUXOutputChannel(self, name, auxchannum)
             auxoutputchannels.append(auxchannel)
             self.add_submodule(name, auxchannel)
-        auxoutputchannels.lock()
-        self.add_submodule('aux_out_channels', auxoutputchannels)
+        self.add_submodule("aux_out_channels", auxoutputchannels.to_channel_tuple())
         ########################################
         # SWEEPER PARAMETERS
 

--- a/qcodes/instrument_drivers/rigol/DG1062.py
+++ b/qcodes/instrument_drivers/rigol/DG1062.py
@@ -362,6 +362,5 @@ class DG1062(VisaInstrument):
             channels.append(channel)
             self.add_submodule(ch_name, channel)
 
-        channels.lock()
-        self.add_submodule("channels", channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
         self.connect_message()

--- a/qcodes/instrument_drivers/rigol/DS1074Z.py
+++ b/qcodes/instrument_drivers/rigol/DS1074Z.py
@@ -1,8 +1,13 @@
 from typing import Any
 
 import numpy as np
-from qcodes import (ChannelList, InstrumentChannel, ParameterWithSetpoints,
-                    VisaInstrument)
+
+from qcodes import (
+    ChannelList,
+    InstrumentChannel,
+    ParameterWithSetpoints,
+    VisaInstrument,
+)
 from qcodes.utils.validators import Arrays, Enum, Numbers
 
 
@@ -191,8 +196,7 @@ class DS1074Z(VisaInstrument):
                                           )
             channels.append(channel)
 
-        channels.lock()
-        self.add_submodule('channels', channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/rigol/DS4000.py
+++ b/qcodes/instrument_drivers/rigol/DS4000.py
@@ -291,8 +291,7 @@ class DS4000(VisaInstrument):
             channel = RigolDS4000Channel(self, f"ch{channel_number}", channel_number)
             channels.append(channel)
 
-        channels.lock()
-        self.add_submodule('channels', channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
     def _check_firmware_version(self) -> None:
         #Require version 00.02.03

--- a/qcodes/instrument_drivers/rigol/private/DP8xx.py
+++ b/qcodes/instrument_drivers/rigol/private/DP8xx.py
@@ -160,8 +160,7 @@ class _RigolDP8xx(VisaInstrument):
             )
             channels.append(channel)
             self.add_submodule(ch_name, channel)
-        channels.lock()
-        self.add_submodule("channels", channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -1,20 +1,19 @@
 import logging
-import numpy as np
 from functools import partial
-from typing import Optional, Any, Tuple
+from typing import Any, Optional, Tuple
 
-from qcodes import VisaInstrument, Instrument
-from qcodes import ChannelList, InstrumentChannel
-from qcodes.utils import validators as vals
+import numpy as np
+
+from qcodes import ChannelList, Instrument, InstrumentChannel, VisaInstrument
 from qcodes.instrument.parameter import (
-    MultiParameter,
-    ManualParameter,
     ArrayParameter,
+    ManualParameter,
+    MultiParameter,
     ParamRawDataType,
 )
-from qcodes.utils.helpers import create_on_off_val_mapping
+from qcodes.utils import validators as vals
 from qcodes.utils.deprecate import deprecate
-
+from qcodes.utils.helpers import create_on_off_val_mapping
 
 log = logging.getLogger(__name__)
 
@@ -963,7 +962,6 @@ class ZNB(VisaInstrument):
                 for j in range(1, num_ports + 1):
                     ch_name = "S" + str(i) + str(j)
                     self.add_channel(ch_name)
-            self.channels.lock()
             self.display_sij_split()
             self.channels.autoscale()
 
@@ -1002,6 +1000,4 @@ class ZNB(VisaInstrument):
         self.write("CALCulate:PARameter:DELete:ALL")
         for submodule in self.submodules.values():
             if isinstance(submodule, ChannelList):
-                submodule._channels = []
-                submodule._channel_mapping = {}
-                submodule._locked = False
+                submodule.clear()

--- a/qcodes/instrument_drivers/rohde_schwarz/private/HMC804x.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/private/HMC804x.py
@@ -1,7 +1,7 @@
-from typing import Union, Any
+from typing import Any, Union
 
-from qcodes import VisaInstrument, validators as vals, Instrument
-from qcodes import InstrumentChannel, ChannelList
+from qcodes import ChannelList, Instrument, InstrumentChannel, VisaInstrument
+from qcodes import validators as vals
 
 
 class RohdeSchwarzHMC804xChannel(InstrumentChannel):
@@ -90,7 +90,6 @@ class _RohdeSchwarzHMC804x(VisaInstrument):
             channel = RohdeSchwarzHMC804xChannel(self, ch_name, ch_num)
             channels.append(channel)
             self.add_submodule(ch_name, channel)
-        channels.lock()
-        self.add_submodule("channels", channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         self.connect_message()

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -956,8 +956,7 @@ class SR86x(VisaInstrument):
             data_channels.append(data_channel)
             self.add_submodule(ch_name, data_channel)
 
-        data_channels.lock()
-        self.add_submodule("data_channels", data_channels)
+        self.add_submodule("data_channels", data_channels.to_channel_tuple())
 
         # Interface
         self.add_function('reset', call_cmd='*RST')

--- a/qcodes/instrument_drivers/tektronix/AWG70000A.py
+++ b/qcodes/instrument_drivers/tektronix/AWG70000A.py
@@ -478,8 +478,7 @@ class AWG70000A(VisaInstrument):
                 chanlist.append(channel)
 
         if self.num_channels > 2:
-            chanlist.lock()
-            self.add_submodule('channels', chanlist)
+            self.add_submodule("channels", chanlist.to_channel_tuple())
 
         # Folder on the AWG where to files are uplaoded by default
         self.wfmxFileFolder = "\\Users\\OEM\\Documents"

--- a/qcodes/instrument_drivers/tektronix/TPS2012.py
+++ b/qcodes/instrument_drivers/tektronix/TPS2012.py
@@ -1,14 +1,14 @@
-import logging
 import binascii
-from typing import Any, Tuple, Union, Dict
-from typing_extensions import TypedDict
+import logging
+from functools import partial
+from typing import Any, Dict, Tuple, Union
 
 import numpy as np
 from pyvisa.errors import VisaIOError
-from functools import partial
+from typing_extensions import TypedDict
 
-from qcodes import VisaInstrument, validators as vals
-from qcodes import InstrumentChannel, ChannelList
+from qcodes import ChannelList, InstrumentChannel, VisaInstrument
+from qcodes import validators as vals
 from qcodes.instrument.parameter import ArrayParameter, ParamRawDataType
 
 log = logging.getLogger(__name__)
@@ -335,8 +335,7 @@ class TPS2012(VisaInstrument):
             channel = TPS2012Channel(self, ch_name, ch_num)
             channels.append(channel)
             self.add_submodule(ch_name, channel)
-        channels.lock()
-        self.add_submodule("channels", channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
         # Necessary settings for parsing the binary curve data
         self.visa_handle.encoding = 'latin-1'

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -28,7 +28,7 @@ import ruamel.yaml
 import qcodes
 import qcodes.utils.validators as validators
 from qcodes.instrument.base import Instrument, InstrumentBase
-from qcodes.instrument.channel import ChannelList
+from qcodes.instrument.channel import ChannelTuple
 from qcodes.instrument.parameter import (
     DelegateParameter,
     ManualParameter,
@@ -74,7 +74,7 @@ def get_config_use_monitor() -> Optional[str]:
     return qcodes.config["station"]["use_monitor"]
 
 
-ChannelOrInstrumentBase = Union[InstrumentBase, ChannelList]
+ChannelOrInstrumentBase = Union[InstrumentBase, ChannelTuple]
 
 
 class ValidationWarning(Warning):
@@ -529,8 +529,8 @@ class Station(Metadatable, DelegateAttributes):
             try:
                 for level in identifier.split('.'):
                     instrument = checked_getattr(
-                        instrument, level,
-                        (InstrumentBase, ChannelList))
+                        instrument, level, (InstrumentBase, ChannelTuple)
+                    )
             except TypeError:
                 raise RuntimeError(
                     f'Cannot resolve `{level}` in {identifier} to an '

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -420,7 +420,7 @@ class DummyChannelInstrument(Instrument):
             channel = DummyChannel(self, f'Chan{chan_name}', chan_name)
             channels.append(channel)
             self.add_submodule(chan_name, channel)
-        self.add_submodule("channels", channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
 
 class MultiGetter(MultiParameter):
@@ -997,7 +997,7 @@ class MockDAC(Instrument):
             channel = MockDACChannel(parent=self, name=chan_name, num=num)
             channels.append(channel)
             self.add_submodule(chan_name, channel)
-        self.add_submodule("channels", channels)
+        self.add_submodule("channels", channels.to_channel_tuple())
 
 
 class MockCustomChannel(InstrumentChannel):

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -7,6 +7,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from numpy.testing import assert_allclose, assert_array_equal
 
+from qcodes import Instrument
 from qcodes.data.location import FormatLocation
 from qcodes.instrument.channel import ChannelList
 from qcodes.instrument.parameter import Parameter
@@ -24,6 +25,24 @@ def _make_dci():
     finally:
         dci.close()
 
+
+@pytest.fixture(scope="function", name="dci_with_list")
+def _make_dci_with_list():
+    for i in range(10):
+        pass
+
+    dci = Instrument(name="dci")
+    channels = ChannelList(dci, "ListElem", DummyChannel, snapshotable=False)
+    for chan_name in ("A", "B", "C", "D", "E", "F"):
+        channel = DummyChannel(dci, f"Chan{chan_name}", chan_name)
+        channels.append(channel)
+        dci.add_submodule(chan_name, channel)
+    dci.add_submodule("channels", channels)
+
+    try:
+        yield dci
+    finally:
+        dci.close()
 
 def test_channels_call_function(dci, caplog):
     """

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -419,6 +419,44 @@ def test_delete_from_channel_list(dci_with_list):
         with pytest.raises(KeyError):
             dci_with_list.channels.get_channel_by_name(chan.short_name)
 
+    dci_with_list.channels.lock()
+    with pytest.raises(
+        AttributeError, match="Cannot delete from a locked channel list"
+    ):
+        del dci_with_list.channels[0]
+    assert len(dci_with_list.channels) == n_channels - 3
+
+
+def test_set_element_by_int(dci_with_list):
+
+    dci_with_list.channels[0] = dci_with_list.channels[1]
+    assert dci_with_list.channels[0] is dci_with_list.channels[1]
+
+
+def test_set_element_by_slice(dci_with_list):
+    foo = DummyChannel(dci_with_list, name="foo", channel="foo")
+    bar = DummyChannel(dci_with_list, name="bar", channel="bar")
+    dci_with_list.channels[0:2] = [foo, bar]
+    assert dci_with_list.channels[0] is foo
+    assert dci_with_list.channels[1] is bar
+
+    assert (
+        dci_with_list.channels.get_channel_by_name("foo") == dci_with_list.channels[0]
+    )
+    assert (
+        dci_with_list.channels.get_channel_by_name("bar") == dci_with_list.channels[1]
+    )
+
+
+def test_set_element_locked_raises(dci_with_list):
+
+    dci_with_list.channels.lock()
+
+    with pytest.raises(
+        AttributeError, match="Cannot set item in a locked channel list"
+    ):
+        dci_with_list.channels[0] = dci_with_list.channels[1]
+    assert dci_with_list.channels[0] is not dci_with_list.channels[1]
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(myindexs=hst.lists(elements=hst.integers(0, 7), min_size=2))

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -300,6 +300,26 @@ def test_channel_tuple_index(dci):
     for i, chan in enumerate(dci.channels):
         assert dci.channels.index(chan) == i
 
+def test_channel_tuple_snapshot(dci):
+    snapshot = dci.channels.snapshot()
+    assert snapshot["snapshotable"] is False
+    assert len(snapshot.keys()) == 2
+
+
+def test_channel_tuple_snapshot_enabled(empty_instrument):
+
+    channels = ChannelList(
+        empty_instrument, "ListElem", DummyChannel, snapshotable=True
+    )
+    for chan_name in ("A", "B", "C", "D", "E", "F"):
+        channel = DummyChannel(empty_instrument, f"Chan{chan_name}", chan_name)
+        channels.append(channel)
+    empty_instrument.add_submodule("channels", channels)
+
+    snapshot = empty_instrument.channels.snapshot()
+    assert snapshot["snapshotable"] is True
+    assert len(snapshot.keys()) == 3
+    assert "channels" in snapshot.keys()
 
 def test_channel_tuple_dir(dci):
 

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -138,7 +138,7 @@ def test_wrong_chan_type_raises(empty_instrument):
         )
 
 
-def test_add_channel(dci_with_list):
+def test_append_channel(dci_with_list):
     n_channels_pre = len(dci_with_list.channels)
     n_channels_post = n_channels_pre + 1
     chan_num = 11
@@ -157,6 +157,16 @@ def test_add_channel(dci_with_list):
         channel = DummyChannel(dci_with_list, "Chan" + name, name)
         dci_with_list.channels.append(channel)
     assert len(dci_with_list.channels) == n_channels_post
+
+
+def test_append_channel_wrong_type_raises(dci_with_list):
+    n_channels = len(dci_with_list.channels)
+
+    channel = EmptyChannel(dci_with_list, "foo")
+    with pytest.raises(TypeError, match="All items in a channel list must"):
+        dci_with_list.channels.append(channel)
+
+    assert len(dci_with_list.channels) == n_channels
 
 
 def test_extend_channels_from_generator(dci_with_list):

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -283,6 +283,32 @@ def test_access_channels_by_tuple(dci, myindexs):
         assert chan.name == f"dci_Chan{names[chanindex]}"
 
 
+def test_access_channels_by_name_empty_raises(dci):
+    # todo this should raise a less generic error type
+    with pytest.raises(Exception, match="one or more names must be given"):
+        dci.channels.get_channel_by_name()
+
+
+def test_delete_from_channel_list(dci_with_list):
+    n_channels = len(dci_with_list.channels)
+    chan0 = dci_with_list.channels[0]
+    del dci_with_list.channels[0]
+    assert chan0 not in dci_with_list.channels
+    assert len(dci_with_list.channels) == n_channels - 1
+
+    with pytest.raises(KeyError):
+        dci_with_list.channels.get_channel_by_name(chan0.short_name)
+
+    end_channels = dci_with_list.channels[-2:]
+    del dci_with_list.channels[-2:]
+    assert len(dci_with_list.channels) == n_channels - 3
+    assert all(chan not in dci_with_list.channels for chan in end_channels)
+
+    for chan in end_channels:
+        with pytest.raises(KeyError):
+            dci_with_list.channels.get_channel_by_name(chan.short_name)
+
+
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(myindexs=hst.lists(elements=hst.integers(0, 7), min_size=2))
 def test_access_channels_by_name(dci, myindexs):

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -93,88 +93,88 @@ def test_channel_access_is_identical(dci, value, channel):
     # as this is a multi parameter that currently does not support set.
 
 
-def test_add_channel(dci):
-    n_channels = len(dci.channels)
-    name = 'foo'
-    channel = DummyChannel(dci, 'Chan'+name, name)
-    dci.channels.append(channel)
-    dci.add_submodule(name, channel)
+def test_add_channel(dci_with_list):
+    n_channels_pre = len(dci_with_list.channels)
+    n_channels_post = n_channels_pre + 1
+    chan_num = 11
+    name = f"Chan{chan_num}"
 
-    assert len(dci.channels) == n_channels+1
+    channel = DummyChannel(dci_with_list, name, chan_num)
+    dci_with_list.channels.append(channel)
+    dci_with_list.add_submodule(name, channel)
 
-    dci.channels.lock()
+    assert len(dci_with_list.channels) == n_channels_post
+
+    dci_with_list.channels.lock()
     # after locking the channels it's not possible to add any more channels
     with pytest.raises(AttributeError):
-        name = 'bar'
-        channel = DummyChannel(dci, 'Chan' + name, name)
-        dci.channels.append(channel)
-    assert len(dci.channels) == n_channels + 1
+        name = "bar"
+        channel = DummyChannel(dci_with_list, "Chan" + name, name)
+        dci_with_list.channels.append(channel)
+    assert len(dci_with_list.channels) == n_channels_post
 
 
-def test_add_channels_from_generator(dci):
-    n_channels = len(dci.channels)
-    names = ('foo', 'bar', 'foobar')
-    channels = (DummyChannel(dci, 'Chan'+name, name)
-                for name in names)
-    dci.channels.extend(channels)
+def test_add_channels_from_generator(dci_with_list):
+    n_channels = len(dci_with_list.channels)
+    names = ("foo", "bar", "foobar")
+    channels = (DummyChannel(dci_with_list, "Chan" + name, name) for name in names)
+    dci_with_list.channels.extend(channels)
 
-    assert len(dci.channels) == n_channels + len(names)
-
-
-def test_add_channels_from_tuple(dci):
-    n_channels = len(dci.channels)
-    names = ('foo', 'bar', 'foobar')
-    channels = tuple(DummyChannel(dci, 'Chan'+name, name)
-                     for name in names)
-    dci.channels.extend(channels)
-
-    assert len(dci.channels) == n_channels + len(names)
+    assert len(dci_with_list.channels) == n_channels + len(names)
 
 
-def test_extend_then_remove(dci):
-    n_channels = len(dci.channels)
-    names = ('foo', 'bar', 'foobar')
-    channels = [DummyChannel(dci, 'Chan' + name, name)
-                for name in names]
-    dci.channels.extend(channels)
+def test_add_channels_from_tuple(dci_with_list):
+    n_channels = len(dci_with_list.channels)
+    names = ("foo", "bar", "foobar")
+    channels = tuple(DummyChannel(dci_with_list, "Chan" + name, name) for name in names)
+    dci_with_list.channels.extend(channels)
 
-    assert len(dci.channels) == n_channels + len(names)
-    last_channel = dci.channels[-1]
-    dci.channels.remove(last_channel)
-    assert last_channel not in dci.channels
-    assert len(dci.channels) == n_channels + len(names) - 1
+    assert len(dci_with_list.channels) == n_channels + len(names)
 
 
-def test_insert_channel(dci):
-    n_channels_pre = len(dci.channels)
-    name = 'foo'
-    channel = DummyChannel(dci, 'Chan'+name, name)
-    dci.channels.insert(1, channel)
-    dci.add_submodule(name, channel)
+def test_extend_then_remove(dci_with_list):
+    n_channels = len(dci_with_list.channels)
+    names = ("foo", "bar", "foobar")
+    channels = [DummyChannel(dci_with_list, "Chan" + name, name) for name in names]
+    dci_with_list.channels.extend(channels)
+
+    assert len(dci_with_list.channels) == n_channels + len(names)
+    last_channel = dci_with_list.channels[-1]
+    dci_with_list.channels.remove(last_channel)
+    assert last_channel not in dci_with_list.channels
+    assert len(dci_with_list.channels) == n_channels + len(names) - 1
+
+
+def test_insert_channel(dci_with_list):
+    n_channels_pre = len(dci_with_list.channels)
+    name = "foo"
+    channel = DummyChannel(dci_with_list, "Chan" + name, name)
+    dci_with_list.channels.insert(1, channel)
+    dci_with_list.add_submodule(name, channel)
 
     n_channels_post = n_channels_pre + 1
 
-    assert dci.channels.get_channel_by_name(f"Chan{name}") is channel
-    assert len(dci.channels) == n_channels_post
-    assert dci.channels[1] is channel
-    dci.channels.lock()
+    assert dci_with_list.channels.get_channel_by_name(f"Chan{name}") is channel
+    assert len(dci_with_list.channels) == n_channels_post
+    assert dci_with_list.channels[1] is channel
+    dci_with_list.channels.lock()
     # after locking the channels it's not possible to add any more channels
     with pytest.raises(AttributeError):
-        name = 'bar'
-        channel = DummyChannel(dci, 'Chan' + name, name)
-        dci.channels.insert(2, channel)
-    assert len(dci.channels) == n_channels_post
-    assert len(dci.channels._channel_mapping) == n_channels_post
+        name = "bar"
+        channel = DummyChannel(dci_with_list, "Chan" + name, name)
+        dci_with_list.channels.insert(2, channel)
+    assert len(dci_with_list.channels) == n_channels_post
+    assert len(dci_with_list.channels._channel_mapping) == n_channels_post
 
 
-def test_clear_channels(dci):
-    channels = dci.channels
+def test_clear_channels(dci_with_list):
+    channels = dci_with_list.channels
     channels.clear()
     assert len(channels) == 0
 
 
-def test_clear_locked_channels(dci):
-    channels = dci.channels
+def test_clear_locked_channels(dci_with_list):
+    channels = dci_with_list.channels
     original_length = len(channels)
     channels.lock()
     with pytest.raises(AttributeError):
@@ -182,9 +182,9 @@ def test_clear_locked_channels(dci):
     assert len(channels) == original_length
 
 
-def test_remove_channel(dci):
-    channels = dci.channels
-    chan_a = dci.A
+def test_remove_channel(dci_with_list):
+    channels = dci_with_list.channels
+    chan_a = dci_with_list.A
     original_length = len(channels.temperature())
     channels.remove(chan_a)
     with pytest.raises(AttributeError):
@@ -193,24 +193,26 @@ def test_remove_channel(dci):
     assert len(channels.temperature()) == original_length-1
 
 
-def test_remove_locked_channel(dci):
-    channels = dci.channels
-    chan_a = dci.A
+def test_remove_locked_channel(dci_with_list):
+    channels = dci_with_list.channels
+    chan_a = dci_with_list.A
     channels.lock()
     with pytest.raises(AttributeError):
         channels.remove(chan_a)
 
 
-def test_remove_tupled_channel(dci):
+def test_remove_tupled_channel(dci_with_list):
     channel_tuple = tuple(
-        DummyChannel(dci, f'Chan{C}', C)
-        for C in ('A', 'B', 'C', 'D', 'E', 'F')
+        DummyChannel(dci_with_list, f"Chan{C}", C)
+        for C in ("A", "B", "C", "D", "E", "F")
     )
-    channels = ChannelList(dci,
-                           "TempSensorsTuple",
-                           DummyChannel,
-                           channel_tuple,
-                           snapshotable=False)
+    channels = ChannelList(
+        dci_with_list,
+        "TempSensorsTuple",
+        DummyChannel,
+        channel_tuple,
+        snapshotable=False,
+    )
     chan_a = channels.ChanA
     with pytest.raises(AttributeError):
         channels.remove(chan_a)

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -283,6 +283,18 @@ def test_channel_tuple_get_validator(dci):
     for chan in dci.channels:
         validator.validate(chan)
 
+
+def test_channel_list_get_validator(dci_with_list):
+    dci_with_list.channels.lock()
+    validator = dci_with_list.channels.get_validator()
+    for chan in dci_with_list.channels:
+        validator.validate(chan)
+
+
+def test_channel_list_get_validator_not_locked_raised(dci_with_list):
+    with pytest.raises(AttributeError, match="Cannot create a validator"):
+        dci_with_list.channels.get_validator()
+
 def test_channel_tuple_index(dci):
 
     for i, chan in enumerate(dci.channels):

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -167,6 +167,18 @@ def test_insert_channel(dci_with_list):
     assert len(dci_with_list.channels._channel_mapping) == n_channels_post
 
 
+def test_add_none_channel_tuple_to_channel_tuple_raises(dci):
+
+    with pytest.raises(TypeError, match="Can't add objects of type"):
+        _ = dci.channels + [1]
+
+
+def test_channel_tuple_index(dci):
+
+    for i, chan in enumerate(dci.channels):
+        assert dci.channels.index(chan) == i
+
+
 def test_clear_channels(dci_with_list):
     channels = dci_with_list.channels
     channels.clear()

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -229,6 +229,11 @@ def test_insert_channel(dci_with_list):
     assert len(dci_with_list.channels._channel_mapping) == n_channels_post
 
 
+def test_insert_channel_wrong_type_raises(dci_with_list):
+    with pytest.raises(TypeError, match="All items in a channel list"):
+        dci_with_list.channels.insert(1, EmptyChannel(parent=dci_with_list, name="foo"))
+
+
 def test_add_none_channel_tuple_to_channel_tuple_raises(dci):
 
     with pytest.raises(TypeError, match="Can't add objects of type"):


### PR DESCRIPTION
This creates a cleaner interface where the ChannelTuple does not contain modifying methods (which would just raise)

* ChannelList now implementes the full MutableSequece ABC
* All drivers that used lock have been updated to convert the channellist to a channeltuple
* Instrument and station has been updated to allow channeltuples. 
* Code coverage of ChannelList/Tuple has been improved to almost 100 % 

One could significantly cleanup the code by removing the whole lock functionality but that will need to be left till 
the things has been deprecated for a while. 

Question? Should we get rid of the whole `_channels` being a tuple or a list. That would significantly simplify the typing and remove the need for casting in the list implementation.

- [x] Update drivers as possible. Any driver that does not modify its channellists should probably use ChannelTuple
- [x] remove locking logic leftover from channeltuple
- [x] Fix update of channelmapping
- [x] Update tests to cover this. Let the DummyChannelInstrument use a ChannelTuple and rewrite test that modifies channellist to use a channellist. Cover new methods added, ensure that channelmapping logic is covered
- [x] Fix znb driver that modifies internal state of the ChannelList
- [x] Update docs
Possible future improvements 
- [ ] Deprecate lock ? Probably not yet. We should first update contrib drivers 
- [ ] Can we make this more generic so myinstr.chanels is a ChannelTuple[Mychanneltype]