### PR TITLE
Add random sample to guid

### DIFF
--- a/docs/changes/newsfragments/4763.breaking
+++ b/docs/changes/newsfragments/4763.breaking
@@ -1,0 +1,5 @@
+Explicitly setting a sample id in the `qcodesrc.json` config file has been deprecated. This feature is
+expected to be very lightly used. Please do get in touch if you rely on it. This will eventually
+be replaced by a random string. For the same reason `load_by_run_spec` will no longer print
+`sample_id` as part of the output when more than one potential match is found.
+Note that this is different from the sample_name set as part of an experiment which is still supported.

--- a/docs/examples/DataSet/Extracting-runs-from-one-DB-file-to-another.ipynb
+++ b/docs/examples/DataSet/Extracting-runs-from-one-DB-file-to-another.ipynb
@@ -20,7 +20,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,11 +28,9 @@
     "\n",
     "import numpy as np\n",
     "\n",
-    "from qcodes.dataset.database_extract_runs import extract_runs_into_db\n",
-    "from qcodes.dataset.experiment_container import Experiment, load_experiment_by_name\n",
+    "from qcodes.dataset import extract_runs_into_db, load_or_create_experiment, load_experiment_by_name, Measurement\n",
     "from qcodes.tests.instrument_mocks import DummyInstrument\n",
-    "from qcodes.dataset.measurements import Measurement\n",
-    "from qcodes import Station\n",
+    "from qcodes.station import Station\n",
     "\n",
     "# The following function is imported and used here only for the sake\n",
     "# of explicitness. As a qcodes user, please, consider this function\n",
@@ -43,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,34 +51,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Upgrading database; v0 -> v1: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v1 -> v2: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 407.89it/s]\n",
-      "Upgrading database; v2 -> v3: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v3 -> v4: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v4 -> v5: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 333.17it/s]\n",
-      "Upgrading database; v5 -> v6: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v6 -> v7: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 166.47it/s]\n",
-      "Upgrading database; v7 -> v8: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 250.05it/s]\n",
-      "Upgrading database; v8 -> v9: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 499.56it/s]\n",
-      "Upgrading database; v0 -> v1: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v1 -> v2: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 333.33it/s]\n",
-      "Upgrading database; v2 -> v3: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v3 -> v4: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v4 -> v5: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 333.38it/s]\n",
-      "Upgrading database; v5 -> v6: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v6 -> v7: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 166.56it/s]\n",
-      "Upgrading database; v7 -> v8: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 499.74it/s]\n",
-      "Upgrading database; v8 -> v9: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 500.45it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "source_conn = connect(source_path)\n",
     "target_conn = connect(target_path)"
