### PR TITLE
CI / test improvements 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20
   rebase-strategy: "disabled"
 - package-ecosystem: github-actions
   directory: "/"

--- a/.github/workflows/pytest-min-versions.yaml
+++ b/.github/workflows/pytest-min-versions.yaml
@@ -52,6 +52,10 @@ jobs:
       run: |
         pip install -r min_requirements.txt
         pip install .[test]
-    - name: Run tests
+    - name: Run parallel tests
       run: |
-        pytest --hypothesis-profile ci qcodes
+        pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes
+# a subset of the tests fails when run in parallel on Windows so run those in serial here
+    - name: Run serial tests
+      run: |
+        pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci qcodes

--- a/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
+++ b/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
@@ -1,5 +1,7 @@
-import pytest
+import sys
 import timeit
+
+import pytest
 
 import qcodes.instrument.sims as sims
 from qcodes.instrument_drivers.tektronix.DPO7200xx import TektronixDPO7000xx
@@ -18,7 +20,9 @@ def tektronix_dpo():
     yield driver
     driver.close()
 
-
+@pytest.mark.xfail(
+    condition=sys.platform == "win32", reason="Time resolution is too low on windows"
+)
 def test_adjust_timer(tektronix_dpo):
     """
     After adjusting the type of the measurement or the source of the


### PR DESCRIPTION
# increase dependabot limit to 20

There are times where a lot of jobs are opened on the same day
There is no benefit for not opening all of them at once

# xfail a test that randomly fails on windows due to time resolution


# run min requirements tests with parallel / serial split

These have the same random failures as the regular tests
