### PR TITLE
Mypy: Enable no implicit re export

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,10 +164,7 @@ warn_unused_ignores = true
 # this triggers failures due to returning
 # values from untyped 3th party libs
 warn_return_any = false
-# this happens both internally
-# and in external libs that dont use
-# __all__ in their public reexported api
-no_implicit_reexport = false
+no_implicit_reexport = true
 strict_equality = true
 strict_concatenate = true
 

--- a/qcodes/__init__.py
+++ b/qcodes/__init__.py
@@ -6,11 +6,13 @@
 import warnings
 from typing import Any
 
+import qcodes._version
 import qcodes.configuration as qcconfig
 from qcodes.logger.logger import conditionally_start_all_logging
-from qcodes.utils import add_to_spyder_UMR_excludelist
+from qcodes.utils.spyder_utils import add_to_spyder_UMR_excludelist
 
-from ._version import __version__
+__version__ = qcodes._version.__version__
+
 
 config: qcconfig.Config = qcconfig.Config()
 

--- a/qcodes/dataset/data_set_cache.py
+++ b/qcodes/dataset/data_set_cache.py
@@ -24,9 +24,9 @@ if TYPE_CHECKING:
     import pandas as pd
     import xarray as xr
 
-    from .data_set import DataSet, ParameterData
+    from .data_set import DataSet
     from .data_set_in_memory import DataSetInMem
-    from .data_set_protocol import DataSetProtocol
+    from .data_set_protocol import DataSetProtocol, ParameterData
 
 DatasetType = TypeVar("DatasetType", bound="DataSetProtocol", covariant=True)
 

--- a/qcodes/dataset/database_fix_functions.py
+++ b/qcodes/dataset/database_fix_functions.py
@@ -16,7 +16,7 @@ from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.versioning.converters import old_to_new
 from qcodes.dataset.descriptions.versioning.rundescribertypes import RunDescriberV1Dict
 from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic, atomic_transaction
