### PR TITLE
Add method to invalidate cache of an Instrument

### DIFF
--- a/docs/changes/newsfragments/4161.new
+++ b/docs/changes/newsfragments/4161.new
@@ -1,0 +1,4 @@
+The QCoDeS instrument baseclass has gained a method `invalidate_cache`.
+This will mark the cache of all parameters on the instrument and its submodules as
+invalid. This is useful if you manually (e.g. via the front panel) make changes to
+the instrument that QCoDeS cannot know about.

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -334,6 +334,24 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             submodule.print_readable_snapshot(update=update,
                                               max_chars=max_chars)
 
+    def invalidate_cache(self) -> None:
+        """
+        Invalidate the cache of all parameter on the instrument.
+        Calling this method will recursively mark the cache of all parameters
+        on the instrument and any parameter on instrument modules as invalid.
+
+        This is useful if you have performed manual operations (e.g. using the frontpanel)
+        which changes the state of the instrument outside QCoDeS.
+
+        This in turn means that the next snapshot of the instrument will trigger a (potentially) slow
+        reread of all parameters of the instrument.
+        """
+        for parameter in self.parameters.values():
+            parameter.cache.invalidate()
+
+        for submodule in self.submodules.values():
+            submodule.invalidate_cache()
+
     @property
     def parent(self) -> Optional['InstrumentBase']:
         """

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -340,11 +340,13 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         Calling this method will recursively mark the cache of all parameters
         on the instrument and any parameter on instrument modules as invalid.
 
-        This is useful if you have performed manual operations (e.g. using the frontpanel)
+        This is useful if you have performed manual operations
+        (e.g. using the frontpanel)
         which changes the state of the instrument outside QCoDeS.
 
-        This in turn means that the next snapshot of the instrument will trigger a (potentially slow)
-        reread of all parameters of the instrument.
+        This in turn means that the next snapshot of the instrument will trigger
+        a (potentially slow) reread of all parameters of the instrument if you pass
+        `update=None` to snapshot.
         """
         for parameter in self.parameters.values():
             parameter.cache.invalidate()

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -336,14 +336,14 @@ class InstrumentBase(Metadatable, DelegateAttributes):
 
     def invalidate_cache(self) -> None:
         """
-        Invalidate the cache of all parameter on the instrument.
+        Invalidate the cache of all parameters on the instrument.
         Calling this method will recursively mark the cache of all parameters
         on the instrument and any parameter on instrument modules as invalid.
 
         This is useful if you have performed manual operations (e.g. using the frontpanel)
         which changes the state of the instrument outside QCoDeS.
 
-        This in turn means that the next snapshot of the instrument will trigger a (potentially) slow
+        This in turn means that the next snapshot of the instrument will trigger a (potentially slow)
         reread of all parameters of the instrument.
         """
         for parameter in self.parameters.values():

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -531,7 +531,7 @@ class ChannelTuple(Metadatable, Sequence[InstrumentModuleType]):
 
     def invalidate_cache(self) -> None:
         """
-        Invalidate the cache of all parameter on the ChannelTuple.
+        Invalidate the cache of all parameters on the ChannelTuple.
         """
         for chan in self._channels:
             chan.invalidate_cache()

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -529,6 +529,13 @@ class ChannelTuple(Metadatable, Sequence[InstrumentModuleType]):
                 channel.print_readable_snapshot(update=update,
                                                 max_chars=max_chars)
 
+    def invalidate_cache(self) -> None:
+        """
+        Invalidate the cache of all parameter on the ChannelTuple.
+        """
+        for chan in self._channels:
+            chan.invalidate_cache()
+
 # we ignore a mypy error here since the __getitem__ signature above
 # taking a tuple is not compatible with MutableSequence
 # for some reason this does not happen with Sequence

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -315,18 +315,24 @@ class DummyChannel(InstrumentChannel):
                            get_cmd=None,
                            set_cmd=None)
 
