### PR TITLE
Add public api for installation info functions

### DIFF
--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -9,9 +9,7 @@ from typing import Any
 import qcodes.configuration as qcconfig
 from qcodes.logger.logger import conditionally_start_all_logging
 from qcodes.utils.helpers import add_to_spyder_UMR_excludelist
-from qcodes.utils.installation_info import get_qcodes_version
-
-__version__ = get_qcodes_version()
+from ._version import __version__
 
 config: qcconfig.Config = qcconfig.Config()
 

--- a/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_e4980a.py
@@ -11,8 +11,8 @@ from qcodes.parameters import (
     MultiParameter,
     ParamRawDataType,
 )
+from qcodes.utils import convert_legacy_version_to_supported_version
 from qcodes.utils.helpers import create_on_off_val_mapping
-from qcodes.utils.installation_info import convert_legacy_version_to_supported_version
 from qcodes.validators import Bool, Enum, Ints, Numbers
 
 

--- a/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
+++ b/qcodes/instrument_drivers/Keysight/private/Keysight_344xxA_submodules.py
@@ -13,7 +13,7 @@ from qcodes.instrument_drivers.Keysight.private.error_handling import (
     KeysightErrorQueueMixin,
 )
 from qcodes.parameters import Parameter, ParameterWithSetpoints
-from qcodes.utils.installation_info import convert_legacy_version_to_supported_version
+from qcodes.utils import convert_legacy_version_to_supported_version
 
 
 class Trigger(InstrumentChannel):

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -26,7 +26,10 @@ if TYPE_CHECKING:
     from opencensus.ext.azure.log_exporter import AzureLogHandler
 
 import qcodes as qc
-import qcodes.utils.installation_info as ii
+from qcodes.utils import (
+    get_all_installed_package_versions,
+    is_qcodes_installed_editably,
+)
 from qcodes.utils.helpers import get_qcodes_user_path
 
 log: logging.Logger = logging.getLogger(__name__)
@@ -341,8 +344,8 @@ def log_qcodes_versions(logger: logging.Logger) -> None:
     """
 
     qc_version = qc.__version__
-    qc_e_inst = ii.is_qcodes_installed_editably()
-    ipvs = ii.get_all_installed_package_versions()
+    qc_e_inst = is_qcodes_installed_editably()
+    ipvs = get_all_installed_package_versions()
 
     logger.info(f"QCoDeS version: {qc_version}")
     logger.info(f"QCoDeS installed in editable mode: {qc_e_inst}")
@@ -385,10 +388,10 @@ def conditionally_start_all_logging() -> None:
             return False
         elif config.logger.start_logging_on_import == 'if_telemetry_set_up':
             return (
-                config.GUID_components.location != 0 and
-                config.GUID_components.work_station != 0 and
-                config.telemetry.instrumentation_key != \
-                    "00000000-0000-0000-0000-000000000000"
+                config.GUID_components.location != 0
+                and config.GUID_components.work_station != 0
+                and config.telemetry.instrumentation_key
+                != "00000000-0000-0000-0000-000000000000"
             )
         else:
             raise RuntimeError('Error in qcodesrc validation.')

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -340,7 +340,7 @@ def log_qcodes_versions(logger: logging.Logger) -> None:
     versions of all installed packages.
     """
 
-    qc_version = ii.get_qcodes_version()
+    qc_version = qc.__version__
     qc_e_inst = ii.is_qcodes_installed_editably()
     ipvs = ii.get_all_installed_package_versions()
 

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -1,12 +1,18 @@
+import pytest
+
 import qcodes as qc
 import qcodes.utils.installation_info as ii
+from qcodes.utils import QCoDeSDeprecationWarning
 
 # The get_* functions from installation_info are hard to meaningfully test,
 # but we can at least test that they execute without errors
 
 
 def test_get_qcodes_version():
-    assert ii.get_qcodes_version() == qc.__version__
+    with pytest.warns(QCoDeSDeprecationWarning):
+        version = ii.get_qcodes_version()
+
+    assert version == qc.__version__
 
 
 def test_is_qcodes_installed_editably():

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -2,7 +2,12 @@ import pytest
 
 import qcodes as qc
 import qcodes.utils.installation_info as ii
