### PR TITLE
Significant performance improvements to AddResult / GetParameter

### DIFF
--- a/benchmarking/README.rst
+++ b/benchmarking/README.rst
@@ -21,7 +21,7 @@ following command from this directory:
 
 .. code:: bash
 
-  asv run python=same
+  asv run --python=same
 
 If you do not have an environment set, then ``asv`` can set it up
 automatically. The benchmarks are executed in the same way:

--- a/benchmarking/asv.conf.json
+++ b/benchmarking/asv.conf.json
@@ -29,7 +29,7 @@
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
-    "environment_type": "conda",
+    "environment_type": "virtualenv",
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min

--- a/docs/changes/newsfragments/4446.improved
+++ b/docs/changes/newsfragments/4446.improved
@@ -1,0 +1,1 @@
+Improve performance of ``sqlite3`` converters and adapters used to write and read in the database.

--- a/docs/changes/newsfragments/4446.improved
+++ b/docs/changes/newsfragments/4446.improved
@@ -1,3 +1,3 @@
 Improve performance of ``sqlite3`` converters and adapters used to write and read in the database.
 
-Get rid of irrelevant unpacking from ``sqlite3.Row`` to ``list``.
+Get rid of ``sqlite3.Row`` and irrelevant unpacking to ``list``.

--- a/docs/changes/newsfragments/4446.improved
+++ b/docs/changes/newsfragments/4446.improved
@@ -1,1 +1,3 @@
 Improve performance of ``sqlite3`` converters and adapters used to write and read in the database.
+
+Get rid of irrelevant unpacking from ``sqlite3.Row`` to ``list``.

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1174,11 +1174,14 @@ class DataSet(BaseDataSet):
         """
         Remove all subscribers
         """
-        sql = "select * from sqlite_master where type = 'trigger';"
+        sql = """
+        SELECT name FROM sqlite_master
+        WHERE type = 'trigger'
+        """
         triggers = atomic_transaction(self.conn, sql).fetchall()
         with atomic(self.conn) as conn:
-            for trigger in triggers:
-                remove_trigger(conn, trigger['name'])
+            for (trigger,) in triggers:
+                remove_trigger(conn, trigger)
             for sub in self.subscribers.values():
                 sub.schedule_stop()
                 sub.join()

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -169,8 +169,10 @@ class Experiment(Sized):
 
     def data_sets(self) -> list[DataSetProtocol]:
         """Get all the datasets of this experiment"""
-        runs = get_runs(self.conn, self.exp_id)
-        return [load_by_id(run['run_id'], conn=self.conn) for run in runs]
+        return [
+            load_by_id(run_id, conn=self.conn)
+            for run_id in get_runs(self.conn, self.exp_id)
+        ]
 
     def last_data_set(self) -> DataSetProtocol:
         """Get the last dataset of this experiment"""
@@ -216,8 +218,7 @@ def experiments(conn: ConnectionPlus | None = None) -> list[Experiment]:
     """
     conn = conn_from_dbpath_or_conn(conn=conn, path_to_db=None)
     log.info(f"loading experiments from {conn.path_to_dbfile}")
-    rows = get_experiments(conn)
-    return [load_experiment(row['exp_id'], conn) for row in rows]
+    return [load_experiment(exp_id, conn) for exp_id in get_experiments(conn)]
 
 
 def new_experiment(

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -6,6 +6,7 @@ database version and possibly perform database upgrades.
 from __future__ import annotations
 
 import io
+import math
 import sqlite3
 import sys
 from collections.abc import Iterator
@@ -37,15 +38,20 @@ def _adapt_array(arr: np.ndarray) -> sqlite3.Binary:
     https://stackoverflow.com/questions/3425320/sqlite3-programmingerror-you-must-not-use-8-bit-bytestrings-unless-you-use-a-te
     """
     out = io.BytesIO()
-    np.save(out, arr)
+    # Directly use np.lib.format.write_array instead of np.save, force version to be
+    # 3.0 (when reading, version 1.0 and 2.0 can result in a slow clean up step to
+    # ensure backward compatibility with python 2) and disable pickle (slow and
+    # insecure)
+    np.lib.format.write_array(out, arr, version=(3, 0), allow_pickle=False)
     out.seek(0)
     return sqlite3.Binary(out.read())
 
 
 def _convert_array(text: bytes) -> np.ndarray:
-    out = io.BytesIO(text)
-    out.seek(0)
-    return np.load(out)
+    # Using np.lib.format.read_array (counterpart of np.lib.format.write_array)
+    # npy format version 3.0 is 3 times faster than previous verions (no clean up step
+    # for python 2 backward compatibility)
+    return np.lib.format.read_array(io.BytesIO(text), allow_pickle=False)
 
 
 def _convert_complex(text: bytes) -> np.complexfloating:
@@ -75,36 +81,29 @@ def _convert_numeric(value: bytes) -> float | int | str:
     try:
         # First, try to convert bytes to float
         numeric = float(value)
