### PR TITLE
Strip attributes from channels when closing an instrument.

### DIFF
--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -652,6 +652,17 @@ class Instrument(InstrumentBase, AbstractInstrument):
         if hasattr(self, 'connection') and hasattr(self.connection, 'close'):
             self.connection.close()
 
+        # check for the existense first since this may already
+        # have been striped e.g. if the instrument has been closed once before
+        if hasattr(self, "instrument_modules"):
+            for module in self.instrument_modules.values():
+                strip_attrs(module, whitelist=["_short_name", "_parent"])
+
+        if hasattr(self, "_channel_lists"):
+            for channellist in self._channel_lists.values():
+                for channel in channellist:
+                    strip_attrs(channel, whitelist=["_short_name", "_parent"])
+
         strip_attrs(self, whitelist=["_short_name"])
         self.remove_instance(self)
 

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -145,6 +145,10 @@ def test_attr_access_channels(testdummychannelinstr):
     assert channel.name == "testdummy_ChanA"
     assert channel.full_name == "testdummy_ChanA"
     assert channel.short_name == "ChanA"
+    assert not hasattr(channel, "parameters")
+    assert not hasattr(channel, "submodules")
+    assert not hasattr(channel, "instrument_modules")
+    assert not hasattr(channel, "functions")
 
 
 def test_get_idn(testdummy):


### PR DESCRIPTION
Contains the changes from https://github.com/QCoDeS/Qcodes/pull/3912 which should be merged before this.

instrument.close stripes the attributes of an instrument but not of the modules within the instrument. It is unclear to me if it really makes sense to strip the atters but if we do that we should also do it here