-        self.add_parameter('dummy_stop',
-                           unit='some unit',
-                           label='f stop',
-                           vals=Numbers(1, 1e3),
-                           get_cmd=None,
-                           set_cmd=None)
+        self.add_parameter(
+            "dummy_stop",
+            initial_value=100,
+            unit="some unit",
+            label="f stop",
+            vals=Numbers(1, 1e3),
+            get_cmd=None,
+            set_cmd=None,
+        )
 
-        self.add_parameter('dummy_n_points',
-                           unit='',
-                           vals=Numbers(1, 1e3),
-                           get_cmd=None,
-                           set_cmd=None)
+        self.add_parameter(
+            "dummy_n_points",
+            initial_value=101,
+            unit="",
+            vals=Numbers(1, 1e3),
+            get_cmd=None,
+            set_cmd=None,
+        )
 
         self.add_parameter('dummy_start_2',
                            initial_value=0,
@@ -336,18 +342,24 @@ class DummyChannel(InstrumentChannel):
                            get_cmd=None,
                            set_cmd=None)
 
-        self.add_parameter('dummy_stop_2',
-                           unit='some unit',
-                           label='f stop',
-                           vals=Numbers(1, 1e3),
-                           get_cmd=None,
-                           set_cmd=None)
+        self.add_parameter(
+            "dummy_stop_2",
+            initial_value=100,
+            unit="some unit",
+            label="f stop",
+            vals=Numbers(1, 1e3),
+            get_cmd=None,
+            set_cmd=None,
+        )
 
-        self.add_parameter('dummy_n_points_2',
-                           unit='',
-                           vals=Numbers(1, 1e3),
-                           get_cmd=None,
-                           set_cmd=None)
+        self.add_parameter(
+            "dummy_n_points_2",
+            initial_value=101,
+            unit="",
+            vals=Numbers(1, 1e3),
+            get_cmd=None,
+            set_cmd=None,
+        )
 
         self.add_parameter('dummy_sp_axis',
                            unit='some unit',

--- a/qcodes/tests/parameter/conftest.py
+++ b/qcodes/tests/parameter/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from qcodes.instrument.base import InstrumentBase
 from qcodes.instrument.parameter import Parameter
 import qcodes.utils.validators as vals
+from qcodes.tests.instrument_mocks import DummyChannelInstrument
 
 NOT_PASSED = 'NOT_PASSED'
 
@@ -38,6 +39,13 @@ def update(request):
 @pytest.fixture(params=(True, False))
 def cache_is_valid(request):
     return request.param
+
+
+@pytest.fixture(name="dummy_instrument")
+def _make_dummy_instrument():
+    instr = DummyChannelInstrument("dummy")
+    yield instr
+    instr.close()
 
 
 class GettableParam(Parameter):

--- a/qcodes/tests/parameter/test_parameter_cache.py
+++ b/qcodes/tests/parameter/test_parameter_cache.py
@@ -366,22 +366,14 @@ def test_marking_invalid_via_instrument(dummy_instrument):
 
         for instrument_module in dummy_instrument.instrument_modules.values():
             for param in instrument_module.parameters.values():
-                # Multi Array and ParamWithSetpoints are not updated in snapshot
-                # so not marked valid by snapshot.update(None)
-                # here we therefor exclude them
-                if param.short_name not in [
-                    "dummy_multi_parameter",
-                    "dummy_scalar_multi_parameter",
-                    "dummy_2d_multi_parameter",
-                    "dummy_2d_multi_parameter_2",
-                    "dummy_array_parameter",
-                    "dummy_sp_axis",
-                    "dummy_sp_axis_2",
-                    "dummy_complex_array_parameter",
-                    "dummy_parameter_with_setpoints",
-                    "dummy_parameter_with_setpoints_2d",
-                    "dummy_parameter_with_setpoints_complex",
-                ]:
+                # parameters not snapshotted will not have a cache
+                # updated when calling snapshot(update=None) os
+                # exclude them
+                if (
+                    param._snapshot_get is True
+                    and param.snapshot_value is True
+                    and param.snapshot_exclude is False
+                ):
                     assert param.cache.valid is valid, param.full_name
 
     dummy_instrument.snapshot(update=None)


### PR DESCRIPTION
This is handy when some change e.g. touching the frontpanel invalidates our knowlege about the instrument. 