### PR TITLE
run blueracer action with linux on 3.11 only

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,7 +37,6 @@ jobs:
         submodules: true
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
-      if: runner.os == 'Linux'
     # install libhdf5-dev untill we have wheels for python 3.11
     - name: install libhdf5
       run: sudo apt install libhdf5-dev
@@ -63,7 +62,8 @@ jobs:
       run: |
         pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes --csv test_durations.csv --csv-columns name,duration
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
-    - name: Compare test duration time
+    - name: Compare test duration time on linux py311 
+      if: $${{ runner.os == 'Linux' &&  matrix.python-version == "3.11"}}
       uses: actions/upload-artifact@v3
       with:
         name: blueracer

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,6 +37,7 @@ jobs:
         submodules: true
     - name: setup ubuntu-latest xvfb
       uses: ./.github/actions/setup-ubuntu-latest-xvfb
+      if: runner.os == 'Linux'
     # install libhdf5-dev untill we have wheels for python 3.11
     - name: install libhdf5
       run: sudo apt install libhdf5-dev

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,6 +30,7 @@ jobs:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
+      RUN_BLUERACER: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' }}
 
     steps:
     - uses: actions/checkout@v3.1.0
@@ -63,12 +64,12 @@ jobs:
       run: |
         pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes --csv test_durations.csv --csv-columns name,duration
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
-    - name: Compare test duration time on linux py311 
-      if: $${{ matrix.os == 'ubuntu-latest' &&  matrix.python-version == "3.11"}}
+    - name: Compare test duration time on linux py311
       uses: actions/upload-artifact@v3
       with:
         name: blueracer
         path: test_durations.csv
+      if: ${{ fromJSON(env.RUN_BLUERACER) }}
     - name: Run serial tests
       run: |
         pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci qcodes

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -64,7 +64,7 @@ jobs:
         pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes --csv test_durations.csv --csv-columns name,duration
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
     - name: Compare test duration time on linux py311 
-      if: $${{ runner.os == 'Linux' &&  matrix.python-version == "3.11"}}
+      if: $${{ matrix.os == 'ubuntu-latest' &&  matrix.python-version == "3.11"}}
       uses: actions/upload-artifact@v3
       with:
         name: blueracer


### PR DESCRIPTION
PR to only upload to blueracer test duration action if running with os linux and python 3.11.

This was needed because blue racer currently doesn't have support for matrix builds.