### PR TITLE
Replace config context managers with pytest fixtures

### DIFF
--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -12,6 +12,7 @@ import pytest
 import qcodes
 from qcodes.configuration import Config, DotDict
 from qcodes.metadatable import Metadatable
+from qcodes.utils import deprecate
 
 if TYPE_CHECKING:
     from pytest import ExceptionInfo
@@ -212,13 +213,13 @@ def default_config(user_config: Optional[str] = None):
             qcodes.config.current_config = default_config_obj
 
 
+@deprecate(reason="Unused internally", alternative="reset_config_on_exit fixture")
 @contextmanager
 def reset_config_on_exit():
     """
-    Context manager to clean any modefication of the in memory config on exit
+    Context manager to clean any modification of the in memory config on exit
 
     """
-
     default_config_obj: Optional[DotDict] = copy.deepcopy(
         qcodes.config.current_config
     )

--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -161,6 +161,7 @@ class DumyPar(Metadatable):
         return value
 
 
+@deprecate(reason="Unused internally", alternative="default_config fixture")
 @contextmanager
 def default_config(user_config: Optional[str] = None):
     """

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -52,7 +52,7 @@ def disable_telemetry():
 
 
 @pytest.fixture(scope="function")
-def default_config(user_config: str | None = None):
+def default_config():
     """
     Fixture to temporarily establish default config settings.
     This is achieved by overwriting the config paths of the user-,
@@ -60,9 +60,6 @@ def default_config(user_config: str | None = None):
     config file in the qcodes repository,
     additionally the current config object `qcodes.config` gets copied and
     reestablished.
-
-    Args:
-        user_config: represents the user config file content.
     """
     home_file_name = Config.home_file_name
     schema_home_file_name = Config.schema_home_file_name
@@ -75,9 +72,6 @@ def default_config(user_config: str | None = None):
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_name = os.path.join(tmpdirname, "user_config.json")
         file_name_schema = os.path.join(tmpdirname, "user_config_schema.json")
-        if user_config is not None:
-            with open(file_name, "w") as f:
-                f.write(user_config)
 
         Config.home_file_name = file_name
         Config.schema_home_file_name = file_name_schema

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -52,7 +52,7 @@ def disable_telemetry():
 
 
 @pytest.fixture(scope="function")
-def default_config():
+def default_config(tmp_path):
     """
     Fixture to temporarily establish default config settings.
     This is achieved by overwriting the config paths of the user-,
@@ -68,32 +68,30 @@ def default_config():
     cwd_file_name = Config.cwd_file_name
     schema_cwd_file_name = Config.schema_cwd_file_name
 
-    Config.home_file_name = ""
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        file_name = os.path.join(tmpdirname, "user_config.json")
-        file_name_schema = os.path.join(tmpdirname, "user_config_schema.json")
+    file_name = str(tmp_path / "user_config.json")
+    file_name_schema = str(tmp_path / "user_config_schema.json")
 
-        Config.home_file_name = file_name
-        Config.schema_home_file_name = file_name_schema
-        Config.env_file_name = ""
-        Config.schema_env_file_name = ""
-        Config.cwd_file_name = ""
-        Config.schema_cwd_file_name = ""
+    Config.home_file_name = file_name
+    Config.schema_home_file_name = file_name_schema
+    Config.env_file_name = ""
+    Config.schema_env_file_name = ""
+    Config.cwd_file_name = ""
+    Config.schema_cwd_file_name = ""
 
-        default_config_obj: DotDict | None = copy.deepcopy(qc.config.current_config)
-        qc.config = Config()
+    default_config_obj: DotDict | None = copy.deepcopy(qc.config.current_config)
+    qc.config = Config()
 
-        try:
-            yield
-        finally:
-            Config.home_file_name = home_file_name
-            Config.schema_home_file_name = schema_home_file_name
-            Config.env_file_name = env_file_name
-            Config.schema_env_file_name = schema_env_file_name
-            Config.cwd_file_name = cwd_file_name
-            Config.schema_cwd_file_name = schema_cwd_file_name
+    try:
+        yield
+    finally:
+        Config.home_file_name = home_file_name
+        Config.schema_home_file_name = schema_home_file_name
+        Config.env_file_name = env_file_name
+        Config.schema_env_file_name = schema_env_file_name
+        Config.cwd_file_name = cwd_file_name
+        Config.schema_cwd_file_name = schema_cwd_file_name
 
-            qc.config.current_config = default_config_obj
+        qc.config.current_config = default_config_obj
 
 
 @pytest.fixture(scope="function")

