### PR TITLE
fix pytest7 deprecation warnings

### DIFF
--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -212,7 +212,7 @@ def test_runs_table_columns(empty_temp_db):
 
 def test_get_data_no_columns(scalar_dataset):
     ds = scalar_dataset
-    with pytest.warns(None) as record:
+    with pytest.warns() as record:
         ref = mut_queries.get_data(ds.conn, ds.table_name, [])
 
     assert ref == [[]]

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -26,6 +26,7 @@ from qcodes.dataset.sqlite import query_helpers as mut_help
 from qcodes.dataset.sqlite.connection import path_to_dbfile
 from qcodes.dataset.sqlite.database import get_DB_location
 from qcodes.tests.common import error_caused_by
+from qcodes.utils.deprecate import QCoDeSDeprecationWarning
 
 from .helper_functions import verify_data_dict
 
@@ -212,7 +213,7 @@ def test_runs_table_columns(empty_temp_db):
 
 def test_get_data_no_columns(scalar_dataset):
     ds = scalar_dataset
-    with pytest.warns() as record:
+    with pytest.warns(QCoDeSDeprecationWarning) as record:
         ref = mut_queries.get_data(ds.conn, ds.table_name, [])
 
     assert ref == [[]]

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/conftest.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+from pyvisa import VisaIOError
+
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_base import (
+    KeysightB1500,
+)
+
+
+@pytest.fixture(name="b1500")
+def _make_b1500(request):
+    request.addfinalizer(KeysightB1500.close_all)
+
+    try:
+        resource_name = "insert_Keysight_B2200_VISA_resource_name_here"
+        instance = KeysightB1500("SPA", address=resource_name)
+    except (ValueError, VisaIOError):
+        # Either there is no VISA lib installed or there was no real
+        # instrument found at the specified address => use simulated instrument
+        import qcodes.instrument.sims as sims
+
+        path_to_yaml = sims.__file__.replace("__init__.py", "keysight_b1500.yaml")
+
+        instance = KeysightB1500(
+            "SPA", address="GPIB::1::INSTR", visalib=path_to_yaml + "@sim"
+        )
+
+    instance.get_status()
+    instance.reset()
+
+    yield instance

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/conftest.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 from pyvisa import VisaIOError
 
@@ -28,3 +30,8 @@ def _make_b1500(request):
     instance.reset()
 
     yield instance
+
+
+@pytest.fixture(name="mainframe")
+def _make_mainframe():
+    yield MagicMock()

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
@@ -1,27 +1,26 @@
+import warnings
 from unittest.mock import MagicMock
 
 import pytest
 from pyvisa import VisaIOError
 
 from qcodes.instrument_drivers.Keysight.keysightb1500 import constants
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_base \
-    import KeysightB1500
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1511B import \
-    B1511B
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import \
-    B1517A
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1520A import \
-    B1520A
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1530A import \
-    B1530A
-from qcodes.instrument_drivers.Keysight.keysightb1500.constants import \
-    SlotNr, ChNr, CALResponse
-
-# pylint: disable=redefined-outer-name
+from qcodes.instrument_drivers.Keysight.keysightb1500.constants import (
+    CALResponse,
+    ChNr,
+    SlotNr,
+)
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_base import (
+    KeysightB1500,
+)
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1511B import B1511B
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import B1517A
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1520A import B1520A
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1530A import B1530A
 
 
-@pytest.fixture
-def b1500(request):
+@pytest.fixture(name="b1500")
+def _make_b1500(request):
     request.addfinalizer(KeysightB1500.close_all)
 
     try:
@@ -82,9 +81,9 @@ def test_init(b1500):
 
 
 def test_snapshot_does_not_raise_warnings(b1500):
