### PR TITLE
Enable pep 585 and pep 604 using from __future__ import annotations

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,6 +30,9 @@ jobs:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
       UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      # we expect no warnings from Sphinx in 3.10 and above
+      SPHIX_WARNINGS_AS_ERROR: ${{ matrix.python-version == '3.10' }}
+      SPHIX_OPTS: "-v"
     steps:
     - uses: actions/checkout@v3.0.2
       with:
@@ -39,6 +42,10 @@ jobs:
       if: ${{ fromJSON(env.UPLOAD_TO_GHPAGES) }}
     - uses: actions/checkout@v3.0.2
       if: ${{ !fromJSON(env.UPLOAD_TO_GHPAGES) }}
+    - name: set-sphinx-opts
+      run: |
+        echo "SPHIX_OPTS=-W -v" >> $GITHUB_ENV
+      if: ${{ fromJSON(env.SPHIX_WARNINGS_AS_ERROR) }}
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
       if: runner.os == 'Linux'
@@ -70,13 +77,13 @@ jobs:
     - name: Build docs on linux
       run: |
         cd docs
-        export SPHINXOPTS="-W -v"
+        export SPHINXOPTS="${{ env.SPHIX_OPTS }}"
         make html
       if: runner.os == 'Linux'
     - name: Build docs on windows
       run: |
         cd docs
-        $env:SPHINXOPTS = "-W -v"
+        $env:SPHINXOPTS = "${{ env.SPHIX_OPTS }}"
         ./make.bat html
       if: runner.os == 'Windows'
     - name: Upload build docs

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.9, "3.10"]
+        python-version: ["3.7", "3.9", "3.10"]
         exclude:
           - os: windows-latest
             python-version: 3.9
@@ -29,7 +29,7 @@ jobs:
     env:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
-      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      UPLOAD_TO_GHPAGES: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     steps:
     - uses: actions/checkout@v3.0.2
       with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     rev: v2.37.3
     hooks:
     - id: pyupgrade
-      args: ['--py37-plus', '--keep-runtime-typing']
+      args: ['--py37-plus']
   - repo: https://github.com/akaihola/darker
     rev: 1.5.0
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -416,9 +416,8 @@ texinfo_show_urls = 'footnote'
 intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
-    "python": ("https://docs.python.org/3.7/", None),
+    "python": ("https://docs.python.org/3.10/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "py": ("https://pylib.readthedocs.io/en/stable/", None),
     "pyvisa": ("https://pyvisa.readthedocs.io/en/stable/", None),
     "IPython": ("https://ipython.readthedocs.io/en/stable/", None),
 }

--- a/qcodes/calibrations/keithley.py
+++ b/qcodes/calibrations/keithley.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING, Optional, Dict
+from typing import TYPE_CHECKING
 
 from qcodes.instrument import Instrument
 from qcodes.parameters import Parameter
