### PR TITLE
Pin transitive dependencies to versions that fix known security issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,13 @@ install_requires =
 ; see   https://github.com/h5netcdf/h5netcdf/issues/154
    setuptools>=48
    versioningit>=0.3.0
+;  transitive dependencies. We list these explicitly to
+;  ensure that we always use versions that do not have
+;  known security vulnerabilities
+   ipython>=7.31.1,!=8.0.0
+   pillow>=9.0.0
+   rsa>=4.7
+
 
 [options.package_data]
 qcodes =


### PR DESCRIPTION
See 

* https://nvd.nist.gov/vuln/detail/CVE-2020-25658
* https://nvd.nist.gov/vuln/detail/CVE-2022-21699
* https://nvd.nist.gov/vuln/detail/CVE-2021-20270
