### PR TITLE
ChannelTuple: add ability to call regular callable

### DIFF
--- a/docs/changes/newsfragments/4292.improved
+++ b/docs/changes/newsfragments/4292.improved
@@ -1,0 +1,2 @@
+``ChannelTuple`` and ``ChannelList`` has gained the ability to call methods defined on the channels
+in the sequence in a way similar to how QCoDeS Functions can be called.

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -386,8 +386,8 @@ class ChannelTuple(Metadatable, Sequence[InstrumentModuleType]):
             name: The name of the parameter, function or channel that we want to
                 operate on.
         """
-        # Check if this is a valid parameter
         if len(self) > 0:
+            # Check if this is a valid parameter
             if name in self._channels[0].parameters:
                 param = self._construct_multiparam(name)
                 return param
@@ -401,6 +401,17 @@ class ChannelTuple(Metadatable, Sequence[InstrumentModuleType]):
                         chan.functions[name](*args)
 
                 return multi_func
+
+            # check if this is a method on the channels in the
+            # sequence
+            maybe_callable = getattr(self._channels[0], name, None)
+            if callable(maybe_callable):
+
+                def multi_callable(*args: Any) -> None:
+                    for chan in self._channels:
+                        getattr(chan, name)(*args)
+
+                return multi_callable
 
         try:
             return self._channel_mapping[name]

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -156,8 +156,12 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         This functionality is meant for simple cases, principally things that
         map to simple commands like ``*RST`` (reset) or those with just a few
         arguments. It requires a fixed argument count, and positional args
-        only. If your case is more complicated, you're probably better off
-        simply making a new method in your ``Instrument`` subclass definition.
+        only.
+
+        Note:
+            We do not recommend the usage of Function for any new driver.
+            Function does not add any significant features over a method
+            defined on the class.
 
         Args:
             name: How the Function will be stored within

--- a/qcodes/parameters/function.py
+++ b/qcodes/parameters/function.py
@@ -17,10 +17,7 @@ class Function(Metadatable):
     map to simple commands like ``*RST`` (reset) or those with just a few
     arguments.
     It requires a fixed argument count, and positional args
-    only. If your case is more complicated, you're probably better off
-    simply making a new method in your Instrument subclass definition.
-    The function validators.validate_all can help reduce boilerplate code
-    in this case.
+    only.
 
     You execute this function object like a normal function, or use its
     .call method.
@@ -28,6 +25,12 @@ class Function(Metadatable):
     Note:
         Parsers only apply if call_cmd is a string. The function form of
         call_cmd should do its own parsing.
+
+    Note:
+        We do not recommend the usage of Function for any new driver.
+        Function does not add any significant features over a method
+        defined on the class.
+
 
     Args:
         name: the local name of this function

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -427,6 +427,9 @@ class DummyChannel(InstrumentChannel):
         self.add_function(name='log_my_name',
                           call_cmd=partial(log.debug, f'{name}'))
 
+    def turn_on(self) -> None:
+        pass
+
 
 class DummyChannelInstrument(Instrument):
     """

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -829,7 +829,6 @@ def test_channel_tuple_call_method_called_as_expected(dci, mocker):
 
     result = dci.channels.turn_on("bar")
     # We never return the result (same for Function)
-    # should we?
     assert result is None
     for channel in dci.channels:
         channel.turn_on.assert_called_with("bar")

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -59,6 +59,7 @@ def _make_empty_instrument():
 class EmptyChannel(InstrumentChannel):
     pass
 
+
 def test_channels_call_function(dci, caplog):
     """
     Test that dci.channels.some_function() calls
@@ -301,10 +302,12 @@ def test_channel_list_get_validator_not_locked_raised(dci_with_list):
     with pytest.raises(AttributeError, match="Cannot create a validator"):
         dci_with_list.channels.get_validator()
 
+
 def test_channel_tuple_index(dci):
 
     for i, chan in enumerate(dci.channels):
         assert dci.channels.index(chan) == i
+
 
 def test_channel_tuple_snapshot(dci):
     snapshot = dci.channels.snapshot()
@@ -327,6 +330,7 @@ def test_channel_tuple_snapshot_enabled(empty_instrument):
     assert len(snapshot.keys()) == 3
     assert "channels" in snapshot.keys()
 
+
 def test_channel_tuple_dir(dci):
 
     dir_list = dir(dci.channels)
@@ -336,6 +340,7 @@ def test_channel_tuple_dir(dci):
 
     for param in dci.channels[0].parameters.values():
         assert param.short_name in dir_list
+
 
 def test_clear_channels(dci_with_list):
     channels = dci_with_list.channels
@@ -376,6 +381,7 @@ def test_channel_list_lock_twice(dci_with_list):
     channels.lock()
     # locking twice should be a no op
     channels.lock()
+
 
 def test_remove_tupled_channel(dci_with_list):
     channel_tuple = tuple(
@@ -511,6 +517,7 @@ def test_set_element_locked_raises(dci_with_list):
         dci_with_list.channels[0] = dci_with_list.channels[1]
     assert dci_with_list.channels[0] is not dci_with_list.channels[1]
 
+
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(myindexs=hst.lists(elements=hst.integers(0, 7), min_size=2))
 def test_access_channels_by_name(dci, myindexs):
@@ -522,6 +529,7 @@ def test_access_channels_by_name(dci, myindexs):
     mychans = chlist.get_channel_by_name(*channel_names)
     for chan, chanindex in zip(mychans, myindexs):
         assert chan.name == f'dci_Chan{names[chanindex]}'
+
 
 def test_channels_contain(dci):
     names = ("A", "B", "C", "D", "E", "F", "G", "H")

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -817,6 +817,24 @@ def test_get_attr_on_empty_channellist_works_as_expected(empty_instrument):
         _ = empty_instrument.channels.temperature
 
 
+def test_channel_tuple_call_method_basic_test(dci):
+    result = dci.channels.turn_on()
+    assert result is None
+
+
+def test_channel_tuple_call_method_called_as_expected(dci, mocker):
+
+    for channel in dci.channels:
+        channel.turn_on = mocker.MagicMock(return_value=1)
+
+    result = dci.channels.turn_on("bar")
+    # We never return the result (same for Function)
+    # should we?
+    assert result is None
+    for channel in dci.channels:
+        channel.turn_on.assert_called_with("bar")
+
+
 def _verify_multiparam_data(data):
     assert 'multi_setpoint_param_this_setpoint_set' in data.arrays.keys()
     assert_array_equal(


### PR DESCRIPTION
This IMHO eliminates the only important feature Functions has over a regular method on a InstrumentModule/Channel

TODO

- [x] Add a changelog entry