@@ -92,8 +65,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exp = Experiment(\n",
-    "    name=\"extract_runs_experiment\", sample_name=\"no_sample\", conn=source_conn\n",
+    "exp = load_or_create_experiment(\n",
+    "    experiment_name=\"extract_runs_experiment\", sample_name=\"no_sample\", conn=source_conn\n",
     ")\n",
     "\n",
     "my_inst = DummyInstrument(\"my_inst\", gates=[\"voltage\", \"current\"])\n",
@@ -206,7 +179,7 @@
     {
      "data": {
       "text/plain": [
-       "'aaaaaaaa-0000-0000-0000-017ea07e4a31'"
+       "'aaaaaaaa-0000-0000-0000-0184198c6857'"
       ]
      },
      "execution_count": 9,
@@ -226,7 +199,7 @@
     {
      "data": {
       "text/plain": [
-       "'aaaaaaaa-0000-0000-0000-017ea07e4a31'"
+       "'aaaaaaaa-0000-0000-0000-0184198c6857'"
       ]
      },
      "execution_count": 10,
@@ -299,41 +272,25 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Upgrading database; v0 -> v1: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v1 -> v2: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 500.04it/s]\n",
-      "Upgrading database; v2 -> v3: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v3 -> v4: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v4 -> v5: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 333.89it/s]\n",
-      "Upgrading database; v5 -> v6: : 0it [00:00, ?it/s]\n",
-      "Upgrading database; v6 -> v7: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 199.91it/s]\n",
-      "Upgrading database; v7 -> v8: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 333.44it/s]\n",
-      "Upgrading database; v8 -> v9: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 333.36it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "source_extra_conn = connect(extra_source_path)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
-    "exp = Experiment(\n",
-    "    name=\"extract_runs_experiment_aux\", sample_name=\"no_sample\", conn=source_extra_conn\n",
+    "exp = load_or_create_experiment(\n",
+    "    experiment_name=\"extract_runs_experiment_aux\", sample_name=\"no_sample\", conn=source_extra_conn\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -368,16 +325,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'aaaaaaaa-0000-0000-0000-017ea07e5986'"
+       "'aaaaaaaa-0000-0000-0000-0184198cbc78'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -388,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,16 +372,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'aaaaaaaa-0000-0000-0000-017ea07e5986'"
+       "'aaaaaaaa-0000-0000-0000-0184198cbc78'"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -442,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -451,7 +408,7 @@
        "3"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -478,11 +435,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qcodes.dataset.data_set import (\n",
+    "from qcodes.dataset import (\n",
     "    load_by_guid,\n",
     "    load_by_run_spec,\n",
     "    get_guids_by_run_spec,\n",
@@ -491,17 +448,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['aaaaaaaa-0000-0000-0000-017ea07e4a31',\n",
-       " 'aaaaaaaa-0000-0000-0000-017ea07e5986']"
+       "['aaaaaaaa-0000-0000-0000-0184198c6857',\n",
+       " 'aaaaaaaa-0000-0000-0000-0184198cbc78']"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -513,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -525,75 +482,13 @@
        "my_inst_current - numeric"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "load_by_guid(guids[0], conn=target_conn)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "results #4@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\extract_runs_notebook_target.db\n",
-       "------------------------------------------------------------------------------------------------------\n",
-       "my_inst_current - numeric\n",
-       "my_inst_voltage - numeric"
-      ]
-     },
-     "execution_count": 24,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "load_by_guid(guids[1], conn=target_conn)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To enable loading of runs that may share the same `captured_run_id`, the function `load_by_run_data` is supplied.\n",
-    "This function takes one or more optional sets of metadata. If more than one run matching this information is found the metadata of the matching runs is printed and an error is raised. It is now possible to suply more information to the function to uniquely identify a specific run."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  captured_run_id    captured_counter  experiment_name              sample_name      sample_id    location    work_station\n",
-      "-----------------  ------------------  ---------------------------  -------------  -----------  ----------  --------------\n",
-      "                3                   3  extract_runs_experiment      no_sample       2863311530           0               0\n",
-      "                3                   3  extract_runs_experiment_aux  no_sample       2863311530           0               0\n",
-      "Caught a NameError\n"
-     ]
-    }
-   ],
-   "source": [
-    "try:\n",
-    "    load_by_run_spec(captured_run_id=3, conn=target_conn)\n",
-    "except NameError:\n",
-    "    print(\"Caught a NameError\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To single out one of these two runs, we can thus specify the `experiment_name`:"
    ]
   },
   {
@@ -616,17 +511,72 @@
     }
    ],
    "source": [
-    "load_by_run_spec(\n",
-    "    captured_run_id=3, experiment_name=\"extract_runs_experiment_aux\", conn=target_conn\n",
-    ")"
+    "load_by_guid(guids[1], conn=target_conn)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To enable loading of runs that may share the same `captured_run_id`, the function `load_by_run_data` is supplied.\n",
+    "This function takes one or more optional sets of metadata. If more than one run matching this information is found the metadata of the matching runs is printed and an error is raised. It is now possible to suply more information to the function to uniquely identify a specific run."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  captured_run_id    captured_counter  experiment_name              sample_name      location    work_station\n",
+      "-----------------  ------------------  ---------------------------  -------------  ----------  --------------\n",
+      "                3                   3  extract_runs_experiment      no_sample               0               0\n",
+      "                3                   3  extract_runs_experiment_aux  no_sample               0               0\n",
+      "Caught a NameError\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    load_by_run_spec(captured_run_id=3, conn=target_conn)\n",
+    "except NameError:\n",
+    "    print(\"Caught a NameError\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To single out one of these two runs, we can thus specify the `experiment_name`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "results #4@C:\\Users\\jenielse\\source\\repos\\Qcodes\\docs\\examples\\DataSet\\extract_runs_notebook_target.db\n",
+       "------------------------------------------------------------------------------------------------------\n",
+       "my_inst_current - numeric\n",
+       "my_inst_voltage - numeric"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "load_by_run_spec(\n",
+    "    captured_run_id=3, experiment_name=\"extract_runs_experiment_aux\", conn=target_conn\n",
+    ")"
+   ]
   }
  ],
  "metadata": {
@@ -645,7 +595,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.6"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -74,7 +74,7 @@
         "export_prefix": "qcodes_",
         "export_path": "~",
         "export_name_elements": ["captured_run_id", "guid"],
-        "guid_type": "explicit_sample"
+        "GUID_type": "explicit_sample"
     },
     "telemetry":
     {

--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -59,6 +59,7 @@
         "use_monitor": false
     },
     "GUID_components": {
+        "GUID_type": "explicit_sample",
         "location": 0,
         "work_station": 0,
         "sample": 0
@@ -73,8 +74,7 @@
         "export_type": null,
         "export_prefix": "qcodes_",
         "export_path": "~",
-        "export_name_elements": ["captured_run_id", "guid"],
-        "GUID_type": "explicit_sample"
+        "export_name_elements": ["captured_run_id", "guid"]
     },
     "telemetry":
     {

--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -73,7 +73,8 @@
         "export_type": null,
         "export_prefix": "qcodes_",
         "export_path": "~",
-        "export_name_elements": ["captured_run_id", "guid"]
+        "export_name_elements": ["captured_run_id", "guid"],
+        "guid_type": "explicit_sample"
     },
     "telemetry":
     {

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -351,6 +351,12 @@
                         "enum": ["captured_run_id", "guid", "exp_name", "sample_name", "name", "captured_counter"]
                     },
                     "default": ["captured_run_id", "guid"]
