### PR TITLE
Add devN marker to signal a dev release

### DIFF
--- a/docs/changes/newsfragments/3890.improved
+++ b/docs/changes/newsfragments/3890.improved
@@ -1,6 +1,10 @@
 Development versions of QCoDeS are now formatted as
-``{version}.dev{distance}+{vcs}{rev}.dirty``
-e.g. ``0.32.0.dev14+gxxxxx(.dirty)``
+``{version}.dev{distance}+{branch}{vcs}{rev}.dirty``
+e.g. ``0.32.0.dev14+name.of.branch.gxxxxx(.dirty)``
 rather than "{version}+{distance}.{vcs}{rev}". This is
 done since pip in some cases considers the later equal to the released
-version.
+version and include more info to let you easily identify the
+branch installed from. Note that due to limitations in characters
+in version numbers `/_-` are normalized to `.` e.g. a branch named
+``myname/my_branch-name`` becomes `myname.my.branch.name` in the
+version number.

--- a/docs/changes/newsfragments/3890.improved
+++ b/docs/changes/newsfragments/3890.improved
@@ -1,0 +1,6 @@
+Development versions of QCoDeS are now formatted as
+``{version}.dev{distance}+{vcs}{rev}.dirty``
+e.g. ``0.32.0.dev14+gxxxxx(.dirty)``
+rather than "{version}+{distance}.{vcs}{rev}". This is
+done since pip in some cases considers the later equal to the released
+version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,9 +111,9 @@ showcontent = true
 default-version = "0.0"
 
 [tool.versioningit.format]
-distance = "{version}.dev{distance}+{vcs}{rev}"
-dirty = "{version}.dev{distance}+{vcs}{rev}.dirty"
-distance-dirty = "{version}.dev{distance}+{vcs}{rev}.dirty"
+distance = "{version}.dev{distance}+{branch}.{vcs}{rev}"
+dirty = "{version}.dev{distance}+{branch}.{vcs}{rev}.dirty"
+distance-dirty = "{version}.dev{distance}+{branch}.{vcs}{rev}.dirty"
 
 [tool.versioningit.vcs]
 method = "git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,9 +111,9 @@ showcontent = true
 default-version = "0.0"
 
 [tool.versioningit.format]
-distance = "{version}+{distance}.{vcs}{rev}"
-dirty = "{version}+{distance}.{vcs}{rev}.dirty"
-distance-dirty = "{version}+{distance}.{vcs}{rev}.dirty"
+distance = "{version}.dev{distance}+{vcs}{rev}"
+dirty = "{version}.dev{distance}+{vcs}{rev}.dirty"
+distance-dirty = "{version}.dev{distance}+{vcs}{rev}.dirty"
 
 [tool.versioningit.vcs]
 method = "git"


### PR DESCRIPTION
Otherwise as far as pip is concerned `0.32.0+nnxxxx` is equal to `0.32.0` i.e.

`pip install qcodes==0.32.0` will do nothing if you have a dev version of qcodes installed (in the form `0.32.0+nnxx`)

This is as expected if you read pip 440 carefully https://www.python.org/dev/peps/pep-0440/