### PR TITLE
Add better skip messages to tests if missing fixutures

### DIFF
--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -872,7 +872,7 @@ def test_latest_available_version():
     assert _latest_available_version() == 9
 
 
-@pytest.mark.parametrize('version', VERSIONS)
+@pytest.mark.parametrize("version", VERSIONS[:-1])
 def test_getting_db_version(version):
 
     fixpath = os.path.join(fixturepath, 'db_files', f'version{version}')

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -68,6 +68,15 @@ VERSIONS = tuple(range(LATEST_VERSION + 1))
 LATEST_VERSION_ARG = -1
 
 
+def _skip_if_no_fixtures(dbname):
+    if not os.path.exists(dbname):
+        pytest.skip(
+            "No db-file fixtures found. "
+            "Make sure that your git clone of qcodes has submodules "
+            "This can be done by executing: `git submodule update --init`"
+        )
+
+
 @pytest.mark.parametrize('ver', VERSIONS + (LATEST_VERSION_ARG,))
 def test_connect_upgrades_user_version(ver):
     expected_version = ver if ver != LATEST_VERSION_ARG else LATEST_VERSION
@@ -129,10 +138,7 @@ def test_perform_actual_upgrade_0_to_1():
 
     dbname_old = os.path.join(v0fixpath, 'empty.db')
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=0) as conn:
 
@@ -158,9 +164,7 @@ def test_perform_actual_upgrade_1_to_2():
 
     dbname_old = os.path.join(v1fixpath, 'empty.db')
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the legacy_DB_generation folder")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=1) as conn:
 
@@ -188,10 +192,7 @@ def test_perform_actual_upgrade_2_to_3_empty():
 
     dbname_old = os.path.join(v2fixpath, 'empty.db')
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=2) as conn:
 
@@ -218,10 +219,7 @@ def test_perform_actual_upgrade_2_to_3_empty_runs():
 
     dbname_old = os.path.join(v2fixpath, 'empty_runs.db')
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=2) as conn:
 
@@ -234,10 +232,7 @@ def test_perform_actual_upgrade_2_to_3_some_runs():
 
     dbname_old = os.path.join(v2fixpath, 'some_runs.db')
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the"
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=2) as conn:
 
@@ -328,10 +323,7 @@ def test_perform_upgrade_v2_v3_to_v4_fixes():
 
     dbname_old = os.path.join(v3fixpath, 'some_runs_upgraded_2.db')
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the"
-                    " https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=3) as conn:
 
@@ -474,10 +466,7 @@ def test_perform_upgrade_v3_to_v4():
 
     dbname_old = os.path.join(v3fixpath, 'some_runs_upgraded_2.db')
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=3) as conn:
 
@@ -642,10 +631,7 @@ def test_perform_actual_upgrade_4_to_5(db_file):
     db_file += '.db'
     dbname_old = os.path.join(v4fixpath, db_file)
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=4) as conn:
         # firstly, assert the situation with 'snapshot' column of 'runs' table
@@ -667,10 +653,7 @@ def test_perform_actual_upgrade_5_to_6():
     db_file = 'empty.db'
     dbname_old = os.path.join(fixpath, db_file)
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=5) as conn:
         perform_db_upgrade_5_to_6(conn)
@@ -704,10 +687,7 @@ def test_perform_upgrade_6_7():
     db_file = 'empty.db'
     dbname_old = os.path.join(fixpath, db_file)
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=6) as conn:
         perform_db_upgrade_6_to_7(conn)
@@ -721,10 +701,7 @@ def test_perform_actual_upgrade_6_to_7():
     db_file = 'some_runs.db'
     dbname_old = os.path.join(fixpath, db_file)
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=6) as conn:
         assert isinstance(conn, ConnectionPlus)
@@ -780,10 +757,7 @@ def test_perform_actual_upgrade_6_to_newest_add_new_data():
     db_file = 'some_runs.db'
     dbname_old = os.path.join(fixpath, db_file)
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=6) as conn:
         assert isinstance(conn, ConnectionPlus)
@@ -871,10 +845,7 @@ def test_perform_actual_upgrade_7_to_8(db_file):
     db_file += '.db'
     dbname_old = os.path.join(v7fixpath, db_file)
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=7) as conn:
 
@@ -908,10 +879,7 @@ def test_getting_db_version(version):
 
     dbname = os.path.join(fixpath, 'empty.db')
 
-    if not os.path.exists(dbname):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname)
 
     (db_v, new_v) = get_db_version_and_newest_available_version(dbname)
 
@@ -928,10 +896,7 @@ def test_perform_actual_upgrade_8_to_9(db_file):
     db_file += '.db'
     dbname_old = os.path.join(v8fixpath, db_file)
 
-    if not os.path.exists(dbname_old):
-        pytest.skip("No db-file fixtures found. You can generate test db-files"
-                    " using the scripts in the "
-                    "https://github.com/QCoDeS/qcodes_generate_test_db/ repo")
+    _skip_if_no_fixtures(dbname_old)
 
     with temporarily_copied_DB(dbname_old, debug=False, version=8) as conn:
 


### PR DESCRIPTION
Partial fix for https://github.com/QCoDeS/qcodes_generate_test_db/issues/8

Also:
* There are no fixtures for the current version so don't try to run test_getting_db_version on that version.
* Unify the skip logic for consistent output message