### PR TITLE
pin ipywidgets to 7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
    importlib-metadata>=3.6.0,<5.0.0; python_version < '3.10'
    typing_extensions>=3.10.0
    packaging>=20.0
-   ipywidgets>=7.5.0
+   ipywidgets>=7.5.0,<8.0.0
    broadbean>=0.9.1
    uncertainties>=3.1.4
    h5netcdf>=0.10.0,!=0.14.0


### PR DESCRIPTION
There are sufficient api changes in the upcomming 8 series that our tests are failing so pin to 7 series until we can add support