### PR TITLE
Dependabot python use increase-if-necessary

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     interval: daily
   open-pull-requests-limit: 20
   rebase-strategy: "disabled"
+  versioning-strategy: increase-if-necessary
 - package-ecosystem: github-actions
   directory: "/"
   rebase-strategy: "disabled"


### PR DESCRIPTION
This should prevent dependabot from issuing upgrades for x~=1.1.0 to 1.1.1 when 1.1.1 is released since that is already matched by ~=

See https://github.blog/changelog/2022-10-24-reduce-dependabot-version-updates-in-your-python-projects-with-the-increase-if-necessary-strategy/
