### PR TITLE
log getting and setting dummy parameters for examples

### DIFF
--- a/qcodes/dataset/dond/do_nd.py
+++ b/qcodes/dataset/dond/do_nd.py
@@ -699,6 +699,7 @@ def dond(
             # https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable
             # https://github.com/python/cpython/issues/86992#issuecomment-1093897307
             for set_events in tqdm(sweeper, disable=not show_progress):  # type: ignore[call-overload]
+                LOG.debug(f"processing set events: {set_events}")
                 results: dict[ParameterBase, Any] = {}
                 for set_event in set_events:
                     if set_event.should_set:

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -207,8 +207,9 @@ class DmmExponentialParameter(Parameter):
         provide a ``get`` method on the parameter instance.
         """
         dac = self.root_instrument._setter_instr
-        val = self._ed.send(dac.ch1())
+        val = self._ed.send(dac.ch1.cache.get())
         next(self._ed)
+        log.debug(f"Getting raw value parameter {self.full_name} as {val}")
         return val
 
     @staticmethod
@@ -238,8 +239,9 @@ class DmmGaussParameter(Parameter):
         provide a ``get`` method on the parameter instance.
         """
         dac = self.root_instrument._setter_instr
-        val = self._gauss.send((dac.ch1.get(), dac.ch2.get()))
+        val = self._gauss.send((dac.ch1.cache.get(), dac.ch2.cache.get()))
         next(self._gauss)
+        log.debug(f"Getting raw value parameter {self.full_name} as {val}")
         return val
 
     def _gauss_model(self):


### PR DESCRIPTION
This brings dummy parameters for the 2 instruments used in examples inline with regular instruments (that log via write/ask) The aim of this is to eventually be able to write a notebook explaining how one can use debugging to understand a measurement