### PR TITLE
Avoid setup.py when using cmd_classes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools >= 56.0",
     "wheel >= 0.29.0",
-    "versioningit ~= 1.1.0",
+    "git+https://github.com/jenshnielsen/versioningit.git@cmd_class_setupcfg",
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,11 @@ project_urls =
 zip_safe = False
 packages = find:
 python_requires = >=3.7
+cmdclass =
+    sdist = versioningit.cmdclasses.VersioningitSdist
+    build_py = versioningit.cmdclasses.VersioningitBuildPy
+
+
 install_requires =
    numpy>=1.17.0
    pyvisa>=1.11.0, <1.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ zip_safe = False
 packages = find:
 python_requires = >=3.7
 cmdclass =
-    sdist = versioningit.cmdclasses.VersioningitSdist
-    build_py = versioningit.cmdclasses.VersioningitBuildPy
+    sdist = versioningit.VersioningitSdist
+    build_py = versioningit.VersioningitBuildPy
 
 
 install_requires =

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
 from setuptools import setup
-from versioningit import get_cmdclasses
 
 if __name__ == "__main__":
-    setup(
-        cmdclass=get_cmdclasses(),
-    )
+    setup()


### PR DESCRIPTION
This is wip and requires an experimental branch of versioningit but seems to be working ok. Not to be merged before that has been approved upstream