### PR TITLE
Config: Cleanup typing of dotdict

### DIFF
--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -448,7 +448,9 @@ class DotDict(Dict[Any, Any]):
         target = dict.__getitem__(self, myKey)
         return target[restOfKey]
 
-    def __contains__(self, key: str) -> bool:  # type: ignore[override]
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, str):
+            return False
         if '.' not in key:
             return dict.__contains__(self, key)
         myKey, restOfKey = key.split('.', 1)

--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -424,7 +424,7 @@ class DotDict(Dict[str, Any]):
     Requires keys to be strings.
     """
 
-    def __init__(self, value: Optional[Dict[str, Any]] = None):
+    def __init__(self, value: Optional[Mapping[str, Any]] = None):
         if value is None:
             pass
         else:

--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -417,7 +417,7 @@ class Config:
         return output
 
 
-class DotDict(Dict[Any, Any]):
+class DotDict(Dict[str, Any]):
     """
     Wrapper dict that allows to get dotted attributes
 


### PR DESCRIPTION
* Remove ignore by allowing any object to be passed to contains (and return False if not a str)
* Make explicit in type annotation that keys must be str
* Take a generic mapping as input to constructor