@@ -33,7 +33,7 @@ def calibrate_keithley_smu_v(
     src_Z: float = 1e-30,
     time_delay: float = 3.0,
     save_calibrations: bool = False,
-    dmm_range_per_smu_range_mapping: Optional[Dict[str, float]] = None
+    dmm_range_per_smu_range_mapping: dict[str, float] | None = None,
 ) -> None:
     if dmm_range_per_smu_range_mapping is None:
         dmm_range_per_smu_range_mapping = {

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Dict, Generic, Mapping, Optional, Tuple, TypeVar
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 import numpy as np
 
@@ -48,18 +49,18 @@ class DataSetCache(Generic[DatasetType]):
         self._dataset = dataset
         self._data: ParameterData = {}
         #: number of rows read per parameter tree (by the name of the dependent parameter)
-        self._read_status: Dict[str, int] = {}
+        self._read_status: dict[str, int] = {}
         #: number of rows written per parameter tree (by the name of the dependent parameter)
-        self._write_status: Dict[str, Optional[int]] = {}
+        self._write_status: dict[str, int | None] = {}
         self._loaded_from_completed_ds = False
-        self._live: Optional[bool] = None
+        self._live: bool | None = None
 
     @property
     def rundescriber(self) -> RunDescriber:
         return self._dataset.description
 
     @property
-    def live(self) -> Optional[bool]:
+    def live(self) -> bool | None:
         """
         If true this cache has been produced by appending data as measured.
         If false the data has been read from disk.
@@ -130,7 +131,7 @@ class DataSetCache(Generic[DatasetType]):
         if not all(status is None for status in self._write_status.values()):
             self._live = True
 
-    def to_pandas_dataframe_dict(self) -> Dict[str, pd.DataFrame]:
+    def to_pandas_dataframe_dict(self) -> dict[str, pd.DataFrame]:
         """
         Convert the cached dataset to Pandas dataframes. The returned dataframes
         are in the same format :py:class:`.DataSet.to_pandas_dataframe_dict`.
@@ -155,7 +156,7 @@ class DataSetCache(Generic[DatasetType]):
         return load_to_concatenated_dataframe(data)
 
     @deprecate(alternative="to_pandas_dataframe or to_pandas_dataframe_dict")
-    def to_pandas(self) -> Dict[str, pd.DataFrame]:
+    def to_pandas(self) -> dict[str, pd.DataFrame]:
         """
         Returns the values stored in the :class:`.dataset.data_set.DataSet` as a
         concatenated :py:class:`pandas.DataFrame` s
@@ -175,7 +176,7 @@ class DataSetCache(Generic[DatasetType]):
         """
         return self.to_pandas_dataframe_dict()
 
-    def to_xarray_dataarray_dict(self) -> Dict[str, xr.DataArray]:
+    def to_xarray_dataarray_dict(self) -> dict[str, xr.DataArray]:
         """
         Returns the values stored in the :class:`.dataset.data_set.DataSet` as a dict of
         :py:class:`xr.DataArray` s
@@ -212,10 +213,10 @@ def load_new_data_from_db_and_append(
     conn: ConnectionPlus,
     table_name: str,
     rundescriber: RunDescriber,
-    write_status: Mapping[str, Optional[int]],
+    write_status: Mapping[str, int | None],
     read_status: Mapping[str, int],
     existing_data: Mapping[str, Mapping[str, np.ndarray]],
-) -> Tuple[Dict[str, Optional[int]], Dict[str, int], Dict[str, Dict[str, np.ndarray]]]:
+) -> tuple[dict[str, int | None], dict[str, int], dict[str, dict[str, np.ndarray]]]:
     """
     Append any new data in the db to an already existing datadict and return the merged
     data.
@@ -253,10 +254,10 @@ def load_new_data_from_db_and_append(
 
 def append_shaped_parameter_data_to_existing_arrays(
     rundescriber: RunDescriber,
-    write_status: Mapping[str, Optional[int]],
+    write_status: Mapping[str, int | None],
     existing_data: Mapping[str, Mapping[str, np.ndarray]],
     new_data: Mapping[str, Mapping[str, np.ndarray]],
-) -> Tuple[Dict[str, Optional[int]], Dict[str, Dict[str, np.ndarray]]]:
+) -> tuple[dict[str, int | None], dict[str, dict[str, np.ndarray]]]:
     """
     Append datadict to an already existing datadict and return the merged
     data.
@@ -303,12 +304,13 @@ def append_shaped_parameter_data_to_existing_arrays(
     return updated_write_status, merged_data
 
 
-def _merge_data(existing_data: Mapping[str, np.ndarray],
-                new_data: Mapping[str, np.ndarray],
-                shape: Optional[Tuple[int, ...]],
-                single_tree_write_status: Optional[int],
-                meas_parameter: str,
-                ) -> Tuple[Dict[str, np.ndarray], Optional[int]]:
+def _merge_data(
+    existing_data: Mapping[str, np.ndarray],
+    new_data: Mapping[str, np.ndarray],
+    shape: tuple[int, ...] | None,
+    single_tree_write_status: int | None,
+    meas_parameter: str,
+) -> tuple[dict[str, np.ndarray], int | None]:
 
     subtree_merged_data = {}
     subtree_parameters = existing_data.keys()
@@ -320,7 +322,7 @@ def _merge_data(existing_data: Mapping[str, np.ndarray],
             f"{set(new_data.keys() - existing_data.keys())}"
         )
 
-    new_write_status: Optional[int]
+    new_write_status: int | None
     single_param_merged_data, new_write_status = _merge_data_single_param(
         existing_data.get(meas_parameter),
         new_data.get(meas_parameter),
@@ -346,11 +348,12 @@ def _merge_data(existing_data: Mapping[str, np.ndarray],
 
 
 def _merge_data_single_param(
-        existing_values: Optional[np.ndarray],
-        new_values: Optional[np.ndarray],
-        shape: Optional[Tuple[int, ...]],
-        single_tree_write_status: Optional[int]) -> Tuple[Optional[np.ndarray], Optional[int]]:
-    merged_data: Optional[np.ndarray]
+    existing_values: np.ndarray | None,
+    new_values: np.ndarray | None,
+    shape: tuple[int, ...] | None,
+    single_tree_write_status: int | None,
+) -> tuple[np.ndarray | None, int | None]:
+    merged_data: np.ndarray | None
     if (
         existing_values is not None and existing_values.size != 0
     ) and new_values is not None:
@@ -372,9 +375,9 @@ def _merge_data_single_param(
     return merged_data, new_write_status
 
 
-def _create_new_data_dict(new_values: np.ndarray,
-                          shape: Optional[Tuple[int, ...]]
-                          ) -> Tuple[np.ndarray, int]:
+def _create_new_data_dict(
+    new_values: np.ndarray, shape: tuple[int, ...] | None
+) -> tuple[np.ndarray, int]:
     if shape is None:
         return new_values, new_values.size
     elif new_values.size > 0:
@@ -393,11 +396,11 @@ def _create_new_data_dict(new_values: np.ndarray,
 
 
 def _insert_into_data_dict(
-        existing_values: np.ndarray,
-        new_values: np.ndarray,
-        write_status: Optional[int],
-        shape: Optional[Tuple[int, ...]]
-) -> Tuple[np.ndarray, Optional[int]]:
+    existing_values: np.ndarray,
+    new_values: np.ndarray,
+    write_status: int | None,
+    shape: tuple[int, ...] | None,
+) -> tuple[np.ndarray, int | None]:
     if new_values.size == 0:
         return existing_values, write_status
 
@@ -439,7 +442,7 @@ def _insert_into_data_dict(
 
 def _expand_single_param_dict(
         single_param_dict: Mapping[str, np.ndarray]
-) -> Dict[str, np.ndarray]:
+) -> dict[str, np.ndarray]:
     sizes = {name: array.size for name, array in single_param_dict.items()}
     maxsize = max(sizes.values())
     max_names = tuple(name for name, size in sizes.items() if size == maxsize)

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -6,8 +6,9 @@ import logging
 import os
 import time
 import warnings
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -70,14 +71,14 @@ class DataSetInMem(BaseDataSet):
         exp_name: str,
         sample_name: str,
         guid: str,
-        path_to_db: Optional[str],
-        run_timestamp_raw: Optional[float],
-        completed_timestamp_raw: Optional[float],
-        snapshot: Optional[str] = None,
-        metadata: Optional[Mapping[str, Any]] = None,
-        rundescriber: Optional[RunDescriber] = None,
-        parent_dataset_links: Optional[Sequence[Link]] = None,
-        export_info: Optional[ExportInfo] = None,
+        path_to_db: str | None,
+        run_timestamp_raw: float | None,
+        completed_timestamp_raw: float | None,
+        snapshot: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        rundescriber: RunDescriber | None = None,
+        parent_dataset_links: Sequence[Link] | None = None,
+        export_info: ExportInfo | None = None,
     ) -> None:
         """Note that the constructor is considered private.
 
@@ -120,9 +121,7 @@ class DataSetInMem(BaseDataSet):
         self._metadata["export_info"] = self._export_info.to_str()
         self._snapshot_raw_data = snapshot
 
-    def _dataset_is_in_runs_table(
-        self, path_to_db: Optional[Union[str, Path]] = None
-    ) -> bool:
+    def _dataset_is_in_runs_table(self, path_to_db: str | Path | None = None) -> bool:
         """
         Does this run exist in the given db
 
@@ -136,9 +135,7 @@ class DataSetInMem(BaseDataSet):
             run_id = get_runid_from_guid(conn, self.guid)
         return run_id is not None
 
-    def write_metadata_to_db(
-        self, path_to_db: Optional[Union[str, Path]] = None
-    ) -> None:
+    def write_metadata_to_db(self, path_to_db: str | Path | None = None) -> None:
         from .experiment_container import load_or_create_experiment
 
         if self._dataset_is_in_runs_table(path_to_db=path_to_db):
@@ -163,8 +160,8 @@ class DataSetInMem(BaseDataSet):
     def _create_new_run(
         cls,
         name: str,
-        path_to_db: Optional[Union[Path, str]] = None,
-        exp_id: Optional[int] = None,
+        path_to_db: Path | str | None = None,
+        exp_id: int | None = None,
     ) -> DataSetInMem:
         if path_to_db is not None:
             path_to_db = str(path_to_db)
@@ -203,7 +200,7 @@ class DataSetInMem(BaseDataSet):
 
     @classmethod
     def _load_from_netcdf(
-        cls, path: Union[Path, str], path_to_db: Optional[Union[Path, str]] = None
+        cls, path: Path | str, path_to_db: Path | str | None = None
     ) -> DataSetInMem:
         """
         Create a in memory dataset from a netcdf file.
@@ -334,7 +331,7 @@ class DataSetInMem(BaseDataSet):
         return ds
 
     @classmethod
-    def _set_cache_from_netcdf(cls, ds: DataSetInMem, xr_path: Optional[str]) -> bool:
+    def _set_cache_from_netcdf(cls, ds: DataSetInMem, xr_path: str | None) -> bool:
         import xarray as xr
 
         success = True
@@ -359,7 +356,7 @@ class DataSetInMem(BaseDataSet):
             success = False
         return success
 
-    def set_netcdf_location(self, path: Union[str, Path]) -> None:
+    def set_netcdf_location(self, path: str | Path) -> None:
         """
         Change the location that a DataSetInMem refers to and
         load the raw data into the cache from this location.
@@ -382,8 +379,8 @@ class DataSetInMem(BaseDataSet):
     @staticmethod
     def _from_xarray_dataset_to_qcodes_raw_data(
         xr_data: xr.Dataset,
-    ) -> Dict[str, Dict[str, np.ndarray]]:
-        output: Dict[str, Dict[str, np.ndarray]] = {}
+    ) -> dict[str, dict[str, np.ndarray]]:
+        output: dict[str, dict[str, np.ndarray]] = {}
         for datavar in xr_data.data_vars:
             output[str(datavar)] = {}
             data = xr_data[datavar]
@@ -509,11 +506,11 @@ class DataSetInMem(BaseDataSet):
         return self._sample_name
 
     @property
-    def path_to_db(self) -> Optional[str]:
+    def path_to_db(self) -> str | None:
         return self._path_to_db
 
     @property
-    def run_timestamp_raw(self) -> Optional[float]:
+    def run_timestamp_raw(self) -> float | None:
         """
         Returns run timestamp as number of seconds since the Epoch
 
@@ -523,7 +520,7 @@ class DataSetInMem(BaseDataSet):
         return self._run_timestamp_raw
 
     @property
-    def completed_timestamp_raw(self) -> Optional[float]:
+    def completed_timestamp_raw(self) -> float | None:
         """
         Returns timestamp when measurement run was completed
         as number of seconds since the Epoch
@@ -533,7 +530,7 @@ class DataSetInMem(BaseDataSet):
         return self._completed_timestamp_raw
 
     @property
-    def snapshot(self) -> Optional[Dict[str, Any]]:
+    def snapshot(self) -> dict[str, Any] | None:
         """Snapshot of the run as dictionary (or None)."""
         snapshot_json = self._snapshot_raw
         if snapshot_json is not None:
@@ -559,7 +556,7 @@ class DataSetInMem(BaseDataSet):
             )
 
     @property
-    def _snapshot_raw(self) -> Optional[str]:
+    def _snapshot_raw(self) -> str | None:
         """Snapshot of the run as a JSON-formatted string (or None)."""
         return self._snapshot_raw_data
 
@@ -588,11 +585,11 @@ class DataSetInMem(BaseDataSet):
                     add_data_to_dynamic_columns(aconn, self.run_id, {tag: data})
 
     @property
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         return self._metadata
 
     @property
-    def paramspecs(self) -> Dict[str, ParamSpec]:
+    def paramspecs(self) -> dict[str, ParamSpec]:
         return {ps.name: ps for ps in self._get_paramspecs()}
 
     @property
@@ -600,7 +597,7 @@ class DataSetInMem(BaseDataSet):
         return self._rundescriber
 
     @property
-    def parent_dataset_links(self) -> List[Link]:
+    def parent_dataset_links(self) -> list[Link]:
         """
         Return a list of Link objects. Each Link object describes a link from
         this dataset to one of its parent datasets
@@ -641,7 +638,7 @@ class DataSetInMem(BaseDataSet):
         interdeps = self._rundescriber.interdeps
 
         toplevel_params = set(interdeps.dependencies).intersection(set(result_dict))
-        new_results: Dict[str, Dict[str, np.ndarray]] = {}
+        new_results: dict[str, dict[str, np.ndarray]] = {}
         for toplevel_param in toplevel_params:
             inff_params = set(interdeps.inferences.get(toplevel_param, ()))
             deps_params = set(interdeps.dependencies.get(toplevel_param, ()))
@@ -676,7 +673,7 @@ class DataSetInMem(BaseDataSet):
 
     # not part of the protocol specified api
 
-    def _set_parent_dataset_links(self, links: List[Link]) -> None:
+    def _set_parent_dataset_links(self, links: list[Link]) -> None:
         """
         Assign one or more links to parent datasets to this dataset. It is an
         error to assign links to a non-pristine dataset
@@ -776,7 +773,7 @@ class DataSetInMem(BaseDataSet):
         so the length is represented by the number of all datapoints,
         summing across parameter trees.
         """
-        values: List[int] = []
+        values: list[int] = []
         for sub_dataset in self.cache.data().values():
             subvals = tuple(val.size for val in sub_dataset.values() if val is not None)
             values.extend(subvals)
@@ -799,7 +796,7 @@ class DataSetInMem(BaseDataSet):
         return "\n".join(out)
 
     @property
-    def _parameters(self) -> Optional[str]:
+    def _parameters(self) -> str | None:
         psnames = [ps.name for ps in self.description.interdeps.paramspecs]
         if len(psnames) > 0:
             return ",".join(psnames)
@@ -808,54 +805,54 @@ class DataSetInMem(BaseDataSet):
 
     def to_xarray_dataarray_dict(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
-    ) -> Dict[str, xr.DataArray]:
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> dict[str, xr.DataArray]:
         self._warn_if_set(*params, start=start, end=end)
         return self.cache.to_xarray_dataarray_dict()
 
     def to_xarray_dataset(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
     ) -> xr.Dataset:
         self._warn_if_set(*params, start=start, end=end)
         return self.cache.to_xarray_dataset()
 
     def to_pandas_dataframe_dict(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
-    ) -> Dict[str, pd.DataFrame]:
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> dict[str, pd.DataFrame]:
         self._warn_if_set(*params, start=start, end=end)
         return self.cache.to_pandas_dataframe_dict()
 
     def to_pandas_dataframe(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
     ) -> pd.DataFrame:
         self._warn_if_set(*params, start=start, end=end)
         return self.cache.to_pandas_dataframe()
 
     def get_parameter_data(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
     ) -> ParameterData:
         self._warn_if_set(*params, start=start, end=end)
         return self.cache.data()
 
     @staticmethod
     def _warn_if_set(
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int],
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None,
     ) -> None:
         if len(params) > 0 or start is not None or end is not None:
             warnings.warn(
@@ -866,7 +863,7 @@ class DataSetInMem(BaseDataSet):
 
 
 def load_from_netcdf(
-    path: Union[Path, str], path_to_db: Optional[Union[Path, str]] = None
+    path: Path | str, path_to_db: Path | str | None = None
 ) -> DataSetInMem:
     """
     Create a in memory dataset from a netcdf file.

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -2,19 +2,9 @@ from __future__ import annotations
 
 import os
 import warnings
+from collections.abc import Mapping, Sized
 from enum import Enum
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Sized,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, Sequence, Tuple, Union
 
 import numpy as np
 from typing_extensions import Protocol, TypeAlias, runtime_checkable
@@ -46,6 +36,8 @@ if TYPE_CHECKING:
 
     from .data_set_cache import DataSetCache
 
+# even with from __future__ import annotations
+# type aliases must use the old format until we drop 3.8/3.9
 array_like_types = (tuple, list, np.ndarray)
 scalar_res_types: TypeAlias = Union[
     str, complex, np.integer, np.floating, np.complexfloating
@@ -71,7 +63,7 @@ class DataSetProtocol(Protocol, Sized):
     # the "persistent traits" are the attributes/properties of the DataSet
     # that are NOT tied to the representation of the DataSet in any particular
     # database
-    persistent_traits: Tuple[str, ...] = (
+    persistent_traits: tuple[str, ...] = (
         "name",
         "guid",
         "number_of_results",
@@ -156,46 +148,46 @@ class DataSetProtocol(Protocol, Sized):
     def sample_name(self) -> str:
         pass
 
-    def run_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> Optional[str]:
+    def run_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> str | None:
         pass
 
     @property
-    def run_timestamp_raw(self) -> Optional[float]:
+    def run_timestamp_raw(self) -> float | None:
         pass
 
-    def completed_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> Optional[str]:
+    def completed_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> str | None:
         pass
 
     @property
-    def completed_timestamp_raw(self) -> Optional[float]:
+    def completed_timestamp_raw(self) -> float | None:
         pass
 
     # snapshot and metadata
     @property
-    def snapshot(self) -> Optional[Dict[str, Any]]:
+    def snapshot(self) -> dict[str, Any] | None:
         pass
 
     def add_snapshot(self, snapshot: str, overwrite: bool = False) -> None:
         pass
 
     @property
-    def _snapshot_raw(self) -> Optional[str]:
+    def _snapshot_raw(self) -> str | None:
         pass
 
     def add_metadata(self, tag: str, metadata: Any) -> None:
         pass
 
     @property
-    def metadata(self) -> Dict[str, Any]:
+    def metadata(self) -> dict[str, Any]:
         pass
 
     @property
-    def path_to_db(self) -> Optional[str]:
+    def path_to_db(self) -> str | None:
         pass
 
     # dataset description and links
     @property
-    def paramspecs(self) -> Dict[str, ParamSpec]:
+    def paramspecs(self) -> dict[str, ParamSpec]:
         pass
 
     @property
@@ -203,16 +195,16 @@ class DataSetProtocol(Protocol, Sized):
         pass
 
     @property
-    def parent_dataset_links(self) -> List[Link]:
+    def parent_dataset_links(self) -> list[Link]:
         pass
 
     # data related members
 
     def export(
         self,
-        export_type: Optional[Union[DataExportType, str]] = None,
-        path: Optional[str] = None,
-        prefix: Optional[str] = None,
+        export_type: DataExportType | str | None = None,
+        path: str | None = None,
+        prefix: str | None = None,
     ) -> None:
         pass
 
@@ -226,9 +218,9 @@ class DataSetProtocol(Protocol, Sized):
 
     def get_parameter_data(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
     ) -> ParameterData:
         pass
 
@@ -237,40 +229,40 @@ class DataSetProtocol(Protocol, Sized):
         pass
 
     @property
-    def dependent_parameters(self) -> Tuple[ParamSpecBase, ...]:
+    def dependent_parameters(self) -> tuple[ParamSpecBase, ...]:
         pass
 
     # exporters to other in memory formats
 
     def to_xarray_dataarray_dict(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
-    ) -> Dict[str, xr.DataArray]:
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> dict[str, xr.DataArray]:
         pass
 
     def to_xarray_dataset(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
     ) -> xr.Dataset:
         pass
 
     def to_pandas_dataframe_dict(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
-    ) -> Dict[str, pd.DataFrame]:
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
+    ) -> dict[str, pd.DataFrame]:
         pass
 
     def to_pandas_dataframe(
         self,
-        *params: Union[str, ParamSpec, ParameterBase],
-        start: Optional[int] = None,
-        end: Optional[int] = None,
+        *params: str | ParamSpec | ParameterBase,
+        start: int | None = None,
+        end: int | None = None,
     ) -> pd.DataFrame:
         pass
 
@@ -283,7 +275,7 @@ class DataSetProtocol(Protocol, Sized):
         pass
 
     @property
-    def _parameters(self) -> Optional[str]:
+    def _parameters(self) -> str | None:
         pass
 
     def _set_export_info(self, export_info: ExportInfo) -> None:
@@ -332,9 +324,9 @@ class BaseDataSet(DataSetProtocol):
 
     def export(
         self,
-        export_type: Optional[Union[DataExportType, str]] = None,
-        path: Optional[str] = None,
-        prefix: Optional[str] = None,
+        export_type: DataExportType | str | None = None,
+        path: str | None = None,
+        prefix: str | None = None,
     ) -> None:
         """Export data to disk with file name {prefix}{run_id}.{ext}.
         Values for the export type, path and prefix can also be set in the "dataset"
@@ -378,9 +370,9 @@ class BaseDataSet(DataSetProtocol):
     def _export_data(
         self,
         export_type: DataExportType,
-        path: Optional[str] = None,
-        prefix: Optional[str] = None,
-    ) -> Optional[str]:
+        path: str | None = None,
+        prefix: str | None = None,
+    ) -> str | None:
         """Export data to disk with file name {prefix}{run_id}.{ext}.
 
         Values for the export type, path and prefix can also be set in the qcodes
@@ -460,9 +452,7 @@ class BaseDataSet(DataSetProtocol):
                 )
 
     @staticmethod
-    def _validate_parameters(
-        *params: Union[str, ParamSpec, ParameterBase]
-    ) -> List[str]:
+    def _validate_parameters(*params: str | ParamSpec | ParameterBase) -> list[str]:
         """
         Validate that the provided parameters have a name and return those
         names as a list.
