### PR TITLE
Add metadata to netcdf file where the DataSet is exported to

### DIFF
--- a/docs/changes/newsfragments/3932.improved
+++ b/docs/changes/newsfragments/3932.improved
@@ -1,0 +1,2 @@
+Metadata added after ``DataSet`` ``export`` to a netcdf file is now also added
+to that exported netcdf file

--- a/docs/changes/newsfragments/3932.improved
+++ b/docs/changes/newsfragments/3932.improved
@@ -1,2 +1,4 @@
 Metadata added after ``DataSet`` ``export`` to a netcdf file is now also added
-to that exported netcdf file
+to that exported netcdf file (unless the exported netcdf file has been moved
+to a new location and ``set_netcdf_location`` was not called with that new
+location of the file)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -570,7 +570,8 @@ class DataSet(BaseDataSet):
         with atomic(self.conn) as conn:
             add_data_to_dynamic_columns(conn, self.run_id, {tag: metadata})
 
-        self._add_metadata_to_netcdf_if_nc_exported(tag, metadata)
+        if tag != "export_info":
+            self._add_metadata_to_netcdf_if_nc_exported(tag, metadata)
 
     def add_snapshot(self, snapshot: str, overwrite: bool = False) -> None:
         """

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -565,9 +565,12 @@ class DataSet(BaseDataSet):
         """
 
         self._metadata[tag] = metadata
+
         # `add_data_to_dynamic_columns` is not atomic by itself, hence using `atomic`
         with atomic(self.conn) as conn:
             add_data_to_dynamic_columns(conn, self.run_id, {tag: metadata})
+
+        self._add_metadata_to_netcdf_if_nc_exported(tag, metadata)
 
     def add_snapshot(self, snapshot: str, overwrite: bool = False) -> None:
         """

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -576,7 +576,8 @@ class DataSetInMem(BaseDataSet):
 
         self._metadata[tag] = metadata
         self._add_to_dyn_column_if_in_db(tag, metadata)
-        self._add_metadata_to_netcdf_if_nc_exported(tag, metadata)
+        if tag != "export_info":
+            self._add_metadata_to_netcdf_if_nc_exported(tag, metadata)
 
     def _add_to_dyn_column_if_in_db(self, tag: str, data: Any) -> None:
         if self._dataset_is_in_runs_table():

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -576,8 +576,7 @@ class DataSetInMem(BaseDataSet):
 
         self._metadata[tag] = metadata
         self._add_to_dyn_column_if_in_db(tag, metadata)
-        if tag != "export_info":
-            self._add_metadata_to_netcdf_if_nc_exported(tag, metadata)
+        self._add_metadata_to_netcdf_if_nc_exported(tag, metadata)
 
     def _add_to_dyn_column_if_in_db(self, tag: str, data: Any) -> None:
         if self._dataset_is_in_runs_table():
@@ -614,6 +613,15 @@ class DataSetInMem(BaseDataSet):
     @property
     def export_info(self) -> ExportInfo:
         return self._export_info
+
+    def _set_export_info(self, export_info: ExportInfo) -> None:
+        tag = "export_info"
+        metadata = export_info.to_str()
+
+        self._metadata[tag] = metadata
+        self._add_to_dyn_column_if_in_db(tag, metadata)
+
+        self._export_info = export_info
 
     def _enqueue_results(self, result_dict: Mapping[ParamSpecBase, np.ndarray]) -> None:
         """

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -576,6 +576,7 @@ class DataSetInMem(BaseDataSet):
 
         self._metadata[tag] = metadata
         self._add_to_dyn_column_if_in_db(tag, metadata)
+        self._add_metadata_to_netcdf_if_nc_exported(tag, metadata)
 
     def _add_to_dyn_column_if_in_db(self, tag: str, data: Any) -> None:
         if self._dataset_is_in_runs_table():

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -285,6 +285,9 @@ class DataSetProtocol(Protocol, Sized):
     def _parameters(self) -> Optional[str]:
         pass
 
+    def _set_export_info(self, export_info: ExportInfo) -> None:
+        pass
+
 
 class BaseDataSet(DataSetProtocol):
 
@@ -370,10 +373,6 @@ class BaseDataSet(DataSetProtocol):
             )
 
         self._set_export_info(export_info)
