### PR TITLE
avoid generating full name twice

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -51,7 +51,6 @@ class InstrumentBase(Metadatable, DelegateAttributes):
     """
 
     def __init__(self, name: str, metadata: Optional[Mapping[Any, Any]] = None) -> None:
-        self._name = str(name)
         self._short_name = str(name)
 
         self.parameters: Dict[str, _BaseParameter] = {}
@@ -89,16 +88,6 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         self._meta_attrs = ['name']
 
         self.log = get_instrument_logger(self, __name__)
-
-    @property
-    def name(self) -> str:
-        """Name of the instrument"""
-        return self._name
-
-    @property
-    def short_name(self) -> str:
-        """Short name of the instrument"""
-        return self._short_name
 
     def add_parameter(
         self, name: str, parameter_class: type = Parameter, **kwargs: Any
@@ -376,6 +365,18 @@ class InstrumentBase(Metadatable, DelegateAttributes):
     @property
     def full_name(self) -> str:
         return "_".join(self.name_parts)
+
+    @property
+    def name(self) -> str:
+        """Name of the instrument
+        This is equivalent to full_name for backwards compatibility.
+        """
+        return self.full_name
+
+    @property
+    def short_name(self) -> str:
+        """Short name of the instrument"""
+        return self._short_name
 
     def _is_abstract(self) -> bool:
         """

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -652,7 +652,7 @@ class Instrument(InstrumentBase, AbstractInstrument):
         if hasattr(self, 'connection') and hasattr(self.connection, 'close'):
             self.connection.close()
 
-        strip_attrs(self, whitelist=['_name'])
+        strip_attrs(self, whitelist=["_short_name"])
         self.remove_instance(self)
 
     @classmethod

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -56,11 +56,6 @@ class InstrumentModule(InstrumentBase):
         # scope of `Base`
         self._parent = parent
         super().__init__(name=name, **kwargs)
-        # Naming insanity:
-        # (see https://github.com/QCoDeS/Qcodes/issues/1140 for a nice table)
-        # this has been a confusion about names. don't use name but
-        # full_name, or short_name.
-        self._name = f"{parent.name}_{str(name)}"
 
     def __repr__(self) -> str:
         """Custom repr to give parent information"""


### PR DESCRIPTION
Instead always let name return the full name

This has no user facing changes since name was always equivalent to full_name for instrument sub classes but avoids some internal logic. 