@@ -500,7 +490,7 @@ class BaseDataSet(DataSetProtocol):
             new_data = param_data.ravel()
         return new_data
 
-    def run_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> Optional[str]:
+    def run_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> str | None:
         """
         Returns run timestamp in a human-readable format
 
@@ -512,7 +502,7 @@ class BaseDataSet(DataSetProtocol):
         """
         return raw_time_to_str_time(self.run_timestamp_raw, fmt)
 
-    def completed_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> Optional[str]:
+    def completed_timestamp(self, fmt: str = "%Y-%m-%d %H:%M:%S") -> str | None:
         """
         Returns timestamp when measurement run was completed
         in a human-readable format
@@ -524,7 +514,7 @@ class BaseDataSet(DataSetProtocol):
         return raw_time_to_str_time(self.completed_timestamp_raw, fmt)
 
     @property
-    def dependent_parameters(self) -> Tuple[ParamSpecBase, ...]:
+    def dependent_parameters(self) -> tuple[ParamSpecBase, ...]:
         """
         Return all the parameters that explicitly depend on other parameters
         """

--- a/qcodes/dataset/exporters/export_to_csv.py
+++ b/qcodes/dataset/exporters/export_to_csv.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Mapping, Optional
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -19,7 +20,7 @@ def dataframe_to_csv(
     dfdict: Mapping[str, pd.DataFrame],
     path: str,
     single_file: bool = False,
-    single_file_name: Optional[str] = None,
+    single_file_name: str | None = None,
 ) -> None:
     import pandas as pd
 

--- a/qcodes/dataset/exporters/export_to_pandas.py
+++ b/qcodes/dataset/exporters/export_to_pandas.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Dict, Iterator, Mapping, Union
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
     from qcodes.dataset.data_set import ParameterData
 
 
-def load_to_dataframe_dict(datadict: ParameterData) -> Dict[str, pd.DataFrame]:
+def load_to_dataframe_dict(datadict: ParameterData) -> dict[str, pd.DataFrame]:
     dfs = {}
     for name, subdict in datadict.items():
         index = _generate_pandas_index(subdict)
@@ -37,7 +38,7 @@ def load_to_concatenated_dataframe(datadict: ParameterData) -> pd.DataFrame:
 
 
 def _data_to_dataframe(
-    data: Mapping[str, np.ndarray], index: Union[pd.Index, pd.MultiIndex, None]
+    data: Mapping[str, np.ndarray], index: pd.Index | pd.MultiIndex | None
 ) -> pd.DataFrame:
     import pandas as pd
     if len(data) == 0:
@@ -59,7 +60,7 @@ def _data_to_dataframe(
 
 def _generate_pandas_index(
     data: Mapping[str, np.ndarray]
-) -> Union[pd.Index, pd.MultiIndex, None]:
+) -> pd.Index | pd.MultiIndex | None:
     # the first element in the dict given by parameter_tree is always the dependent
     # parameter and the index is therefore formed from the rest
     import pandas as pd
@@ -93,7 +94,7 @@ def _parameter_data_identical(
 
 def _same_setpoints(datadict: ParameterData) -> bool:
 
-    def _get_setpoints(dd: ParameterData) -> Iterator[Dict[str, np.ndarray]]:
+    def _get_setpoints(dd: ParameterData) -> Iterator[dict[str, np.ndarray]]:
 
         for dep_name, param_dict in dd.items():
             out = {

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -103,7 +103,7 @@ def load_to_xarray_dataset(dataset: DataSetProtocol, data: ParameterData) -> xr.
 
     # Casting Hashable for the key type until python/mypy#1114
     # and python/typing#445 are resolved.
-    xrdataset = xr.Dataset(cast(dict[Hashable, xr.DataArray], data_xrdarray_dict))
+    xrdataset = xr.Dataset(cast("dict[Hashable, xr.DataArray]", data_xrdarray_dict))
 
     _add_param_spec_to_xarray_coords(dataset, xrdataset)
     _add_param_spec_to_xarray_data_vars(dataset, xrdataset)

--- a/qcodes/instrument/delegate/delegate_channel_instrument.py
+++ b/qcodes/instrument/delegate/delegate_channel_instrument.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Mapping, Optional, Sequence
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any
 
 from .delegate_instrument import DelegateInstrument
 
@@ -69,7 +70,7 @@ class DelegateChannelInstrument(DelegateInstrument):
         station: Station,
         channels: str,
         parameters: Mapping[str, Sequence[str]],
-        initial_values: Optional[Mapping[str, Any]] = None,
+        initial_values: Mapping[str, Any] | None = None,
         set_initial_values_on_load: bool = False,
         **kwargs: Any):
         _channels = self.parse_instrument_path(parent=station, path=channels)

--- a/qcodes/instrument/delegate/delegate_instrument.py
+++ b/qcodes/instrument/delegate/delegate_instrument.py
@@ -3,20 +3,9 @@ from __future__ import annotations
 import importlib
 import logging
 from collections import abc
+from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from functools import partial
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    List,
-    Mapping,
-    MutableMapping,
-    Optional,
-    Sequence,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any
 
 from qcodes.parameters import (
     DelegateGroup,
@@ -117,17 +106,13 @@ class DelegateInstrument(InstrumentBase):
         self,
         name: str,
         station: Station,
-        parameters: Optional[
-            Union[Mapping[str, Sequence[str]], Mapping[str, str]]
-        ] = None,
-        channels: Optional[
-            Union[Mapping[str, Mapping[str, Any]], Mapping[str, str]]
-        ] = None,
-        initial_values: Optional[Mapping[str, Any]] = None,
+        parameters: None | (Mapping[str, Sequence[str]] | Mapping[str, str]) = None,
+        channels: None | (Mapping[str, Mapping[str, Any]] | Mapping[str, str]) = None,
+        initial_values: Mapping[str, Any] | None = None,
         set_initial_values_on_load: bool = False,
-        setters: Optional[Mapping[str, MutableMapping[str, Any]]] = None,
-        units: Optional[Mapping[str, str]] = None,
-        metadata: Optional[Mapping[Any, Any]] = None,
+        setters: Mapping[str, MutableMapping[str, Any]] | None = None,
+        units: Mapping[str, str] | None = None,
+        metadata: Mapping[Any, Any] | None = None,
     ):
         super().__init__(name=name, metadata=metadata)
         if parameters is not None:
@@ -150,7 +135,7 @@ class DelegateInstrument(InstrumentBase):
 
     @staticmethod
     def parse_instrument_path(
-        parent: Union[Station, InstrumentBase],
+        parent: Station | InstrumentBase,
         path: str,
     ) -> Any:
         """Parse a string path and return the object relative to a station or
