### PR TITLE
better warning when excluding parameter from snapshot

### DIFF
--- a/docs/changes/newsfragments/3884.improved
+++ b/docs/changes/newsfragments/3884.improved
@@ -1,0 +1,3 @@
+The warning triggered when a parameter is added to the snapshot incorrectly has been improved to include the
+name of the full instrument and two levels of stack information. This should make it easier to find the
+problematic parameter.

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -481,8 +481,10 @@ class _BaseParameter(Metadatable):
         """
         if self.snapshot_exclude:
             warnings.warn(
-                f"Parameter ({self.name}) is used in the snapshot while it "
-                f"should be excluded from the snapshot")
+                f"Parameter ({self.full_name}) is used in the snapshot while it "
+                f"should be excluded from the snapshot",
+                stacklevel=2,
+            )
 
         state: Dict[str, Any] = {'__class__': full_class(self),
                                  'full_name': str(self)}


### PR DESCRIPTION
This warning in it current form is hard to track down to anything meaningful so
Change it to 
* Include full name with instrument, 
* set stacklevel to see where its called from