--- a/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
@@ -318,36 +318,36 @@ def test_setting_write_period(wp):
 @given(wp=hst.one_of(hst.integers(), hst.floats(allow_nan=False),
                      hst.text()))
 @pytest.mark.usefixtures("experiment")
+@pytest.mark.usefixtures("reset_config_on_exit")
 def test_setting_write_period_from_config(wp):
-    with reset_config_on_exit():
-        qc.config.dataset.write_period = wp
+    qc.config.dataset.write_period = wp
 
-        if isinstance(wp, str):
-            with pytest.raises(ValueError):
-                Measurement()
-        elif wp < 1e-3:
-            with pytest.raises(ValueError):
-                Measurement()
-        else:
-            meas = Measurement()
-            assert meas.write_period == float(wp)
-            meas.register_custom_parameter(name='dummy')
-            with meas.run() as datasaver:
-                assert datasaver.write_period == float(wp)
+    if isinstance(wp, str):
+        with pytest.raises(ValueError):
+            Measurement()
+    elif wp < 1e-3:
+        with pytest.raises(ValueError):
+            Measurement()
+    else:
+        meas = Measurement()
+        assert meas.write_period == float(wp)
+        meas.register_custom_parameter(name="dummy")
+        with meas.run() as datasaver:
+            assert datasaver.write_period == float(wp)
 
 
 @pytest.mark.parametrize("write_in_background", [True, False])
 @pytest.mark.usefixtures("experiment")
+@pytest.mark.usefixtures("reset_config_on_exit")
 def test_setting_write_in_background_from_config(write_in_background):
-    with reset_config_on_exit():
-        qc.config.dataset.write_in_background = write_in_background
+    qc.config.dataset.write_in_background = write_in_background
 
-        meas = Measurement()
-        meas.register_custom_parameter(name='dummy')
-        with meas.run() as datasaver:
-            ds = datasaver.dataset
-            assert isinstance(ds, DataSet)
-            assert ds._writer_status.write_in_background is write_in_background
+    meas = Measurement()
+    meas.register_custom_parameter(name="dummy")
+    with meas.run() as datasaver:
+        ds = datasaver.dataset
+        assert isinstance(ds, DataSet)
+        assert ds._writer_status.write_in_background is write_in_background
 
 
 @pytest.mark.usefixtures("experiment")

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -15,73 +15,72 @@ from qcodes.dataset.guids import (
     set_guid_work_station_code,
     validate_guid_format,
 )
-from qcodes.tests.common import default_config
 
 
+@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=1000)
 @given(loc=hst.integers(0, 255), stat=hst.integers(0, 65535),
        smpl=hst.integers(0, 4294967295))
 def test_generate_guid(loc, stat, smpl):
     # update config to generate a particular guid. Read it back to verify
-    with default_config():
-        cfg = qc.config
-        cfg['GUID_components']['location'] = loc
-        cfg['GUID_components']['work_station'] = stat
-        cfg['GUID_components']['sample'] = smpl
+    cfg = qc.config
+    cfg["GUID_components"]["location"] = loc
+    cfg["GUID_components"]["work_station"] = stat
+    cfg["GUID_components"]["sample"] = smpl
 
-        guid = generate_guid()
-        gen_time = int(np.round(time.time()*1000))
+    guid = generate_guid()
+    gen_time = int(np.round(time.time() * 1000))
 
-        comps = parse_guid(guid)
+    comps = parse_guid(guid)
 
-        if smpl == 0:
-            smpl = int('a'*8, base=16)
+    if smpl == 0:
+        smpl = int("a" * 8, base=16)
 
-        assert comps['location'] == loc
-        assert comps['work_station'] == stat
-        assert comps['sample'] == smpl
-        assert comps['time'] - gen_time < 2
+    assert comps["location"] == loc
+    assert comps["work_station"] == stat
+    assert comps["sample"] == smpl
+    assert comps["time"] - gen_time < 2
 
 
+@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=None,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(loc=hst.integers(-10, 350))
 def test_set_guid_location_code(loc, monkeypatch):
     monkeypatch.setattr('builtins.input', lambda x: str(loc))
+    orig_cfg = qc.config
+    original_loc = orig_cfg["GUID_components"]["location"]
+    set_guid_location_code()
 
-    with default_config():
-        orig_cfg = qc.config
-        original_loc = orig_cfg['GUID_components']['location']
-        set_guid_location_code()
+    cfg = qc.config
 
