### PR TITLE
Update: zhinst instrument driver stubs

### DIFF
--- a/docs/changes/newsfragments/3969.improved_driver
+++ b/docs/changes/newsfragments/3969.improved_driver
@@ -1,0 +1,2 @@
+The Zurich instrument driver stubs in ``qcodes.instrument_drivers.zurich_instruments`` have been updated
+to use the 0.3 version of ``zhinst-qcodes``

--- a/qcodes/instrument_drivers/zurich_instruments/hdawg.py
+++ b/qcodes/instrument_drivers/zurich_instruments/hdawg.py
@@ -5,7 +5,7 @@
 
 
 try:
-    from zhinst.qcodes.hdawg import *
+    from zhinst.qcodes import HDAWG
 except ImportError:
     raise ImportError('''Could not find Zurich Instruments QCodes drivers.
                          Please install package zhinst-qcodes.

--- a/qcodes/instrument_drivers/zurich_instruments/hdawg.py
+++ b/qcodes/instrument_drivers/zurich_instruments/hdawg.py
@@ -7,6 +7,10 @@
 try:
     from zhinst.qcodes import HDAWG
 except ImportError:
-    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
-                         Please install package zhinst-qcodes.
-                      ''')
+    raise ImportError(
+        """
+        Could not find Zurich Instruments QCodes drivers.
+        Please install package zhinst-qcodes.
+        """
+    )
+__all__ = ["HDAWG"]

--- a/qcodes/instrument_drivers/zurich_instruments/hf2.py
+++ b/qcodes/instrument_drivers/zurich_instruments/hf2.py
@@ -1,11 +1,11 @@
-# Zurich Instrument MFLI stub
+# Zurich Instrument HF2 stub
 #
 # For the real implementation, please look into the package zhinst-qcodes
 # at https://github.com/zhinst/zhinst-qcodes
 
 
 try:
-    from zhinst.qcodes import MFLI
+    from zhinst.qcodes import HF2
 except ImportError:
     raise ImportError('''Could not find Zurich Instruments QCodes drivers.
                          Please install package zhinst-qcodes.

--- a/qcodes/instrument_drivers/zurich_instruments/hf2.py
+++ b/qcodes/instrument_drivers/zurich_instruments/hf2.py
@@ -7,6 +7,10 @@
 try:
     from zhinst.qcodes import HF2
 except ImportError:
-    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
-                         Please install package zhinst-qcodes.
-                      ''')
+    raise ImportError(
+        """
+        Could not find Zurich Instruments QCodes drivers.
+        Please install package zhinst-qcodes.
+        """
+    )
+__all__ = ["HF2"]

--- a/qcodes/instrument_drivers/zurich_instruments/mfli.py
+++ b/qcodes/instrument_drivers/zurich_instruments/mfli.py
@@ -7,6 +7,10 @@
 try:
     from zhinst.qcodes import MFLI
 except ImportError:
-    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
-                         Please install package zhinst-qcodes.
-                      ''')
+    raise ImportError(
+        """
+        Could not find Zurich Instruments QCodes drivers.
+        Please install package zhinst-qcodes.
+        """
+    )
+__all__ = ["MFLI"]

--- a/qcodes/instrument_drivers/zurich_instruments/pqsc.py
+++ b/qcodes/instrument_drivers/zurich_instruments/pqsc.py
@@ -7,6 +7,10 @@
 try:
     from zhinst.qcodes import PQSC
 except ImportError:
-    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
-                         Please install package zhinst-qcodes.
-                      ''')
+    raise ImportError(
+        """
+        Could not find Zurich Instruments QCodes drivers.
+        Please install package zhinst-qcodes.
+        """
+    )
+__all__ = ["PQSC"]

--- a/qcodes/instrument_drivers/zurich_instruments/pqsc.py
+++ b/qcodes/instrument_drivers/zurich_instruments/pqsc.py
@@ -1,11 +1,11 @@
-# Zurich Instrument MFLI stub
+# Zurich Instrument PQSC stub
 #
 # For the real implementation, please look into the package zhinst-qcodes
 # at https://github.com/zhinst/zhinst-qcodes
 
 
 try:
