### PR TITLE
Document correct signature for Instruments

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,9 +33,13 @@ from packaging.version import parse
 # rather than `__init__` that is unhelpful
 # for instruments. When building the docs
 # we patch it back to ABCMeta
+# this should happen as early as possible
 import qcodes.instrument.instrument_meta
 
 qcodes.instrument.instrument_meta.InstrumentMeta = ABCMeta
+# we need to reload any module that has been imported and
+# makes use of this metaclass. The modules below are all imported
+# by importing qcodes.instrument so we need to reload them
 reload(qcodes.instrument.instrument)
 reload(qcodes.instrument.ip)
 reload(qcodes.instrument.visa)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,8 @@
 #
 import os
 import sys
+from abc import ABCMeta
+from importlib import reload
 
 # Import matplotlib and set the backend
 # before qcodes imports pyplot and automatically
@@ -25,6 +27,19 @@ import sys
 import matplotlib
 import sphinx_rtd_theme
 from packaging.version import parse
+
+# setting the metaclass will cause sphinx
+# to document the signature of `__call__`
+# rather than `__init__` that is unhelpful
+# for instruments. When building the docs
+# we patch it back to ABCMeta
+import qcodes.instrument.instrument_meta
+
+qcodes.instrument.instrument_meta.InstrumentMeta = ABCMeta
+reload(qcodes.instrument.instrument)
+reload(qcodes.instrument.ip)
+reload(qcodes.instrument.visa)
+reload(qcodes.instrument)
 
 import qcodes
 

--- a/qcodes/instrument/instrument.py
+++ b/qcodes/instrument/instrument.py
@@ -2,7 +2,6 @@
 import logging
 import time
 import weakref
-from abc import ABCMeta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,54 +19,14 @@ from typing_extensions import Protocol
 from qcodes.utils import strip_attrs
 from qcodes.validators import Anything
 
+from .instrument_base import InstrumentBase
+from .instrument_meta import InstrumentMeta
+
 if TYPE_CHECKING:
     from qcodes.logger.instrument_logger import InstrumentLoggerAdapter
 
-from .instrument_base import InstrumentBase
 
 log = logging.getLogger(__name__)
-
-
-class InstrumentMeta(ABCMeta):
-    """
-    Metaclass used to customize Instrument creation. We want to register the
-    instance iff __init__ successfully runs, however we can only do this if
-    we customize the instance initialization process, otherwise there is no
-    way to run `register_instance` after `__init__` but before the created
-    instance is returned to the caller.
-
-    Instead we use the fact that `__new__` and `__init__` are called inside
-    `type.__call__`
-    (https://github.com/python/cpython/blob/main/Objects/typeobject.c#L1077,
-    https://github.com/python/typeshed/blob/master/stdlib/builtins.pyi#L156)
-    which we will overload to insert our own custom code AFTER `__init__` is
-    complete. Note this is part of the spec and will work in alternate python
-    implementations like pypy too.
-
-    We inherit from ABCMeta rather than type for backwards compatibility
-    reasons. There may be instrument interfaces that are defined in
-    terms of an ABC. Inheriting directly from type here would then give
-    `TypeError: metaclass conflict: the metaclass of a derived class must
-    be a (non-strict) subclass of the metaclasses of all its bases`
-    for a class that inherits from ABC
-    """
-
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
-        """
-        Overloads `type.__call__` to add code that runs only if __init__ completes
-        successfully.
-        """
-        new_inst = super().__call__(*args, **kwargs)
-        is_abstract = new_inst._is_abstract()
-        if is_abstract:
-            new_inst.close()
-            raise NotImplementedError(
-                f"{new_inst} has un-implemented Abstract Parameter "
-                f"and cannot be initialized"
-            )
-
-        new_inst.record_instance(new_inst)
-        return new_inst
 
 
 class InstrumentProtocol(Protocol):

--- a/qcodes/instrument/instrument_meta.py
+++ b/qcodes/instrument/instrument_meta.py
@@ -1,0 +1,44 @@
+from abc import ABCMeta
+from typing import Any
+
+
+class InstrumentMeta(ABCMeta):
+    """
+    Metaclass used to customize Instrument creation. We want to register the
+    instance iff __init__ successfully runs, however we can only do this if
+    we customize the instance initialization process, otherwise there is no
+    way to run `register_instance` after `__init__` but before the created
+    instance is returned to the caller.
+
+    Instead we use the fact that `__new__` and `__init__` are called inside
+    `type.__call__`
+    (https://github.com/python/cpython/blob/main/Objects/typeobject.c#L1077,
+    https://github.com/python/typeshed/blob/master/stdlib/builtins.pyi#L156)
+    which we will overload to insert our own custom code AFTER `__init__` is
+    complete. Note this is part of the spec and will work in alternate python
+    implementations like pypy too.
+
+    We inherit from ABCMeta rather than type for backwards compatibility
+    reasons. There may be instrument interfaces that are defined in
+    terms of an ABC. Inheriting directly from type here would then give
+    `TypeError: metaclass conflict: the metaclass of a derived class must
+    be a (non-strict) subclass of the metaclasses of all its bases`
+    for a class that inherits from ABC
+    """
+
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+        """
+        Overloads `type.__call__` to add code that runs only if __init__ completes
+        successfully.
+        """
+        new_inst = super().__call__(*args, **kwargs)
+        is_abstract = new_inst._is_abstract()
+        if is_abstract:
+            new_inst.close()
+            raise NotImplementedError(
+                f"{new_inst} has un-implemented Abstract Parameter "
+                f"and cannot be initialized"
+            )
+
+        new_inst.record_instance(new_inst)
+        return new_inst

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -51,7 +51,7 @@ class VisaInstrument(Instrument):
         self,
         name: str,
         address: str,
-        timeout: Union[int, float] = 5,
+        timeout: float = 5,
         terminator: Optional[str] = None,
         device_clear: bool = True,
         visalib: Optional[str] = None,


### PR DESCRIPTION
Fixes #4370 by not using custom metaclass when documenting to work around sphinx documenting __call__ rather than __init__

This feels like a bit of a hack so not sure if its ok. Inspired by https://stackoverflow.com/questions/20843737/check-if-sphinx-doc-called-the-script