-        cfg = qc.config
-
-        if 257 > loc > 0:
-            assert cfg['GUID_components']['location'] == loc
-        else:
-            assert cfg['GUID_components']['location'] == original_loc
+    if 257 > loc > 0:
+        assert cfg["GUID_components"]["location"] == loc
+    else:
+        assert cfg["GUID_components"]["location"] == original_loc
 
 
+@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=1000,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(ws=hst.integers(-10, 17000000))
 def test_set_guid_workstation_code(ws, monkeypatch):
     monkeypatch.setattr('builtins.input', lambda x: str(ws))
 
-    with default_config():
-        orig_cfg = qc.config
-        original_ws = orig_cfg['GUID_components']['work_station']
+    orig_cfg = qc.config
+    original_ws = orig_cfg["GUID_components"]["work_station"]
 
-        set_guid_work_station_code()
+    set_guid_work_station_code()
 
-        cfg = qc.config
+    cfg = qc.config
 
-        if 16777216 > ws > 0:
-            assert cfg['GUID_components']['work_station'] == ws
-        else:
-            assert cfg['GUID_components']['work_station'] == original_ws
+    if 16777216 > ws > 0:
+        assert cfg["GUID_components"]["work_station"] == ws
+    else:
+        assert cfg["GUID_components"]["work_station"] == original_ws
 
 
+@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=1000)
 @given(locs=hst.lists(hst.integers(0, 255), min_size=2, max_size=2,
                       unique=True),
@@ -109,84 +108,77 @@ def test_filter_guid(locs, stats, smpls):
 
         return guid
 
-    with default_config():
+    guids = []
+    cfg = qc.config
 
-        guids = []
-        cfg = qc.config
+    corrected_smpls = [smpl if smpl != 0 else int("a" * 8, base=16) for smpl in smpls]
+    # there is a possibility that we could generate 0 and 2863311530, which
+    # are considered equivalent since int('a' * 8, base=16) == 2863311530.
+    # We want unique samples, so we exclude this case.
+    assume(corrected_smpls[0] != corrected_smpls[1])
 
-        corrected_smpls = [smpl if smpl != 0 else int('a' * 8, base=16)
-                           for smpl in smpls]
-        # there is a possibility that we could generate 0 and 2863311530, which
-        # are considered equivalent since int('a' * 8, base=16) == 2863311530.
-        # We want unique samples, so we exclude this case.
-        assume(corrected_smpls[0] != corrected_smpls[1])
+    # first we generate a guid that we are going to match against
+    guids.append(make_test_guid(cfg, locs[0], corrected_smpls[0], stats[0]))
 
-        # first we generate a guid that we are going to match against
-        guids.append(make_test_guid(cfg, locs[0], corrected_smpls[0], stats[0]))
+    # now generate some guids that will not match because one of the
+    # components changed
+    guids.append(make_test_guid(cfg, locs[1], corrected_smpls[0], stats[0]))
+    guids.append(make_test_guid(cfg, locs[0], corrected_smpls[1], stats[0]))
+    guids.append(make_test_guid(cfg, locs[0], corrected_smpls[0], stats[1]))
 
-        # now generate some guids that will not match because one of the
-        # components changed
-        guids.append(make_test_guid(cfg, locs[1], corrected_smpls[0], stats[0]))
-        guids.append(make_test_guid(cfg, locs[0], corrected_smpls[1], stats[0]))
-        guids.append(make_test_guid(cfg, locs[0], corrected_smpls[0], stats[1]))
+    assert len(guids) == 4
 
-        assert len(guids) == 4
+    # first filter on all parts. This should give exactly one matching guid
+    filtered_guids = filter_guids_by_parts(
+        guids, location=locs[0], sample_id=corrected_smpls[0], work_station=stats[0]
+    )
 
-        # first filter on all parts. This should give exactly one matching guid
-        filtered_guids = filter_guids_by_parts(guids,
-                                               location=locs[0],
-                                               sample_id=corrected_smpls[0],
-                                               work_station=stats[0]
-                                               )
+    assert len(filtered_guids) == 1
+    assert filtered_guids[0] == guids[0]
 
-        assert len(filtered_guids) == 1
-        assert filtered_guids[0] == guids[0]
+    # now filter on 2 components
+    filtered_guids = filter_guids_by_parts(
+        guids, location=locs[0], sample_id=corrected_smpls[0]
+    )
+    assert len(filtered_guids) == 2
+    assert filtered_guids[0] == guids[0]
+    assert filtered_guids[1] == guids[3]
 
-        # now filter on 2 components
-        filtered_guids = filter_guids_by_parts(guids,
-                                               location=locs[0],
-                                               sample_id=corrected_smpls[0])
-        assert len(filtered_guids) == 2
-        assert filtered_guids[0] == guids[0]
-        assert filtered_guids[1] == guids[3]
+    filtered_guids = filter_guids_by_parts(
+        guids, location=locs[0], work_station=stats[0]
+    )
+    assert len(filtered_guids) == 2
+    assert filtered_guids[0] == guids[0]
+    assert filtered_guids[1] == guids[2]
 
-        filtered_guids = filter_guids_by_parts(guids,
-                                               location=locs[0],
-                                               work_station=stats[0])
-        assert len(filtered_guids) == 2
-        assert filtered_guids[0] == guids[0]
-        assert filtered_guids[1] == guids[2]
+    filtered_guids = filter_guids_by_parts(
+        guids, sample_id=corrected_smpls[0], work_station=stats[0]
+    )
+    assert len(filtered_guids) == 2
+    assert filtered_guids[0] == guids[0]
+    assert filtered_guids[1] == guids[1]
 
-        filtered_guids = filter_guids_by_parts(guids,
-                                               sample_id=corrected_smpls[0],
-                                               work_station=stats[0]
-                                               )
-        assert len(filtered_guids) == 2
-        assert filtered_guids[0] == guids[0]
-        assert filtered_guids[1] == guids[1]
+    # now filter on 1 component
+    filtered_guids = filter_guids_by_parts(guids, location=locs[0])
+    assert len(filtered_guids) == 3
+    assert filtered_guids[0] == guids[0]
+    assert filtered_guids[1] == guids[2]
+    assert filtered_guids[2] == guids[3]
 
-        # now filter on 1 component
-        filtered_guids = filter_guids_by_parts(guids,
-                                               location=locs[0])
-        assert len(filtered_guids) == 3
-        assert filtered_guids[0] == guids[0]
-        assert filtered_guids[1] == guids[2]
-        assert filtered_guids[2] == guids[3]
+    filtered_guids = filter_guids_by_parts(guids, work_station=stats[0])
+    assert len(filtered_guids) == 3
+    assert filtered_guids[0] == guids[0]
+    assert filtered_guids[1] == guids[1]
+    assert filtered_guids[2] == guids[2]
 
-        filtered_guids = filter_guids_by_parts(guids,
-                                               work_station=stats[0])
-        assert len(filtered_guids) == 3
-        assert filtered_guids[0] == guids[0]
-        assert filtered_guids[1] == guids[1]
-        assert filtered_guids[2] == guids[2]
-
-        filtered_guids = filter_guids_by_parts(guids,
-                                               sample_id=corrected_smpls[0],
-                                               )
-        assert len(filtered_guids) == 3
-        assert filtered_guids[0] == guids[0]
-        assert filtered_guids[1] == guids[1]
-        assert filtered_guids[2] == guids[3]
+    filtered_guids = filter_guids_by_parts(
+        guids,
+        sample_id=corrected_smpls[0],
+    )
+    assert len(filtered_guids) == 3
+    assert filtered_guids[0] == guids[0]
+    assert filtered_guids[1] == guids[1]
+    assert filtered_guids[2] == guids[3]
 
 
 def test_validation():

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -10,7 +10,6 @@ import pytest
 
 import qcodes
 from qcodes.configuration import Config
-from qcodes.tests.common import default_config
 
 VALID_JSON = "{}"
 ENV_KEY = "/dev/random"
@@ -282,24 +281,23 @@ def test_update_and_validate_user_config(config, mocker):
     assert config.current_schema == UPDATED_SCHEMA
 
 
+@pytest.mark.usefixtures("default_config")
 def test_update_from_path(path_to_config_file_on_disk):
-    with default_config():
-        cfg = qcodes.config
+    cfg = qcodes.config
 
-        # check that the default is still the default
-        assert cfg["core"]["db_debug"] is False
+    # check that the default is still the default
+    assert cfg["core"]["db_debug"] is False
 
-        cfg.update_config(path=path_to_config_file_on_disk)
-        assert cfg['core']['db_debug'] is True
+    cfg.update_config(path=path_to_config_file_on_disk)
+    assert cfg["core"]["db_debug"] is True
 
-        # check that the settings NOT specified in our config file on path
-        # are still saved as configurations
-        assert cfg['gui']['notebook'] is True
-        assert cfg['station']['default_folder'] == '.'
+    # check that the settings NOT specified in our config file on path
+    # are still saved as configurations
+    assert cfg["gui"]["notebook"] is True
+    assert cfg["station"]["default_folder"] == "."
 
-        expected_path = os.path.join(path_to_config_file_on_disk,
-                                     'qcodesrc.json')
-        assert cfg.current_config_path == expected_path
+    expected_path = os.path.join(path_to_config_file_on_disk, "qcodesrc.json")
+    assert cfg.current_config_path == expected_path
 
 
 def test_repr():
@@ -313,24 +311,30 @@ def test_repr():
     assert rep == expected_rep
 
 
+@pytest.mark.usefixtures("default_config")
 def test_add_and_describe():
     """
-    Test that a key an be added and described
+    Test that a key can be added and described
     """
-    with default_config():
+    key = "newkey"
+    value = "testvalue"
+    value_type = "string"
+    description = "A test"
+    default = "testdefault"
 
-        key = 'newkey'
-        value = 'testvalue'
-        value_type = 'string'
-        description = 'A test'
-        default = 'testdefault'
+    cfg = qcodes.config
+    cfg.add(
+        key=key,
+        value=value,
+        value_type=value_type,
+        description=description,
+        default=default,
+    )
 
-        cfg = qcodes.config
-        cfg.add(key=key, value=value, value_type=value_type,
-                description=description, default=default)
+    desc = cfg.describe(f"user.{key}")
+    expected_desc = (
+        f"{description}.\nCurrent value: {value}. "
+        f"Type: {value_type}. Default: {default}."
+    )
 
-        desc = cfg.describe(f'user.{key}')
-        expected_desc = (f"{description}.\nCurrent value: {value}. "
-                         f"Type: {value_type}. Default: {default}.")
-
-        assert desc == expected_desc
+    assert desc == expected_desc

--- a/qcodes/tests/test_plot_utils.py
+++ b/qcodes/tests/test_plot_utils.py
@@ -2,6 +2,7 @@
 Tests for `qcodes.utils.plotting`.
 """
 import matplotlib
+import pytest
 
 # set matplotlib backend before importing pyplot
 matplotlib.use("Agg")
@@ -11,7 +12,6 @@ from pytest import fixture
 
 import qcodes
 from qcodes.dataset.plotting import plot_by_id
-from qcodes.tests.common import default_config
 
 from .dataset_generators import dataset_with_outliers_generator
 
@@ -47,21 +47,15 @@ def test_extend(dataset_with_outliers):
     plt.close()
 
 
+@pytest.mark.usefixtures("default_config")
 def test_defaults(dataset_with_outliers):
     run_id = dataset_with_outliers.run_id
 
-    # plot_by_id loads from the database location provided in the qcodes
-    # config. But the tests are supposed to run with the standard config.
-    # Therefore we need to backup the db location and add it to the default
-    # config context.
-    db_location = qcodes.config.core.db_location
-    with default_config():
-        qcodes.config.core.db_location = db_location
-        _, cb = plot_by_id(run_id)
-        assert cb[0].extend == 'neither'
+    _, cb = plot_by_id(run_id)
+    assert cb[0].extend == "neither"
 
-        qcodes.config.plotting.auto_color_scale.enabled = True
+    qcodes.config.plotting.auto_color_scale.enabled = True
 
-        _, cb = plot_by_id(run_id)
-        assert cb[0].extend == 'both'
+    _, cb = plot_by_id(run_id)
+    assert cb[0].extend == "both"
     plt.close()

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -16,7 +16,6 @@ from qcodes.instrument import Instrument
 from qcodes.monitor import Monitor
 from qcodes.parameters import DelegateParameter, Parameter
 from qcodes.station import SCHEMA_PATH, Station, ValidationWarning, update_config_schema
-from qcodes.tests.common import default_config
 from qcodes.tests.instrument_mocks import DummyInstrument
 from qcodes.utils import NumpyJSONEncoder, QCoDeSDeprecationWarning, get_qcodes_path
 from qcodes.utils.deprecate import deprecation_message
@@ -25,9 +24,9 @@ from .common import DumyPar
 
 
 @pytest.fixture(autouse=True)
+@pytest.mark.usefixtures("default_config")
 def use_default_config():
-    with default_config():
-        yield
+    yield
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Extracted from https://github.com/QCoDeS/Qcodes/pull/4763

* Using fixtures avoids the patterns of tests that are completely within a context manger improving readability
* Since the context mangers cooperate, we avoid the logic of having to patch config objects within the test 