### PR TITLE
add ci job that runs darker

### DIFF
--- a/.github/workflows/darker.yaml
+++ b/.github/workflows/darker.yaml
@@ -1,0 +1,16 @@
+name: Lint with Darker
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: akaihola/darker@1.4.0
+        with:
+          options: "--check --diff -r master -i"
+          src: "./qcodes"
+          version: "1.4.0"


### PR DESCRIPTION
pre-commit ci is not that great for running darker since it cannot see the git history. This runs darker as a separate ci job