-    from zhinst.qcodes import MFLI
+    from zhinst.qcodes import PQSC
 except ImportError:
     raise ImportError('''Could not find Zurich Instruments QCodes drivers.
                          Please install package zhinst-qcodes.

--- a/qcodes/instrument_drivers/zurich_instruments/shfqa.py
+++ b/qcodes/instrument_drivers/zurich_instruments/shfqa.py
@@ -1,11 +1,11 @@
-# Zurich Instrument MFLI stub
+# Zurich Instrument SHFQA stub
 #
 # For the real implementation, please look into the package zhinst-qcodes
 # at https://github.com/zhinst/zhinst-qcodes
 
 
 try:
-    from zhinst.qcodes import MFLI
+    from zhinst.qcodes import SHFQA
 except ImportError:
     raise ImportError('''Could not find Zurich Instruments QCodes drivers.
                          Please install package zhinst-qcodes.

--- a/qcodes/instrument_drivers/zurich_instruments/shfqa.py
+++ b/qcodes/instrument_drivers/zurich_instruments/shfqa.py
@@ -7,6 +7,10 @@
 try:
     from zhinst.qcodes import SHFQA
 except ImportError:
-    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
-                         Please install package zhinst-qcodes.
-                      ''')
+    raise ImportError(
+        """
+        Could not find Zurich Instruments QCodes drivers.
+        Please install package zhinst-qcodes.
+        """
+    )
+__all__ = ["SHFQA"]

--- a/qcodes/instrument_drivers/zurich_instruments/shfsg.py
+++ b/qcodes/instrument_drivers/zurich_instruments/shfsg.py
@@ -7,6 +7,10 @@
 try:
     from zhinst.qcodes import SHFSG
 except ImportError:
-    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
-                         Please install package zhinst-qcodes.
-                      ''')
+    raise ImportError(
+        """
+        Could not find Zurich Instruments QCodes drivers.
+        Please install package zhinst-qcodes.
+        """
+    )
+__all__ = ["SHFSG"]

--- a/qcodes/instrument_drivers/zurich_instruments/shfsg.py
+++ b/qcodes/instrument_drivers/zurich_instruments/shfsg.py
@@ -1,11 +1,11 @@
-# Zurich Instrument MFLI stub
+# Zurich Instrument SHFSG stub
 #
 # For the real implementation, please look into the package zhinst-qcodes
 # at https://github.com/zhinst/zhinst-qcodes
 
 
 try:
-    from zhinst.qcodes import MFLI
+    from zhinst.qcodes import SHFSG
 except ImportError:
     raise ImportError('''Could not find Zurich Instruments QCodes drivers.
                          Please install package zhinst-qcodes.

--- a/qcodes/instrument_drivers/zurich_instruments/uhfli.py
+++ b/qcodes/instrument_drivers/zurich_instruments/uhfli.py
@@ -7,6 +7,10 @@
 try:
     from zhinst.qcodes import UHFLI
 except ImportError:
-    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
-                         Please install package zhinst-qcodes.
-                      ''')
+    raise ImportError(
+        """
+        Could not find Zurich Instruments QCodes drivers.
+        Please install package zhinst-qcodes.
+        """
+    )
+__all__ = ["UHFLI"]

--- a/qcodes/instrument_drivers/zurich_instruments/uhfli.py
+++ b/qcodes/instrument_drivers/zurich_instruments/uhfli.py
@@ -5,7 +5,7 @@
 
 
 try:
-    from zhinst.qcodes.uhfli import *
+    from zhinst.qcodes import UHFLI
 except ImportError:
     raise ImportError('''Could not find Zurich Instruments QCodes drivers.
                          Please install package zhinst-qcodes.

--- a/qcodes/instrument_drivers/zurich_instruments/uhfqa.py
+++ b/qcodes/instrument_drivers/zurich_instruments/uhfqa.py
@@ -7,6 +7,10 @@
 try:
     from zhinst.qcodes import UHFQA
 except ImportError:
-    raise ImportError('''Could not find Zurich Instruments QCodes drivers.
-                         Please install package zhinst-qcodes.
-                      ''')
+    raise ImportError(
+        """
+        Could not find Zurich Instruments QCodes drivers.
+        Please install package zhinst-qcodes.
+        """
+    )
+__all__ = ["UHFQA"]

--- a/qcodes/instrument_drivers/zurich_instruments/uhfqa.py
+++ b/qcodes/instrument_drivers/zurich_instruments/uhfqa.py
@@ -5,7 +5,7 @@
 
 
 try:
-    from zhinst.qcodes.uhfqa import *
+    from zhinst.qcodes import UHFQA
 except ImportError:
     raise ImportError('''Could not find Zurich Instruments QCodes drivers.
                          Please install package zhinst-qcodes.

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,7 @@ qcodes =
 [options.extras_require]
 QtPlot = pyqtgraph>=0.11.0
 Slack = slack-sdk>=3.4.2
-ZurichInstruments = zhinst-qcodes>=0.1.1
+ZurichInstruments = zhinst-qcodes>=0.3
 test =
     pytest>=6.0.0
     PyVisa-sim>=0.4.0


### PR DESCRIPTION
Update driver stubs for Zurich Instruments devices.

With the latest release of LabOne 22.02 the QCoDeS driver for our instruments changed quite a bit. Not only did we add 
support for all of our devices but also we changed the import statements. 

This PR maps the existing stubs to the correct imports and adds new files for the newly supported device.