### PR TITLE
use next_version for prerelease version number

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,9 +111,9 @@ showcontent = true
 default-version = "0.0"
 
 [tool.versioningit.format]
-distance = "{version}.dev{distance}+{branch}.{vcs}{rev}"
-dirty = "{version}.dev{distance}+{branch}.{vcs}{rev}.dirty"
-distance-dirty = "{version}.dev{distance}+{branch}.{vcs}{rev}.dirty"
+distance = "{next_version}.dev{distance}+{branch}.{vcs}{rev}"
+dirty = "{next_version}.dev{distance}+{branch}.{vcs}{rev}.dirty"
+distance-dirty = "{next_version}.dev{distance}+{branch}.{vcs}{rev}.dirty"
 
 [tool.versioningit.vcs]
 method = "git"


### PR DESCRIPTION
This mens that a prerelease will correctly be identifed as > current relase