@@ -202,7 +187,7 @@ class DelegateInstrument(InstrumentBase):
     def _create_and_add_parameters(
         self,
         station: Station,
-        parameters: Union[Mapping[str, Sequence[str]], Mapping[str, str]],
+        parameters: Mapping[str, Sequence[str]] | Mapping[str, str],
         setters: Mapping[str, MutableMapping[str, Any]],
         units: Mapping[str, str],
     ) -> None:
@@ -229,7 +214,7 @@ class DelegateInstrument(InstrumentBase):
             )
 
     @staticmethod
-    def _parameter_names(parameters: Sequence[Parameter]) -> List[str]:
+    def _parameter_names(parameters: Sequence[Parameter]) -> list[str]:
         """Get the endpoint names"""
         parameter_names = [_e.name for _e in parameters]
         if len(parameter_names) != len(set(parameter_names)):
@@ -263,10 +248,10 @@ class DelegateInstrument(InstrumentBase):
         group_name: str,
         station: Station,
         paths: Sequence[str],
-        setter: Optional[MutableMapping[str, Any]] = None,
-        getter: Optional[Callable[..., Any]] = None,
-        formatter: Optional[Callable[..., Any]] = None,
-        unit: Optional[str] = None,
+        setter: MutableMapping[str, Any] | None = None,
+        getter: Callable[..., Any] | None = None,
+        formatter: Callable[..., Any] | None = None,
+        unit: str | None = None,
         **kwargs: Any
     ) -> None:
         """Create delegate parameter that links to a given set of paths
@@ -308,11 +293,11 @@ class DelegateInstrument(InstrumentBase):
     def _create_and_add_channels(
         self,
         station: Station,
-        channels: Mapping[str, Union[str, Mapping[str, Any]]],
+        channels: Mapping[str, str | Mapping[str, Any]],
     ) -> None:
         """Add channels to the instrument."""
         channel_wrapper = None
-        chnnls_dict: Dict[str, Union[str, Mapping[str, Any]]] = dict(channels)
+        chnnls_dict: dict[str, str | Mapping[str, Any]] = dict(channels)
         channel_type_global = chnnls_dict.pop("type", None)
         if channel_type_global is not None and \
            not isinstance(channel_type_global, str):
@@ -346,8 +331,8 @@ class DelegateInstrument(InstrumentBase):
         self,
         channel_name: str,
         station: Station,
-        input_params: Union[str, Mapping[str, Any]],
-        channel_wrapper: Optional[Type[InstrumentChannel]],
+        input_params: str | Mapping[str, Any],
+        channel_wrapper: type[InstrumentChannel] | None,
         **kwargs: Any,
     ) -> None:
         """Adds a channel to the instrument."""
@@ -385,8 +370,8 @@ class DelegateInstrument(InstrumentBase):
 
 
 def _get_channel_wrapper_class(
-    channel_type: Optional[str],
-) -> Optional[Type[InstrumentChannel]]:
+    channel_type: str | None,
+) -> type[InstrumentChannel] | None:
     """Get channel class from string specified in yaml."""
     if channel_type is None:
         return None

--- a/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
+++ b/qcodes/instrument_drivers/AlazarTech/dll_wrapper.py
@@ -11,19 +11,10 @@ import concurrent
 import concurrent.futures
 import ctypes
 import logging
+from collections.abc import Callable, Sequence
 from functools import partial
 from threading import Lock
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    NamedTuple,
-    NewType,
-    Sequence,
-    Tuple,
-    TypeVar,
-)
+from typing import Any, NamedTuple, NewType, TypeVar
 from weakref import WeakValueDictionary
 
 from qcodes.parameters import ParameterBase
@@ -52,8 +43,8 @@ def _api_call_task(
     return retval
 
 
-def _normalize_params(*args: T) -> List[T]:
-    args_out: List[T] = []
+def _normalize_params(*args: T) -> list[T]:
+    args_out: list[T] = []
     for arg in args:
         if isinstance(arg, ParameterBase):
             args_out.append(arg.raw_value)
@@ -69,10 +60,8 @@ def _mark_params_as_updated(*args: Any) -> None:
 
 
 def _check_error_code(
-        return_code: int,
-        func: Callable[..., Any],
-        arguments: Tuple[Any, ...]
-) -> Tuple[Any, ...]:
+    return_code: int, func: Callable[..., Any], arguments: tuple[Any, ...]
+) -> tuple[Any, ...]:
     if (return_code != API_SUCCESS) and (return_code != API_DMA_IN_PROGRESS):
         argrepr = repr(arguments)
         if len(argrepr) > 100:
@@ -96,9 +85,7 @@ def _check_error_code(
 
 
 def _convert_bytes_to_str(
-        output: bytes,
-        func: Callable[..., Any],
-        arguments: Tuple[Any, ...]
+    output: bytes, func: Callable[..., Any], arguments: tuple[Any, ...]
 ) -> str:
     return output.decode()
 
@@ -168,7 +155,7 @@ class WrappedDll(metaclass=DllWrapperMeta):
         dll_path: Path to the DLL library to load and wrap
     """
 
