### PR TITLE
Wait 2 hours for github jobs to finish

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -29,3 +29,4 @@ pr_status = [
 ]
 delete_merged_branches = true
 required_approvals = 1
+prerun_timeout_sec = 7200


### PR DESCRIPTION
This only lightly documented setting controls how long bors waits for ci to go green and then merge to staging/
This can easily take more than the default 30 min since some of our jobs are ~ 30 min without wait time

Note I don't think this will solve all our issues like this since bors is supposed to comment if this happens. 
but i did see a comment like that in https://github.com/QCoDeS/Qcodes/pull/3893 

Looks like there is a deeper issue in https://github.com/bors-ng/bors-ng/issues/1434


