### PR TITLE
Remove unused shared_kwargs attribute from instrument

### DIFF
--- a/docs/changes/newsfragments/4427.breaking
+++ b/docs/changes/newsfragments/4427.breaking
@@ -1,0 +1,1 @@
+The unused attribute shared_kwargs on the ``Instrument`` class has been removed.

--- a/qcodes/instrument/instrument.py
+++ b/qcodes/instrument/instrument.py
@@ -57,8 +57,6 @@ class Instrument(InstrumentBase, metaclass=InstrumentMeta):
 
     """
 
-    shared_kwargs = ()
-
     _all_instruments: "weakref.WeakValueDictionary[str, Instrument]" = (
         weakref.WeakValueDictionary()
     )


### PR DESCRIPTION
This was part of the long gone instrument server and is completely unused within qcodes. 