### PR TITLE
Dataset/add initialised database at to dataset api

### DIFF
--- a/qcodes/dataset/__init__.py
+++ b/qcodes/dataset/__init__.py
@@ -28,4 +28,25 @@ from .sqlite.database import (
 )
 from .sqlite.settings import SQLiteSettings
 
-# flake8: noqa (we don't need the "<...> imported but unused" error)
+__all__ = [
+    "load_by_counter",
+    "load_by_guid",
+    "load_by_id",
+    "load_by_run_spec",
+    "new_data_set",
+    "load_from_netcdf",
+    "DataSetProtocol",
+    "DataSetType",
+    "ParamSpec",
+    "experiments",
+    "load_experiment",
+    "load_experiment_by_name",
+    "load_last_experiment",
+    "load_or_create_experiment",
+    "new_experiment",
+    "Measurement",
+    "initialise_database",
+    "initialise_or_create_database_at",
+    "initialised_database_at",
+    "SQLiteSettings",
+]

--- a/qcodes/dataset/__init__.py
+++ b/qcodes/dataset/__init__.py
@@ -21,7 +21,11 @@ from .experiment_container import (
     new_experiment,
 )
 from .measurements import Measurement
-from .sqlite.database import initialise_database, initialise_or_create_database_at
+from .sqlite.database import (
+    initialise_database,
+    initialise_or_create_database_at,
+    initialised_database_at,
+)
 from .sqlite.settings import SQLiteSettings
 
 # flake8: noqa (we don't need the "<...> imported but unused" error)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1673,7 +1673,8 @@ def load_by_counter(
     data to another db file. We recommend using :func:`.load_by_run_spec` which
     does not have this issue and is significantly more flexible.
 
-    If the raw data is in the database this will be loaded as a :class:`.DataSet`
+    If the raw data is in the database this will be loaded as a
+    :class:`qcodes.dataset.data_set.DataSet`
     otherwise it will be loaded as a :class:`.DataSetInMemory`
 
     Args:
