### PR TITLE
Avoid passing classes as default args

### DIFF
--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -132,6 +132,8 @@ class ChannelTuple(Metadatable, Sequence[InstrumentModuleType]):
             the object to be returned by the :meth:`__getattr__`
             method of :class:`ChannelTuple`.
             Should be a subclass of :class:`.MultiChannelInstrumentParameter`.
+            Defaults to :class:`.MultiChannelInstrumentParameter` if None.
+
 
     Raises:
         ValueError: If ``chan_type`` is not a subclass of
@@ -149,8 +151,11 @@ class ChannelTuple(Metadatable, Sequence[InstrumentModuleType]):
         chan_type: Type[InstrumentModuleType],
         chan_list: Optional[Sequence[InstrumentModuleType]] = None,
         snapshotable: bool = True,
-        multichan_paramclass: type = MultiChannelInstrumentParameter,
+        multichan_paramclass: Optional[Type[MultiChannelInstrumentParameter]] = None,
     ):
+        if multichan_paramclass is None:
+            multichan_paramclass = MultiChannelInstrumentParameter
+
         super().__init__()
 
         self._parent = parent
@@ -521,6 +526,7 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentModuleType]):  # type:
             the object to be returned by the :meth:`__getattr__`
             method of :class:`ChannelList`.
             Should be a subclass of :class:`.MultiChannelInstrumentParameter`.
+            Defaults to :class:`.MultiChannelInstrumentParameter` if None.
 
     Raises:
         ValueError: If ``chan_type`` is not a subclass of
@@ -538,8 +544,10 @@ class ChannelList(ChannelTuple, MutableSequence[InstrumentModuleType]):  # type:
         chan_type: Type[InstrumentModuleType],
         chan_list: Optional[Sequence[InstrumentModuleType]] = None,
         snapshotable: bool = True,
-        multichan_paramclass: type = MultiChannelInstrumentParameter,
+        multichan_paramclass: Optional[Type[MultiChannelInstrumentParameter]] = None,
     ):
+        if multichan_paramclass is None:
+            multichan_paramclass = MultiChannelInstrumentParameter
         super().__init__(
             parent, name, chan_type, chan_list, snapshotable, multichan_paramclass
         )

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -11,6 +11,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Type,
     Union,
 )
 
@@ -82,7 +83,10 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         self.log = get_instrument_logger(self, __name__)
 
     def add_parameter(
-        self, name: str, parameter_class: type = Parameter, **kwargs: Any
+        self,
+        name: str,
+        parameter_class: Optional[Type[ParameterBase]] = None,
+        **kwargs: Any,
     ) -> None:
         """
         Bind one Parameter to this instrument.
@@ -112,6 +116,9 @@ class InstrumentBase(Metadatable, DelegateAttributes):
                 unit of the new parameter is inconsistent with the existing
                 one.
         """
+        if parameter_class is None:
+            parameter_class = Parameter
+
         if "bind_to_instrument" not in kwargs.keys():
             kwargs["bind_to_instrument"] = True
 


### PR DESCRIPTION
This improves the sphinx rendering of the type signature.

Compare:

<img width="703" alt="image" src="https://user-images.githubusercontent.com/548266/174820544-c625e0e4-5d1a-48af-bd58-f1cb4ecce0e7.png">


To:

<img width="714" alt="image" src="https://user-images.githubusercontent.com/548266/174820620-9108034a-f606-4cb9-9549-037af4b4b721.png">

