### PR TITLE
Avoid recursion for bytes / bytearrays in json encoder

### DIFF
--- a/docs/changes/newsfragments/4621.improved
+++ b/docs/changes/newsfragments/4621.improved
@@ -1,0 +1,2 @@
+Fixed a bug in the QCoDeS JSON encoder that would trigger an infinite recursion for snapshots containing
+bytes (bytestrings with a b prefix).

--- a/qcodes/tests/helpers/test_json_encoder.py
+++ b/qcodes/tests/helpers/test_json_encoder.py
@@ -168,3 +168,25 @@ def test_numpy_encoder_examplemetadata():
         'myuserdict': {'a': 1}
     }
     assert metadata == data_dict
+
+
+def test_bytes():
+    e = NumpyJSONEncoder()
+    value = b"abc123"
+    v = e.encode(value)
+
+    default_encoder = json.JSONEncoder()
+    # encoding bytes is the same as using the
+    # default encode on the str value of the bytes
+    assert v == default_encoder.encode(str(value))
+
+
+def test_bytes_array():
+    e = NumpyJSONEncoder()
+    value = bytearray(b"abc123")
+    v = e.encode(value)
+
+    default_encoder = json.JSONEncoder()
+    # encoding bytes is the same as using the
+    # default encode on the str value of the bytes array
+    assert v == default_encoder.encode(str(value))

--- a/qcodes/tests/helpers/test_json_encoder.py
+++ b/qcodes/tests/helpers/test_json_encoder.py
@@ -2,8 +2,10 @@ import json
 import warnings
 from collections import OrderedDict, UserDict
 
+import hypothesis.strategies as hst
 import numpy as np
 import pytest
+from hypothesis import given
 
 with warnings.catch_warnings():
     # this context manager can be removed when uncertainties
@@ -170,20 +172,21 @@ def test_numpy_encoder_examplemetadata():
     assert metadata == data_dict
 
 
-def test_bytes():
+@given(bytes_to_encode=hst.binary(max_size=100))
+def test_bytes(bytes_to_encode):
     e = NumpyJSONEncoder()
-    value = b"abc123"
-    v = e.encode(value)
+    v = e.encode(bytes_to_encode)
 
     default_encoder = json.JSONEncoder()
     # encoding bytes is the same as using the
     # default encode on the str value of the bytes
-    assert v == default_encoder.encode(str(value))
+    assert v == default_encoder.encode(str(bytes_to_encode))
 
 
-def test_bytes_array():
+@given(bytes_to_encode=hst.binary(max_size=100))
+def test_bytes_array(bytes_to_encode):
     e = NumpyJSONEncoder()
-    value = bytearray(b"abc123")
+    value = bytearray(bytes_to_encode)
     v = e.encode(value)
 
     default_encoder = json.JSONEncoder()

--- a/qcodes/utils/json_utils.py
+++ b/qcodes/utils/json_utils.py
@@ -74,7 +74,12 @@ class NumpyJSONEncoder(json.JSONEncoder):
                     return obj.data
                 # See if the object supports the pickle protocol.
                 # If so, we should be able to use that to serialize.
-                if hasattr(obj, "__getnewargs__"):
+                # __getnewargs__ will return bytes for a bytes object
+                # causing an infinte recursion, so we do not
+                # try to pickle bytes or bytearrays
+                if hasattr(obj, "__getnewargs__") and not isinstance(
+                    obj, (bytes, bytearray)
+                ):
                     return {
                         "__class__": type(obj).__name__,
                         "__args__": getattr(obj, "__getnewargs__")(),


### PR DESCRIPTION
Fixes #4620 

Note that this does not in any way attempt to support bytes that cannot be converted to a string but at least these will not trigger an infinite recursion. 