-from qcodes.dataset.sqlite.db_upgrades import get_user_version
+from qcodes.dataset.sqlite.db_upgrades.version import get_user_version
 from qcodes.dataset.sqlite.queries import (
     _get_parameters,
     _update_run_description,

--- a/qcodes/dataset/exporters/export_to_pandas.py
+++ b/qcodes/dataset/exporters/export_to_pandas.py
@@ -9,7 +9,7 @@ import numpy as np
 if TYPE_CHECKING:
     import pandas as pd
 
-    from qcodes.dataset.data_set import ParameterData
+    from qcodes.dataset.data_set_protocol import ParameterData
 
 
 def load_to_dataframe_dict(datadict: ParameterData) -> dict[str, pd.DataFrame]:

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -19,8 +19,7 @@ from .export_to_pandas import (
 if TYPE_CHECKING:
     import xarray as xr
 
-    from qcodes.dataset.data_set import ParameterData
-    from qcodes.dataset.data_set_protocol import DataSetProtocol
+    from qcodes.dataset.data_set_protocol import DataSetProtocol, ParameterData
 
 
 def _load_to_xarray_dataarray_dict_no_metadata(

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -33,7 +33,7 @@ import numpy as np
 
 import qcodes as qc
 import qcodes.validators as vals
-from qcodes.dataset.data_set import VALUE, DataSet, load_by_guid
+from qcodes.dataset.data_set import DataSet, load_by_guid
 from qcodes.dataset.data_set_in_memory import DataSetInMem
 from qcodes.dataset.data_set_protocol import (
     DataSetProtocol,
@@ -52,6 +52,7 @@ from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 from qcodes.dataset.experiment_container import Experiment
 from qcodes.dataset.export_config import get_data_export_automatic
+from qcodes.dataset.sqlite.query_helpers import VALUE
 from qcodes.parameters import (
     ArrayParameter,
     GroupedParameter,

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -22,9 +22,9 @@ from qcodes.dataset.experiment_settings import reset_default_experiment_id
 from qcodes.dataset.sqlite.connection import ConnectionPlus
 from qcodes.dataset.sqlite.db_upgrades import (
     _latest_available_version,
-    get_user_version,
     perform_db_upgrade,
 )
+from qcodes.dataset.sqlite.db_upgrades.version import get_user_version
 from qcodes.dataset.sqlite.initial_schema import init_db
 from qcodes.utils.types import complex_types, numpy_floats, numpy_ints
 

--- a/qcodes/dataset/threading.py
+++ b/qcodes/dataset/threading.py
@@ -25,7 +25,7 @@ from typing import (
 from qcodes.utils import RespondingThread
 
 if TYPE_CHECKING:
-    from qcodes.dataset.data_set_protocol import values_type
+    from qcodes.dataset.data_set_protocol import values_type, res_type
     from qcodes.parameters import ParamDataType, ParameterBase
 
 ParamMeasT = Union["ParameterBase", Callable[[], None]]

--- a/qcodes/dataset/threading.py
+++ b/qcodes/dataset/threading.py
@@ -25,7 +25,7 @@ from typing import (
 from qcodes.utils import RespondingThread
 
 if TYPE_CHECKING:
-    from qcodes.dataset.data_set_protocol import values_type, res_type
+    from qcodes.dataset.data_set_protocol import res_type, values_type
     from qcodes.parameters import ParamDataType, ParameterBase
 
 ParamMeasT = Union["ParameterBase", Callable[[], None]]

--- a/qcodes/instrument/base.py
+++ b/qcodes/instrument/base.py
@@ -6,13 +6,9 @@ Will be deprecated and eventually removed.
 
 from qcodes.parameters import Parameter
 
-from .instrument import (
-    Instrument,
-    InstrumentMeta,
-    InstrumentProtocol,
-    find_or_create_instrument,
-)
+from .instrument import Instrument, InstrumentProtocol, find_or_create_instrument
 from .instrument_base import InstrumentBase
+from .instrument_meta import InstrumentMeta
 
 __all__ = [
     "InstrumentBase",

--- a/qcodes/instrument/mockers/simulated_ats_api.py
+++ b/qcodes/instrument/mockers/simulated_ats_api.py
@@ -13,11 +13,12 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import numpy as np
 
 from qcodes.instrument_drivers.AlazarTech.ats_api import AlazarATSAPI
-from qcodes.instrument_drivers.AlazarTech.constants import API_SUCCESS, Capability
-from qcodes.instrument_drivers.AlazarTech.dll_wrapper import (
+from qcodes.instrument_drivers.AlazarTech.constants import (
+    API_SUCCESS,
+    Capability,
     ReturnCode,
-    _mark_params_as_updated,
 )
+from qcodes.instrument_drivers.AlazarTech.dll_wrapper import _mark_params_as_updated
 
 
 class SimulatedATS9360API(AlazarATSAPI):

--- a/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -3,7 +3,7 @@ import time
 from typing import Any, Sequence, Union
 
 import numpy as np
-from pyvisa import errors
+from pyvisa import constants, errors
 
 from qcodes.instrument import ChannelList, InstrumentChannel, VisaInstrument
 from qcodes.parameters import (
@@ -600,7 +600,7 @@ class PNABase(VisaInstrument):
             active_trace = self.active_trace()
         except errors.VisaIOError as e:
             self.log.debug("Exception on querying active trace: %r", e)
-            if e.error_code == errors.StatusCode.error_timeout:
+            if e.error_code == constants.StatusCode.error_timeout:
                 self.log.info("No active trace on PNA")
                 active_trace = None
             else:

--- a/qcodes/interactive_widget.py
+++ b/qcodes/interactive_widget.py
@@ -29,9 +29,8 @@ from ipywidgets import (
 from ruamel.yaml import YAML
 
 import qcodes
-from qcodes.dataset import initialise_or_create_database_at
+from qcodes.dataset import experiments, initialise_or_create_database_at, plot_dataset
 from qcodes.dataset.data_set_protocol import DataSetProtocol
-from qcodes.dataset.plotting import plot_dataset
 
 if TYPE_CHECKING:
     from qcodes.dataset.descriptions.param_spec import ParamSpecBase
@@ -516,9 +515,7 @@ def experiments_widget(
     if data_sets is None:
         if db is not None:
             initialise_or_create_database_at(db)
-        data_sets = [
-            ds for exp in qcodes.experiments() for ds in exp.data_sets()
-        ]
+        data_sets = [ds for exp in experiments() for ds in exp.data_sets()]
     if sort_by == "run_id":
         data_sets = sorted(data_sets, key=lambda ds: ds.run_id)
     elif sort_by == "timestamp":

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -10,6 +10,9 @@ import inspect
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
 import parso
+import parso.python
+import parso.python.tree
+import parso.tree
 from sphinx.util import logging
 from sphinx.util.inspect import safe_getattr
 
@@ -44,7 +47,7 @@ def find_class(
     for child in node.children:
         if isinstance(child, parso.python.tree.Class) and child.name.value == classname:
             nodes.append(child)
-        elif isinstance(child, parso.python.tree.Node):
+        elif isinstance(child, parso.tree.Node):
             nodes.extend(find_class(child, classname))
     return tuple(nodes)
 
@@ -60,7 +63,7 @@ def find_init_func(
             and child.name.value == "__init__"
         ):
             nodes.append(child)
-        elif isinstance(child, parso.python.tree.Node):
+        elif isinstance(child, parso.tree.Node):
             nodes.extend(find_init_func(child))
     return tuple(nodes)
 
@@ -98,7 +101,7 @@ def extract_statements_from_node(
     for child in parso_node.children:
         if isinstance(child, parso.python.tree.ExprStmt):
             nodes.append(child)
-        elif isinstance(child, parso.python.tree.Node):
+        elif isinstance(child, parso.tree.Node):
             nodes.extend(extract_statements_from_node(child))
     return tuple(nodes)
 
@@ -129,14 +132,14 @@ def extract_code_as_repr(
     lhs = stm.children[0]
     rhs = stm.get_rhs()
 
-    if isinstance(lhs, parso.python.tree.BaseNode) and len(lhs.children) == 2:
+    if isinstance(lhs, parso.tree.BaseNode) and len(lhs.children) == 2:
         obj1 = lhs.children[0]
         obj2 = lhs.children[1]
         if (
-            isinstance(obj1, parso.python.tree.Leaf)
+            isinstance(obj1, parso.tree.Leaf)
             and obj1.value == "self"
-            and isinstance(obj2, parso.python.tree.BaseNode)
-            and isinstance(obj2.children[1], parso.python.tree.Leaf)
+            and isinstance(obj2, parso.tree.BaseNode)
+            and isinstance(obj2.children[1], parso.tree.Leaf)
         ):
             name = obj2.children[1].value
             code = " ".join(rhs.get_code().strip().split())

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from hypothesis import settings
 
 import qcodes as qc
-from qcodes import initialise_database, new_data_set
+from qcodes.dataset import initialise_database, new_data_set
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.experiment_container import new_experiment

--- a/qcodes/tests/dataset/test_concurrent_datasets.py
+++ b/qcodes/tests/dataset/test_concurrent_datasets.py
@@ -3,7 +3,7 @@ Test that multiple datasets can coexist as expected
 """
 import pytest
 
-from qcodes import new_experiment
+from qcodes.dataset import new_experiment
 from qcodes.dataset.data_set import DataSet
 
 

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -9,24 +9,27 @@ import pytest
 import qcodes as qc
 import qcodes.dataset.descriptions.versioning.serialization as serial
 import qcodes.tests.dataset
-from qcodes import new_data_set, new_experiment
-from qcodes.dataset.data_set import load_by_counter, load_by_id, load_by_run_spec
+from qcodes.dataset import (
+    ConnectionPlus,
+    connect,
+    initialise_database,
+    initialise_or_create_database_at,
+    load_by_counter,
+    load_by_id,
+    load_by_run_spec,
+    new_data_set,
+    new_experiment,
+)
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.versioning.v0 import InterDependencies
 from qcodes.dataset.guids import parse_guid
-from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic_transaction
-from qcodes.dataset.sqlite.database import (
-    connect,
-    get_db_version_and_newest_available_version,
-    initialise_database,
-    initialise_or_create_database_at,
-)
+from qcodes.dataset.sqlite.connection import atomic_transaction
+from qcodes.dataset.sqlite.database import get_db_version_and_newest_available_version
 
 # pylint: disable=unused-import
 from qcodes.dataset.sqlite.db_upgrades import (
     _latest_available_version,
-    get_user_version,
     perform_db_upgrade,
     perform_db_upgrade_0_to_1,
     perform_db_upgrade_1_to_2,
@@ -37,8 +40,8 @@ from qcodes.dataset.sqlite.db_upgrades import (
     perform_db_upgrade_6_to_7,
     perform_db_upgrade_7_to_8,
     perform_db_upgrade_8_to_9,
-    set_user_version,
 )
+from qcodes.dataset.sqlite.db_upgrades.version import get_user_version, set_user_version
 from qcodes.dataset.sqlite.queries import get_run_description, update_GUIDs
 from qcodes.dataset.sqlite.query_helpers import (
     get_description_map,

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -13,7 +13,6 @@ from numpy.testing import assert_array_equal
 
 import qcodes as qc
 import qcodes.tests.dataset
-from qcodes import Station
 from qcodes.dataset import do1d, do2d
 from qcodes.dataset.data_set import (
     DataSet,
@@ -34,6 +33,7 @@ from qcodes.dataset.measurements import Measurement
 from qcodes.dataset.sqlite.connection import path_to_dbfile
 from qcodes.dataset.sqlite.database import get_db_version_and_newest_available_version
 from qcodes.dataset.sqlite.queries import get_experiments
+from qcodes.station import Station
 from qcodes.tests.common import error_caused_by, skip_if_no_fixtures
 from qcodes.tests.instrument_mocks import DummyInstrument
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -11,14 +11,15 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 
 import qcodes as qc
-from qcodes import (
+from qcodes.dataset import (
     experiments,
     load_by_counter,
     load_by_id,
     new_data_set,
     new_experiment,
 )
-from qcodes.dataset.data_set import CompletedError, DataSet
+from qcodes.dataset.data_set import DataSet
+from qcodes.dataset.data_set_protocol import CompletedError
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.rundescriber import RunDescriber

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -5,7 +5,7 @@ import pytest
 import xarray as xr
 
 import qcodes
-from qcodes import new_data_set
+from qcodes.dataset import new_data_set
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.versioning import serialization as serial

--- a/qcodes/tests/dataset/test_dataset_in_memory.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory.py
@@ -11,8 +11,7 @@ import xarray
 from hypothesis import HealthCheck, given, settings
 from numpy.testing import assert_almost_equal
 
-from qcodes import load_by_id
-from qcodes.dataset import load_by_run_spec
+from qcodes.dataset import load_by_id, load_by_run_spec
 from qcodes.dataset.data_set_in_memory import DataSetInMem
 from qcodes.dataset.data_set_protocol import DataSetType
 from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic_transaction

--- a/qcodes/tests/dataset/test_dataset_in_memory_bacis.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory_bacis.py
@@ -4,11 +4,10 @@ from typing import List
 import pytest
 
 import qcodes as qc
-from qcodes import load_by_guid, load_or_create_experiment
+from qcodes.dataset import connect, load_by_guid, load_or_create_experiment
 from qcodes.dataset.data_set_in_memory import DataSetInMem
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
-from qcodes.dataset.sqlite.database import connect
 
 
 def test_create_dataset_in_memory_explicit_db(empty_temp_db):

--- a/qcodes/tests/dataset/test_fix_functions.py
+++ b/qcodes/tests/dataset/test_fix_functions.py
@@ -13,7 +13,7 @@ from qcodes.dataset.database_fix_functions import (
 from qcodes.dataset.descriptions.param_spec import ParamSpec
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.versioning.converters import old_to_new
-from qcodes.dataset.sqlite.db_upgrades import get_user_version
+from qcodes.dataset.sqlite.db_upgrades.version import get_user_version
 from qcodes.dataset.sqlite.queries import get_run_description
 from qcodes.tests.common import skip_if_no_fixtures
 from qcodes.tests.dataset.conftest import temporarily_copied_DB

--- a/qcodes/tests/dataset/test_nested_measurements.py
+++ b/qcodes/tests/dataset/test_nested_measurements.py
@@ -6,10 +6,9 @@ import pytest
 from hypothesis import given, settings
 from numpy.testing import assert_allclose
 
-from qcodes import new_data_set
+from qcodes.dataset import Measurement, new_data_set
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
-from qcodes.dataset.measurements import Measurement
 from qcodes.dataset.sqlite.connection import atomic_transaction
 from qcodes.tests.common import retry_until_does_not_throw
 

--- a/qcodes/tests/dataset/test_string_data.py
+++ b/qcodes/tests/dataset/test_string_data.py
@@ -7,7 +7,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 
 import qcodes as qc
-from qcodes.dataset.data_export import load_by_id
+from qcodes.dataset import load_by_id
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.measurements import DataSaver, Measurement

--- a/qcodes/tests/delegate/test_device.py
+++ b/qcodes/tests/delegate/test_device.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import pytest
 
-from qcodes import Measurement
+from qcodes.dataset import Measurement
 from qcodes.tests.instrument_mocks import DummyChannel, MockCustomChannel
 
 

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_sampling_measurement.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_sampling_measurement.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from qcodes.instrument_drivers.Keysight.keysightb1500 import constants
-from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_sampling_measurement import (
+from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1500_module import (
     MeasurementNotTaken,
 )
 

--- a/qcodes/tests/drivers/test_AimTTi_PL601P.py
+++ b/qcodes/tests/drivers/test_AimTTi_PL601P.py
@@ -1,14 +1,14 @@
 import pytest
 
 import qcodes.instrument.sims as sims
-from qcodes.instrument_drivers.AimTTi.AimTTi_PL601P_channels import AimTTi
+from qcodes.instrument_drivers.AimTTi import AimTTiPL601
 
 visalib = sims.__file__.replace('__init__.py', 'AimTTi_PL601P.yaml@sim')
 
 
 @pytest.fixture(scope='function')
 def driver():
-    driver = AimTTi('AimTTi', address='GPIB::1::INSTR', visalib=visalib)
+    driver = AimTTiPL601("AimTTi", address="GPIB::1::INSTR", visalib=visalib)
 
     yield driver
     driver.close()

--- a/qcodes/tests/drivers/test_Keithley_2450.py
+++ b/qcodes/tests/drivers/test_Keithley_2450.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import qcodes.instrument.sims as sims
-from qcodes.instrument_drivers.tektronix.Keithley_2450 import Keithley2450
+from qcodes.instrument_drivers.Keithley import Keithley2450
 
 visalib = sims.__file__.replace('__init__.py', 'Keithley_2450.yaml@sim')
 

--- a/qcodes/tests/drivers/test_keithley_7510.py
+++ b/qcodes/tests/drivers/test_keithley_7510.py
@@ -4,7 +4,7 @@ import pytest
 from hypothesis import given, settings
 
 import qcodes.instrument.sims as sims
-from qcodes.instrument_drivers.tektronix.keithley_7510 import Keithley7510
+from qcodes.instrument_drivers.Keithley import Keithley7510
 
 VISALIB = sims.__file__.replace('__init__.py', 'keithley_7510.yaml@sim')
 

--- a/qcodes/tests/drivers/test_lakeshore_325_legacy.py
+++ b/qcodes/tests/drivers/test_lakeshore_325_legacy.py
@@ -3,12 +3,12 @@ from hypothesis import given
 
 from qcodes.instrument_drivers.Lakeshore import Model_325
 
-STATUS = Model_325.Status
+STATUS = Model_325.Status  # type: ignore[attr-defined]
 
 
 @given(
     st.lists(st.sampled_from(list(STATUS)), min_size=1, max_size=5, unique=True).map(
-        sorted  # type: ignore[arg-type]
+        sorted
     )
 )
 def test_decode_sensor_status(list_of_codes):

--- a/qcodes/tests/legacy/test_generic_formatter.py
+++ b/qcodes/tests/legacy/test_generic_formatter.py
@@ -7,6 +7,7 @@ import qcodes.measure
 from qcodes.data.data_set import load_data
 from qcodes.data.gnuplot_format import GNUPlotFormat
 from qcodes.data.hdf5_format import HDF5Format, HDF5FormatMetadata
+from qcodes.parameters import Parameter
 from qcodes.tests.legacy.data_mocks import DataSet2D
 
 
@@ -42,10 +43,11 @@ class TestNoSorting(TestCase):
     formatter, so I guess it goes here.
     """
 
-    param = qcodes.Parameter(name='mixed_val_mapping_param',
-                             get_cmd=lambda: np.random.randint(1, 3),
-                             val_mapping={1: 1, '2': 2}
-                             )
+    param = Parameter(
+        name="mixed_val_mapping_param",
+        get_cmd=lambda: np.random.randint(1, 3),
+        val_mapping={1: 1, "2": 2},
+    )
 
     def test_can_measure(self):
         qcodes.measure.Measure(self.param).run(name="test_no_sorting")

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -7,9 +7,8 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from numpy.testing import assert_allclose, assert_array_equal
 
-from qcodes import Instrument
 from qcodes.data.location import FormatLocation
-from qcodes.instrument import ChannelList, ChannelTuple, InstrumentChannel
+from qcodes.instrument import ChannelList, ChannelTuple, Instrument, InstrumentChannel
 from qcodes.loops import Loop
 from qcodes.parameters import Parameter
 from qcodes.tests.instrument_mocks import DummyChannel, DummyChannelInstrument

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -9,8 +9,8 @@ import weakref
 import pytest
 
 from qcodes.instrument import Instrument, InstrumentBase, find_or_create_instrument
+from qcodes.metadatable import Metadatable
 from qcodes.parameters import Function, Parameter
-from qcodes.utils.metadata import Metadatable
 
 from .instrument_mocks import (
     DummyChannelInstrument,

--- a/qcodes/tests/test_slack.py
+++ b/qcodes/tests/test_slack.py
@@ -4,7 +4,7 @@ import pytest
 from requests.exceptions import ConnectTimeout, HTTPError, ReadTimeout
 from urllib3.exceptions import ReadTimeoutError
 
-from qcodes import Parameter
+from qcodes.parameters import Parameter
 
 
 class AnyStringWith(str):

--- a/qcodes/utils/__init__.py
+++ b/qcodes/utils/__init__.py
@@ -21,7 +21,6 @@ from .numpy_utils import list_of_data_to_maybe_ragged_nd_array
 from .partial_utils import partial_with_docstring
 from .path_helpers import get_qcodes_path, get_qcodes_user_path
 from .snapshot_helpers import ParameterDiff, diff_param_values, extract_param_values
-from .spyder_utils import add_to_spyder_UMR_excludelist
 from .threading_utils import RespondingThread, thread_map
 
 __all__ = [


### PR DESCRIPTION
* Avoid imports from pyvisa/parso that are imported from modules where they are not defined/added to `__all__`
* Update internal updated to either use public api or original definition 