### PR TITLE
add precommit hook to ensure no case conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
       exclude: asv.conf.json
     - id: check-toml
     - id: check-yaml
+    - id: check-case-conflict
     - id: debug-statements
     - id: mixed-line-ending
       args: ['--fix=no']


### PR DESCRIPTION
With the landing of #4248 we no longer have case conflicts in the QCoDeS codebase. Lets ensure we don't get them again