### PR TITLE
Significant performance improvements for complex scalars

### DIFF
--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -24,7 +24,11 @@ from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.guids import parse_guid
 from qcodes.dataset.sqlite.connection import atomic, path_to_dbfile
-from qcodes.dataset.sqlite.database import _convert_array, get_DB_location
+from qcodes.dataset.sqlite.database import (
+    _convert_array,
+    _convert_complex,
+    get_DB_location,
+)
 from qcodes.dataset.sqlite.queries import _rewrite_timestamps, _unicode_categories
 from qcodes.tests.common import error_caused_by
 from qcodes.tests.dataset.helper_functions import verify_data_dict
@@ -613,6 +617,15 @@ def test_backward_compat__adapt_array_v0_33():
         np.save(out, arr)
         out.seek(0)
         assert arr == _convert_array(out.read())
+
+
+def test_backward_compat__adapt_complex_v0_33():
+    for dtype in complex_types:
+        value = dtype(1j)
+        out = io.BytesIO()
+        np.save(out, np.array([value]))
+        out.seek(0)
+        assert value == _convert_complex(out.read())
 
 
 def test_missing_keys(dataset):

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -54,6 +54,7 @@ All numpy float types
 """
 
 numpy_concrete_complex = (np.complex64, np.complex128)
+numpy_complex_map_size2type = {np.dtype(t).itemsize: t for t in numpy_concrete_complex}
 """
 Complex types with fixed sizes.
 """


### PR DESCRIPTION
Following https://github.com/QCoDeS/Qcodes/pull/4446

To be more explicit, I write two scripts corresponding to the current situation and my PR:

master 
```python
import io
import timeit

import numpy as np


def _adapt_complex(value):
    out = io.BytesIO()
    np.save(out, np.array([value]))
    out.seek(0)
    return out.read()


def _convert_complex(text):
    out = io.BytesIO(text)
    out.seek(0)
    return np.load(out)[0]


value = np.complex128()
print(f"----- Input to adapt : size {np.dtype(value).itemsize} bytes -----")
print(value)
repetition = 1000000
print(
    f"-- Adapt time : {timeit.timeit('_adapt_complex(value)', globals=globals(), number=repetition)*1e6 / repetition:.4g} us --"
)
text = _adapt_complex(value)
print(
    f"----- Resulting data : size {len(text)} bytes, overhead {100*(len(text)/ np.dtype(value).itemsize - 1):.2f} % -----"
)
print(text)
repetition = 100000
print(
    f"-- Convert time : {timeit.timeit('_convert_complex(text)', globals=globals(), number=repetition)*1e6 / repetition:.4g} us --"
)
```
On my computer with `python -OO`, it gives:
```
----- Input to adapt : size 16 bytes -----
0j
-- Adapt time : 11.96 us --
----- Resulting data : size 144 bytes, overhead 800.00 % -----
b"\x93NUMPY\x01\x00v\x00{'descr': '<c16', 'fortran_order': False, 'shape': (1,), }                                                           \n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-- Convert time : 126.3 us --
```

improvement
```python
import timeit

import numpy as np


def _adapt_complex(value):
    return (
        value if isinstance(value, np.complexfloating) else np.complex_(value)
    ).tobytes()


numpy_concrete_complex = (np.complex64, np.complex128)
numpy_complex_map_size2type = {np.dtype(t).itemsize: t for t in numpy_concrete_complex}


def _convert_complex(text):
    try:
        value_size = len(text) % 64
        return np.frombuffer(
            text[-value_size:], dtype=numpy_complex_map_size2type[value_size]
        ).item()
    except KeyError as exc:
        raise ValueError(f"Cannot parse {str(text)}") from exc


value = np.complex128()
print(f"----- Input to adapt : size {np.dtype(value).itemsize} bytes -----")
print(value)
repetition = 10000000
print(
    f"-- Adapt time : {timeit.timeit('_adapt_complex(value)', globals=globals(), number=repetition)*1e6 / repetition:.4g} us --"
)
text = _adapt_complex(value)
print(
    f"----- Resulting data : size {len(text)} bytes, overhead {100*(len(text)/ np.dtype(value).itemsize - 1):.2f} % -----"
)
print(text)
repetition = 10000000
print(
    f"-- Convert time : {timeit.timeit('_convert_complex(text)', globals=globals(), number=repetition)*1e6 / repetition:.4g} us --"
)
```
On my computer with `python -OO`, it gives:
```
----- Input to adapt : size 16 bytes -----
0j
-- Adapt time : 0.5586 us --
----- Resulting data : size 16 bytes, overhead 0.00 % -----
b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-- Convert time : 0.7448 us --
```

Both for time and memory, it looks like major improvements.