### PR TITLE
Update darker job to match latest version

### DIFF
--- a/.github/workflows/darker.yaml
+++ b/.github/workflows/darker.yaml
@@ -11,6 +11,7 @@ jobs:
           fetch-depth: 0
       - uses: akaihola/darker@1.4.1
         with:
-          options: "--check --diff -r origin/master -i"
+          options: "--check --diff"
+          revision: "master..."
           src: "./qcodes"
-          version: "1.4.0"
+          version: "1.4.1"

--- a/.github/workflows/darker.yaml
+++ b/.github/workflows/darker.yaml
@@ -12,6 +12,6 @@ jobs:
       - uses: akaihola/darker@1.4.1
         with:
           options: "--check --diff"
-          revision: "master..."
           src: "./qcodes"
+          revision: "origin/master..."
           version: "1.4.1"


### PR DESCRIPTION
I 1.4.1 the recommended way to run darker jobs has changed.

See https://github.com/akaihola/darker#github-actions-integration
