### PR TITLE
remove execution of test from docs of data.dataformat

### DIFF
--- a/docs/examples/legacy/Datasaving examples.ipynb
+++ b/docs/examples/legacy/Datasaving examples.ipynb
@@ -119,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -205,137 +203,11 @@
     "data2 = qc.data.data_set.DataSet(location=data_l.location, formatter=h5fmt)\n",
     "data2.read()"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Run the tests for the dataformat"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "test_closed_file (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... root - WARNING - Cannot close file, data_set has no open hdf5 file\n",
-      "root - WARNING - Cannot close file, data_set has no open hdf5 file\n",
-      "ok\n",
-      "test_dataset_closing (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_dataset_finalize_closes_file (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... qcodes.data.data_set - DEBUG - Finalising the DataSet. Writing.\n",
-      "ok\n",
-      "test_dataset_flush_after_write (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_dataset_with_missing_attrs (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_double_closing_gives_warning (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_full_write_read_1D (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format)\n",
-      "Test writing and reading a file back in ... ok\n",
-      "test_full_write_read_2D (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format)\n",
-      "Test writing and reading a file back in ... ok\n",
-      "test_incremental_write (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_loop_writing (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... qcodes.instrument.base - DEBUG - [Loop_writing_test(MockParabola)] Error getting or interpreting *IDN?: ''\n",
-      "qcodes.data.data_set - DEBUG - Attempting to write\n",
-      "qcodes.data.data_set - DEBUG - Finalising the DataSet. Writing.\n",
-      "ok\n",
-      "test_loop_writing_2D (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... qcodes.instrument.base - DEBUG - [Loop_writing_test_2D(MockParabola)] Error getting or interpreting *IDN?: ''\n",
-      "qcodes.data.data_set - DEBUG - Attempting to write\n",
-      "qcodes.data.data_set - DEBUG - Finalising the DataSet. Writing.\n",
-      "ok\n",
-      "test_metadata_write_read (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format)\n",
-      "Test is based on the snapshot of the 1D dataset. ... ok\n",
-      "test_partial_dataset (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_read_writing_dicts_withlists_to_hdf5 (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_reading_into_existing_data_array (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_str_to_bool (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_writing_metadata (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format) ... ok\n",
-      "test_writing_unsupported_types_to_hdf5 (qcodes.tests.legacy.test_hdf5formatter.TestHDF5_Format)\n",
-      "Tests writing of ... root - WARNING - Type \"<class 'qcodes.data.data_set.DataSet'>\" for \"nested_dataset\":\"DataSet:\n",
-      "   location = 'c:\\\\users\\\\jens-work\\\\source\\\\repos\\\\qcodes\\\\qcodes\\\\tests\\\\unittest_data/2020-10-04/#036_test_missing_attr_11-50-36'\n",
-      "   <Type> | <array_id> | <array.name> | <array.shape>\" not supported, storing as string\n",
-      "root - WARNING - List of type \"<class 'qcodes.data.data_set.DataSet'>\" for \"list_of_dataset\":\"[DataSet:\n",
-      "   location = 'c:\\\\users\\\\jens-work\\\\source\\\\repos\\\\qcodes\\\\qcodes\\\\tests\\\\unittest_data/2020-10-04/#036_test_missing_attr_11-50-36'\n",
-      "   <Type> | <array_id> | <array.name> | <array.shape>, DataSet:\n",
-      "   location = 'c:\\\\users\\\\jens-work\\\\source\\\\repos\\\\qcodes\\\\qcodes\\\\tests\\\\unittest_data/2020-10-04/#036_test_missing_attr_11-50-36'\n",
-      "   <Type> | <array_id> | <array.name> | <array.shape>]\" not supported, storing as string\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Started at 2020-10-04 11:50:36\n",
-      "DataSet:\n",
-      "   location = 'c:\\\\users\\\\jens-work\\\\source\\\\repos\\\\qcodes\\\\qcodes\\\\tests\\\\unittest_data/2020-10-04/#029_MockLoop_hdf5_test_11-50-36'\n",
-      "   <Type>   | <array_id>                        | <array.name>    | <array.shape>\n",
-      "   Setpoint | Loop_writing_test_x_set           | x               | (10,)\n",
-      "   Measured | Loop_writing_test_skewed_parabola | skewed_parabola | (10,)\n",
-      "Finished at 2020-10-04 11:50:36\n",
-      "Started at 2020-10-04 11:50:36\n",
-      "DataSet:\n",
-      "   location = 'c:\\\\users\\\\jens-work\\\\source\\\\repos\\\\qcodes\\\\qcodes\\\\tests\\\\unittest_data/2020-10-04/#030_MockLoop_hdf5_test_11-50-36'\n",
-      "   <Type>   | <array_id>                           | <array.name>    | <array.shape>\n",
-      "   Setpoint | Loop_writing_test_2D_x_set           | x               | (10,)\n",
-      "   Setpoint | Loop_writing_test_2D_y_set           | y               | (10, 10)\n",
-      "   Measured | Loop_writing_test_2D_skewed_parabola | skewed_parabola | (10, 10)\n",
-      "Finished at 2020-10-04 11:50:36\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "ok\n",
-      "\n",
-      "----------------------------------------------------------------------\n",
-      "Ran 18 tests in 0.302s\n",
-      "\n",
-      "OK\n"
-     ]
-    }
-   ],
-   "source": [
-    "from qcodes.utils import helpers\n",
-    "reload(helpers)\n",
-    "reload(hdf5_format)\n",
-    "import unittest\n",
-    "h5fmt = hdf5_format.HDF5Format()\n",
-    "import qcodes.tests.legacy.test_hdf5formatter as tf\n",
-    "reload(tf)\n",
-    "tst = tf.TestHDF5_Format\n",
-    "suite = unittest.defaultTestLoader.loadTestsFromTestCase(tst)\n",
-    "result = unittest.TextTestRunner(verbosity=2).run(suite)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -349,7 +221,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.13"
   },
   "toc": {
    "base_numbering": 1,
@@ -394,10 +266,13 @@
    "window_display": false
   },
   "widgets": {
-   "state": {},
-   "version": "1.1.1"
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
We don't recommend running the tests like this and it creates a dependency on the tests (and pytest) in the docs