-    signatures: Dict[str, Signature] = {}
+    signatures: dict[str, Signature] = {}
     """
     Signatures for loaded DLL functions;
     It is to be filled with :class:`Signature` instances for the DLL

--- a/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any
 
 from qcodes.instrument import ChannelList, Instrument, InstrumentChannel
 from qcodes.validators import Ints
@@ -32,7 +32,7 @@ class SwitchChannelBase(InstrumentChannel):
             get_cmd=self._get_switch,
             vals=Ints(1, 2))
 
-    def __call__(self, *args: int) -> Optional[int]:
+    def __call__(self, *args: int) -> int | None:
         if len(args) == 1:
             self.switch(args[0])
             return None
@@ -58,7 +58,7 @@ class SPDT_Base(Instrument):
             self, "Channels", self.CHANNEL_CLASS, snapshotable=False)
 
         _chanlist = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
-        self._deprecated_attributes: Dict[str, str] = {
+        self._deprecated_attributes: dict[str, str] = {
             f'channel_{k}': k
             for k in _chanlist
         }

--- a/qcodes/interactive_widget.py
+++ b/qcodes/interactive_widget.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 import io
 import operator
 import traceback
+from collections.abc import Callable, Iterable, Sequence
 from datetime import datetime
 from functools import partial, reduce
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Sequence
+from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 from IPython.display import clear_output, display
@@ -39,18 +40,18 @@ if TYPE_CHECKING:
 _META_DATA_KEY = "widget_notes"
 
 
-def _get_in(nested_keys: Sequence[str], dct: Dict[str, Any]) -> Dict[str, Any]:
+def _get_in(nested_keys: Sequence[str], dct: dict[str, Any]) -> dict[str, Any]:
     """ Returns dct[i0][i1]...[iX] where [i0, i1, ..., iX]==nested_keys."""
     return reduce(operator.getitem, nested_keys, dct)
 
 
 def button(
     description: str,
-    button_style: Optional[str] = None,
-    on_click: Optional[Callable[[Any], None]] = None,
-    tooltip: Optional[str] = None,
-    layout_kwargs: Optional[Dict[str, Any]] = None,
-    button_kwargs: Optional[Dict[str, Any]] = None,
+    button_style: str | None = None,
+    on_click: Callable[[Any], None] | None = None,
+    tooltip: str | None = None,
+    layout_kwargs: dict[str, Any] | None = None,
+    button_kwargs: dict[str, Any] | None = None,
 ) -> Button:
     """Returns a `ipywidgets.Button`."""
     layout_kwargs = layout_kwargs or {}
@@ -117,7 +118,7 @@ def label(description: str) -> Label:
 
 
 def _update_nested_dict_browser(
-    nested_keys: Sequence[str], nested_dict: Dict[Any, Any], box: Box
+    nested_keys: Sequence[str], nested_dict: dict[Any, Any], box: Box
 ) -> Callable[[Button], None]:
     def update_box(_: Button) -> None:
         box.children = (_nested_dict_browser(nested_keys, nested_dict, box),)
@@ -127,7 +128,7 @@ def _update_nested_dict_browser(
 
 def _nested_dict_browser(
     nested_keys: Sequence[str],
-    nested_dict: Dict[Any, Any],
+    nested_dict: dict[Any, Any],
     box: Box,
     max_nrows: int = 30,
 ) -> GridspecLayout:
@@ -207,7 +208,7 @@ def _nested_dict_browser(
 
 
 def nested_dict_browser(
-    nested_dict: Dict[Any, Any], nested_keys: Sequence[str] = ()
+    nested_dict: dict[Any, Any], nested_keys: Sequence[str] = ()
 ) -> Box:
     """Returns a widget to interactive browse a nested dictionary."""
     box = Box([])
@@ -348,17 +349,17 @@ def editable_metadata(ds: DataSetProtocol) -> Box:
     return box
 
 
-def _yaml_dump(dct: Dict[str, Any]) -> str:
+def _yaml_dump(dct: dict[str, Any]) -> str:
     with io.StringIO() as f:
         YAML().dump(dct, f)
         return f.getvalue()
 
 
-def _get_parameters(ds: DataSetProtocol) -> Dict[str, Dict[str, Any]]:
+def _get_parameters(ds: DataSetProtocol) -> dict[str, dict[str, Any]]:
     independent = {}
     dependent = {}
 
-    def _get_attr(p: ParamSpecBase) -> Dict[str, Any]:
+    def _get_attr(p: ParamSpecBase) -> dict[str, Any]:
         return {
             "unit": p.unit,
             "label": p.label,
@@ -491,10 +492,10 @@ def _experiment_widget(
 
 
 def experiments_widget(
-    db: Optional[str] = None,
-    data_sets: Optional[Sequence[DataSetProtocol]] = None,
+    db: str | None = None,
+    data_sets: Sequence[DataSetProtocol] | None = None,
     *,
-    sort_by: Optional[Literal["timestamp", "run_id"]] = "run_id",
+    sort_by: Literal["timestamp", "run_id"] | None = "run_id",
 ) -> VBox:
     r"""Displays an interactive widget that shows the :func:`qcodes.dataset.experiments`.
 

