### PR TITLE
run conda jobs against python 3.9

### DIFF
--- a/.github/static/environment_forge_full.yml
+++ b/.github/static/environment_forge_full.yml
@@ -2,7 +2,7 @@ name: qcodesforge
 channels:
  - conda-forge
 dependencies:
- - python=3.7.9
+ - python=3.9
  # recommended to be explicitly specified by conda-incubator/setup-miniconda@v2
  - pip
  # dependencies for setup.cfg


### PR DESCRIPTION
For some reason solving the env on 3.7 has become very slow (~20 min on ubuntu)
We have other tests covering 3.7 lets upgrade this.

