### PR TITLE
migrate setuptools pep621 config to pyproject.toml

### DIFF
--- a/.github/workflows/pytest-min-versions.yaml
+++ b/.github/workflows/pytest-min-versions.yaml
@@ -45,6 +45,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.python-version }}-pip-
     - name: generate min_requirements.txt
+#     Use fork of requirements-builder until official version
+#     has support for pyproject.toml (pep621)
       run: |
         pip install git+https://github.com/jenshnielsen/requirements-builder.git
         pip install versioningit

--- a/.github/workflows/pytest-min-versions.yaml
+++ b/.github/workflows/pytest-min-versions.yaml
@@ -46,7 +46,7 @@ jobs:
           ${{ runner.os }}-${{ matrix.python-version }}-pip-
     - name: generate min_requirements.txt
       run: |
-        pip install requirements-builder
+        pip install git+https://github.com/jenshnielsen/requirements-builder.git
         pip install versioningit
         requirements-builder -l min -e test setup.py -o min_requirements.txt
     - name: install min_requirements.txt

--- a/docs/changes/newsfragments/4382.breaking
+++ b/docs/changes/newsfragments/4382.breaking
@@ -1,0 +1,4 @@
+The standard metadata as defined by pep621 has moved from setup.cfg
+to pyproject.toml. This should have no user facing consequences unless
+you install qcodes from source using a very old version of pip (<19)
+or use unusual pip configurations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,95 @@
 [build-system]
 requires = [
-    "setuptools >= 56.0",
+    "setuptools >= 61.0",
     "wheel >= 0.29.0",
     "versioningit ~= 1.1.0",
 ]
 build-backend = 'setuptools.build_meta'
+
+[project]
+name = "qcodes"
+maintainers = [{name = "QCoDeS Core Developers", email = "qcodes-support@microsoft.com"}]
+description = "Python-based data acquisition framework developed by the Copenhagen / Delft / Sydney / Microsoft quantum computing consortium"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: Scientific/Engineering",
+]
+license = {text = "MIT"}
+requires-python = ">=3.7"
+dependencies = [
+    "numpy>=1.17.0",
+    "pyvisa>=1.11.0, <1.12.0",
+    "h5py>=3.0.0",
+    "websockets>=7.0",
+    "jsonschema>=3.0.0",
+    "ruamel.yaml>=0.16.0,!=0.16.6",
+    "wrapt>=1.10.4",
+    "pandas>=1.0.0",
+    "xarray>=0.18.0",
+    "tabulate>=0.8.0",
+    "tqdm>=4.32.2",
+    "opencensus>=0.7.10",
+    "opencensus-ext-azure>=1.0.4, <2.0.0",
+    "matplotlib>=3.3.0",
+    "importlib-metadata>=3.6.0,<5.0.0; python_version < '3.10'",
+    "importlib-resources>=2.0.0; python_version < '3.9'",
+    "typing_extensions>=3.10.0",
+    "packaging>=20.0",
+    "ipywidgets>=7.5.0,<8.0.0",
+    "broadbean>=0.9.1",
+    "uncertainties>=3.1.4",
+    "h5netcdf>=0.10.0,!=0.14.0",
+    # see https://github.com/h5netcdf/h5netcdf/issues/154
+    "versioningit>=1.1.0",
+    # transitive dependencies. We list these explicitly to",
+    # ensure that we always use versions that do not have",
+    # known security vulnerabilities",
+    "ipython>=7.31.1,!=8.0.0",
+    "pillow>=9.0.0",
+    "rsa>=4.7",
+]
+
+dynamic = ["version"]
+
+[project.readme]
+file = "README.rst"
+content-type = "text/x-rst"
+
+[project.urls]
+Homepage = "https://github.com/QCoDeS/Qcodes"
+Documentation = "https://qcodes.github.io/Qcodes/"
+Source = "https://github.com/qcodes/qcodes"
+Tracker = "https://github.com/QCoDeS/Qcodes/issues"
+Changelog = "https://qcodes.github.io/Qcodes/changes/index.html"
+
+[project.optional-dependencies]
+qtplot = ["pyqtgraph>=0.11.0"]
+slack = ["slack-sdk>=3.4.2"]
+zurichinstruments = ["zhinst-qcodes>=0.3"]
+test = [
+    "pytest>=6.0.0",
+    "PyVisa-sim>=0.4.0",
+    "hypothesis>=5.49.0",
+    "pytest-xdist>=2.0.0",
+    "deepdiff>=5.0.2",
+    "pytest-mock>=3.0.0",
+    "pytest-rerunfailures>=5.0.0",
+    "lxml>=4.3.0",
+    "types_requests>=0.1.8",
+    "types-setuptools>=57.0.0",
+    "types-tabulate>=0.1.0",
+    "Sphinx>=4.1.2",
+]
+
+[project.scripts]
+qcodes-monitor = "qcodes.monitor.monitor:main"
 
 [tool.coverage.run]
 omit = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,63 +1,6 @@