-
-    def _set_export_info(self, export_info: ExportInfo) -> None:
-        self.add_metadata("export_info", export_info.to_str())
-        self._export_info = export_info
 
     def _export_data(
         self,

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -445,7 +445,7 @@ class BaseDataSet(DataSetProtocol):
         if nc_file is not None:
             import h5netcdf
 
-            with h5netcdf.File(nc_file, mode="w") as h5nc_file:
+            with h5netcdf.File(nc_file, mode="r+") as h5nc_file:
                 h5nc_file.attrs[tag] = data
 
             # xr_ds = xr.open_dataset(nc_file, engine="h5netcdf")

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -34,6 +34,7 @@ from qcodes.dataset.linked_datasets.links import Link
 from .descriptions.versioning.converters import new_to_old
 from .exporters.export_info import ExportInfo
 from .exporters.export_to_csv import dataframe_to_csv
+from .exporters.export_to_xarray import xarray_to_h5netcdf_with_complex_numbers
 from .sqlite.queries import raw_time_to_str_time
 
 if TYPE_CHECKING:
@@ -424,21 +425,7 @@ class BaseDataSet(DataSetProtocol):
         """Export data as netcdf to a given path with file prefix"""
         file_path = os.path.join(path, file_name)
         xarr_dataset = self.to_xarray_dataset()
-        data_var_kinds = [
-            xarr_dataset.data_vars[data_var].dtype.kind
-            for data_var in xarr_dataset.data_vars
-        ]
-        coord_kinds = [
-            xarr_dataset.coords[coord].dtype.kind for coord in xarr_dataset.coords
-        ]
-        if "c" in data_var_kinds or "c" in coord_kinds:
-            # see http://xarray.pydata.org/en/stable/howdoi.html
-            # for how to export complex numbers
-            xarr_dataset.to_netcdf(
-                path=file_path, engine="h5netcdf", invalid_netcdf=True
-            )
-        else:
-            xarr_dataset.to_netcdf(path=file_path, engine="h5netcdf")
+        xarray_to_h5netcdf_with_complex_numbers(xarr_dataset, file_path)
         return file_path
 
     def _export_as_csv(self, path: str, file_name: str) -> str:

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -439,6 +439,20 @@ class BaseDataSet(DataSetProtocol):
         )
         return os.path.join(path, file_name)
 
