### PR TITLE
Station example notebook: fix header levels

### DIFF
--- a/docs/examples/Station.ipynb
+++ b/docs/examples/Station.ipynb
@@ -15,18 +15,13 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Useful imports"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Useful imports:\n",
+    "\n",
     "from pprint import pprint  # for pretty-printing python variables like 'dict'\n",
     "\n",
     "import qcodes\n",


### PR DESCRIPTION
to fix header level rendering

before:

![image](https://user-images.githubusercontent.com/15662810/169085718-40f4e302-6f79-4bb0-8629-d661a3244459.png)

after:

![image](https://user-images.githubusercontent.com/15662810/169096462-dd9acb96-f6a4-498f-bfc5-5372d3f022ab.png)

So the lesson is that one should never skip a level :) in this case, there was first level 1 header and then level 3 header for "useful imports", and apparently sphinx or nbconverter just assumes that level 2 headers won't be there anymore or thinks that they are the same as level 3 headers.