### PR TITLE
Stop N52xx intercepting keyboard interrupts

### DIFF
--- a/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -281,6 +281,7 @@ class PNATrace(InstrumentChannel):
                 msg += "The trigger source is external. Is the trigger " \
                        "source functional?"
             self.log.warning(msg)
+            raise
 
         # Return previous mode, incase we want to restore this
         return prev_mode


### PR DESCRIPTION
Since run_sweep prints a warning message on a keyboard interrupt by catching the exception - it makes it difficult to interrupt a sweep on using the PNA. Let's raise the exception after printing the warning.