### PR TITLE
Restrict python patch version in ci

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -18,7 +18,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # we need to pin to 3.10.6 until
+        # https://github.com/python/mypy/pull/13500
+        # is part of a released version of mypy
+        python-version: ["3.7", "3.8", "3.9", "3.10.6"]
         exclude:
           - os: windows-latest
             python-version: "3.7"

--- a/bors.toml
+++ b/bors.toml
@@ -7,8 +7,8 @@ status = [
   "pytestmypy (ubuntu-latest, 3.7)",
   "pytestmypy (ubuntu-latest, 3.8)",
   "pytestmypy (ubuntu-latest, 3.9)",
-  "pytestmypy (ubuntu-latest, 3.10)",
-  "pytestmypy (windows-latest, 3.10)",
+  "pytestmypy (ubuntu-latest, 3.10.6)",
+  "pytestmypy (windows-latest, 3.10.6)",
   "pytestmin (ubuntu-latest, 3.7)"
 ]
 # these are the checks that must pass before a branch can be merged to staging using bors r+
@@ -20,8 +20,8 @@ pr_status = [
   "pytestmypy (ubuntu-latest, 3.7)",
   "pytestmypy (ubuntu-latest, 3.8)",
   "pytestmypy (ubuntu-latest, 3.9)",
-  "pytestmypy (ubuntu-latest, 3.10)",
-  "pytestmypy (windows-latest, 3.10)",
+  "pytestmypy (ubuntu-latest, 3.10.6)",
+  "pytestmypy (windows-latest, 3.10.6)",
   "pytestmin (ubuntu-latest, 3.7)",
   "pre-commit.ci - pr"
 ]


### PR DESCRIPTION
This can be reverted once a mypy version with https://github.com/python/mypy/pull/13500 is out

