### PR TITLE
Make use of version in git 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools >= 56.0",
     "wheel >= 0.29.0",
-    "versioningit ~= 0.3.0",
+    "versioningit ~= 1.1.0",
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,3 +118,7 @@ distance-dirty = "{version}.dev{distance}+{branch}.{vcs}{rev}.dirty"
 [tool.versioningit.vcs]
 method = "git"
 match = ["v*"]
+
+[tool.versioningit.onbuild]
+source-file = "qcodes/_version.py"
+build-file = "qcodes/_version.py"

--- a/qcodes/_version.py
+++ b/qcodes/_version.py
@@ -1,0 +1,12 @@
+def _get_version() -> str:
+    from pathlib import Path
+
+    import versioningit
+
+    import qcodes
+
+    qcodes_path = Path(qcodes.__file__).parent
+    return versioningit.get_version(project_dir=qcodes_path.parent)
+
+
+__version__ = _get_version()

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -48,21 +48,7 @@ def get_qcodes_version() -> str:
     """
     Get the version of the currently installed QCoDeS
     """
-    import qcodes
-    package_name = "qcodes"
-
-    qcodes_path = Path(qcodes.__file__).parent
-    if _has_pyproject_toml_and_is_git_repo(qcodes_path.parent):
-        log.info(
-            f"QCoDeS seems to be installed editably trying to look up version "
-            f"from git repo in {qcodes_path}"
-        )
-
-        import versioningit
-
-        __version__ = versioningit.get_version(project_dir=qcodes_path.parent)
-    else:
-        __version__ = version(package_name)
+    from qcodes._version import __version__
     return __version__
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
    h5netcdf>=0.10.0,!=0.14.0
 ; see   https://github.com/h5netcdf/h5netcdf/issues/154
    setuptools>=48
-   versioningit>=0.3.0
+   versioningit>=1.1.0
 ;  transitive dependencies. We list these explicitly to
 ;  ensure that we always use versions that do not have
 ;  known security vulnerabilities

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
 from setuptools import setup
+from versioningit import get_cmdclasses
 
 if __name__ == "__main__":
-    setup()
+    setup(
+        cmdclass=get_cmdclasses(),
+    )


### PR DESCRIPTION
This enables us to use a cmdclass to overwrite the definition of ``__version__`` when building an s or b dist similar to how versioneer does it. 
