### PR TITLE
Minicircuits 4SPDT driver fix for .NET 4.5+ versions

### DIFF
--- a/docs/changes/newsfragments/4623.improved_driver
+++ b/docs/changes/newsfragments/4623.improved_driver
@@ -1,0 +1,1 @@
+The Minicircuits USB SPDT driver now supports running with the more modern version of the driver DLL `mcl_RF_Switch_Controller_NET45.dll`

--- a/docs/examples/driver_examples/Qcodes example with Minicircuits Switch boxes (USB-XSPDT).ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Minicircuits Switch boxes (USB-XSPDT).ipynb
@@ -17,6 +17,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -26,12 +27,15 @@
     "\n",
     "https://www.minicircuits.com/softwaredownload/rfswitchcontroller.html\n",
     "\n",
-    "Download .NET dll and save somewhere. Unblock it (right click properties) and specify the path."
+    "Download .NET dll and save somewhere. Unblock it (right click properties) and specify the path.\n",
+    "\n",
+    "The downloaded ZIP file contains two DLLs. We recommend using mcl_RF_Switch_Controller_NET45.dll\n",
+    "which supports the most recent .net versions. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -45,7 +49,7 @@
    "source": [
     "dev = USB_SPDT('test',\n",
     "               serial_number='11703020018',\n",
-    "               driver_path= r'C:\\Users\\a-dovoge\\Qcodes\\qcodes\\instrument_drivers\\Minicircuits\\mcl_RF_Switch_Controller64')"
+    "               driver_path= r'C:\\Users\\a-dovoge\\Qcodes\\qcodes\\instrument_drivers\\Minicircuits\\mcl_RF_Switch_Controller_NET45')"
    ]
   },
   {
@@ -117,7 +121,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "qcodespip310",
    "language": "python",
    "name": "python3"
   },
@@ -131,10 +135,15 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.10.8 | packaged by conda-forge | (main, Nov 24 2022, 14:07:00) [MSC v.1916 64 bit (AMD64)]"
   },
   "nbsphinx": {
    "execute": "never"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "2643ef1ecb4e72f15331668d402315679b29a004e65b7ec963f6cfe589581b49"
+   }
   }
  },
  "nbformat": 4,

--- a/docs/examples/driver_examples/Qcodes example with Minicircuits Switch boxes (USB-XSPDT).ipynb
+++ b/docs/examples/driver_examples/Qcodes example with Minicircuits Switch boxes (USB-XSPDT).ipynb
@@ -24,7 +24,7 @@
     "\n",
     "The driver_path should specify the url of the dll for controlling the instrument. You can find it here:\n",
     "\n",
-    "https://ww2.minicircuits.com/softwaredownload/rfswitchcontroller.html\n",
+    "https://www.minicircuits.com/softwaredownload/rfswitchcontroller.html\n",
     "\n",
     "Download .NET dll and save somewhere. Unblock it (right click properties) and specify the path."
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ module = [
     "lomentum.tools",
     "matplotlib.*",
     "mcl_RF_Switch_Controller64",
+    "mcl_RF_Switch_Controller_NET45",
     "opencensus.ext.azure.*",
     "pythoncom",
     "pyqtgraph.*",

--- a/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
@@ -70,7 +70,7 @@ class USB_SPDT(SPDT_Base):
             )
         try:
             import mcl_RF_Switch_Controller64 as mw_driver  # pyright: ignore[reportMissingImports]
-        except:
+        except ImportError:
             import mcl_RF_Switch_Controller_NET45 as mw_driver  # pyright: ignore[reportMissingImports]
 
         self.switch = mw_driver.USB_RF_SwitchBox()

--- a/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
@@ -68,8 +68,12 @@ class USB_SPDT(SPDT_Base):
                 the dll to open properties and check the 'unblock' checkmark
                 in the bottom. Check that your python installation is 64bit."""
             )
-        import mcl_RF_Switch_Controller64  # pyright: ignore[reportMissingImports]
-        self.switch = mcl_RF_Switch_Controller64.USB_RF_SwitchBox()
+        try:
+            import mcl_RF_Switch_Controller64 as mw_driver  # pyright: ignore[reportMissingImports]
+        except:
+            import mcl_RF_Switch_Controller_NET45 as mw_driver  # pyright: ignore[reportMissingImports]
+
+        self.switch = mw_driver.USB_RF_SwitchBox()
 
         if not self.switch.Connect(serial_number):
             raise RuntimeError('Could not connect to device')

--- a/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/USB_SPDT.py
@@ -37,7 +37,8 @@ class USB_SPDT(SPDT_Base):
     """
 
     CHANNEL_CLASS = SwitchChannelUSB
-    PATH_TO_DRIVER = r'mcl_RF_Switch_Controller64'
+    PATH_TO_DRIVER = r"mcl_RF_Switch_Controller64"
+    PATH_TO_DRIVER_45 = r"mcl_RF_Switch_Controller_NET45"
 
     def __init__(self, name: str, driver_path: Optional[str] = None,
                  serial_number: Optional[str] = None, **kwargs: Any):
@@ -57,15 +58,18 @@ class USB_SPDT(SPDT_Base):
             raise ImportError("""This driver only works in Windows.""")
         try:
             if driver_path is None:
-                clr.AddReference(self.PATH_TO_DRIVER)
+                try:
+                    clr.AddReference(self.PATH_TO_DRIVER)
+                except FileNotFoundError:
+                    clr.AddReference(self.PATH_TO_DRIVER_45)
             else:
                 clr.AddReference(driver_path)
 
         except (ImportError, FileNotFoundException):
             raise ImportError(
-                """Load of mcl_RF_Switch_Controller64.dll not possible. Make sure
-                the dll file is not blocked by Windows. To unblock right-click
-                the dll to open properties and check the 'unblock' checkmark
+                """Load of mcl_RF_Switch_Controller64.dll or mcl_RF_Switch_Controller_NET45.dll
+                not possible. Make sure the dll file is not blocked by Windows.
+                To unblock right-click the dll to open properties and check the 'unblock' checkmark
                 in the bottom. Check that your python installation is 64bit."""
             )
         try:


### PR DESCRIPTION
There are two different dll files depending on the version of .NET on the system:
.Net 4.5 and above: mcl_RF_Switch_Controller_NET45.dll
Earlier .Net versions: mcl_RF_Switch_Controller64.dll

Had a quick look but couldn't find an easy way to check the .NET version from python although would expect it should be possible. The most rudimentary solution is to just try importing both and renaming the package in python as shown suggested here but would be nice with a cleaner implementation.