### PR TITLE
rigol notebook remove unused and deprecated import

### DIFF
--- a/docs/examples/driver_examples/Qcodes example with Rigol DS1074Z.ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Rigol DS1074Z.ipynb
@@ -27,8 +27,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import visa\n",
-    "\n",
     "#Qcodes import\n",
     "from qcodes.dataset.plotting import plot_dataset\n",
     "from qcodes.instrument_drivers.rigol.DS1074Z import DS1074Z\n",
@@ -178,7 +176,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -192,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.12"
   },
   "nbsphinx": {
    "execute": "never"
@@ -238,8 +236,15 @@
     "_Feature"
    ],
    "window_display": false
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
the visa module has been deprecated from pyvisa