### PR TITLE
SR86x don't explicitly set _parent

### DIFF
--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -77,7 +77,6 @@ class SR86xBuffer(InstrumentChannel):
 
     def __init__(self, parent: 'SR86x', name: str) -> None:
         super().__init__(parent, name)
-        self._parent = parent
 
         self.add_parameter(
             "capture_length_in_kb",


### PR DESCRIPTION
This is done by the super class anyway
redoing it here only makes the code less portable