-[metadata]
-name = qcodes
-maintainer = QCoDeS Core Developers
-maintainer_email = qcodes-support@microsoft.com
-description = Python-based data acquisition framework developed by the Copenhagen / Delft / Sydney / Microsoft quantum computing consortium
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-url = https://github.com/QCoDeS/Qcodes
-classifiers =
-    Development Status :: 3 - Alpha
-    Intended Audience :: Science/Research
-    License :: OSI Approved :: MIT License
-    Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
-    Topic :: Scientific/Engineering
-license = MIT
-project_urls =
-    Documentation = https://qcodes.github.io/Qcodes/
-    Source = https://github.com/qcodes/qcodes
-    Tracker = https://github.com/QCoDeS/Qcodes/issues
-    Changelog = https://qcodes.github.io/Qcodes/changes/index.html
-
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
-install_requires =
-   numpy>=1.17.0
-   pyvisa>=1.11.0, <1.12.0
-   h5py>=3.0.0
-   websockets>=7.0
-   jsonschema>=3.0.0
-   ruamel.yaml>=0.16.0,!=0.16.6
-   wrapt>=1.10.4
-   pandas>=1.0.0
-   xarray>=0.18.0
-   tabulate>=0.8.0
-   tqdm>=4.32.2
-   opencensus>=0.7.10
-   opencensus-ext-azure>=1.0.4, <2.0.0
-   matplotlib>=3.3.0
-   importlib-metadata>=3.6.0,<5.0.0; python_version < '3.10'
-   importlib-resources>=2.0.0; python_version < '3.9'
-   typing_extensions>=3.10.0
-   packaging>=20.0
-   ipywidgets>=7.5.0,<8.0.0
-   broadbean>=0.9.1
-   uncertainties>=3.1.4
-   h5netcdf>=0.10.0,!=0.14.0
-; see   https://github.com/h5netcdf/h5netcdf/issues/154
-   versioningit>=1.1.1
-;  transitive dependencies. We list these explicitly to
-;  ensure that we always use versions that do not have
-;  known security vulnerabilities
-   ipython>=7.31.1,!=8.0.0
-   pillow>=9.0.0
-   rsa>=4.7
 
 [options.package_data]
 qcodes =
@@ -72,24 +15,3 @@ qcodes =
     py.typed
     dist/schemas/*
     dist/tests/station/*
-
-[options.extras_require]
-QtPlot = pyqtgraph>=0.11.0
-Slack = slack-sdk>=3.4.2
-ZurichInstruments = zhinst-qcodes>=0.3
-test =
-    pytest>=6.0.0
-    PyVisa-sim>=0.4.0
-    hypothesis>=5.49.0
-    pytest-xdist>=2.0.0
-    deepdiff>=5.0.2
-    pytest-mock>=3.0.0
-    pytest-rerunfailures>=5.0.0
-    lxml>=4.3.0
-    types_requests>=0.1.8
-    types-tabulate>=0.1.0
-    Sphinx>=4.1.2
-
-[options.entry_points]
-console_scripts =
-    qcodes-monitor = qcodes.monitor.monitor:main

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+# note that only setuptools specific configuration is
+# in this file. Std configuration as defined by pep621
+# and configuration for other tools goes into pyproject.toml
+
 [options]
 zip_safe = False
 packages = find:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,15 @@ if int(setuptools.__version__.split(".")[0]) < 61:
         "At least setuptools 61 is required to install qcodes from source"
     )
 
+try:
+    import pip
+
+    if int(pip.__version__.split(".")[0]) < 19:
+        raise RuntimeError("At least pip 19 is required to install qcodes from source")
+except ImportError:
+    # we are not being executed from pip so pip version is not important
+    pass
+
 if __name__ == "__main__":
     setup(
         cmdclass=get_cmdclasses(),

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,11 @@ import setuptools
 from setuptools import setup
 from versioningit import get_cmdclasses
 
+# this file does not contain configuration
+# std configuration as defined by pep621
+# is in pyproject.toml
+# and setuptools specific config in setup.cfg
+
 if int(setuptools.__version__.split(".")[0]) < 61:
     raise RuntimeError(
         "At least setuptools 61 is required to install qcodes from source"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
+import setuptools
 from setuptools import setup
 from versioningit import get_cmdclasses
+
+if int(setuptools.__version__.split(".")[0]) < 61:
+    raise RuntimeError(
+        "At least setuptools 61 is required to install qcodes from source"
+    )
 
 if __name__ == "__main__":
     setup(


### PR DESCRIPTION
This moves the supported and non experimental
parts of setuptools config to pyproject.toml
These are the parts standardized by pep621 and
supported in setuptools >=65 

These are the supported parts of https://github.com/QCoDeS/Qcodes/pull/4049

- [x] Verify how this works with older versions of pip and make sure we handle that reasonably
- [x] Check that editable/normal install from source works as expected
- [x] Verify that package content is identical
- [x] requirements-builder does not yet support this so out min requirements build fails: Pr open here https://github.com/inveniosoftware/requirements-builder/pull/56
