### PR TITLE
explicitly import collections.abc

### DIFF
--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import copy
 import json
 import logging

--- a/qcodes/data/data_array.py
+++ b/qcodes/data/data_array.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import numpy as np

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -73,6 +73,7 @@ more specialized ones:
 # if everyone is happy to use these classes.
 
 import collections
+import collections.abc
 import enum
 import logging
 import os

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import logging
 import numbers
 import time
@@ -15,7 +15,6 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
-    cast,
 )
 
 import numpy as np

--- a/qcodes/utils/validators.py
+++ b/qcodes/utils/validators.py
@@ -2,7 +2,7 @@
 Provides validators for different types of values. Validator validates if the
 value belongs to the given type and is in the provided range.
 """
-import collections
+import collections.abc
 import math
 
 # rename on import since this file implements its own classes


### PR DESCRIPTION
This silences a warning from pyright/pycharm about there not being a module abc in collections.

I suspect the automatic import of acb only works because of the deprecated import of abc members into the main module so its probably better this way
