### PR TITLE
Fix Breaking: Restore do0d

### DIFF
--- a/qcodes/utils/dataset/doNd.py
+++ b/qcodes/utils/dataset/doNd.py
@@ -1,3 +1,4 @@
+from qcodes.dataset.dond.do_0d import do0d
 from qcodes.dataset.dond.do_1d import do1d
 from qcodes.dataset.dond.do_2d import do2d
 from qcodes.dataset.dond.do_nd import (


### PR DESCRIPTION
Restore `do0d` to `qcodes.utils.dataset.doNd`. It seems to have been accidentally removed in commit 934aa4575b7bc341bd04ca5fca7b3fa622b46b64

@jenshnielsen 