-from qcodes.utils import QCoDeSDeprecationWarning
+from qcodes.utils import (
+    QCoDeSDeprecationWarning,
+    convert_legacy_version_to_supported_version,
+    get_all_installed_package_versions,
+    is_qcodes_installed_editably,
+)
 
 # The get_* functions from installation_info are hard to meaningfully test,
 # but we can at least test that they execute without errors
@@ -16,13 +21,13 @@ def test_get_qcodes_version():
 
 
 def test_is_qcodes_installed_editably():
-    answer = ii.is_qcodes_installed_editably()
+    answer = is_qcodes_installed_editably()
 
     assert isinstance(answer, bool)
 
 
 def test_get_all_installed_package_versions():
-    ipvs = ii.get_all_installed_package_versions()
+    ipvs = get_all_installed_package_versions()
 
     assert isinstance(ipvs, dict)
     assert len(ipvs) > 0
@@ -34,10 +39,10 @@ def test_get_all_installed_package_versions():
 
 def test_convert_legacy_version_to_supported_version():
     legacy_verstr = "a.1.4"
-    assert ii.convert_legacy_version_to_supported_version(legacy_verstr) == "65.1.4"
+    assert convert_legacy_version_to_supported_version(legacy_verstr) == "65.1.4"
 
     legacy_verstr = "10.4.7"
-    assert ii.convert_legacy_version_to_supported_version(legacy_verstr) == "10.4.7"
+    assert convert_legacy_version_to_supported_version(legacy_verstr) == "10.4.7"
 
     legacy_verstr = "C.2.1"
-    assert ii.convert_legacy_version_to_supported_version(legacy_verstr) == "67.2.1"
+    assert convert_legacy_version_to_supported_version(legacy_verstr) == "67.2.1"

--- a/qcodes/utils/__init__.py
+++ b/qcodes/utils/__init__.py
@@ -1,12 +1,20 @@
 from . import validators
 from .delaykeyboardinterrupt import DelayedKeyboardInterrupt
 from .deprecate import QCoDeSDeprecationWarning, deprecate, issue_deprecation_warning
+from .installation_info import (
+    convert_legacy_version_to_supported_version,
+    get_all_installed_package_versions,
+    is_qcodes_installed_editably,
+)
 from .json_utils import NumpyJSONEncoder
 
 __all__ = [
     "DelayedKeyboardInterrupt",
     "NumpyJSONEncoder",
-    "deprecate",
     "QCoDeSDeprecationWarning",
+    "convert_legacy_version_to_supported_version",
+    "deprecate",
+    "get_all_installed_package_versions",
+    "is_qcodes_installed_editably",
     "issue_deprecation_warning",
 ]

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -17,7 +17,7 @@ else:
     # 3.9 and earlier
     from importlib_metadata import distributions
 
-from qcodes.utils import deprecate
+from qcodes.utils.deprecate import deprecate
 
 log = logging.getLogger(__name__)
 

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -7,7 +7,6 @@ import json
 import logging
 import subprocess
 import sys
-from pathlib import Path
 from typing import Dict, Optional
 
 if sys.version_info >= (3, 10):
@@ -77,9 +76,3 @@ def convert_legacy_version_to_supported_version(ver: str) -> str:
         else:
             temp_list.append(v)
     return "".join(temp_list)
-
-
-def _has_pyproject_toml_and_is_git_repo(path: Path) -> bool:
-    has_pyproject_toml = (path / "pyproject.toml").exists()
-    is_git_repo = (path / ".git").exists()
-    return has_pyproject_toml and is_git_repo

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -18,6 +18,8 @@ else:
     # 3.9 and earlier
     from importlib_metadata import distributions
 
+from qcodes.utils import deprecate
+
 log = logging.getLogger(__name__)
 
 
@@ -44,6 +46,7 @@ def is_qcodes_installed_editably() -> Optional[bool]:
     return answer
 
 
+@deprecate("function 'get_qcodes_version'", alternative="qcodes.__version__")
 def get_qcodes_version() -> str:
     """
     Get the version of the currently installed QCoDeS


### PR DESCRIPTION
Stop using get_qcodes_version and deprecate. It does not seem to add any value over using qcodes.__version__ which is a convention