### PR TITLE
Api: add get_instrument_logger to public api

### DIFF
--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -16,7 +16,7 @@ from typing import (
 
 import numpy as np
 
-from qcodes.logger.instrument_logger import get_instrument_logger
+from qcodes.logger import get_instrument_logger
 from qcodes.parameters import Function, Parameter, ParameterBase
 from qcodes.utils.helpers import DelegateAttributes, full_class
 from qcodes.utils.metadata import Metadatable

--- a/qcodes/instrument/ip_to_visa.py
+++ b/qcodes/instrument/ip_to_visa.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 import qcodes.utils.validators as vals
 from qcodes.instrument_drivers.american_magnetics.AMI430 import AMI430
-from qcodes.logger.instrument_logger import get_instrument_logger
+from qcodes.logger import get_instrument_logger
 from qcodes.utils.helpers import strip_attrs
 
 from .instrument import Instrument

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -7,7 +7,7 @@ import pyvisa.constants as vi_const
 import pyvisa.resources
 
 import qcodes.utils.validators as vals
-from qcodes.logger.instrument_logger import get_instrument_logger
+from qcodes.logger import get_instrument_logger
 from qcodes.utils.delaykeyboardinterrupt import DelayedKeyboardInterrupt
 from qcodes.utils.deprecate import deprecate
 

--- a/qcodes/logger/__init__.py
+++ b/qcodes/logger/__init__.py
@@ -9,7 +9,7 @@ and functions to extract log messages to :class:`pandas.DataFrame` s
 
 """
 
-from .instrument_logger import filter_instrument
+from .instrument_logger import filter_instrument, get_instrument_logger
 from .log_analysis import (
     capture_dataframe,
     log_to_dataframe,
@@ -39,6 +39,7 @@ __all__ = [
     "flush_telemetry_traces",
     "get_console_handler",
     "get_file_handler",
+    "get_instrument_logger",
     "get_level_code",
     "get_level_name",
     "get_log_file_name",

--- a/qcodes/tests/drivers/test_lakeshore.py
+++ b/qcodes/tests/drivers/test_lakeshore.py
@@ -10,7 +10,7 @@ import qcodes.instrument.sims as sims
 from qcodes.instrument import InstrumentBase
 from qcodes.instrument_drivers.Lakeshore.lakeshore_base import BaseSensorChannel
 from qcodes.instrument_drivers.Lakeshore.Model_372 import Model_372
-from qcodes.logger.instrument_logger import get_instrument_logger
+from qcodes.logger import get_instrument_logger
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This is used outside the logging module so should be public IMHO @Dominik-Vogel 