### PR TITLE
API: Add DelatedKeyboardInterrupt and depreacate to api

### DIFF
--- a/docs/api/utils/deprecate.rst
+++ b/docs/api/utils/deprecate.rst
@@ -1,5 +1,0 @@
-qcodes.utils.deprecate
-----------------------
-
-.. automodule:: qcodes.utils.deprecate
-   :members:

--- a/docs/api/utils/index.rst
+++ b/docs/api/utils/index.rst
@@ -7,7 +7,6 @@ qcodes.utils
 .. autosummary::
 
     qcodes.utils
-    qcodes.utils.deprecate
     qcodes.utils.helpers
     qcodes.utils.magic
     qcodes.utils.metadata
@@ -22,7 +21,6 @@ qcodes.utils
    :maxdepth: 4
    :hidden:
 
-   deprecate
    helpers
    magic
    metadata

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -76,7 +76,7 @@ from qcodes.station import Station
 atexit.register(Instrument.close_all)
 
 if config.core.import_legacy_api:
-    from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+    from qcodes.utils import QCoDeSDeprecationWarning
 
     warnings.warn(
         "import_legacy_api config option is deprecated and will be removed "

--- a/qcodes/dataset/data_export.py
+++ b/qcodes/dataset/data_export.py
@@ -7,7 +7,7 @@ from typing_extensions import TypedDict
 from qcodes.dataset.data_set import load_by_id
 from qcodes.dataset.data_set_protocol import DataSetProtocol
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 from qcodes.utils.numpy_utils import list_of_data_to_maybe_ragged_nd_array
 
 log = logging.getLogger(__name__)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -84,8 +84,8 @@ from qcodes.dataset.sqlite.query_helpers import (
     one,
     select_one_where,
 )
-from qcodes.utils import NumpyJSONEncoder
-from qcodes.utils.deprecate import (
+from qcodes.utils import (
+    NumpyJSONEncoder,
     QCoDeSDeprecationWarning,
     deprecate,
     issue_deprecation_warning,

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -8,7 +8,7 @@ import numpy as np
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.sqlite.connection import ConnectionPlus
 from qcodes.dataset.sqlite.queries import completed, load_new_data_for_rundescriber
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 
 from .exporters.export_to_pandas import (
     load_to_concatenated_dataframe,

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -65,7 +65,7 @@ from qcodes.parameters import (
     expand_setpoints_helper,
 )
 from qcodes.station import Station
-from qcodes.utils.delaykeyboardinterrupt import DelayedKeyboardInterrupt
+from qcodes.utils import DelayedKeyboardInterrupt
 
 if TYPE_CHECKING:
     from qcodes.dataset.sqlite.connection import ConnectionPlus

--- a/qcodes/dataset/sqlite/connection.py
+++ b/qcodes/dataset/sqlite/connection.py
@@ -10,7 +10,7 @@ from typing import Union, Any, Iterator
 
 import wrapt
 
-from qcodes.utils.delaykeyboardinterrupt import DelayedKeyboardInterrupt
+from qcodes.utils import DelayedKeyboardInterrupt
 
 log = logging.getLogger(__name__)
 

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -53,7 +53,7 @@ from qcodes.dataset.sqlite.query_helpers import (
     sql_placeholder_string,
     update_where,
 )
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 from qcodes.utils.numpy_utils import list_of_data_to_maybe_ragged_nd_array
 
 log = logging.getLogger(__name__)

--- a/qcodes/dataset/sqlite/query_helpers.py
+++ b/qcodes/dataset/sqlite/query_helpers.py
@@ -17,7 +17,7 @@ from qcodes.dataset.sqlite.connection import (
     transaction,
 )
 from qcodes.dataset.sqlite.settings import SQLiteSettings
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 
 # represent the type of  data we can/want map to sqlite column
 VALUE = Union[str, complex, List, ndarray, bool, None]

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -25,7 +25,7 @@ from qcodes.utils.metadata import Metadatable
 if TYPE_CHECKING:
     from qcodes.instrument.channel import ChannelTuple, InstrumentModule
 
-from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.utils import QCoDeSDeprecationWarning
 
 log = logging.getLogger(__name__)
 

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -8,8 +8,7 @@ import pyvisa.resources
 
 import qcodes.validators as vals
 from qcodes.logger import get_instrument_logger
-from qcodes.utils import DelayedKeyboardInterrupt
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import DelayedKeyboardInterrupt, deprecate
 
 from .instrument import Instrument
 from .instrument_base import InstrumentBase

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -8,7 +8,7 @@ import pyvisa.resources
 
 import qcodes.validators as vals
 from qcodes.logger import get_instrument_logger
-from qcodes.utils.delaykeyboardinterrupt import DelayedKeyboardInterrupt
+from qcodes.utils import DelayedKeyboardInterrupt
 from qcodes.utils.deprecate import deprecate
 
 from .instrument import Instrument

--- a/qcodes/instrument_drivers/Keysight/Infiniium.py
+++ b/qcodes/instrument_drivers/Keysight/Infiniium.py
@@ -11,7 +11,7 @@ from qcodes.instrument import VisaInstrument
 from qcodes.instrument.base import InstrumentBase
 from qcodes.instrument.channel import ChannelList, InstrumentChannel, InstrumentModule
 from qcodes.parameters import Parameter, ParameterWithSetpoints
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 from qcodes.utils.helpers import create_on_off_val_mapping
 
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1517A.py
@@ -18,7 +18,7 @@ from typing_extensions import Literal, TypedDict, overload
 import qcodes.validators as vals
 from qcodes.instrument import InstrumentChannel
 from qcodes.parameters import Group, GroupParameter, Parameter, ParamRawDataType
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 
 from . import constants
 from .constants import (

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -23,7 +23,7 @@ import numpy as np
 from qcodes.instrument import Instrument, InstrumentChannel, IPInstrument
 from qcodes.math_utils import FieldVector
 from qcodes.parameters import Parameter
-from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.utils import QCoDeSDeprecationWarning
 from qcodes.validators import Anything, Bool, Enum, Ints, Numbers
 
 log = logging.getLogger(__name__)

--- a/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -25,7 +25,7 @@ from pyvisa import VisaIOError
 from qcodes.instrument import Instrument, InstrumentChannel, VisaInstrument
 from qcodes.math_utils import FieldVector
 from qcodes.parameters import Parameter
-from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.utils import QCoDeSDeprecationWarning
 from qcodes.validators import Anything, Bool, Enum, Ints, Numbers
 
 log = logging.getLogger(__name__)

--- a/qcodes/instrument_drivers/oxford/mercuryiPS.py
+++ b/qcodes/instrument_drivers/oxford/mercuryiPS.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from qcodes.instrument import IPInstrument
 from qcodes.parameters import MultiParameter
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 from qcodes.validators import Bool, Enum
 
 log = logging.getLogger(__name__)

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -12,7 +12,7 @@ from qcodes.parameters import (
     MultiParameter,
     ParamRawDataType,
 )
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 from qcodes.utils.helpers import create_on_off_val_mapping
 
 log = logging.getLogger(__name__)

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -47,7 +47,7 @@ from qcodes.parameters import (
     Parameter,
     ParameterBase,
 )
-from qcodes.utils.deprecate import issue_deprecation_warning
+from qcodes.utils import issue_deprecation_warning
 from qcodes.utils.helpers import (
     YAML,
     DelegateAttributes,

--- a/qcodes/tests/dataset/test__get_data_from_ds.py
+++ b/qcodes/tests/dataset/test__get_data_from_ds.py
@@ -9,7 +9,7 @@ from qcodes.dataset.data_export import _get_data_from_ds, get_data_by_id
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.measurements import Measurement
-from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.utils import QCoDeSDeprecationWarning
 
 
 def test_get_data_by_id_order(dataset):

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -21,7 +21,7 @@ from qcodes.dataset.sqlite.queries import (
     get_raw_run_attributes,
     raw_time_to_str_time,
 )
-from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.utils import QCoDeSDeprecationWarning
 
 
 @pytest.mark.usefixtures("experiment")

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -26,7 +26,7 @@ from qcodes.dataset.sqlite import query_helpers as mut_help
 from qcodes.dataset.sqlite.connection import path_to_dbfile
 from qcodes.dataset.sqlite.database import get_DB_location
 from qcodes.tests.common import error_caused_by
-from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.utils import QCoDeSDeprecationWarning
 
 from .helper_functions import verify_data_dict
 

--- a/qcodes/tests/parameter/test_parameter_registration.py
+++ b/qcodes/tests/parameter/test_parameter_registration.py
@@ -2,7 +2,7 @@ import pytest
 
 from qcodes.parameters import Parameter
 from qcodes.tests.instrument_mocks import DummyAttrInstrument
-from qcodes.utils.deprecate import QCoDeSDeprecationWarning
+from qcodes.utils import QCoDeSDeprecationWarning
 
 
 class BrokenParameter(Parameter):

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -6,7 +6,7 @@ from qcodes.sphinx_extensions.parse_parameter_attr import (
     ParameterProxy,
     qcodes_parameter_attr_getter,
 )
-from qcodes.utils.deprecate import deprecate
+from qcodes.utils import deprecate
 
 
 class DummyTestClass(InstrumentBase):

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -17,8 +17,8 @@ from qcodes.parameters import DelegateParameter, Parameter
 from qcodes.station import SCHEMA_PATH, Station, ValidationWarning, update_config_schema
 from qcodes.tests.common import default_config
 from qcodes.tests.instrument_mocks import DummyInstrument
-from qcodes.utils import NumpyJSONEncoder
-from qcodes.utils.deprecate import assert_deprecated, deprecation_message
+from qcodes.utils import NumpyJSONEncoder, QCoDeSDeprecationWarning
+from qcodes.utils.deprecate import deprecation_message
 from qcodes.utils.helpers import YAML, get_qcodes_path
 
 from .common import DumyPar
@@ -755,11 +755,11 @@ instruments:
     driver: qcodes.tests.instrument_mocks
     type: DummyChannelInstrument
     """)
-    with assert_deprecated(
-        deprecation_message(
-            'use of the "driver"-keyword in the station configuration file',
-            alternative='the "type"-keyword instead, prepending the driver value'
-                        ' to it')):
+    message = deprecation_message(
+        'use of the "driver"-keyword in the station configuration file',
+        alternative='the "type"-keyword instead, prepending the driver value' " to it",
+    )
+    with pytest.warns(QCoDeSDeprecationWarning, match=message):
         st.load_instrument('mock')
 
 
@@ -774,11 +774,11 @@ instruments:
       ch1:
         limits: -10, 10
     """)
-    with assert_deprecated(
-        deprecation_message(
-            'use of a comma separated string for the limits keyword',
-            alternative='an array like "[lower_lim, upper_lim]"')
-    ):
+    message = deprecation_message(
+        "use of a comma separated string for the limits keyword",
+        alternative=r'an array like "\[lower_lim, upper_lim\]"',
+    )
+    with pytest.warns(QCoDeSDeprecationWarning, match=message):
         st.load_instrument('mock')
 
 

--- a/qcodes/utils/__init__.py
+++ b/qcodes/utils/__init__.py
@@ -1,4 +1,5 @@
 from . import validators
+from .delaykeyboardinterrupt import DelayedKeyboardInterrupt
 from .json_utils import NumpyJSONEncoder
 
-__all__ = ["NumpyJSONEncoder"]
+__all__ = ["DelayedKeyboardInterrupt", "NumpyJSONEncoder"]

--- a/qcodes/utils/__init__.py
+++ b/qcodes/utils/__init__.py
@@ -1,5 +1,12 @@
 from . import validators
 from .delaykeyboardinterrupt import DelayedKeyboardInterrupt
+from .deprecate import QCoDeSDeprecationWarning, deprecate, issue_deprecation_warning
 from .json_utils import NumpyJSONEncoder
 
-__all__ = ["DelayedKeyboardInterrupt", "NumpyJSONEncoder"]
+__all__ = [
+    "DelayedKeyboardInterrupt",
+    "NumpyJSONEncoder",
+    "deprecate",
+    "QCoDeSDeprecationWarning",
+    "issue_deprecation_warning",
+]

--- a/qcodes/utils/deprecate.py
+++ b/qcodes/utils/deprecate.py
@@ -7,7 +7,10 @@ import wrapt
 
 
 class QCoDeSDeprecationWarning(RuntimeWarning):
-    """Fix for `DeprecationWarning` being suppressed by default."""
+    """
+    A DeprecationWarning used internally in QCoDeS. This
+    fixes `DeprecationWarning` being suppressed by default.
+    """
 
 
 def deprecation_message(

--- a/qcodes/utils/deprecate.py
+++ b/qcodes/utils/deprecate.py
@@ -33,6 +33,9 @@ def issue_deprecation_warning(
     alternative: Optional[str] = None,
     stacklevel: int = 2,
 ) -> None:
+    """
+    Issue a `QCoDeSDeprecationWarning` with a consistently formatted message
+    """
     warnings.warn(
         deprecation_message(what, reason, alternative),
         QCoDeSDeprecationWarning,


### PR DESCRIPTION
A few questions

* The deprecate module contains 2 methods to assert deprecation messages. One of those were used in test_station. I have replaced that with the warnings testing logic from pytest. I think that using the pytest code is cleaner and more portable so I suggest that we only use that going forward and don't document these methods. 
* test_station still makes use of the function to generate a test message ``deprecation_message`` I don't however think this should be part of the public api. We could rewrite the tests to not make use of this function? 