### PR TITLE
xfail failing tests on windows

### DIFF
--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1,5 +1,6 @@
 import random
 import re
+import sys
 from copy import copy
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -272,8 +273,10 @@ def test_load_by_id_for_none():
        dataset_name=hst.text(hst.characters(whitelist_categories=_unicode_categories),
                              min_size=1))
 @pytest.mark.usefixtures("empty_temp_db")
-def test_add_experiments(experiment_name,
-                         sample_name, dataset_name):
+@pytest.mark.xfail(
+    condition=sys.platform == "win32", reason="Time resolution is too low on windows"
+)
+def test_add_experiments(experiment_name, sample_name, dataset_name):
     global n_experiments
     n_experiments += 1
 


### PR DESCRIPTION
This test has started failing on windows ci build. In the long term we should make the guid more robust against low resolution clocks. This is just to unblock ci