+                },
+                "GUID_type": {
+                    "type": "string",
+                    "enum": ["explicit_sample", "random_sample"],
+                    "default": "explicit_sample",
+                    "description": "Data export type for exporting datasets to disk after a measurement finishes. Does not export if set to null (default). Currently supported type(s): netcdf, csv"
                 }
             },
             "description": "Settings related to the DataSet and Measurement Context manager",

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -276,6 +276,12 @@
         "GUID_components":{
             "type": "object",
             "properties": {
+                "GUID_type": {
+                    "type": "string",
+                    "enum": ["explicit_sample", "random_sample"],
+                    "default": "explicit_sample",
+                    "description": "Type of GUID to use. Currently possible to chose between an explicitly assigned 'Sample identification code' and a random string as the first part of the GUID"
+                },
                 "location": {
                     "type": "integer",
                     "default": 0,
@@ -351,12 +357,6 @@
                         "enum": ["captured_run_id", "guid", "exp_name", "sample_name", "name", "captured_counter"]
                     },
                     "default": ["captured_run_id", "guid"]
-                },
-                "GUID_type": {
-                    "type": "string",
-                    "enum": ["explicit_sample", "random_sample"],
-                    "default": "explicit_sample",
-                    "description": "Data export type for exporting datasets to disk after a measurement finishes. Does not export if set to null (default). Currently supported type(s): netcdf, csv"
                 }
             },
             "description": "Settings related to the DataSet and Measurement Context manager",

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -280,7 +280,7 @@
                     "type": "string",
                     "enum": ["explicit_sample", "random_sample"],
                     "default": "explicit_sample",
