### PR TITLE
Allow pyvisa-sim instrs to be loaded from yaml file

### DIFF
--- a/qcodes/dist/schemas/station-template.schema.json
+++ b/qcodes/dist/schemas/station-template.schema.json
@@ -51,6 +51,9 @@
                         "init": {
                             "type": "object"
                         },
+                        "virtual_instrument_yaml_file": {
+                            "type": "string"
+                        },
                         "add_parameters": {
                             "type": "object",
                             "patternProperties": {

--- a/qcodes/instrument/sims/__init__.py
+++ b/qcodes/instrument/sims/__init__.py
@@ -1,1 +1,13 @@
-# :)
+import sys
+from importlib.abc import Traversable
+
+if sys.version_info >= (3, 9):
+    from importlib.resources import as_file, files
+else:
+    from importlib_resources import as_file, files
+
+
+def get_sim_file_path(filename: str) -> Traversable:
+
+    file = files("qcodes.instrument.sims") / filename
+    return file

--- a/qcodes/instrument/sims/__init__.py
+++ b/qcodes/instrument/sims/__init__.py
@@ -1,13 +1,25 @@
+from __future__ import annotations
+
 import sys
-from importlib.abc import Traversable
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 if sys.version_info >= (3, 9):
+    from importlib.abc import Traversable
     from importlib.resources import as_file, files
 else:
     from importlib_resources import as_file, files
+    from importlib_resources.abc import Traversable
 
 
 def get_sim_file_path(filename: str) -> Traversable:
 
     file = files("qcodes.instrument.sims") / filename
     return file
+
+
+@contextmanager
+def sims_visalib(filename: str) -> Iterator[str]:
+    traversable_file = get_sim_file_path(filename=filename)
+    with as_file(traversable_file) as file:
+        yield f"{str(file)}@sim"

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -11,9 +11,9 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis.strategies import floats, tuples
 
-import qcodes.instrument.sims as sims
 from qcodes.instrument import Instrument
 from qcodes.instrument.ip_to_visa import AMI430_VISA
+from qcodes.instrument.sims import sims_visalib
 from qcodes.instrument_drivers.american_magnetics.AMI430 import (
     AMI430,
     AMI430_3D,
@@ -36,9 +36,6 @@ field_limit = [
     lambda x, y, z: np.linalg.norm([x, y, z]) < 2
 ]
 
-# path to the .yaml file containing the simulated instrument
-visalib = sims.__file__.replace('__init__.py', 'AMI430.yaml@sim')
-
 LOG_NAME = "qcodes.instrument.instrument_base"
 
 
@@ -48,12 +45,16 @@ def magnet_axes_instances():
     Start three mock instruments representing current drivers for the x, y,
     and z directions.
     """
-    mag_x = AMI430_VISA('x', address='GPIB::1::INSTR', visalib=visalib,
-                        terminator='\n', port=1)
-    mag_y = AMI430_VISA('y', address='GPIB::2::INSTR', visalib=visalib,
-                        terminator='\n', port=1)
-    mag_z = AMI430_VISA('z', address='GPIB::3::INSTR', visalib=visalib,
-                        terminator='\n', port=1)
+    with sims_visalib("AMI430.yaml") as visalib:
+        mag_x = AMI430_VISA(
+            "x", address="GPIB::1::INSTR", visalib=visalib, terminator="\n", port=1
+        )
+        mag_y = AMI430_VISA(
+            "y", address="GPIB::2::INSTR", visalib=visalib, terminator="\n", port=1
+        )
+        mag_z = AMI430_VISA(
+            "z", address="GPIB::3::INSTR", visalib=visalib, terminator="\n", port=1
+        )
 
     yield mag_x, mag_y, mag_z
 
@@ -79,8 +80,10 @@ def _make_current_driver(magnet_axes_instances):
 
 @pytest.fixture(scope="function", name="ami430")
 def _make_ami430():
-    mag = AMI430_VISA('ami430', address='GPIB::1::INSTR', visalib=visalib,
-                      terminator='\n', port=1)
+    with sims_visalib("AMI430.yaml") as visalib:
+        mag = AMI430_VISA(
+            "ami430", address="GPIB::1::INSTR", visalib=visalib, terminator="\n", port=1
+        )
     yield mag
     mag.close()
 


### PR DESCRIPTION
This makes it simpler to write examples of station yaml files that makes use of pyvisa-sim instruments 

The visalib argument to the driver needs to have the full path to the sim file so it is not practical to put in the file in a portable way. As a workaround, I have added a different argument that allows the users to supply the name of the file which is then looked up in the default bundled location. Happy for other suggestions to how this could be done

In the process I have added logic to allow the loading of a pyvisa-sim yaml file using importlib-resources in the recommended portable way. 

TODO

- [ ] Tests of the station loading
- [ ] Docstrings
- [ ] Update other driver tests to make use of the new loaded rather than the `__file__` hack
- [ ] Examples of this in docs?




