### PR TITLE
Fix typo in Agilent alias

### DIFF
--- a/qcodes/instrument_drivers/agilent/Agilent_34400A.py
+++ b/qcodes/instrument_drivers/agilent/Agilent_34400A.py
@@ -6,5 +6,5 @@ from ._Agilent_344xxA import _Agilent344xxA
 @deprecate(
     alternative="Keysight 344xxA drivers or Agilent34401A, Agilent34410A, Agilent34411A"
 )
-class Agilent34400A(_Agilent344xxA):
+class Agilent_34400A(_Agilent344xxA):
     pass


### PR DESCRIPTION
This restores a name of a deprecated non conformant class as it was in 0.34.1 