### PR TITLE
adding test duration comparison in CI

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -58,7 +58,7 @@ jobs:
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
     - name: Run serial tests
       run: |
-        pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci --csv test_durations.csv --csv-columns name,duration qcodes
+        pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci qcodes --csv test_durations.csv --csv-columns name,duration
     - name: Compare test duration time
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -54,16 +54,16 @@ jobs:
       run: mypy -p qcodes
     - name: Run parallel tests
       run: |
-        pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes
+        pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes --csv test_durations.csv --csv-columns name,duration
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
-    - name: Run serial tests
-      run: |
-        pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci qcodes --csv test_durations.csv --csv-columns name,duration
     - name: Compare test duration time
       uses: actions/upload-artifact@v3
       with:
         name: blueracer
         path: test_durations.csv
+    - name: Run serial tests
+      run: |
+        pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci qcodes
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3.1.1
       with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -58,7 +58,12 @@ jobs:
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
     - name: Run serial tests
       run: |
-        pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci qcodes
+        pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci --csv test_durations.csv --csv-columns name,duration qcodes
+    - name: Compare test duration time
+      uses: actions/upload-artifact@v3
+      with:
+        name: blueracer
+        path: test_durations.csv
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3.1.1
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ test = [
     "pytest>=6.1.0",
     "pytest-asyncio>=0.19.0",
     "pytest-cov>=3.0.0",
+    "pytest-csv>=3.0.0",
     "pytest-mock>=3.0.0",
     "pytest-rerunfailures>=10.0",
     "pytest-xdist>=2.0.0",


### PR DESCRIPTION
Adding action to record test duration comparison on serial run unit tests. Let's see if this adds any insight to our test flow.