### PR TITLE
[wip] Deprecate various parameter related functions from dataset 

### DIFF
--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -416,6 +416,7 @@ class DataSet(BaseDataSet):
         return captured_counter
 
     @property
+    @deprecate(alternative="dataset.rundescriber.parameters")
     def _parameters(self) -> Optional[str]:
         if self.pristine:
             psnames = [ps.name for ps in self.description.interdeps.paramspecs]
@@ -431,10 +432,12 @@ class DataSet(BaseDataSet):
             return parameters
 
     @property
+    @deprecate(alternative="dataset.rundescriber.parameters")
     def parameters(self) -> Optional[str]:
         return self._parameters
 
     @property
+    @deprecate(alternative="dataset.rundescriber.parameters")
     def paramspecs(self) -> Dict[str, ParamSpec]:
         return {ps.name: ps
                 for ps in self.get_parameters()}

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -40,6 +40,7 @@ from qcodes.dataset.sqlite.queries import (
     update_parent_datasets,
     update_run_description,
 )
+from qcodes.utils.deprecate import deprecate
 from qcodes.utils.helpers import NumpyJSONEncoder
 
 from .data_set_cache import DataSetCacheInMem
@@ -592,6 +593,7 @@ class DataSetInMem(BaseDataSet):
         return self._metadata
 
     @property
+    @deprecate(alternative="dataset.rundescriber.parameters")
     def paramspecs(self) -> Dict[str, ParamSpec]:
         return {ps.name: ps for ps in self._get_paramspecs()}
 
@@ -721,6 +723,7 @@ class DataSetInMem(BaseDataSet):
             raise RuntimeError(mssg)
         self._rundescriber = RunDescriber(interdeps, shapes=shapes)
 
+    @deprecate(alternative="dataset.rundescriber.parameters")
     def _get_paramspecs(self) -> SPECS:
         old_interdeps = new_to_old(self.description.interdeps)
         return list(old_interdeps.paramspecs)
@@ -799,6 +802,7 @@ class DataSetInMem(BaseDataSet):
         return "\n".join(out)
 
     @property
+    @deprecate(alternative="dataset.rundescriber.parameters")
     def _parameters(self) -> Optional[str]:
         psnames = [ps.name for ps in self.description.interdeps.paramspecs]
         if len(psnames) > 0:

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -31,6 +31,7 @@ from qcodes.dataset.export_config import (
     get_data_export_type,
 )
 from qcodes.dataset.linked_datasets.links import Link
+from qcodes.utils.deprecate import deprecate
 
 from .descriptions.versioning.converters import new_to_old
 from .exporters.export_info import ExportInfo
@@ -326,6 +327,7 @@ class BaseDataSet(DataSetProtocol):
 
         return True
 
+    @deprecate(alternative="dataset.rundescriber.parameters")
     def get_parameters(self) -> SPECS:
         old_interdeps = new_to_old(self.description.interdeps)
         return list(old_interdeps.paramspecs)
@@ -524,6 +526,7 @@ class BaseDataSet(DataSetProtocol):
         return raw_time_to_str_time(self.completed_timestamp_raw, fmt)
 
     @property
+    @deprecate(alternative="dataset.rundescriber.parameters")
     def dependent_parameters(self) -> Tuple[ParamSpecBase, ...]:
         """
         Return all the parameters that explicitly depend on other parameters

--- a/qcodes/utils/deprecate.py
+++ b/qcodes/utils/deprecate.py
@@ -1,7 +1,7 @@
-import warnings
 import types
+import warnings
 from contextlib import contextmanager
-from typing import Optional, Callable, Any, cast, Iterator, List
+from typing import Any, Callable, Iterator, List, Optional, cast
 
 import wrapt
 
@@ -28,7 +28,7 @@ def issue_deprecation_warning(
     what: str,
     reason: Optional[str] = None,
     alternative: Optional[str] = None,
-    stacklevel: int = 2
+    stacklevel: int = 3,
 ) -> None:
     warnings.warn(
         deprecation_message(what, reason, alternative),


### PR DESCRIPTION
This should eventually enable us to cleanup the use of new and old style interdeps

- [ ] Ensure that these are not used internally
- [ ] Update plottr to use non deprecated api
- [ ] Ensure that tests don't trigger warnings
