### PR TITLE
use short parameter annotation in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -430,6 +430,8 @@ autodoc_mock_imports = [
     "gclib",
 ]
 
+autodoc_typehints_format = "short"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
This will become the default in sphinx 5 and makes the docs more readable

E.g. changes 

<img width="700" alt="image" src="https://user-images.githubusercontent.com/548266/173783794-85293cc5-88a7-4617-a0f4-b36f4cb3c6e0.png">


to

<img width="698" alt="image" src="https://user-images.githubusercontent.com/548266/173783749-8ae8a99a-2c90-4132-a9d4-6c3ae58dcf8c.png">

