### PR TITLE
Set Keithley 6500 mode correctly

### DIFF
--- a/docs/changes/newsfragments/4122.improved_driver
+++ b/docs/changes/newsfragments/4122.improved_driver
@@ -1,0 +1,1 @@
+Fixed issue #4121 of setting the mode of the Keithley 6500 by adding single quotes around the mode value in the set_cmd string.

--- a/qcodes/instrument_drivers/tektronix/Keithley_6500.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_6500.py
@@ -1,6 +1,5 @@
-from typing import Any, TypeVar, Callable
 from functools import partial
-from typing import Union
+from typing import Any, Callable, TypeVar, Union
 
 from qcodes import VisaInstrument
 from qcodes.utils.validators import Bool, Enum, Ints, MultiType, Numbers
@@ -78,10 +77,12 @@ class Keithley_6500(VisaInstrument):
                           'dc voltage': 'VOLT:DC', '2w resistance': 'RES', '4w resistance': 'FRES',
                           'temperature': 'TEMP', 'frequency': 'FREQ'}
 
-        self.add_parameter('mode',
-                           get_cmd='SENS:FUNC?',
-                           set_cmd="SENS:FUNC '{}'",
-                           val_mapping=self._mode_map)
+        self.add_parameter(
+            "mode",
+            get_cmd="SENS:FUNC?",
+            set_cmd="SENS:FUNC '{}'",
+            val_mapping=self._mode_map,
+        )
 
         self.add_parameter('nplc',
                            get_cmd=partial(

--- a/qcodes/instrument_drivers/tektronix/Keithley_6500.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_6500.py
@@ -80,7 +80,7 @@ class Keithley_6500(VisaInstrument):
 
         self.add_parameter('mode',
                            get_cmd='SENS:FUNC?',
-                           set_cmd="SENS:FUNC {}",
+                           set_cmd="SENS:FUNC '{}'",
                            val_mapping=self._mode_map)
 
         self.add_parameter('nplc',


### PR DESCRIPTION
Added single quotes around mode value in set_cmd of mode parameter of Keithley_6500

Closes #4121 

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
