### PR TITLE
Mark two clases with test in the name as not tests

### DIFF
--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -428,6 +428,9 @@ def test_snapshot_and_meta_attrs():
 
 
 class TestSnapshotType(Metadatable):
+
+    __test__ = False
+
     def __init__(self, sample_value: int) -> None:
         super().__init__()
         self.sample_value = sample_value
@@ -437,6 +440,9 @@ class TestSnapshotType(Metadatable):
 
 
 class TestInstrument(InstrumentBase):
+
+    __test__ = False
+
     def __init__(self, name, label) -> None:
         super().__init__(name, label=label)
         self._meta_attrs.extend(["test_attribute"])


### PR DESCRIPTION
This fixes a warning from pytest that these cannot be collected as tests