### PR TITLE
Alazar generic output must be input

### DIFF
--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -290,22 +290,22 @@ class AlazarTech_ATS(Instrument):
         return buffer
 
     def acquire(
-            self,
-            mode: Optional[str] = None,
-            samples_per_record: Optional[int] = None,
-            records_per_buffer: Optional[int] = None,
-            buffers_per_acquisition: Optional[int] = None,
-            channel_selection: Optional[str] = None,
-            transfer_offset: Optional[int] = None,
-            external_startcapture: Optional[str] = None,
-            enable_record_headers: Optional[str] = None,
-            alloc_buffers: Optional[str] = None,
-            fifo_only_streaming: Optional[str] = None,
-            interleave_samples:  Optional[str] = None,
-            get_processed_data: Optional[str] = None,
-            allocated_buffers: Optional[int] = None,
-            buffer_timeout: Optional[int] = None,
-            acquisition_controller: Optional["AcquisitionController[Any]"] = None
+        self,
+        mode: Optional[str] = None,
+        samples_per_record: Optional[int] = None,
+        records_per_buffer: Optional[int] = None,
+        buffers_per_acquisition: Optional[int] = None,
+        channel_selection: Optional[str] = None,
+        transfer_offset: Optional[int] = None,
+        external_startcapture: Optional[str] = None,
+        enable_record_headers: Optional[str] = None,
+        alloc_buffers: Optional[str] = None,
+        fifo_only_streaming: Optional[str] = None,
+        interleave_samples: Optional[str] = None,
+        get_processed_data: Optional[str] = None,
+        allocated_buffers: Optional[int] = None,
+        buffer_timeout: Optional[int] = None,
+        acquisition_controller: Optional["AcquisitionController[OutputType]"] = None,
     ) -> OutputType:
         """
         perform a single acquisition with the Alazar board, and set certain

--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -580,13 +580,13 @@ class AlazarTech_ATS(Instrument):
         # return result
         return acquisition_controller.post_acquire()
 
-    def _set_if_present(self, param_name: str, value: int | str | float | None) -> None:
+    def _set_if_present(self, param_name: str, value: str | float | None) -> None:
         if value is not None:
             parameter = self.parameters[param_name]
             parameter.set(value)
 
     def _set_list_if_present(
-        self, param_base: str, value: Sequence[int | str | float]
+        self, param_base: str, value: Sequence[str | float]
     ) -> None:
         if value is not None:
             for i, v in enumerate(value):


### PR DESCRIPTION
With the upcoming mypy 0.980 mypy will enforce that a generic Typevar output is matched by a generic input such that it can infer the type of the output. This reveals that `acquire` would return an unbound typevar. This fixes that by matching it to the type of the ```acquisition_controller ```

Note that the code is typed to accept acquisition_controller being None but that will actually unconditionally raise. 


```python
       if acquisition_controller is None:
            raise RuntimeError("Cannot call acquire without an "
                               "acquisition_controller")
```

Also add `from __future__ import annotations` to make types cleaner