### PR TITLE
Upgrade versioningit to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools >= 61.0",
     "wheel >= 0.29.0",
-    "versioningit ~= 1.1.0",
+    "versioningit ~= 2.0.0",
 ]
 build-backend = 'setuptools.build_meta'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,6 +87,7 @@ traitlets~=5.3.0
 typing-extensions~=4.3.0
 uncertainties~=3.1.7
 urllib3~=1.26.10
+versioningit~=2.0.0
 wcwidth~=0.2.5
 webencodings~=0.5.1
 websockets~=10.3


### PR DESCRIPTION
I manually verified that
* both sdist and bdist have correct version both in metadata and _version.py
* pip install gives the correct version (including ``qcodes.__verison__`` from editable)
