### PR TITLE
Improve performance of qcodes parameter validation

### DIFF
--- a/qcodes/instrument/parameter.py
+++ b/qcodes/instrument/parameter.py
@@ -767,12 +767,18 @@ class _BaseParameter(Metadatable):
             ValueError: If the value is outside the bounds specified by the
                validator.
         """
-        if self._instrument:
-            context = (getattr(self._instrument, 'name', '') or
-                       str(self._instrument.__class__)) + '.' + self.name
-        else:
-            context = self.name
         if self.vals is not None:
+            if self._instrument:
+                context = (
+                    (
+                        getattr(self._instrument, "name", "")
+                        or str(self._instrument.__class__)
+                    )
+                    + "."
+                    + self.name
+                )
+            else:
+                context = self.name
             self.vals.validate(value, 'Parameter: ' + context)
 
     @property


### PR DESCRIPTION
The `context` variable is only constructed in `Parameter.validate` if required.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.


- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
