### PR TITLE
Added the parameter `auto_freq_ref` to N51x1 Keysight signal generators class

### DIFF
--- a/docs/changes/newsfragments/4472.improved_driver
+++ b/docs/changes/newsfragments/4472.improved_driver
@@ -3,4 +3,4 @@ From the Keysight manual:
 This command enables or disables the ability of the signal generator to
 automatically select between the internal and an external reference oscillator.
 
-In addition, the val_mapping dictionary of the `rf_output` parameter is now using the `create_on_off_val_mapping` function. 
+In addition, the val_mapping dictionary of the `rf_output` parameter is now using the `create_on_off_val_mapping` function.

--- a/docs/changes/newsfragments/4472.improved_driver
+++ b/docs/changes/newsfragments/4472.improved_driver
@@ -1,0 +1,6 @@
+A parameter `auto_freq_ref` was added to the `Keysight.N51x1` class.
+From the Keysight manual:
+This command enables or disables the ability of the signal generator to
+automatically select between the internal and an external reference oscillator.
+
+In addition, the val_mapping dictionary of the `rf_output` parameter is now using the `create_on_off_val_mapping` function. 

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, Optional
 
 from qcodes.instrument import VisaInstrument
-from qcodes.validators import Numbers
 from qcodes.parameters import create_on_off_val_mapping
+from qcodes.validators import Numbers
 
 
 class N51x1(VisaInstrument):
@@ -59,15 +59,19 @@ class N51x1(VisaInstrument):
                            unit='rad'
                            )
 
-        self.add_parameter('auto_freq_ref',
-                           get_cmd=':ROSC:SOUR:AUTO?',
-                           set_cmd=':ROSC:SOUR:AUTO {}',
-                           val_mapping=create_on_off_val_mapping(on_val=1, off_val=0))
+        self.add_parameter(
+            "auto_freq_ref",
+            get_cmd=":ROSC:SOUR:AUTO?",
+            set_cmd=":ROSC:SOUR:AUTO {}",
+            val_mapping=create_on_off_val_mapping(on_val=1, off_val=0),
+        )
 
-        self.add_parameter('rf_output',
-                           get_cmd='OUTP:STAT?',
-                           set_cmd='OUTP:STAT {}',
-                           val_mapping=create_on_off_val_mapping(on_val=1, off_val=0))
+        self.add_parameter(
+            "rf_output",
+            get_cmd="OUTP:STAT?",
+            set_cmd="OUTP:STAT {}",
+            val_mapping=create_on_off_val_mapping(on_val=1, off_val=0),
+        )
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -57,7 +57,12 @@ class N51x1(VisaInstrument):
                            set_cmd='SOUR:PHAS {:.2f}',
                            unit='rad'
                            )
-
+        
+        self.add_parameter('auto_freq_ref',
+                           get_cmd=':ROSC:SOUR:AUTO?',
+                           set_cmd=':ROSC:SOUR:AUTO {}',
+                           val_mapping={'on': 1, 'off': 0})
+            
         self.add_parameter('rf_output',
                            get_cmd='OUTP:STAT?',
                            set_cmd='OUTP:STAT {}',

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -57,12 +57,12 @@ class N51x1(VisaInstrument):
                            set_cmd='SOUR:PHAS {:.2f}',
                            unit='rad'
                            )
-        
+
         self.add_parameter('auto_freq_ref',
                            get_cmd=':ROSC:SOUR:AUTO?',
                            set_cmd=':ROSC:SOUR:AUTO {}',
                            val_mapping={'on': 1, 'off': 0})
-            
+
         self.add_parameter('rf_output',
                            get_cmd='OUTP:STAT?',
                            set_cmd='OUTP:STAT {}',

--- a/qcodes/instrument_drivers/Keysight/N51x1.py
+++ b/qcodes/instrument_drivers/Keysight/N51x1.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional
 
 from qcodes.instrument import VisaInstrument
 from qcodes.validators import Numbers
+from qcodes.parameters import create_on_off_val_mapping
 
 
 class N51x1(VisaInstrument):
@@ -61,12 +62,12 @@ class N51x1(VisaInstrument):
         self.add_parameter('auto_freq_ref',
                            get_cmd=':ROSC:SOUR:AUTO?',
                            set_cmd=':ROSC:SOUR:AUTO {}',
-                           val_mapping={'on': 1, 'off': 0})
+                           val_mapping=create_on_off_val_mapping(on_val=1, off_val=0))
 
         self.add_parameter('rf_output',
                            get_cmd='OUTP:STAT?',
                            set_cmd='OUTP:STAT {}',
-                           val_mapping={'on': 1, 'off': 0})
+                           val_mapping=create_on_off_val_mapping(on_val=1, off_val=0))
 
         self.connect_message()
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
