### PR TITLE
Add initialised_database_at to public API

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -45,6 +45,7 @@ from qcodes.dataset.measurements import Measurement
 from qcodes.dataset.sqlite.database import (
     initialise_database,
     initialise_or_create_database_at,
+    initialised_database_at,
 )
 from qcodes.dataset.sqlite.settings import SQLiteSettings
 from qcodes.instrument.base import Instrument, find_or_create_instrument


### PR DESCRIPTION
I think it would make sense to add the initialised_database_at-context manager to the public api. A typical usage pattern would be to use it with `load_by_guid` or similar. 