--- a/qcodes/parameters/cache.py
+++ b/qcodes/parameters/cache.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from typing_extensions import Protocol
 
@@ -21,11 +21,11 @@ class _CacheProtocol(Protocol):
         ...
 
     @property
-    def timestamp(self) -> Optional[datetime]:
+    def timestamp(self) -> datetime | None:
         ...
 
     @property
-    def max_val_age(self) -> Optional[float]:
+    def max_val_age(self) -> float | None:
         ...
 
     @property
@@ -49,7 +49,7 @@ class _CacheProtocol(Protocol):
         *,
         value: ParamDataType,
         raw_value: ParamRawDataType,
-        timestamp: Optional[datetime] = None,
+        timestamp: datetime | None = None,
     ) -> None:
         ...
 
@@ -76,11 +76,11 @@ class _Cache:
             that does not have a get function.
     """
 
-    def __init__(self, parameter: ParameterBase, max_val_age: Optional[float] = None):
+    def __init__(self, parameter: ParameterBase, max_val_age: float | None = None):
         self._parameter = parameter
         self._value: ParamDataType = None
         self._raw_value: ParamRawDataType = None
-        self._timestamp: Optional[datetime] = None
+        self._timestamp: datetime | None = None
         self._max_val_age = max_val_age
         self._marked_valid: bool = False
 
@@ -90,7 +90,7 @@ class _Cache:
         return self._raw_value
 
     @property
-    def timestamp(self) -> Optional[datetime]:
+    def timestamp(self) -> datetime | None:
         """
         Timestamp of the moment when cache was last updated
 