-                    "description": "Type of GUID to use. Currently possible to chose between an explicitly assigned 'Sample identification code' and a random string as the first part of the GUID"
+                    "description": "Type of GUID to use. Currently possible to chose between an explicitly assigned 'Sample identification code' and a random string as the first part of the GUID."
                 },
                 "location": {
                     "type": "integer",

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1773,15 +1773,27 @@ def generate_dataset_table(
     Returns: ASCII art table of information about the supplied guids.
     """
     from tabulate import tabulate
-    headers = ["captured_run_id", "captured_counter", "experiment_name",
-               "sample_name",
-               "sample_id", "location", "work_station"]
+
+    headers = (
+        "captured_run_id",
+        "captured_counter",
+        "experiment_name",
+        "sample_name",
+        "location",
+        "work_station",
+    )
     table = []
     for guid in guids:
         ds = load_by_guid(guid, conn=conn)
         parsed_guid = parse_guid(guid)
-        table.append([ds.captured_run_id, ds.captured_counter, ds.exp_name,
-                      ds.sample_name,
-                      parsed_guid['sample'], parsed_guid['location'],
-                      parsed_guid['work_station']])
+        table.append(
+            [
+                ds.captured_run_id,
+                ds.captured_counter,
+                ds.exp_name,
+                ds.sample_name,
+                parsed_guid["location"],
+                parsed_guid["work_station"],
+            ]
+        )
     return tabulate(table, headers=headers)

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -68,7 +68,7 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
         )
 
     if guid_type == "random_sample":
-        sampleint = random.randint(0, 16**8 - 1)
+        sampleint = random.randint(1, 16**8 - 1)
     elif sampleint == 0:
         sampleint = int('a'*8, base=16)
 

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -32,15 +32,17 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
 
     try:
         guid_type = cfg["dataset"]["GUID_type"]
-    except KeyError:
+    except KeyError as err:
         raise RuntimeError(
             "Invalid QCoDeS config file! No guid_type specified. Can not proceed."
-        )
+        ) from err
     try:
         guid_comp = cfg['GUID_components']
-    except KeyError:
-        raise RuntimeError('Invalid QCoDeS config file! No GUID_components '
-                           'specified. Can not proceed.')
+    except KeyError as err:
+        raise RuntimeError(
+            "Invalid QCoDeS config file! No GUID_components "
+            "specified. Can not proceed."
+        ) from err
 
     location = guid_comp['location']
     station = guid_comp['work_station']

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -31,19 +31,18 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
     cfg = qc.config
 
     try:
-        guid_type = cfg["dataset"]["GUID_type"]
-    except KeyError as err:
-        raise RuntimeError(
-            "Invalid QCoDeS config file! No guid_type specified. Can not proceed."
-        ) from err
-    try:
         guid_comp = cfg['GUID_components']
     except KeyError as err:
         raise RuntimeError(
             "Invalid QCoDeS config file! No GUID_components "
             "specified. Can not proceed."
         ) from err
-
+    try:
+        guid_type = guid_comp["GUID_type"]
+    except KeyError as err:
+        raise RuntimeError(
+            "Invalid QCoDeS config file! No GUID_type specified. Can not proceed."
+        ) from err
     location = guid_comp['location']
     station = guid_comp['work_station']
 
@@ -54,16 +53,17 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
         sampleint = guid_comp['sample']
     if sampleint != 0 and guid_type == "random_sample":
         raise RuntimeError(
-            "QCoDeS is configured to disregard sample from config file but this "
-            "is set to a non default value which is therefore unused."
+            "QCoDeS is configured to disregard GUID_components.sample from config file but this "
+            f"is set to a non default value of {sampleint} which is therefore unused."
         )
 
     if sampleint not in (0, 2863311530):
         warnings.warn(
-            "Setting a non default sample GUID_component is deprecated. "
-            "the sample part of the GUID will be replaced by a randon string "
+            "Setting a non default GUID_components.sample is deprecated. "
+            "The sample part of the GUID will be replaced by a random string "
             "in a future release. To opt in to the new format now "
-            "set GUID_type to `random_sample_str` in your qcodesrc.json config file.",
+            "set GUID_type to `random_sample` in your qcodesrc.json config file. "
+            "If you rely on this feature please get in touch.",
             stacklevel=2,
         )
 

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -31,7 +31,7 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
     cfg = qc.config
 
     try:
-        guid_type = cfg["dataset"]["guid_type"]
+        guid_type = cfg["dataset"]["GUID_type"]
     except KeyError:
         raise RuntimeError(
             "Invalid QCoDeS config file! No guid_type specified. Can not proceed."

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -61,7 +61,8 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
             "Setting a non default sample GUID_component is deprecated. "
             "the sample part of the GUID will be replaced by a randon string "
             "in a future release. To opt in to the new format now "
-            "set GUID_type to `random_sample_str` in your qcodesrc.json config file."
+            "set GUID_type to `random_sample_str` in your qcodesrc.json config file.",
+            stacklevel=2,
         )
 
     if guid_type == "random_sample":

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -51,13 +51,18 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
         timeint = int(np.round(time.time()*1000))
     if sampleint is None:
         sampleint = guid_comp['sample']
-    if sampleint != 0 and guid_type == "random_sample":
+
+    # 2863311530 is the base 10 repr of
+    # aaaaaaaa
+    default_sample_ids = (0, 2863311530)
+
+    if sampleint not in default_sample_ids and guid_type == "random_sample":
         raise RuntimeError(
             "QCoDeS is configured to disregard GUID_components.sample from config file but this "
             f"is set to a non default value of {sampleint} which is therefore unused."
         )
 
-    if sampleint not in (0, 2863311530):
+    if sampleint not in default_sample_ids:
         warnings.warn(
             "Setting a non default GUID_components.sample is deprecated. "
             "The sample part of the GUID will be replaced by a random string "

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -52,9 +52,7 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
     if sampleint is None:
         sampleint = guid_comp['sample']
 
-    # 2863311530 is the base 10 repr of
-    # aaaaaaaa
-    default_sample_ids = (0, 2863311530)
+    default_sample_ids = (0, 0xAA_AAA_AAA)
 
     if sampleint not in default_sample_ids and guid_type == "random_sample":
         raise RuntimeError(
@@ -73,9 +71,9 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
         )
 
     if guid_type == "random_sample":
-        sampleint = random.randint(1, 16**8 - 1)
+        sampleint = random.randint(1, 0xFF_FFF_FFF)
     elif sampleint == 0:
-        sampleint = int('a'*8, base=16)
+        sampleint = 0xAA_AAA_AAA
 
     loc_str = f'{location:02x}'
     stat_str = f'{station:06x}'
@@ -204,6 +202,6 @@ def validate_guid_format(guid: str) -> None:
     future)
     """
     if _guid_pattern.match(guid):
-            return
+        return
     else:
         raise ValueError(f'Did not receive a valid guid. Got {guid}')

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -58,7 +58,7 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
             "is set to a non default value which is therefore unused."
         )
 
-    if sampleint != 0 and sampleint != 2863311530:
+    if sampleint not in (0, 2863311530):
         warnings.warn(
             "Setting a non default sample GUID_component is deprecated. "
             "the sample part of the GUID will be replaced by a randon string "

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -56,7 +56,7 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
             "is set to a non default value which is therefore unused."
         )
 
-    if sampleint != 0:
+    if sampleint != 0 and sampleint != 2863311530:
         warnings.warn(
             "Setting a non default sample GUID_component is deprecated. "
             "the sample part of the GUID will be replaced by a randon string "

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -586,11 +586,6 @@ def test_combine_runs(two_empty_temp_db_connections,
     cfg = qc.config
     guid_comp = cfg['GUID_components']
 
-    # borrowed fallback logic from generate_guid
-    sampleint = guid_comp['sample']
-    if sampleint == 0:
-        sampleint = int('a'*8, base=16)
-
     for i in range(2, len(lines)):
         split_line = re.split(r'\s+', lines[i].strip())
         mydict = {headers[j]: split_line[j] for j in range(len(split_line))}
@@ -599,7 +594,6 @@ def test_combine_runs(two_empty_temp_db_connections,
         assert ds.captured_counter == int(mydict['captured_counter'])
         assert ds.exp_name == mydict['experiment_name']
         assert ds.sample_name == mydict['sample_name']
-        assert int(mydict['sample_id']) == sampleint
         assert guid_comp['location'] == int(mydict['location'])
         assert guid_comp['work_station'] == int(mydict['work_station'])
 

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -540,8 +540,8 @@ def test_combine_runs(two_empty_temp_db_connections,
     source_2_datasets = [DataSet(conn=source_conn_2,
                                  exp_id=source_2_exp.exp_id) for i in range(10)]
 
-    guids_1 = set(dataset.guid for dataset in source_1_datasets)
-    guids_2 = set(dataset.guid for dataset in source_2_datasets)
+    guids_1 = {dataset.guid for dataset in source_1_datasets}
+    guids_2 = {dataset.guid for dataset in source_2_datasets}
 
     guids = guids_1 | guids_2
     assert len(guids) == 20

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -521,7 +521,7 @@ def test_combine_runs(two_empty_temp_db_connections,
     can be reloaded by the original captured_run_id and the experiment
     name.
     """
-    qc.config.dataset.GUID_type = "random_sample"
+    qc.config.GUID_components.GUID_type = "random_sample"
 
     source_conn_1, source_conn_2 = two_empty_temp_db_connections
     target_conn = empty_temp_db_connection

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -540,6 +540,12 @@ def test_combine_runs(two_empty_temp_db_connections,
     source_2_datasets = [DataSet(conn=source_conn_2,
                                  exp_id=source_2_exp.exp_id) for i in range(10)]
 
+    guids_1 = set(dataset.guid for dataset in source_1_datasets)
+    guids_2 = set(dataset.guid for dataset in source_2_datasets)
+
+    guids = guids_1 | guids_2
+    assert len(guids) == 20
+
     source_all_datasets = source_1_datasets + source_2_datasets
 
     shuffled_datasets = source_all_datasets.copy()

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -512,6 +512,7 @@ def test_load_by_X_functions(two_empty_temp_db_connections,
     assert source_ds_2_2.the_same_dataset_as(test_ds)
 
 
+@pytest.mark.usefixtures("reset_config_on_exit")
 def test_combine_runs(two_empty_temp_db_connections,
                       empty_temp_db_connection,
                       some_interdeps):
@@ -520,6 +521,8 @@ def test_combine_runs(two_empty_temp_db_connections,
     can be reloaded by the original captured_run_id and the experiment
     name.
     """
+    qc.config.dataset.GUID_type = "random_sample"
+
     source_conn_1, source_conn_2 = two_empty_temp_db_connections
     target_conn = empty_temp_db_connection
 

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -1,7 +1,6 @@
 import os
 import random
 import re
-import sys
 import uuid
 from contextlib import contextmanager
 from os.path import getmtime
@@ -513,9 +512,6 @@ def test_load_by_X_functions(two_empty_temp_db_connections,
     assert source_ds_2_2.the_same_dataset_as(test_ds)
 
 
-@pytest.mark.xfail(
-    condition=sys.platform == "win32", reason="Time resolution is too low on windows"
-)
 def test_combine_runs(two_empty_temp_db_connections,
                       empty_temp_db_connection,
                       some_interdeps):

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -278,7 +278,10 @@ def test_load_by_id_for_none():
        dataset_name=hst.text(hst.characters(whitelist_categories=_unicode_categories),
                              min_size=1))
 @pytest.mark.usefixtures("empty_temp_db")
+@pytest.mark.usefixtures("reset_config_on_exit")
 def test_add_experiments(experiment_name, sample_name, dataset_name):
+    qc.config.dataset.GUID_type = "random_sample"
+
     global n_experiments
     n_experiments += 1
 

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -1,7 +1,6 @@
 import io
 import random
 import re
-import sys
 from copy import copy
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -279,9 +278,6 @@ def test_load_by_id_for_none():
        dataset_name=hst.text(hst.characters(whitelist_categories=_unicode_categories),
                              min_size=1))
 @pytest.mark.usefixtures("empty_temp_db")
-@pytest.mark.xfail(
-    condition=sys.platform == "win32", reason="Time resolution is too low on windows"
-)
 def test_add_experiments(experiment_name, sample_name, dataset_name):
     global n_experiments
     n_experiments += 1

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -280,7 +280,7 @@ def test_load_by_id_for_none():
 @pytest.mark.usefixtures("empty_temp_db")
 @pytest.mark.usefixtures("reset_config_on_exit")
 def test_add_experiments(experiment_name, sample_name, dataset_name):
-    qc.config.dataset.GUID_type = "random_sample"
+    qc.config.GUID_components.GUID_type = "random_sample"
 
     global n_experiments
     n_experiments += 1

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -25,7 +25,9 @@ from qcodes.utils import QCoDeSDeprecationWarning
 
 
 @pytest.mark.usefixtures("experiment")
+@pytest.mark.usefixtures("reset_config_on_exit")
 def test_load_by_id():
+    qc.config.dataset.GUID_type = "random_sample"
     ds = new_data_set("test-dataset")
     run_id = ds.run_id
     ds.mark_started()

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -28,7 +28,7 @@ from qcodes.utils import QCoDeSDeprecationWarning
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.usefixtures("reset_config_on_exit")
 def test_load_by_id():
-    qc.config.dataset.GUID_type = "random_sample"
+    qc.config.GUID_components.GUID_type = "random_sample"
     ds = new_data_set("test-dataset")
     run_id = ds.run_id
     ds.mark_started()

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -1,4 +1,3 @@
-import sys
 import time
 from math import floor
 
@@ -26,9 +25,6 @@ from qcodes.utils import QCoDeSDeprecationWarning
 
 
 @pytest.mark.usefixtures("experiment")
-@pytest.mark.xfail(
-    condition=sys.platform == "win32", reason="Time resolution is too low on windows"
-)
 def test_load_by_id():
     ds = new_data_set("test-dataset")
     run_id = ds.run_id

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -3,6 +3,7 @@ from math import floor
 
 import pytest
 
+import qcodes as qc
 from qcodes.dataset.data_set import (
     DataSet,
     get_guids_by_run_spec,

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -220,7 +220,7 @@ def test_random_sample_guid():
     cfg = qc.config
     cfg["dataset"]["GUID_type"] = "random_sample"
 
-    expected_guid_prefixes = ["d82c07cd", "6baa9455", "82e2e662"]
+    expected_guid_prefixes = ["d82c07ce", "629f6fbf", "c2094cad"]
     for expected_guid_prefix in expected_guid_prefixes:
         guid = generate_guid()
         assert guid.split("-")[0] == expected_guid_prefix

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -1,4 +1,5 @@
 import random
+import re
 import time
 from uuid import uuid4
 
@@ -46,7 +47,8 @@ def test_generate_guid(loc, stat, smpl):
         guid = generate_guid()
     else:
         with pytest.warns(
-            expected_warning=Warning, match="Setting a non default sample"
+            expected_warning=Warning,
+            match=re.escape("Setting a non default GUID_components.sample"),
         ):
             guid = generate_guid()
 
@@ -121,7 +123,8 @@ def test_filter_guid(locs, stats, smpls):
             guid = generate_guid()
         else:
             with pytest.warns(
-                expected_warning=Warning, match="Setting a non default sample"
+                expected_warning=Warning,
+                match=re.escape("Setting a non default GUID_components.sample"),
             ):
                 guid = generate_guid()
 
@@ -222,7 +225,7 @@ def test_validation():
 def test_random_sample_guid():
 
     cfg = qc.config
-    cfg["dataset"]["GUID_type"] = "random_sample"
+    cfg["GUID_components"]["GUID_type"] = "random_sample"
 
     expected_guid_prefixes = ["d82c07ce", "629f6fbf", "c2094cad"]
     for expected_guid_prefix in expected_guid_prefixes:
@@ -234,15 +237,21 @@ def test_random_sample_guid():
 def test_random_sample_and_sample_int_in_guid_raises():
 
     cfg = qc.config
-    cfg["dataset"]["GUID_type"] = "random_sample"
+    cfg["GUID_components"]["GUID_type"] = "random_sample"
 
     with pytest.raises(
-        RuntimeError, match="QCoDeS is configured to disregard sample from config"
+        RuntimeError,
+        match=re.escape(
+            "QCoDeS is configured to disregard GUID_components.sample from config"
+        ),
     ):
         generate_guid(sampleint=10)
 
 
 @pytest.mark.usefixtures("default_config")
 def test_sample_int_in_guid_warns():
-    with pytest.warns(expected_warning=Warning, match="Setting a non default sample"):
+    with pytest.warns(
+        expected_warning=Warning,
+        match=re.escape("Setting a non default GUID_components.sample"),
+    ):
         generate_guid(sampleint=10)

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -30,8 +30,11 @@ def _make_seed_random():
 
 @pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=1000)
-@given(loc=hst.integers(0, 255), stat=hst.integers(0, 65535),
-       smpl=hst.integers(0, 4294967295))
+@given(
+    loc=hst.integers(0, 255),
+    stat=hst.integers(0, 65535),
+    smpl=hst.integers(0, 4_294_967_295),
+)
 def test_generate_guid(loc, stat, smpl):
     # update config to generate a particular guid. Read it back to verify
     cfg = qc.config
@@ -39,7 +42,12 @@ def test_generate_guid(loc, stat, smpl):
     cfg["GUID_components"]["work_station"] = stat
     cfg["GUID_components"]["sample"] = smpl
 
-    guid = generate_guid()
+    if smpl == 0 or smpl == 2_863_311_530:
+        guid = generate_guid()
+    else:
+        with pytest.warns(match="Setting a non default sample"):
+            guid = generate_guid()
+
     gen_time = int(np.round(time.time() * 1000))
 
     comps = parse_guid(guid)
@@ -107,7 +115,12 @@ def test_filter_guid(locs, stats, smpls):
         cfg['GUID_components']['work_station'] = stat
         cfg['GUID_components']['sample'] = smpl
 
-        guid = generate_guid()
+        if smpl == 0 or smpl == 2_863_311_530:
+            guid = generate_guid()
+        else:
+            with pytest.warns(match="Setting a non default sample"):
+                guid = generate_guid()
+
         gen_time = int(np.round(time.time() * 1000))
 
         comps = parse_guid(guid)

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -45,7 +45,9 @@ def test_generate_guid(loc, stat, smpl):
     if smpl == 0 or smpl == 2_863_311_530:
         guid = generate_guid()
     else:
-        with pytest.warns(match="Setting a non default sample"):
+        with pytest.warns(
+            expected_warning=Warning, match="Setting a non default sample"
+        ):
             guid = generate_guid()
 
     gen_time = int(np.round(time.time() * 1000))
@@ -118,7 +120,9 @@ def test_filter_guid(locs, stats, smpls):
         if smpl == 0 or smpl == 2_863_311_530:
             guid = generate_guid()
         else:
-            with pytest.warns(match="Setting a non default sample"):
+            with pytest.warns(
+                expected_warning=Warning, match="Setting a non default sample"
+            ):
                 guid = generate_guid()
 
         gen_time = int(np.round(time.time() * 1000))
@@ -240,5 +244,5 @@ def test_random_sample_and_sample_int_in_guid_raises():
 
 @pytest.mark.usefixtures("default_config")
 def test_sample_int_in_guid_warns():
-    with pytest.warns(match="Setting a non default sample"):
+    with pytest.warns(expected_warning=Warning, match="Setting a non default sample"):
         generate_guid(sampleint=10)


### PR DESCRIPTION
The current time resolution, especially on windows, is insufficient to ensure that we always avoid collisions in guids. Since sample names are available within the dataset metadata and the sample part of the guid is cumbersome to use I suggest that we replace that with a random string.

The broad plan is 
* Make guid type configurable
* Warn if the sample name guid is set to something other than the default value. 
* Update tests that have problems with guid collisions to use the new guid type
* Eventually change the default to the new type

For now we ami to completely remove the support of setting a sample_id. If actual use shows up we are open to allow this to be enabled as an explicit option