-    except ValueError as e:
-        # If an exception has been raised, we first need to find out
-        # if the reason was the conversion to float, and, if so, we are sure
-        # that we need to return a string
-        if "could not convert string to float" in str(e):
-            return str(value, encoding=this_session_default_encoding)
-        else:
-            # otherwise, the exception is forwarded up the stack
-            raise e
+    except ValueError:
+        # Let string casting fail if bytes encoding is invalid
+        return str(value, encoding=this_session_default_encoding)
 
-    # If that worked, e.g. did not raise an exception, then we check if the
-    # outcome is 'nan'
-    if np.isnan(numeric):
+    # If that worked, e.g. did not raise an exception, then we check if the outcome is
+    # either an infinity or a NaN
+    # For a single value, math.isfinite is 10 times faster than np.isinfinite (or
+    # combining np.isnan and np.isinf)
+    if not math.isfinite(numeric):
         return numeric
 
-    # Then we check if the outcome is 'inf', includes +inf and -inf
-    if np.isinf(numeric):
-        return numeric
-
-    # If it is not 'nan' and not 'inf', then we need to see if the value is
-    # really an integer or with floating point digits
+    # If it is not 'nan' and not 'inf', then we need to see if the value is really an
+    # integer or with floating point digits
     numeric_int = int(numeric)
     if numeric != numeric_int:
         return numeric
     else:
         return numeric_int
 
-
 def _adapt_float(fl: float) -> float | str:
-    if np.isnan(fl):
+    # For a single value, math.isnan is 10 times faster than np.isnan
+    # Overall, saving floats with numeric format is 2 times faster with math.isnan
+    if math.isnan(fl):
         return "nan"
     return float(fl)
 

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -149,9 +149,6 @@ def connect(name: str | Path, debug: bool = False, version: int = -1) -> Connect
                            f"version of QCoDeS supports up to "
                            f"version {latest_supported_version}")
 
-    # sqlite3 options
-    conn.row_factory = sqlite3.Row
-
     # Make sure numpy ints and floats types are inserted properly
     for numpy_int in numpy_ints:
         sqlite3.register_adapter(numpy_int, int)

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -227,9 +227,10 @@ def test_runs_table_columns(empty_temp_db):
     colnames = list(mut_queries.RUNS_TABLE_COLUMNS)
     conn = mut_db.connect(get_DB_location())
     query = "PRAGMA table_info(runs)"
-    cursor = conn.cursor()
-    for row in cursor.execute(query):
-        colnames.remove(row['name'])
+    cursor = conn.execute(query)
+    description = mut_help.get_description_map(cursor)
+    for row in cursor.fetchall():
+        colnames.remove(row[description["name"]])
 
     assert colnames == []
 

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -239,7 +239,7 @@ def test_get_data_no_columns(scalar_dataset):
     with pytest.warns(QCoDeSDeprecationWarning) as record:
         ref = mut_queries.get_data(ds.conn, ds.table_name, [])
 
-    assert ref == [[]]
+    assert ref == [tuple()]
     assert len(record) == 2
     assert str(record[0].message).startswith("The function <get_data>")
     assert str(record[1].message).startswith("get_data")

--- a/qcodes/tests/dataset/test_sqlite_connection.py
+++ b/qcodes/tests/dataset/test_sqlite_connection.py
@@ -332,5 +332,4 @@ def test_connect():
     assert isinstance(conn, sqlite3.Connection)
     assert isinstance(conn, ConnectionPlus)
     assert False is conn.atomic_in_progress
-
-    assert sqlite3.Row is conn.row_factory
+    assert None is conn.row_factory


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->

Saving and loading data from the SQL database rely on `_adapt_xxx` and `_convert_xxx` methods. However, currently they are using many `numpy` functions (`np.isnan`, `np.isinf`, `np.save`, `np.load`) that are slow when dealing with arrays containing single values. This PR makes the following changes that significantly improve data loading and saving performance:
- For `float`: Replace `numpy` functions by `math` functions, use `math.isinfinite` instead of combining `isnan` and `isinf`;
- For `complex`: Do not save complex single values as `numpy` arrays of one value. It saves both time and space if we avoid reading and writing the relatively large `numpy` header. This changes the representation of the data in the database, but it's fully backwards compatible (and tested);
- For `array`: Use directly functions from `np.lib.format`, it skips some work of `np.save` and `np.load`;

b0b6528 rewrites adapters and converters avoiding `numpy` functions and significantly improves  performance (around x3 when loading regular numeric data and up to x70 for complex data).

20c58d7 is a minor improvement (~10% when loading complex or numeric data), it avoids unpacking `sqlite3.Row` to `list` when it's unnecessary (those functions can reorder the columns however, it's most of the time unnecessary because the SQL queries are properly sorted).

3d7b0fd follows the previous one: as the SQL queries are properly sorted, the named tuple feature of `sqlite3.Row` (`row[column_name]`) becomes superfluous.

459b342 is up-to-date benchmarks. (Note that the benchmarks are not run in CI.)

Commit b0b6528 is the most important one, the two other modifications give pretty minor improvements compared to the number of changes to the codebase. If you feel that it's not worth changing so much for such a small gain, they can be left out.

(we worked on these preformance improvements together with @mgunyho)

closes #1238 (?)