+    def _add_metadata_to_netcdf_if_nc_exported(self, tag: str, data: Any) -> None:
+        export_paths = self.export_info.export_paths
+        nc_file = export_paths.get(DataExportType.NETCDF.value, None)
+        if nc_file is not None:
+            import h5netcdf
+
+            with h5netcdf.File(nc_file, mode="w") as h5nc_file:
+                h5nc_file.attrs[tag] = data
+
+            # xr_ds = xr.open_dataset(nc_file, engine="h5netcdf")
+            # xr_ds.attrs[tag] = data
+            # from .exporters.export_to_xarray import xarray_to_h5netcdf_with_complex_numbers
+            # xarray_to_h5netcdf_with_complex_numbers(xr_ds, nc_file)
+
     @staticmethod
     def _validate_parameters(
         *params: Union[str, ParamSpec, _BaseParameter]

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -448,11 +448,6 @@ class BaseDataSet(DataSetProtocol):
             with h5netcdf.File(nc_file, mode="r+") as h5nc_file:
                 h5nc_file.attrs[tag] = data
 
-            # xr_ds = xr.open_dataset(nc_file, engine="h5netcdf")
-            # xr_ds.attrs[tag] = data
-            # from .exporters.export_to_xarray import xarray_to_h5netcdf_with_complex_numbers
-            # xarray_to_h5netcdf_with_complex_numbers(xr_ds, nc_file)
-
     @staticmethod
     def _validate_parameters(
         *params: Union[str, ParamSpec, _BaseParameter]

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -444,8 +445,17 @@ class BaseDataSet(DataSetProtocol):
         if nc_file is not None:
             import h5netcdf
 
-            with h5netcdf.File(nc_file, mode="r+") as h5nc_file:
-                h5nc_file.attrs[tag] = data
+            try:
+                with h5netcdf.File(nc_file, mode="r+") as h5nc_file:
+                    h5nc_file.attrs[tag] = data
+            except (
+                FileNotFoundError,
+                OSError,
+            ):  # older versions of h5py may throw a OSError here
+                warnings.warn(
+                    f"Could not add metadata to the exported NetCDF file, "
+                    f"was the file moved? GUID {self.guid}, NetCDF file {nc_file}"
+                )
 
     @staticmethod
     def _validate_parameters(

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Hashable, Mapping, Union, cast
 
 import numpy as np
@@ -138,3 +139,21 @@ def _paramspec_dict_with_extras(
     paramspec_dict["units"] = paramspec_dict.get("unit", "")
     paramspec_dict["long_name"] = paramspec_dict.get("label", "")
     return paramspec_dict
+
+
+def xarray_to_h5netcdf_with_complex_numbers(
+    xarray_dataset: xr.Dataset, file_path: Union[str, Path]
+) -> None:
+    data_var_kinds = [
+        xarray_dataset.data_vars[data_var].dtype.kind
+        for data_var in xarray_dataset.data_vars
+    ]
+    coord_kinds = [
+        xarray_dataset.coords[coord].dtype.kind for coord in xarray_dataset.coords
+    ]
+    if "c" in data_var_kinds or "c" in coord_kinds:
+        # see http://xarray.pydata.org/en/stable/howdoi.html
+        # for how to export complex numbers
+        xarray_dataset.to_netcdf(path=file_path, engine="h5netcdf", invalid_netcdf=True)
+    else:
+        xarray_dataset.to_netcdf(path=file_path, engine="h5netcdf")

--- a/qcodes/tests/dataset/test_dataset_in_memory.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory.py
@@ -393,7 +393,7 @@ def test_load_from_db_dataset_moved(meas_with_registered_param, DMM, DAC, tmp_pa
     assert loaded_ds.cache.data() == {}
 
     with pytest.warns(
-            UserWarning, match="Could not add metadata to the exported NetCDF file"
+        UserWarning, match="Could not add metadata to the exported NetCDF file"
     ):
         ds.add_metadata("metadata_added_after_move", 696)
 

--- a/qcodes/tests/dataset/test_dataset_in_memory.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory.py
@@ -392,7 +392,7 @@ def test_load_from_db_dataset_moved(meas_with_registered_param, DMM, DAC, tmp_pa
 
     assert loaded_ds.cache.data() == {}
 
-    with pytest.warns(match="Could not add metadata to the exported NetCDF file"):
+    with pytest.warns(UserWarning, match="Could not add metadata to the exported NetCDF file"):
         ds.add_metadata("metadata_added_after_move", 696)
 
     with contextlib.closing(xarray.open_dataset(new_path)) as new_xr_ds:

--- a/qcodes/tests/dataset/test_dataset_in_memory.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory.py
@@ -172,6 +172,9 @@ def test_dataset_in_reload_from_netcdf(meas_with_registered_param, DMM, DAC, tmp
     assert isinstance(ds, DataSetInMem)
 
     ds.export(export_type="netcdf", path=str(tmp_path))
+
+    ds.add_metadata("metadata_added_after_export", 69)
+
     loaded_ds = DataSetInMem._load_from_netcdf(
         tmp_path / f"qcodes_{ds.captured_run_id}_{ds.guid}.nc"
     )
@@ -206,6 +209,9 @@ def test_dataset_load_from_netcdf_and_db(
     assert isinstance(ds, DataSetInMem)
 
     ds.export(export_type="netcdf", path=str(tmp_path))
+
+    ds.add_metadata("metadata_added_after_export", 69)
+
     loaded_ds = DataSetInMem._load_from_netcdf(
         tmp_path / f"qcodes_{ds.captured_run_id}_{ds.guid}.nc", path_to_db=path_to_db
     )
@@ -298,6 +304,9 @@ def test_load_from_db(meas_with_registered_param, DMM, DAC, tmp_path):
     ds = datasaver.dataset
     ds.add_metadata("foo", "bar")
     ds.export(export_type="netcdf", path=tmp_path)
+
+    ds.add_metadata("metadata_added_after_export", 69)
+
     loaded_ds = load_by_id(ds.run_id)
     assert isinstance(loaded_ds, DataSetInMem)
     assert loaded_ds.snapshot == ds.snapshot
@@ -306,6 +315,8 @@ def test_load_from_db(meas_with_registered_param, DMM, DAC, tmp_path):
 
     assert "foo" in loaded_ds.metadata.keys()
     assert "export_info" in loaded_ds.metadata.keys()
+    assert "metadata_added_after_export" in loaded_ds.metadata.keys()
+    assert loaded_ds.metadata["metadata_added_after_export"] == 69
 
     compare_datasets(ds, loaded_ds)
 
@@ -353,6 +364,8 @@ def test_load_from_db_dataset_moved(meas_with_registered_param, DMM, DAC, tmp_pa
     ds.add_metadata("foo", "bar")
     ds.export(export_type="netcdf", path=tmp_path)
 
+    ds.add_metadata("metadata_added_after_export", 69)
+
     export_path = ds.export_info.export_paths["nc"]
     new_path = str(Path(export_path).parent / "someotherfilename.nc")
 
@@ -370,6 +383,8 @@ def test_load_from_db_dataset_moved(meas_with_registered_param, DMM, DAC, tmp_pa
 
     assert "foo" in loaded_ds.metadata.keys()
     assert "export_info" in loaded_ds.metadata.keys()
+    assert "metadata_added_after_export" in loaded_ds.metadata.keys()
+
     assert loaded_ds.cache.data() == {}
 
     loaded_ds.set_netcdf_location(new_path)

--- a/qcodes/tests/dataset/test_dataset_in_memory.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory.py
@@ -392,7 +392,9 @@ def test_load_from_db_dataset_moved(meas_with_registered_param, DMM, DAC, tmp_pa
 
     assert loaded_ds.cache.data() == {}
 
-    with pytest.warns(UserWarning, match="Could not add metadata to the exported NetCDF file"):
+    with pytest.warns(
+            UserWarning, match="Could not add metadata to the exported NetCDF file"
+    ):
         ds.add_metadata("metadata_added_after_move", 696)
 
     with contextlib.closing(xarray.open_dataset(new_path)) as new_xr_ds:


### PR DESCRIPTION
Otherwise, adding metadata after the export happened will not propagate it to the exported netcdf file.

todo:
- [x] Make sure that the pull request contains a short description of the changes made.
- [x] Please include automatic tests for the changes made when possible.
- [x] Create a file in the docs\changes\newsfragments folder with a short description of the change ``1234.improved``
