### PR TITLE
feature: replace __del__ with weakref.finalize()

### DIFF
--- a/qcodes/instrument/instrument.py
+++ b/qcodes/instrument/instrument.py
@@ -69,6 +69,7 @@ class Instrument(InstrumentBase, metaclass=InstrumentMeta):
         super().__init__(name=name, metadata=metadata, label=label)
 
         self.add_parameter("IDN", get_cmd=self.get_idn, vals=Anything())
+        weakref.finalize(self, self.__finalize)
 
     def get_idn(self) -> dict[str, str | None]:
         """
@@ -143,7 +144,7 @@ class Instrument(InstrumentBase, metaclass=InstrumentMeta):
         """Simplified repr giving just the class and name."""
         return f"<{type(self).__name__}: {self.name}>"
 
-    def __del__(self) -> None:
+    def __finalize(self) -> None:
         """Close the instrument and remove its instance record."""
         try:
             self.close()


### PR DESCRIPTION
Feature addition: replacing __del__ with weakref.finalize() as called method during object garbage collection.

Issue: #3774 

- renamed `__del__` as `__finalize`, logic stays the same. 
- added weakref.finalize() in `__init__` in instrument.py calling upon '__finalize()' during gc. 
 