### PR TITLE
Update N51x1.py

### DIFF
--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -24,7 +24,7 @@ class N51x1(VisaInstrument):
         # Query the instrument to see what frequency range was purchased
         freq_dict = {'501':1e9, '503':3e9, '506':6e9, '513': 13e9, '520':20e9, '532': 31.8e9, '540': 40e9}
 
-        max_freq = freq_dict[self.ask('*OPT?')]  # TODO: use .split(',') to detect other options
+        max_freq = freq_dict[self.ask('*OPT?').split(',')[0]]
         self.add_parameter('frequency',
                            label='Frequency',
                            get_cmd='SOUR:FREQ?',


### PR DESCRIPTION
The added `.split(',')[0]` helps with model N5183B (where the returned string is, e.g.  '520,UNY,UNW') and does no harm when the returned value is a simple string (e.g. '520').

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