@@ -100,7 +100,7 @@ class _Cache:
         return self._timestamp
 
     @property
-    def max_val_age(self) -> Optional[float]:
+    def max_val_age(self) -> float | None:
         """
         Max time (in seconds) to trust a value stored in cache. If the
         parameter has not been set or measured more recently than this,
@@ -157,7 +157,7 @@ class _Cache:
         *,
         value: ParamDataType,
         raw_value: ParamRawDataType,
-        timestamp: Optional[datetime] = None,
+        timestamp: datetime | None = None,
     ) -> None:
         """
         Simply overwrites the value, raw value, and timestamp in this cache

--- a/qcodes/parameters/multi_channel_instrument_parameter.py
+++ b/qcodes/parameters/multi_channel_instrument_parameter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, Sequence, Tuple, TypeVar
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from .multi_parameter import MultiParameter
 from .parameter_base import ParamRawDataType
@@ -35,7 +36,7 @@ class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleTy
         self._channels = channels
         self._param_name = param_name
 
-    def get_raw(self) -> Tuple[ParamRawDataType, ...]:
+    def get_raw(self) -> tuple[ParamRawDataType, ...]:
         """
         Return a tuple containing the data from each of the channels in the
         list.
@@ -54,7 +55,7 @@ class MultiChannelInstrumentParameter(MultiParameter, Generic[InstrumentModuleTy
             getattr(chan, self._param_name).set(value)
 
     @property
-    def full_names(self) -> Tuple[str, ...]:
+    def full_names(self) -> tuple[str, ...]:
         """
         Overwrite full_names because the instrument name is already included
         in the name. This happens because the instrument name is included in


### PR DESCRIPTION
This enables the new style type annotations in pep851 and pep604. Since these things are not supported for python <3.10
this only works in files that uses `from __future__ import annotations` I imagine that if we do this we would gradually add that to all files after this is merged. The actual transforms are done by pyupgrade by removing `--keep-runtime-typing` from the options

 One drawback is that the new syntax still cannot be used in Type aliases. 

Another issue is that this does not build docs without warnings for python <3.10 
I have therefor changed the build to upload from 3.10 build and allow sphinx warnings for python < 3.10

See [pep 585](https://peps.python.org/pep-0585/) and [pep 604](https://peps.python.org/pep-0604/) for more context. 