-    with pytest.warns(None) as warnings_record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         b1500.snapshot(update=True)
-    assert len(warnings_record) == 0, warnings_record
 
 
 def test_submodule_access_by_class(b1500):

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
@@ -18,8 +18,7 @@ from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1520A import B152
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1530A import B1530A
 
 
-def test_make_module_from_model_name():
-    mainframe = MagicMock()
+def test_make_module_from_model_name(mainframe):
 
     with pytest.raises(NotImplementedError):
         KeysightB1500.from_model_name(model='unsupported_module', slot_nr=0,

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
@@ -2,7 +2,6 @@ import warnings
 from unittest.mock import MagicMock
 
 import pytest
-from pyvisa import VisaIOError
 
 from qcodes.instrument_drivers.Keysight.keysightb1500 import constants
 from qcodes.instrument_drivers.Keysight.keysightb1500.constants import (
@@ -17,32 +16,6 @@ from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1511B import B151
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import B1517A
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1520A import B1520A
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1530A import B1530A
-
-
-@pytest.fixture(name="b1500")
-def _make_b1500(request):
-    request.addfinalizer(KeysightB1500.close_all)
-
-    try:
-        resource_name = 'insert_Keysight_B2200_VISA_resource_name_here'
-        instance = KeysightB1500('SPA',
-                                 address=resource_name)
-    except (ValueError, VisaIOError):
-        # Either there is no VISA lib installed or there was no real
-        # instrument found at the specified address => use simulated instrument
-        import qcodes.instrument.sims as sims
-        path_to_yaml = sims.__file__.replace('__init__.py',
-                                             'keysight_b1500.yaml')
-
-        instance = KeysightB1500('SPA',
-                                 address='GPIB::1::INSTR',
-                                 visalib=path_to_yaml + '@sim'
-                                 )
-
-    instance.get_status()
-    instance.reset()
-
-    yield instance
 
 
 def test_make_module_from_model_name():

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
@@ -1,15 +1,21 @@
 import math
 from unittest.mock import MagicMock
 
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import \
-    B1517A
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_module import \
-    parse_module_query_response, format_dcorr_response, _DCORRResponse, \
-    fixed_negative_float, get_name_label_unit_of_impedance_model, \
-    convert_dummy_val_to_nan, _FMTResponse, \
-    convert_dummy_val_to_nan
-from qcodes.instrument_drivers.Keysight.keysightb1500.constants import \
-    SlotNr, DCORR, IMP
+from qcodes.instrument_drivers.Keysight.keysightb1500.constants import (
+    DCORR,
+    IMP,
+    SlotNr,
+)
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_module import (
+    _DCORRResponse,
+    _FMTResponse,
+    convert_dummy_val_to_nan,
+    fixed_negative_float,
+    format_dcorr_response,
+    get_name_label_unit_of_impedance_model,
+    parse_module_query_response,
+)
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import B1517A
 
 
 def test_is_enabled():

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1511b_smu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1511b_smu.py
@@ -1,5 +1,4 @@
 import re
-from unittest.mock import MagicMock
 
 import pytest
 

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1511b_smu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1511b_smu.py
@@ -1,23 +1,17 @@
-from unittest.mock import MagicMock
 import re
+from unittest.mock import MagicMock
 
 import pytest
 
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1511B import \
-    B1511B
-from qcodes.instrument_drivers.Keysight.keysightb1500.constants import \
-    IOutputRange, IMeasRange
-
-# pylint: disable=redefined-outer-name
-
-
-@pytest.fixture
-def mainframe():
-    yield MagicMock()
+from qcodes.instrument_drivers.Keysight.keysightb1500.constants import (
+    IMeasRange,
+    IOutputRange,
+)
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1511B import B1511B
 
 
-@pytest.fixture
-def smu(mainframe):
+@pytest.fixture(name="smu")
+def _make_smu(mainframe):
     slot_nr = 1
     smu = B1511B(parent=mainframe, name='B1511B', slot_nr=slot_nr)
     yield smu

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1517a_smu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1517a_smu.py
@@ -1,26 +1,23 @@
-from unittest.mock import MagicMock, call
-import re
 import math
+import re
+from unittest.mock import MagicMock, call
 
 import pytest
 
 from qcodes.instrument_drivers.Keysight.keysightb1500 import constants
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import \
-    B1517A
-from qcodes.instrument_drivers.Keysight.keysightb1500.constants import \
-    VOutputRange, CompliancePolarityMode, IOutputRange, IMeasRange, \
-    VMeasRange, MM
-
-# pylint: disable=redefined-outer-name
-
-
-@pytest.fixture
-def mainframe():
-    yield MagicMock()
+from qcodes.instrument_drivers.Keysight.keysightb1500.constants import (
+    MM,
+    CompliancePolarityMode,
+    IMeasRange,
+    IOutputRange,
+    VMeasRange,
+    VOutputRange,
+)
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import B1517A
 
 
-@pytest.fixture
-def smu(mainframe):
+@pytest.fixture(name="smu")
+def _make_smu(mainframe):
     slot_nr = 1
     smu = B1517A(parent=mainframe, name='B1517A', slot_nr=slot_nr)
     yield smu
@@ -28,6 +25,7 @@ def smu(mainframe):
 
 def test_snapshot():
     from qcodes.instrument.base import InstrumentBase
+
     # We need to use `InstrumentBase` (not a bare mock) in order for
     # `snapshot` methods call resolution to work out
     mainframe = InstrumentBase(name='mainframe')

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
@@ -1,22 +1,15 @@
 import re
-from unittest.mock import MagicMock, call
+from unittest.mock import call
+
 import numpy as np
 import pytest
 
 from qcodes.instrument_drivers.Keysight.keysightb1500 import constants
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1520A import \
-    B1520A
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1520A import B1520A
 
 
-# pylint: disable=redefined-outer-name
-
-@pytest.fixture
-def mainframe():
-    yield MagicMock()
-
-
-@pytest.fixture
-def cmu(mainframe):
+@pytest.fixture(name="cmu")
+def _make_cmu(mainframe):
     slot_nr = 3
     cmu = B1520A(parent=mainframe, name='B1520A', slot_nr=slot_nr)
     # GroupParameter with initial values write at the init so reset the mock

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_sampling_measurement.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_sampling_measurement.py
@@ -7,7 +7,6 @@ from qcodes.instrument_drivers.Keysight.keysightb1500 import constants
 from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_sampling_measurement import (
     MeasurementNotTaken,
 )
-from qcodes.tests.drivers.keysight_b1500.b1500_driver_tests.test_b1500 import b1500
 
 
 @pytest.fixture


### PR DESCRIPTION
Passing None to pytest.warns is deprecated. Followed https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests to update the code

Also sneaked in some cleanup of imports and fixtures in the b1500 tests since I was there