### PR TITLE
Drop dependency on requirements parser

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,6 @@ dependencies:
  - contextlib2 # for broadbean
  - conda-forge::websockets=8.1
  - conda-forge::schema
- - conda-forge::requirements-parser
  - pip:
     - pyvisa==1.11.1
     - broadbean>=0.9.1

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -68,11 +68,11 @@ def get_qcodes_requirements() -> List[str]:
     """
     Return a list of the names of the packages that QCoDeS requires
     """
-    import requirements
+    import pkg_resources
     qc_pkg = distribution('qcodes').requires
     if qc_pkg is None:
         return []
-    package_names = [list(requirements.parse(req))[0].name for req in qc_pkg]
+    package_names = [pkg_resources.Requirement.parse(req).unsafe_name for req in qc_pkg]
 
     return package_names
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,6 @@ pywin32==303; sys_platform == 'win32'
 pywinpty~=1.1.6; sys_platform == 'win32'
 pyzmq~=22.3.0
 requests~=2.27.1
-requirements-parser~=0.3.1
 rsa~=4.8
 ruamel.yaml==0.17.20
 ruamel.yaml.clib~=0.2.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ install_requires =
    opencensus>=0.7.10, <0.9.0
    opencensus-ext-azure>=1.0.4, <2.0.0
    matplotlib>=3.3.0
-   requirements-parser>=0.2.0
    importlib-metadata>=3.6.0,<5.0.0; python_version < '3.8'
    typing_extensions>=3.10.0
    packaging>=20.0


### PR DESCRIPTION
The feature we are using from there is liberally one line in a call to pkg_resources. We might as well do that directly
