### PR TITLE
Promote unit of parameter to be a property

### DIFF
--- a/docs/changes/newsfragments/3929.improved
+++ b/docs/changes/newsfragments/3929.improved
@@ -1,0 +1,4 @@
+``Parameter.unit`` is now a settable property rather than an attribute.
+This should have few implications for user facing code but makes it possible
+to do the same in a parameter subclass implementing validation or other functionality
+as needed.

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1304,6 +1304,14 @@ class Parameter(_BaseParameter):
                 '',
                 self.__doc__))
 
+    @property
+    def unit(self) -> Optional[str]:
+        return self._unitval
+
+    @unit.setter
+    def unit(self, unit: Optional[str]) -> None:
+        self._unitval = unit
+
     def __getitem__(self, keys: Any) -> 'SweepFixedValues':
         """
         Slice a Parameter to get a SweepValues object

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1275,8 +1275,9 @@ class Parameter(_BaseParameter):
 
         #: Label of the data used for plots etc.
         self.label: str = name if label is None else label
-        #: The unit of measure. Use ``''`` for unitless.
+
         self.unit = unit if unit is not None else ''
+        self._unitval: str
 
         if initial_value is not None and initial_cache_value is not None:
             raise SyntaxError('It is not possible to specify both of the '
@@ -1306,10 +1307,14 @@ class Parameter(_BaseParameter):
 
     @property
     def unit(self) -> str:
+        """
+        The unit of measure. Use ``''`` (the empty string)
+        for unitless.
+        """
         return self._unitval
 
     @unit.setter
-    def unit(self, unit: Optional[str]) -> None:
+    def unit(self, unit: str) -> None:
         self._unitval = unit
 
     def __getitem__(self, keys: Any) -> 'SweepFixedValues':

--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -1305,7 +1305,7 @@ class Parameter(_BaseParameter):
                 self.__doc__))
 
     @property
-    def unit(self) -> Optional[str]:
+    def unit(self) -> str:
         return self._unitval
 
     @unit.setter


### PR DESCRIPTION
Inspired by the typing hacks needed in https://github.com/QCoDeS/Qcodes/pull/3916 to make unit a property 

This eliminates the need for those hacks See https://github.com/QCoDeS/Qcodes/pull/3916/files#diff-5478d126afe3357045220d8be1ef9c6859ee8427f28984ff8d169b9ab1b75902R126

- [x] Should we do this for other _BaseParameter subclasses. No need