@@ -1683,7 +1684,8 @@ def load_by_counter(
           connection to the DB file specified in the config is made
 
     Returns:
-        :class:`.DataSet` or :class:`.DataSetInMemory` of the given counter in
+        :class:`qcodes.dataset.data_set.DataSet` or
+            :class:`.DataSetInMemory` of the given counter in
             the given experiment
     """
     internal_conn = conn or connect(get_DB_location())

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1479,7 +1479,8 @@ def load_by_run_spec(
     run matching the supplied specification is found. Along with the error
     specs of the runs found will be printed.
 
-    If the raw data is in the database this will be loaded as a :class:`.DataSet`
+    If the raw data is in the database this will be loaded as a
+    :class:`qcodes.dataset.data_set.DataSet`
     otherwise it will be loaded as a :class:`.DataSetInMemory`
 
     Args:
@@ -1500,8 +1501,9 @@ def load_by_run_spec(
          exists in the database
 
     Returns:
-        :class:`.DataSet` or :class:`.DataSetInMemory` matching the provided
-            specification.
+        :class:`qcodes.dataset.data_set.DataSet` or
+        :class:`.DataSetInMemory` matching the provided
+        specification.
     """
     internal_conn = conn or connect(get_DB_location())
     d: Optional[DataSetProtocol] = None
@@ -1598,15 +1600,17 @@ def load_by_id(run_id: int, conn: Optional[ConnectionPlus] = None) -> DataSetPro
     data to another db file. We recommend using :func:`.load_by_run_spec` which
     does not have this issue and is significantly more flexible.
 
-    If the raw data is in the database this will be loaded as a :class:`.DataSet`
-    otherwise it will be loaded as a :class:`.DataSetInMemory`
+    If the raw data is in the database this will be loaded as a
+    :class:`qcodes.dataset.data_set.DataSet` otherwise it will be
+    loaded as a :class:`.DataSetInMemory`
 
     Args:
         run_id: run id of the dataset
         conn: connection to the database to load from
 
     Returns:
-        :class:`.DataSet` or :class:`.DataSetInMemory` with the given run id
+        :class:`qcodes.dataset.data_set.DataSet` or
+        :class:`.DataSetInMemory` with the given run id
     """
     if run_id is None:
         raise ValueError("run_id has to be a positive integer, not None.")
@@ -1633,7 +1637,8 @@ def load_by_guid(guid: str, conn: Optional[ConnectionPlus] = None) -> DataSetPro
     If no connection is provided, lookup is performed in the database file that
     is specified in the config.
 
-    If the raw data is in the database this will be loaded as a :class:`.DataSet`
+    If the raw data is in the database this will be loaded as a
+    :class:`qcodes.dataset.data_set.DataSet`
     otherwise it will be loaded as a :class:`.DataSetInMemory`
 
     Args:
@@ -1641,7 +1646,8 @@ def load_by_guid(guid: str, conn: Optional[ConnectionPlus] = None) -> DataSetPro
         conn: connection to the database to load from
 
     Returns:
-        :class:`.DataSet` or :class:`.DataSetInMemory` with the given guid
+        :class:`qcodes.dataset.data_set.DataSet` or
+        :class:`.DataSetInMemory` with the given guid
 
     Raises:
         NameError: if no run with the given GUID exists in the database
@@ -1685,8 +1691,8 @@ def load_by_counter(
 
     Returns:
         :class:`qcodes.dataset.data_set.DataSet` or
-            :class:`.DataSetInMemory` of the given counter in
-            the given experiment
+        :class:`.DataSetInMemory` of the given counter in
+        the given experiment
     """
     internal_conn = conn or connect(get_DB_location())
     d: Optional[DataSetProtocol] = None
@@ -1739,7 +1745,7 @@ def new_data_set(name: str,
             and available as part of the `dataset.cache` object.
 
     Return:
-        the newly created :class:`.DataSet`
+        the newly created :class:`qcodes.dataset.data_set.DataSet`
     """
     # note that passing `conn` is a secret feature that is unfortunately used
     # in `Runner` to pass a connection from an existing `Experiment`.

--- a/qcodes/dataset/legacy_import.py
+++ b/qcodes/dataset/legacy_import.py
@@ -1,12 +1,13 @@
-from typing import List, Optional
 import json
+from typing import List, Optional
+
+import numpy as np
 
 from qcodes.data.data_array import DataArray
-from qcodes.dataset.measurements import Measurement, DataSaver
+from qcodes.data.data_set import DataSet as OldDataSet
 from qcodes.data.data_set import load_data
 from qcodes.dataset.experiment_container import Experiment
-from qcodes.data.data_set import DataSet as OldDataSet
-import numpy as np
+from qcodes.dataset.measurements import DataSaver, Measurement
 
 
 def setup_measurement(dataset: OldDataSet,
@@ -21,7 +22,7 @@ def setup_measurement(dataset: OldDataSet,
         dataset: Legacy dataset to register parameters from.
         exp: experiment that the legacy dataset should be bound to. If
             None the default experiment is used. See the
-            docs of :class:`.Measurement` for more details.
+            docs of :class:`qcodes.dataset.Measurement` for more details.
     """
     meas = Measurement(exp=exp)
     for arrayname, array in dataset.arrays.items():
@@ -77,13 +78,14 @@ def store_array_to_database_alt(meas: Measurement, array: DataArray) -> int:
 def import_dat_file(location: str,
                     exp: Optional[Experiment] = None) -> List[int]:
     """
-    This imports a QCoDeS legacy :class:.`DataSet` into the database.
+    This imports a QCoDeS legacy :class:.`qcodes.data.data_set.DataSet`
+    into the database.
 
     Args:
         location: Path to file containing legacy dataset
         exp: Specify the experiment to store data to.
             If None the default one is used. See the
-            docs of :class:`.Measurement` for more details.
+            docs of :class:`qcodes.dataset.Measurement` for more details.
     """
 
 

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -321,7 +321,7 @@ def plot_by_id(
     """
     Construct all plots for a given `run_id`. Here `run_id` is an
     alias for `captured_run_id` for historical reasons. See the docs
-    of :func:`.load_by_run_spec` for details of loading runs.
+    of :func:`qcodes.dataset.load_by_run_spec` for details of loading runs.
     All other arguments are forwarded
     to :func:`.plot_dataset`, see this for more details.
     """


### PR DESCRIPTION
To match the context manager being added to qcodes top level api.

Also declare __all__ rather than disabling warning since that will correctly mark these apis as reexported by various tools.
@Dominik-Vogel 
