### PR TITLE
do_nd: save plot with 'tight' bbox

### DIFF
--- a/docs/changes/newsfragments/4360.improved
+++ b/docs/changes/newsfragments/4360.improved
@@ -1,0 +1,2 @@
+do_nd: save plot with 'tight' bbox to prevent tick marks with long labels
+pusing out the axis label out of the canvas window and not visible

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -340,10 +340,10 @@ def plot_and_save_image(
     for i, ax in enumerate(axes):
         if save_pdf:
             full_path = os.path.join(pdf_dif, f"{dataid}_{i}.pdf")
-            ax.figure.savefig(full_path, dpi=500, bbox_inches='tight')
+            ax.figure.savefig(full_path, dpi=500, bbox_inches="tight")
         if save_png:
             full_path = os.path.join(png_dir, f"{dataid}_{i}.png")
-            ax.figure.savefig(full_path, dpi=500, bbox_inches='tight')
+            ax.figure.savefig(full_path, dpi=500, bbox_inches="tight")
     res = data, axes, cbs
     return res
 

--- a/qcodes/dataset/plotting.py
+++ b/qcodes/dataset/plotting.py
@@ -340,10 +340,10 @@ def plot_and_save_image(
     for i, ax in enumerate(axes):
         if save_pdf:
             full_path = os.path.join(pdf_dif, f"{dataid}_{i}.pdf")
-            ax.figure.savefig(full_path, dpi=500)
+            ax.figure.savefig(full_path, dpi=500, bbox_inches='tight')
         if save_png:
             full_path = os.path.join(png_dir, f"{dataid}_{i}.png")
-            ax.figure.savefig(full_path, dpi=500)
+            ax.figure.savefig(full_path, dpi=500, bbox_inches='tight')
     res = data, axes, cbs
     return res
 


### PR DESCRIPTION
For tick marks with long labels sometimes the axis label gets pushed out of the canvas window and not visible in the saved png files. Add argument with tight fitting of bbox for matplotlib savefig to ensure full figure with all labels is included in the saved png.