### PR TITLE
ChannelTuple/List correctly handle getting an attribute from an empty list

### DIFF
--- a/docs/changes/newsfragments/3856.improved
+++ b/docs/changes/newsfragments/3856.improved
@@ -1,0 +1,2 @@
+Empty ChannelTuples/Lists now correctly raise an attribute error when trying
+to get a non existing attribute. Previously they would raise an IndexError.

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -429,18 +429,20 @@ class ChannelTuple(Metadatable, Sequence[InstrumentChannel]):
             operate on.
         """
         # Check if this is a valid parameter
-        if name in self._channels[0].parameters:
-            param = self._construct_multiparam(name)
-            return param
+        if len(self) > 0:
+            if name in self._channels[0].parameters:
+                param = self._construct_multiparam(name)
+                return param
 
-        # Check if this is a valid function
-        if name in self._channels[0].functions:
-            # We want to return a reference to a function that would call the
-            # function for each of the channels in turn.
-            def multi_func(*args: Any) -> None:
-                for chan in self._channels:
-                    chan.functions[name](*args)
-            return multi_func
+            # Check if this is a valid function
+            if name in self._channels[0].functions:
+                # We want to return a reference to a function that would call the
+                # function for each of the channels in turn.
+                def multi_func(*args: Any) -> None:
+                    for chan in self._channels:
+                        chan.functions[name](*args)
+
+                return multi_func
 
         try:
             return self._channel_mapping[name]

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from qcodes import Instrument
 from qcodes.data.location import FormatLocation
-from qcodes.instrument.channel import ChannelList, InstrumentChannel
+from qcodes.instrument.channel import ChannelList, ChannelTuple, InstrumentChannel
 from qcodes.instrument.parameter import Parameter
 from qcodes.loops import Loop
 from qcodes.tests.instrument_mocks import DummyChannel, DummyChannelInstrument
@@ -791,6 +791,16 @@ def test_root_instrument(dci):
         assert channel.root_instrument is dci
         for parameter in channel.parameters.values():
             assert parameter.root_instrument is dci
+
+
+def test_get_attr_on_empty_channellist_works_as_expected(empty_instrument):
+    channels = ChannelTuple(empty_instrument, "channels", chan_type=DummyChannel)
+    empty_instrument.add_submodule("channels", channels)
+
+    with pytest.raises(
+        AttributeError, match="'ChannelTuple' object has no attribute 'temperature'"
+    ):
+        _ = empty_instrument.channels.temperature
 
 
 def _verify_multiparam_data(data):


### PR DESCRIPTION
This will ensure that if you do a instr.channel.parameter you get an attribute error as expected and not an index error.
This also means that getattr etc will work as expected since it can catch the correct error. 

Also refactor the getattr code a bit to split out a method for the multiparameter construction to keep the function at a resonable lenght. 

This is done on top of https://github.com/QCoDeS/Qcodes/pull/3851 which should be merged first.