### PR TITLE
Directly use rundescriber to create run when exporting datasets to a new database file

### DIFF
--- a/docs/changes/newsfragments/3956.improved
+++ b/docs/changes/newsfragments/3956.improved
@@ -1,0 +1,1 @@
+Datasets now correctly preserve the shape information when exported to another database.

--- a/qcodes/dataset/dataset_helpers.py
+++ b/qcodes/dataset/dataset_helpers.py
@@ -17,14 +17,6 @@ def _add_run_to_runs_table(
     target_exp_id: int,
     create_run_table: bool = True,
 ) -> Optional[str]:
-    if dataset._parameters is not None:
-        param_names = dataset._parameters.split(",")
-    else:
-        param_names = []
-    parspecs_dict = {
-        p.name: p for p in new_to_old(dataset.description.interdeps).paramspecs
-    }
-    parspecs = [parspecs_dict[p] for p in param_names]
     metadata = dataset.metadata
     snapshot_raw = dataset._snapshot_raw
     captured_run_id = dataset.captured_run_id
@@ -35,13 +27,13 @@ def _add_run_to_runs_table(
         target_exp_id,
         name=dataset.name,
         guid=dataset.guid,
-        parameters=parspecs,
         metadata=metadata,
         captured_run_id=captured_run_id,
         captured_counter=captured_counter,
         parent_dataset_links=parent_dataset_links,
         create_run_table=create_run_table,
         snapshot_raw=snapshot_raw,
+        description=dataset.description,
     )
     mark_run_complete(target_conn, target_run_id)
     _rewrite_timestamps(

--- a/qcodes/dataset/descriptions/dependencies.py
+++ b/qcodes/dataset/descriptions/dependencies.py
@@ -4,8 +4,18 @@ between the parameters of that run. Most importantly, the information about
 which parameters depend on each other is handled here.
 """
 from copy import deepcopy
-from typing import (Any, Dict, FrozenSet, Iterable, List, Optional, Sequence,
-                    Set, Tuple, Type)
+from typing import (
+    Any,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+)
 
 from .param_spec import ParamSpec, ParamSpecBase
 from .versioning.rundescribertypes import InterDependencies_Dict
@@ -59,13 +69,17 @@ class InterDependencies_:
 
         deps_error = self.validate_paramspectree(dependencies)
         if deps_error is not None:
-            old_error = deps_error[0](deps_error[1])
-            raise ValueError('Invalid dependencies') from old_error
+            try:
+                raise deps_error[0](deps_error[1])
+            except Exception as old_error:
+                raise ValueError("Invalid dependencies") from old_error
 
         inffs_error = self.validate_paramspectree(inferences)
         if inffs_error is not None:
-            old_error = inffs_error[0](inffs_error[1])
-            raise ValueError('Invalid inferences') from old_error
+            try:
+                raise inffs_error[0](inffs_error[1])
+            except Exception as old_error:
+                raise ValueError("Invalid inferences") from old_error
 
         link_error = self._validate_double_links(dependencies, inferences)
         if link_error is not None:
@@ -74,10 +88,10 @@ class InterDependencies_:
 
         for ps in standalones:
             if not isinstance(ps, ParamSpecBase):
-                base_error = TypeError('Standalones must be a sequence of '
-                                       'ParamSpecs')
-
-                raise ValueError('Invalid standalones') from base_error
+                try:
+                    raise TypeError("Standalones must be a sequence of ParamSpecs")
+                except TypeError as base_error:
+                    raise ValueError("Invalid standalones") from base_error
 
         self._remove_duplicates(dependencies)
         self._remove_duplicates(inferences)

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -39,13 +39,6 @@ class RunDescriber:
 
         self._interdeps = interdeps
 
-        # since this may be loaded from json
-        # the shape may be a list rather than a tuple
-        # so convert to tuple for consistency
-        if shapes is not None:
-            for name, shape in shapes.items():
-                shapes[name] = tuple(shape)
-
         self._shapes = shapes
         self._version = 3
 

--- a/qcodes/dataset/descriptions/rundescriber.py
+++ b/qcodes/dataset/descriptions/rundescriber.py
@@ -38,6 +38,14 @@ class RunDescriber:
         self._verify_interdeps_shape(interdeps, shapes)
 
         self._interdeps = interdeps
+
+        # since this may be loaded from json
+        # the shape may be a list rather than a tuple
+        # so convert to tuple for consistency
+        if shapes is not None:
+            for name, shape in shapes.items():
+                shapes[name] = tuple(shape)
+
         self._shapes = shapes
         self._version = 3
 
@@ -52,7 +60,6 @@ class RunDescriber:
     @property
     def interdeps(self) -> InterDependencies_:
         return self._interdeps
-
 
     @staticmethod
     def _verify_interdeps_shape(interdeps: InterDependencies_,

--- a/qcodes/dataset/descriptions/versioning/converters.py
+++ b/qcodes/dataset/descriptions/versioning/converters.py
@@ -9,8 +9,12 @@ from typing import Dict, List
 
 from ..dependencies import InterDependencies_
 from ..param_spec import ParamSpec, ParamSpecBase
-from .rundescribertypes import (RunDescriberV0Dict, RunDescriberV1Dict,
-                                RunDescriberV2Dict, RunDescriberV3Dict)
+from .rundescribertypes import (
+    RunDescriberV0Dict,
+    RunDescriberV1Dict,
+    RunDescriberV2Dict,
+    RunDescriberV3Dict,
+)
 from .v0 import InterDependencies
 
 
@@ -57,26 +61,45 @@ def new_to_old(idps: InterDependencies_) -> InterDependencies:
 
     paramspecs: Dict[str, ParamSpec] = {}
 
+
     # first the independent parameters
     for indeps in idps.dependencies.values():
         for indep in indeps:
-            paramspecs.update({indep.name: ParamSpec(name=indep.name,
-                                                     paramtype=indep.type,
-                                                     label=indep.label,
-                                                     unit=indep.unit)})
+            paramspecs.update(
+                {
+                    indep.name: ParamSpec(
+                        name=indep.name,
+                        paramtype=indep.type,
+                        label=indep.label,
+                        unit=indep.unit,
+                    )
+                }
+            )
 
     for inffs in idps.inferences.values():
         for inff in inffs:
-            paramspecs.update({inff.name: ParamSpec(name=inff.name,
-                                                    paramtype=inff.type,
-                                                    label=inff.label,
-                                                    unit=inff.unit)})
+            paramspecs.update(
+                {
+                    inff.name: ParamSpec(
+                        name=inff.name,
+                        paramtype=inff.type,
+                        label=inff.label,
+                        unit=inff.unit,
+                    )
+                }
+            )
 
     for ps_base in idps._paramspec_to_id.keys():
-        paramspecs.update({ps_base.name: ParamSpec(name=ps_base.name,
-                                                   paramtype=ps_base.type,
-                                                   label=ps_base.label,
-                                                   unit=ps_base.unit)})
+        paramspecs.update(
+            {
+                ps_base.name: ParamSpec(
+                    name=ps_base.name,
+                    paramtype=ps_base.type,
+                    label=ps_base.label,
+                    unit=ps_base.unit,
+                )
+            }
+        )
 
     for ps, indeps in idps.dependencies.items():
         for indep in indeps:

--- a/qcodes/dataset/descriptions/versioning/serialization.py
+++ b/qcodes/dataset/descriptions/versioning/serialization.py
@@ -31,17 +31,32 @@ convention where "*" stands for the storage format. Also note the
 """
 import io
 import json
-from typing import Callable, Dict, Tuple, cast, Any
+from typing import Any, Callable, Dict, Tuple, cast
 
 from qcodes.utils.helpers import YAML
 
 from .. import rundescriber as current
-from .converters import (v0_to_v1, v0_to_v2, v0_to_v3, v1_to_v0, v1_to_v2,
-                         v1_to_v3, v2_to_v0, v2_to_v1, v2_to_v3, v3_to_v0,
-                         v3_to_v1, v3_to_v2)
-from .rundescribertypes import (RunDescriberDicts, RunDescriberV0Dict,
-                                RunDescriberV1Dict, RunDescriberV2Dict,
-                                RunDescriberV3Dict)
+from .converters import (
+    v0_to_v1,
+    v0_to_v2,
+    v0_to_v3,
+    v1_to_v0,
+    v1_to_v2,
+    v1_to_v3,
+    v2_to_v0,
+    v2_to_v1,
+    v2_to_v3,
+    v3_to_v0,
+    v3_to_v1,
+    v3_to_v2,
+)
+from .rundescribertypes import (
+    RunDescriberDicts,
+    RunDescriberV0Dict,
+    RunDescriberV1Dict,
+    RunDescriberV2Dict,
+    RunDescriberV3Dict,
+)
 
 STORAGE_VERSION = 3
 # the version of :class:`RunDescriber` object that is used by the data storage
@@ -129,7 +144,17 @@ def from_json_to_current(json_str: str) -> current.RunDescriber:
     """
     Deserialize a JSON string into a RunDescriber of the current version
     """
-    return from_dict_to_current(json.loads(json_str))
+
+    data = json.loads(json_str)
+    # json maps both list and tuple to list
+    # since we always expects shapes to be a tuple
+    # convert it back to a tuple here
+    shapes = data.get("shapes", None)
+    if shapes is not None:
+        for name, shapelist in shapes.items():
+            shapes[name] = tuple(shapelist)
+
+    return from_dict_to_current(data)
 
 
 # YAML

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1716,7 +1716,8 @@ def create_run(
     if parameters is not None:
         warnings.warn(
             "Passing parameters to create_run is deprecated and will "
-            "be removed in the future"
+            "be removed in the future",
+            stacklevel=2,
         )
         description = RunDescriber(old_to_new(v0.InterDependencies(*parameters)))
     elif description is None:

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1711,7 +1711,7 @@ def create_run(
 
     if parameters is not None and description is not None:
         raise RuntimeError(
-            "Passing both parameters and description to create_run is" "not supported."
+            "Passing both parameters and description to create_run is not supported."
         )
     if parameters is not None:
         warnings.warn(

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1688,8 +1688,8 @@ def create_run(
         - exp_id: the experiment id we want to create the run into
         - name: a friendly name for this run
         - guid: the guid adhering to our internal guid format
-        - parameters: optional list of parameters this run has. This is not recommeded
-            please use description instead.
+        - parameters: optional list of parameters this run has (as ParamSpec objects).
+            This is not recommended, please use description instead.
         - values:  optional list of values for the parameters
         - metadata: optional metadata dictionary
         - captured_run_id: The run_id this data was originally captured with.

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -31,7 +31,7 @@ from qcodes.dataset.descriptions.param_spec import ParamSpec, ParamSpecBase
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.versioning import serialization as serial
 from qcodes.dataset.descriptions.versioning import v0
-from qcodes.dataset.descriptions.versioning.converters import old_to_new
+from qcodes.dataset.descriptions.versioning.converters import new_to_old, old_to_new
 from qcodes.dataset.guids import generate_guid, parse_guid
 from qcodes.dataset.sqlite.connection import (
     ConnectionPlus,
@@ -1182,10 +1182,10 @@ def _insert_run(
     exp_id: int,
     name: str,
     guid: str,
-    parameters: Optional[Sequence[ParamSpec]] = None,
     captured_run_id: Optional[int] = None,
     captured_counter: Optional[int] = None,
     parent_dataset_links: str = "[]",
+    description: Optional[RunDescriber] = None,
 ) -> Tuple[int, str, int]:
 
     # get run counter and formatter from experiments
@@ -1216,10 +1216,15 @@ def _insert_run(
     formatted_name = format_table_name(format_string, "results", exp_id, run_counter)
     table = "runs"
 
-    parameters = parameters or []
-
-    run_desc = RunDescriber(old_to_new(v0.InterDependencies(*parameters)))
-    desc_str = serial.to_json_for_storage(run_desc)
+    if description is None:
+        description = RunDescriber(InterDependencies_())
+    desc_str = serial.to_json_for_storage(description)
+    legacy_param_specs = new_to_old(description.interdeps).paramspecs
+    # we need to use legacy_param_specs here not because we need the features
+    # of legacy param specs but because they should be inserted into the layouts
+    # table and parameter column in the same order as data_set.add_parameter does
+    # specifically dependencies should come before the dependent parameters for links
+    # in the layout table to work correctly
 
     if captured_run_id is None:
         with atomic(conn) as conn:
@@ -1237,7 +1242,7 @@ def _insert_run(
 
     with atomic(conn) as conn:
 
-        if parameters:
+        if legacy_param_specs:
             query = f"""
             INSERT INTO {table}
                 (name,
@@ -1264,7 +1269,7 @@ def _insert_run(
                 formatted_name,
                 run_counter,
                 None,
-                ",".join(p.name for p in parameters),
+                ",".join(p.name for p in legacy_param_specs),
                 False,
                 desc_str,
                 captured_run_id,
@@ -1272,7 +1277,8 @@ def _insert_run(
                 parent_dataset_links,
             )
             run_id = curr.lastrowid
-            _add_parameters_to_layout_and_deps(conn, run_id, *parameters)
+
+            _add_parameters_to_layout_and_deps(conn, run_id, *legacy_param_specs)
 
         else:
             query = f"""
@@ -1611,7 +1617,7 @@ def _validate_table_name(table_name: str) -> bool:
 def _create_run_table(
     conn: ConnectionPlus,
     formatted_name: str,
-    parameters: Optional[Sequence[ParamSpec]] = None,
+    parameters: Optional[Sequence[ParamSpecBase]] = None,
     values: Optional[VALUES] = None,
 ) -> None:
     """Create run table with formatted_name as name
@@ -1667,19 +1673,23 @@ def create_run(
     parent_dataset_links: str = "[]",
     create_run_table: bool = True,
     snapshot_raw: Optional[str] = None,
+    description: Optional[RunDescriber] = None,
 ) -> Tuple[int, int, Optional[str]]:
     """Create a single run for the experiment.
 
 
     This will register the run in the runs table, the counter in the
-    experiments table and create a new table with the formatted name.
+    experiments table and optionally create a new table with the formatted name.
+
+    Note that it is an error to supply both Parameters and RunDescriber
 
     Args:
         - conn: the connection to the sqlite database
         - exp_id: the experiment id we want to create the run into
         - name: a friendly name for this run
         - guid: the guid adhering to our internal guid format
-        - parameters: optional list of parameters this run has
+        - parameters: optional list of parameters this run has. This is not recommeded
+            please use description instead.
         - values:  optional list of values for the parameters
         - metadata: optional metadata dictionary
         - captured_run_id: The run_id this data was originally captured with.
@@ -1690,6 +1700,7 @@ def create_run(
             from another database into this database. Otherwise leave as None.
         - create_run_table: Should we create a table to insert the run into.
         - snapshot_raw: Raw string of the snapshot to add to the run.
+        - description: An optional RunDescriber
 
     Returns:
         - run_counter: the id of the newly created run (not unique)
@@ -1697,22 +1708,40 @@ def create_run(
         - formatted_name: the name of the newly created table
     """
     formatted_name: Optional[str]
+
+    if parameters is not None and description is not None:
+        raise RuntimeError(
+            "Passing both parameters and description to create_run is" "not supported."
+        )
+    if parameters is not None:
+        warnings.warn(
+            "passing parameters to create_run is deprecated and will "
+            "be removed in the future"
+        )
+        description = RunDescriber(old_to_new(v0.InterDependencies(*parameters)))
+    elif description is None:
+        description = RunDescriber(InterDependencies_())
+
     with atomic(conn):
-        run_counter, formatted_name, run_id = _insert_run(conn,
-                                                          exp_id,
-                                                          name,
-                                                          guid,
-                                                          parameters,
-                                                          captured_run_id,
-                                                          captured_counter,
-                                                          parent_dataset_links)
+        run_counter, formatted_name, run_id = _insert_run(
+            conn=conn,
+            exp_id=exp_id,
+            name=name,
+            guid=guid,
+            captured_run_id=captured_run_id,
+            captured_counter=captured_counter,
+            parent_dataset_links=parent_dataset_links,
+            description=description,
+        )
         if metadata:
             add_data_to_dynamic_columns(conn, run_id, metadata)
         if snapshot_raw:
             add_data_to_dynamic_columns(conn, run_id, {"snapshot": snapshot_raw})
         _update_experiment_run_counter(conn, exp_id, run_counter)
         if create_run_table:
-            _create_run_table(conn, formatted_name, parameters, values)
+            _create_run_table(
+                conn, formatted_name, description.interdeps.paramspecs, values
+            )
         else:
             formatted_name = None
     return run_counter, run_id, formatted_name

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1715,7 +1715,7 @@ def create_run(
         )
     if parameters is not None:
         warnings.warn(
-            "passing parameters to create_run is deprecated and will "
+            "Passing parameters to create_run is deprecated and will "
             "be removed in the future"
         )
         description = RunDescriber(old_to_new(v0.InterDependencies(*parameters)))

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -52,8 +52,8 @@ def raise_if_file_changed(path_to_file: str):
         raise RuntimeError(f'File {path_to_file} was modified.')
 
 
-@pytest.fixture(scope='function')
-def inst():
+@pytest.fixture(scope="function", name="inst")
+def _make_inst():
     """
     Dummy instrument for testing, ensuring that it's instance gets closed
     and removed from the global register of instruments, which, if not done,
@@ -191,7 +191,7 @@ def test_real_dataset_1d(two_empty_temp_db_connections, inst):
 
     source_exp = load_or_create_experiment(experiment_name="myexp", conn=source_conn)
 
-    source_dataset, a, b = do1d(inst.back, 0, 1, 10, 0, inst.plunger, exp=source_exp)
+    source_dataset, _, _ = do1d(inst.back, 0, 1, 10, 0, inst.plunger, exp=source_exp)
 
     extract_runs_into_db(source_path, target_path, source_dataset.run_id)
 
@@ -217,7 +217,7 @@ def test_real_dataset_2d(two_empty_temp_db_connections, inst):
 
     source_exp = load_or_create_experiment(experiment_name="myexp", conn=source_conn)
 
-    source_dataset, a, b = do2d(
+    source_dataset, _, _ = do2d(
         inst.back, 0, 1, 10, 0, inst.plunger, 0, 0.1, 15, 0, inst.cutter, exp=source_exp
     )
 

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -1,30 +1,34 @@
-from os.path import getmtime
-from contextlib import contextmanager
-import re
 import os
-from pathlib import Path
 import random
+import re
 import uuid
+from contextlib import contextmanager
+from os.path import getmtime
+from pathlib import Path
 
-import pytest
 import numpy as np
+import pytest
 
 import qcodes as qc
 import qcodes.tests.dataset
-from qcodes.dataset.experiment_container import Experiment,\
-    load_experiment_by_name
-from qcodes.dataset.data_set import (DataSet, load_by_guid, load_by_counter,
-                                     load_by_id, load_by_run_spec,
-                                     generate_dataset_table)
-from qcodes.dataset.sqlite.database import get_db_version_and_newest_available_version
-from qcodes.dataset.sqlite.connection import path_to_dbfile
+from qcodes import Station
+from qcodes.dataset.data_set import (
+    DataSet,
+    generate_dataset_table,
+    load_by_counter,
+    load_by_guid,
+    load_by_id,
+    load_by_run_spec,
+)
 from qcodes.dataset.database_extract_runs import extract_runs_into_db
+from qcodes.dataset.experiment_container import Experiment, load_experiment_by_name
+from qcodes.dataset.linked_datasets.links import Link
+from qcodes.dataset.measurements import Measurement
+from qcodes.dataset.sqlite.connection import path_to_dbfile
+from qcodes.dataset.sqlite.database import get_db_version_and_newest_available_version
 from qcodes.dataset.sqlite.queries import get_experiments
 from qcodes.tests.common import error_caused_by
-from qcodes.dataset.measurements import Measurement
-from qcodes import Station
 from qcodes.tests.instrument_mocks import DummyInstrument
-from qcodes.dataset.linked_datasets.links import Link
 
 
 @contextmanager
@@ -130,7 +134,6 @@ def test_basic_extraction(two_empty_temp_db_connections, some_interdeps):
 
     source_dataset.add_metadata('goodness', 'fair')
     source_dataset.add_metadata('test', True)
-
 
     source_dataset.mark_completed()
 

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -21,7 +21,11 @@ from qcodes.dataset.data_set import (
     load_by_run_spec,
 )
 from qcodes.dataset.database_extract_runs import extract_runs_into_db
-from qcodes.dataset.experiment_container import Experiment, load_experiment_by_name
+from qcodes.dataset.experiment_container import (
+    Experiment,
+    load_experiment_by_name,
+    load_or_create_experiment,
+)
 from qcodes.dataset.linked_datasets.links import Link
 from qcodes.dataset.measurements import Measurement
 from qcodes.dataset.sqlite.connection import path_to_dbfile
@@ -29,6 +33,7 @@ from qcodes.dataset.sqlite.database import get_db_version_and_newest_available_v
 from qcodes.dataset.sqlite.queries import get_experiments
 from qcodes.tests.common import error_caused_by
 from qcodes.tests.instrument_mocks import DummyInstrument
+from qcodes.utils.dataset.doNd import do1d
 
 
 @contextmanager
@@ -175,6 +180,26 @@ def test_basic_extraction(two_empty_temp_db_connections, some_interdeps):
     # trying to insert the same run again should be a NOOP
     with raise_if_file_changed(target_path):
         extract_runs_into_db(source_path, target_path, source_dataset.run_id)
+
+
+def test_real_dataset(two_empty_temp_db_connections, inst):
+    source_conn, target_conn = two_empty_temp_db_connections
+
+    source_path = path_to_dbfile(source_conn)
+    target_path = path_to_dbfile(target_conn)
+
+    source_exp = load_or_create_experiment(experiment_name="myexp", conn=source_conn)
+
+    source_dataset, a, b = do1d(inst.back, 0, 1, 10, 0, inst.plunger, exp=source_exp)
+
+    extract_runs_into_db(source_path, target_path, source_dataset.run_id)
+
+    target_dataset = load_by_guid(source_dataset.guid, conn=target_conn)
+
+    assert source_dataset.the_same_dataset_as(target_dataset)
+    # explicit regression  test for https://github.com/QCoDeS/Qcodes/issues/3953
+    assert source_dataset.description.shapes == {"extract_run_inst_plunger": (10,)}
+    assert source_dataset.description.shapes == target_dataset.description.shapes
 
 
 def test_correct_experiment_routing(two_empty_temp_db_connections,

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -14,7 +14,7 @@ from hypothesis import given
 import qcodes.dataset.descriptions.versioning.serialization as serial
 from qcodes.dataset.data_set import DataSet
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
-from qcodes.dataset.descriptions.param_spec import ParamSpec, ParamSpecBase
+from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.guids import generate_guid
 


### PR DESCRIPTION
Resolves https://github.com/QCoDeS/Qcodes/issues/3953 by ensuring that the full run description is copied to the new dataset