### PR TITLE
Update Stanford drivers to conform to docs standard

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -28,7 +28,8 @@ genapi:
 	sphinx-apidoc  -o  _auto  -d 10 ../qcodes \
 		../qcodes/instrument_drivers/AimTTi \
 		../qcodes/instrument_drivers/keysight \
-		../qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/*
+		../qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/* \
+		../qcodes/instrument_drivers/stanford_research/*
 	mkdir -p api/generated/
 	cp _auto/qcodes.instrument_drivers.* api/generated/
 

--- a/docs/drivers_api/srs.rst
+++ b/docs/drivers_api/srs.rst
@@ -1,0 +1,7 @@
+.. _srs_api :
+
+Stanford Research Systems Drivers
+=================================
+
+.. automodule:: qcodes.instrument_drivers.stanford_research
+    :autosummary:

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -39,6 +39,8 @@ REM for storing drivers, not the lower-case one).
 sphinx-apidoc  -o  _auto  -d 10 ..\qcodes ^
 	..\qcodes\instrument_drivers\AimTTi ^
     ..\qcodes\instrument_drivers\QuantumDesign\DynaCoolPPMS\private\*
+    ..\qcodes\instrument_drivers\QuantumDesign\DynaCoolPPMS\private\* ^
+    ..\qcodes\instrument_drivers\stanford_research\*
 mkdir api\generated\
 copy _auto\qcodes.instrument_drivers.* api\generated\
 

--- a/qcodes/instrument_drivers/stanford_research/SG384.py
+++ b/qcodes/instrument_drivers/stanford_research/SG384.py
@@ -3,7 +3,8 @@ from typing import Any
 from qcodes import validators as vals
 from qcodes.instrument import VisaInstrument
 
-class SRS_SG384(VisaInstrument):
+
+class SG384(VisaInstrument):
     """
     This is the code for SG384 RF Signal Generator
     Status: beta version
@@ -153,3 +154,11 @@ class SRS_SG384(VisaInstrument):
                                         'Blank': 5,
                                         'IQ': 6})
         self.connect_message()
+
+
+class SRS_SG384(SG384):
+    """
+    Deprecated alternative name for backwards compatibility
+    """
+
+    pass

--- a/qcodes/instrument_drivers/stanford_research/SG384.py
+++ b/qcodes/instrument_drivers/stanford_research/SG384.py
@@ -6,7 +6,8 @@ from qcodes.instrument import VisaInstrument
 
 class SG384(VisaInstrument):
     """
-    This is the code for SG384 RF Signal Generator
+    QCoDeS driver for the Stanford Research Systems SG384 RF Signal Generator.
+
     Status: beta version
     Includes the essential commands from the manual
     """

--- a/qcodes/instrument_drivers/stanford_research/SR560.py
+++ b/qcodes/instrument_drivers/stanford_research/SR560.py
@@ -62,7 +62,7 @@ class VoltageParameter(MultiParameter):
 
 class SR560(Instrument):
     """
-    This is the qcodes driver for the SR 560 Voltage-preamplifier.
+    QCoDeS driver for the Stanford Research Systems SR560 Voltage-preamplifier.
 
     This is a virtual driver only and will not talk to your instrument.
 

--- a/qcodes/instrument_drivers/stanford_research/SR830.py
+++ b/qcodes/instrument_drivers/stanford_research/SR830.py
@@ -189,7 +189,7 @@ class ChannelBuffer(ArrayParameter):
 
 class SR830(VisaInstrument):
     """
-    QCoDeS driver for the Stanford Research Systems SR860 Lock-in Amplifier.
+    QCoDeS driver for the Stanford Research Systems SR830 Lock-in Amplifier.
     """
 
     _VOLT_TO_N = {2e-9:    0, 5e-9:    1, 10e-9:  2,

--- a/qcodes/instrument_drivers/stanford_research/SR830.py
+++ b/qcodes/instrument_drivers/stanford_research/SR830.py
@@ -24,7 +24,7 @@ class ChannelTrace(ParameterWithSetpoints):
         Args:
             name: The name of the parameter
             channel: The relevant channel (1 or 2). The name should
-                should match this.
+                match this.
         """
         super().__init__(name, **kwargs)
 
@@ -189,8 +189,7 @@ class ChannelBuffer(ArrayParameter):
 
 class SR830(VisaInstrument):
     """
-    This is the qcodes driver for the Stanford Research Systems SR830
-    Lock-in Amplifier
+    QCoDeS driver for the Stanford Research Systems SR860 Lock-in Amplifier.
     """
 
     _VOLT_TO_N = {2e-9:    0, 5e-9:    1, 10e-9:  2,

--- a/qcodes/instrument_drivers/stanford_research/SR860.py
+++ b/qcodes/instrument_drivers/stanford_research/SR860.py
@@ -3,7 +3,12 @@ from qcodes.instrument_drivers.stanford_research.SR86x import SR86x
 
 class SR860(SR86x):
     """
+    QCoDeS driver for the Stanford Research Systems SR860 Lock-in Amplifier.
+
     The SR860 instrument is almost equal to the SR865, except for the max frequency
     """
-    def __init__(self, name: str, address: str, reset: bool=False, **kwargs: str) ->None:
+
+    def __init__(
+        self, name: str, address: str, reset: bool = False, **kwargs: str
+    ) -> None:
         super().__init__(name, address, max_frequency=500e3, reset=reset, **kwargs)

--- a/qcodes/instrument_drivers/stanford_research/SR865.py
+++ b/qcodes/instrument_drivers/stanford_research/SR865.py
@@ -3,7 +3,12 @@ from qcodes.instrument_drivers.stanford_research.SR86x import SR86x
 
 class SR865(SR86x):
     """
+    QCoDeS driver for the Stanford Research Systems SR865 Lock-in Amplifier.
+
     The SR865 instrument is almost equal to the SR860, except for the max frequency
     """
-    def __init__(self, name: str, address: str, reset: bool=False, **kwargs: str) ->None:
-        super().__init__(name, address, max_frequency=2E6, reset=reset, **kwargs)
+
+    def __init__(
+        self, name: str, address: str, reset: bool = False, **kwargs: str
+    ) -> None:
+        super().__init__(name, address, max_frequency=2e6, reset=reset, **kwargs)

--- a/qcodes/instrument_drivers/stanford_research/SR865A.py
+++ b/qcodes/instrument_drivers/stanford_research/SR865A.py
@@ -3,6 +3,8 @@ from qcodes.instrument_drivers.stanford_research.SR86x import SR86x
 
 class SR865A(SR86x):
     """
+    QCoDeS driver for the Stanford Research Systems SR865A Lock-in Amplifier.
+
     The SR865A instrument is almost equal to the SR865, except for the
     max frequency
     """

--- a/qcodes/instrument_drivers/stanford_research/SR86x.py
+++ b/qcodes/instrument_drivers/stanford_research/SR86x.py
@@ -69,8 +69,10 @@ class SR86xBufferReadout(ArrayParameter):
 
 class SR86xBuffer(InstrumentChannel):
     """
-    The buffer module for the SR86x driver. This driver has been verified to
-    work with the SR860 and SR865. For reference, please consult the SR860
+    Buffer module for the SR86x drivers.
+
+    This driver has been verified to work with the SR860 and SR865.
+    For reference, please consult the SR860
     manual: http://thinksrs.com/downloads/PDFs/Manuals/SR860m.pdf
     """
 

--- a/qcodes/instrument_drivers/stanford_research/__init__.py
+++ b/qcodes/instrument_drivers/stanford_research/__init__.py
@@ -1,5 +1,6 @@
 from .SG384 import SG384
 from .SR86x import SR86xBuffer
+from .SR560 import SR560
 from .SR830 import SR830
 from .SR860 import SR860
 from .SR865 import SR865
@@ -7,6 +8,7 @@ from .SR865A import SR865A
 
 __all__ = [
     "SG384",
+    "SR560",
     "SR830",
     "SR860",
     "SR865",

--- a/qcodes/instrument_drivers/stanford_research/__init__.py
+++ b/qcodes/instrument_drivers/stanford_research/__init__.py
@@ -1,0 +1,15 @@
+from .SG384 import SG384
+from .SR86x import SR86xBuffer
+from .SR830 import SR830
+from .SR860 import SR860
+from .SR865 import SR865
+from .SR865A import SR865A
+
+__all__ = [
+    "SG384",
+    "SR830",
+    "SR860",
+    "SR865",
+    "SR865A",
+    "SR86xBuffer",
+]


### PR DESCRIPTION
I have left the drivers in the format SR860. I guess one could argue that they should be named SRSSR860 since SR is part of the model number but that feels too much. 