### PR TITLE
Add Exception to except

### DIFF
--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -285,7 +285,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
                 update_par = update
             try:
                 snap["parameters"][name] = param.snapshot(update=update_par)
-            except:
+            except Exception:
                 # really log this twice. Once verbose for the UI and once
                 # at lower level with more info for file based loggers
                 self.log.warning("Snapshot: Could not update parameter: %s", name)


### PR DESCRIPTION
This PR changes an except statement in `InstrumentBase.snapshot_base` from `except:` to `except Exception`.
This allows other errors, e.g. a `KeyboardInterrupt`, to halt the snapshot.
Without this modification, a snapshot can take a long time if there is a communication error.