### PR TITLE
Give InstrumentBase a label that can be nicely formatted

### DIFF
--- a/docs/changes/newsfragments/4460.new
+++ b/docs/changes/newsfragments/4460.new
@@ -1,0 +1,1 @@
+:class:`InstrumentBase` has a property ``label``. The label can be set in the __init__.

--- a/docs/changes/newsfragments/4460.new
+++ b/docs/changes/newsfragments/4460.new
@@ -1,1 +1,3 @@
-:class:`InstrumentBase` has a property ``label``. The label can be set in the __init__.
+:class:`InstrumentBase` has a property ``label`` that can host
+a human-readable label/title of the instrument.
+The label can be set in the __init__.

--- a/qcodes/instrument/instrument.py
+++ b/qcodes/instrument/instrument.py
@@ -66,10 +66,10 @@ class Instrument(InstrumentBase, metaclass=InstrumentMeta):
     _instances: "weakref.WeakSet[Instrument]" = weakref.WeakSet()
 
     def __init__(
-            self,
-            name: str,
-            metadata: Optional[Mapping[Any, Any]] = None,
-            label: Optional[str] = None,
+        self,
+        name: str,
+        metadata: Optional[Mapping[Any, Any]] = None,
+        label: Optional[str] = None,
     ) -> None:
 
         self._t0 = time.time()

--- a/qcodes/instrument/instrument.py
+++ b/qcodes/instrument/instrument.py
@@ -54,8 +54,10 @@ class Instrument(InstrumentBase, metaclass=InstrumentMeta):
             attaching it to a Station.
         metadata: additional static metadata to add to this
             instrument's JSON snapshot.
-
+        label: nicely formatted name of the instrument; if None, the
+            ``name`` is used.
     """
+
 
     _all_instruments: "weakref.WeakValueDictionary[str, Instrument]" = (
         weakref.WeakValueDictionary()
@@ -63,11 +65,16 @@ class Instrument(InstrumentBase, metaclass=InstrumentMeta):
     _type = None
     _instances: "weakref.WeakSet[Instrument]" = weakref.WeakSet()
 
-    def __init__(self, name: str, metadata: Optional[Mapping[Any, Any]] = None) -> None:
+    def __init__(
+            self,
+            name: str,
+            metadata: Optional[Mapping[Any, Any]] = None,
+            label: Optional[str] = None,
+    ) -> None:
 
         self._t0 = time.time()
 
-        super().__init__(name, metadata)
+        super().__init__(name=name, metadata=metadata, label=label)
 
         self.add_parameter("IDN", get_cmd=self.get_idn, vals=Anything())
 

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -44,10 +44,10 @@ class InstrumentBase(Metadatable, DelegateAttributes):
     """
 
     def __init__(
-            self,
-            name: str,
-            metadata: Optional[Mapping[Any, Any]] = None,
-            label: Optional[str] = None,
+        self,
+        name: str,
+        metadata: Optional[Mapping[Any, Any]] = None,
+        label: Optional[str] = None,
     ) -> None:
         name = self._replace_hyphen(name)
         self._short_name = name

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -39,12 +39,22 @@ class InstrumentBase(Metadatable, DelegateAttributes):
             attaching it to a Station.
         metadata: additional static metadata to add to this
             instrument's JSON snapshot.
+        label: nicely formatted name of the instrument; if None, the
+            ``name`` is used.
     """
 
-    def __init__(self, name: str, metadata: Optional[Mapping[Any, Any]] = None) -> None:
+    def __init__(
+            self,
+            name: str,
+            metadata: Optional[Mapping[Any, Any]] = None,
+            label: Optional[str] = None,
+    ) -> None:
         name = self._replace_hyphen(name)
         self._short_name = name
         self._is_valid_identifier(self.full_name)
+
+        self.label = name if label is None else label
+        self._label: str
 
         self.parameters: Dict[str, ParameterBase] = {}
         """
@@ -78,9 +88,20 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         super().__init__(metadata)
 
         # This is needed for snapshot method to work
-        self._meta_attrs = ["name"]
+        self._meta_attrs = ["name", "label"]
 
         self.log = get_instrument_logger(self, __name__)
