### PR TITLE
Docs: Enable autosummary for instrument module

### DIFF
--- a/docs/api/instrument/index.rst
+++ b/docs/api/instrument/index.rst
@@ -4,3 +4,4 @@ qcodes.instrument
 =================
 
 .. automodule:: qcodes.instrument
+    :autosummary:

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -2,7 +2,7 @@ alabaster==0.7.12
 argon2-cffi==21.3.0
 async-generator==1.10
 attrs==21.4.0
-autodocsumm==0.2.8
+git+https://github.com/Chilipp/autodocsumm.git
 Babel==2.10.3
 backcall==0.2.0
 bleach==5.0.1
@@ -69,7 +69,7 @@ scipy==1.8.1; python_version>='3.8'
 Send2Trash==1.8.0
 six==1.16.0
 snowballstemmer==2.2.0
-Sphinx==4.5.0
+git+https://github.com/jenshnielsen/sphinx.git@fix_9884_50branch
 sphinx-favicon==0.2
 sphinx-jsonschema==1.19.1
 sphinx-rtd-theme==1.0.0

--- a/docs_requirements.txt
+++ b/docs_requirements.txt
@@ -2,7 +2,7 @@ alabaster==0.7.12
 argon2-cffi==21.3.0
 async-generator==1.10
 attrs==21.4.0
-git+https://github.com/Chilipp/autodocsumm.git
+git+https://github.com/Chilipp/autodocsumm.git@c3689c9204afcb2903ca50ca809aefc62f76316d
 Babel==2.10.3
 backcall==0.2.0
 bleach==5.0.1


### PR DESCRIPTION
This currently requires a branch of sphinx to fix documenting inherited attributes. That branch is open as https://github.com/sphinx-doc/sphinx/pull/10691

To install sphinx 5.x we need the master branch of autodocsumm. That does not otherwise carry any fixes

This is done as a branch that carries my changes directly on top of 5.0.x since 5.1.0 broke the build. See https://github.com/sphinx-doc/sphinx/issues/10701

@astafan8 What do you think is it acceptable to build with a patched version of sphinx until that is merged.

This will also enable us to activate autodocsumm for https://github.com/QCoDeS/Qcodes/pull/4371 which will make that way more readable
