### PR TITLE
Add `connect` and `ConnectionPlus` to public API

### DIFF
--- a/qcodes/dataset/__init__.py
+++ b/qcodes/dataset/__init__.py
@@ -33,9 +33,7 @@ from .sqlite.database import (
     initialise_database,
     initialise_or_create_database_at,
     initialised_database_at,
-    connect
 )
-from .sqlite.connection import ConnectionPlus
 from .sqlite.settings import SQLiteSettings
 from .threading import (
     SequentialParamsCaller,

--- a/qcodes/dataset/__init__.py
+++ b/qcodes/dataset/__init__.py
@@ -31,7 +31,9 @@ from .sqlite.database import (
     initialise_database,
     initialise_or_create_database_at,
     initialised_database_at,
+    connect
 )
+from .sqlite.connection import ConnectionPlus
 from .sqlite.settings import SQLiteSettings
 from .threading import (
     SequentialParamsCaller,
@@ -42,6 +44,7 @@ from .threading import (
 __all__ = [
     "AbstractSweep",
     "ArraySweep",
+    "ConnectionPlus",
     "DataSetProtocol",
     "DataSetType",
     "LinSweep",
@@ -52,6 +55,7 @@ __all__ = [
     "SequentialParamsCaller",
     "ThreadPoolParamsCaller",
     "call_params_threaded",
+    "connect",
     "do0d",
     "do1d",
     "do2d",

--- a/qcodes/dataset/__init__.py
+++ b/qcodes/dataset/__init__.py
@@ -27,7 +27,9 @@ from .experiment_settings import get_default_experiment_id, reset_default_experi
 from .legacy_import import import_dat_file
 from .measurements import Measurement
 from .plotting import plot_by_id, plot_dataset
+from .sqlite.connection import ConnectionPlus
 from .sqlite.database import (
+    connect,
     initialise_database,
     initialise_or_create_database_at,
     initialised_database_at,

--- a/qcodes/dataset/sqlite/connection.py
+++ b/qcodes/dataset/sqlite/connection.py
@@ -24,14 +24,17 @@ class ConnectionPlus(wrapt.ObjectProxy):
     It is not allowed to instantiate a new `ConnectionPlus` object from a
     `ConnectionPlus` object.
 
-    Attributes:
-        atomic_in_progress: a bool describing whether the connection is
-            currently in the middle of an atomic block of transactions, thus
-            allowing to nest `atomic` context managers
-        path_to_dbfile: Path to the database file of the connection.
     """
     atomic_in_progress: bool = False
-    path_to_dbfile = ''
+    """
+    a bool describing whether the connection is
+    currently in the middle of an atomic block of transactions, thus
+    allowing to nest `atomic` context managers
+    """
+    path_to_dbfile: str = ""
+    """
+    Path to the database file of the connection.
+    """
 
     def __init__(self, sqlite3_connection: sqlite3.Connection):
         super().__init__(sqlite3_connection)

--- a/qcodes/dataset/sqlite/connection.py
+++ b/qcodes/dataset/sqlite/connection.py
@@ -24,6 +24,8 @@ class ConnectionPlus(wrapt.ObjectProxy):
     It is not allowed to instantiate a new `ConnectionPlus` object from a
     `ConnectionPlus` object.
 
+    It is recommended to create a ConnectionPlus using the function :func:`connect`
+
     """
     atomic_in_progress: bool = False
     """

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -123,13 +123,13 @@ def connect(name: Union[str, Path], debug: bool = False,
 
     Args:
         name: name or path to the sqlite file
-        debug: whether or not to turn on tracing
+        debug: should tracing be turned on.
         version: which version to create. We count from 0. -1 means 'latest'.
             Should always be left at -1 except when testing.
 
     Returns:
-        conn: connection object to the database (note, it is
-            `ConnectionPlus`, not `sqlite3.Connection`
+        connection object to the database (note, it is
+        :class:`ConnectionPlus`, not :class:`sqlite3.Connection`)
 
     """
     # register numpy->binary(TEXT) adapter


### PR DESCRIPTION
Many functions of the public API, like the `load_by_*`s,  are using a `ConnectionPlus` to avoid creating a new connection on every call. This PR exposes `connect` in order to provide the user a way of creating such a connection. `ConnectionPlus` is exposed to enable typing.