+
+    @property
+    def label(self) -> str:
+        """
+        Nicely formatted label of the instrument.
+        """
+        return self._label
+
+    @label.setter
+    def label(self, label: str) -> None:
+        self._label = label
 
     def add_parameter(
         self,

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -284,8 +284,8 @@ class DummyChannel(InstrumentChannel):
     A single dummy channel implementation
     """
 
-    def __init__(self, parent, name, channel):
-        super().__init__(parent, name)
+    def __init__(self, parent, name, channel, **kwargs):
+        super().__init__(parent, name, **kwargs)
 
         self._channel = channel
 

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -60,6 +60,17 @@ class EmptyChannel(InstrumentChannel):
     pass
 
 
+def test_instrument_channel_label():
+    dci = DummyChannelInstrument(name="dci_with_labels", label="Instrument Label")
+    channel = DummyChannel(dci, "A_with_label", "A_wl", label="A with f@ncy label")
+    dci.add_submodule("A_with_label", channel)
+    channel = EmptyChannel(dci, "B_with_label", label="B with f@ncy label")
+    dci.add_submodule("B_with_label", channel)
+    assert dci.label == "Instrument Label"
+    assert dci.A_with_label.label == "A with f@ncy label"
+    assert dci.B_with_label.label == "B with f@ncy label"
+
+
 def test_channels_call_function(dci, caplog):
     """
     Test that dci.channels.some_function() calls

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -393,34 +393,34 @@ def test_instrumentbase_metadata():
 @pytest.mark.parametrize("cls", [(InstrumentBase), (Instrument)])
 def test_instrument_label(cls):
     """Instrument uses nicely formatted label if available."""
-    instrument = cls(name='name')
-    assert instrument.label == 'name'
+    instrument = cls(name="name")
+    assert instrument.label == "name"
 
     random_ascii = "~!@#$%^&*()_-+=`{}[];'\":,./<>?|\\ äöüß"
     instrument.label = random_ascii
     assert instrument.label == random_ascii
 
     label = "Nicely-formatted label"
-    instrument = cls(name='name1', label=label)
+    instrument = cls(name="name1", label=label)
     assert instrument.label == label
 
 
 def test_snapshot_and_meta_attrs():
     """Test snapshot of InstrumentBase contains _meta_attrs attributes"""
-    instr = InstrumentBase('instr', label="Label")
+    instr = InstrumentBase("instr", label="Label")
 
     assert instr.name == 'instr'
 
-    assert hasattr(instr, '_meta_attrs')
-    assert instr._meta_attrs == ['name', 'label']
+    assert hasattr(instr, "_meta_attrs")
+    assert instr._meta_attrs == ["name", "label"]
 
     snapshot = instr.snapshot()
 
     assert 'name' in snapshot
     assert 'instr' == snapshot['name']
 
-    assert 'label' in snapshot
-    assert 'Label' == snapshot['label']
+    assert "label" in snapshot
+    assert "Label" == snapshot["label"]
 
     assert '__class__' in snapshot
     assert 'InstrumentBase' in snapshot['__class__']

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -390,19 +390,37 @@ def test_instrumentbase_metadata():
     assert instrument.metadata == metadatadict
 
 
+@pytest.mark.parametrize("cls", [(InstrumentBase), (Instrument)])
+def test_instrument_label(cls):
+    """Instrument uses nicely formatted label if available."""
+    instrument = cls(name='name')
+    assert instrument.label == 'name'
+
+    random_ascii = "~!@#$%^&*()_-+=`{}[];'\":,./<>?|\\ äöüß"
+    instrument.label = random_ascii
+    assert instrument.label == random_ascii
+
+    label = "Nicely-formatted label"
+    instrument = cls(name='name1', label=label)
+    assert instrument.label == label
+
+
 def test_snapshot_and_meta_attrs():
     """Test snapshot of InstrumentBase contains _meta_attrs attributes"""
-    instr = InstrumentBase('instr')
+    instr = InstrumentBase('instr', label="Label")
 
     assert instr.name == 'instr'
 
     assert hasattr(instr, '_meta_attrs')
-    assert instr._meta_attrs == ['name']
+    assert instr._meta_attrs == ['name', 'label']
 
     snapshot = instr.snapshot()
 
     assert 'name' in snapshot
     assert 'instr' == snapshot['name']
+
+    assert 'label' in snapshot
+    assert 'Label' == snapshot['label']
 
     assert '__class__' in snapshot
     assert 'InstrumentBase' in snapshot['__class__']


### PR DESCRIPTION
Add a label to InstrumentBase that can store a nicely-formatted instrument name. The implementation is similar to the label in Parameter. Previously discussed [here](https://github.com/QCoDeS/Qcodes/discussions/4411).

- [x] Make sure that the pull request contains a short description of the changes made.
- [x] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [x] Please include automatic tests for the changes made when possible.
- [x] Create a file in the docs\changes\newsfragments folder with a short description of the change.
