### PR TITLE
Stop using __file__ outside tests

### DIFF
--- a/qcodes/_version.py
+++ b/qcodes/_version.py
@@ -2,9 +2,9 @@ def _get_version() -> str:
     import sys
 
     if sys.version_info >= (3, 9):
-        from importlib.resources import as_file, files
+        from importlib.resources import files
     else:
-        from importlib_resources import as_file, files
+        from importlib_resources import files
 
     import versioningit
 

--- a/qcodes/_version.py
+++ b/qcodes/_version.py
@@ -1,11 +1,14 @@
 def _get_version() -> str:
-    from pathlib import Path
+    import sys
+
+    if sys.version_info >= (3, 9):
+        from importlib.resources import as_file, files
+    else:
+        from importlib_resources import as_file, files
 
     import versioningit
 
-    import qcodes
-
-    qcodes_path = Path(qcodes.__file__).parent
+    qcodes_path = files("qcodes")
     return versioningit.get_version(project_dir=qcodes_path.parent)
 
 

--- a/qcodes/_version.py
+++ b/qcodes/_version.py
@@ -1,17 +1,16 @@
 def _get_version() -> str:
-    import sys
-
-    if sys.version_info >= (3, 9):
-        from importlib.resources import files
-    else:
-        from importlib_resources import files
+    from importlib.resources import files
+    from pathlib import Path
 
     import versioningit
 
     root_module = __loader__.name.split(".")[0]
 
-    qcodes_path = files(root_module)
-    return versioningit.get_version(project_dir=qcodes_path.parent)
+    module_path = files(root_module)
+    if isinstance(module_path, Path):
+        return versioningit.get_version(project_dir=Path(module_path).parent)
+    else:
+        return "0.0"
 
 
 __version__ = _get_version()

--- a/qcodes/_version.py
+++ b/qcodes/_version.py
@@ -8,7 +8,9 @@ def _get_version() -> str:
 
     import versioningit
 
-    qcodes_path = files("qcodes")
+    root_module = __loader__.name.split(".")[0]
+
+    qcodes_path = files(root_module)
     return versioningit.get_version(project_dir=qcodes_path.parent)
 
 

--- a/qcodes/_version.py
+++ b/qcodes/_version.py
@@ -4,7 +4,8 @@ def _get_version() -> str:
 
     import versioningit
 
-    root_module = __loader__.name.split(".")[0]
+    # https://github.com/python/mypy/issues/4182
+    root_module = __loader__.name.split(".")[0]  # type: ignore[name-defined]
 
     module_path = files(root_module)
     if isinstance(module_path, Path):

--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -1,5 +1,12 @@
 from __future__ import annotations
 
+import sys
+
+if sys.version_info >= (3, 9):
+    from importlib.resources import files
+else:
+    from importlib_resources import files
+
 import copy
 import json
 import logging
@@ -40,14 +47,14 @@ class Config:
     schema_file_name = "qcodesrc_schema.json"
     """Name of schema file"""
     # get abs path of packge config file
-    default_file_name = str(Path(__file__).parent / config_file_name)
+    default_file_name = str(files("qcodes.configuration") / config_file_name)
     """Filename of default config"""
     current_config_path = default_file_name
     """Path of the last loaded config file"""
     _loaded_config_files = [default_file_name]
 
     # get abs path of schema  file
-    schema_default_file_name = str(Path(__file__).parent / schema_file_name)
+    schema_default_file_name = str(files("qcodes.configuration") / schema_file_name)
     """Filename of default schema"""
 
     # home dir, os independent

--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -26,7 +26,9 @@ BASE_SCHEMA = {
     "required": []
 }
 
-_PARENT_MODULE = ".".join(__loader__.name.split(".")[:-1])
+# https://github.com/python/mypy/issues/4182
+_PARENT_MODULE = ".".join(__loader__.name.split(".")[:-1])  # type: ignore[name-defined]
+
 
 class Config:
     """

--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -32,6 +32,7 @@ BASE_SCHEMA = {
     "required": []
 }
 
+_PARENT_MODULE = ".".join(__loader__.name.split(".")[:-1])
 
 class Config:
     """
@@ -47,14 +48,14 @@ class Config:
     schema_file_name = "qcodesrc_schema.json"
     """Name of schema file"""
     # get abs path of packge config file
-    default_file_name = str(files("qcodes.configuration") / config_file_name)
+    default_file_name = str(files(_PARENT_MODULE) / config_file_name)
     """Filename of default config"""
     current_config_path = default_file_name
     """Path of the last loaded config file"""
     _loaded_config_files = [default_file_name]
 
     # get abs path of schema  file
-    schema_default_file_name = str(files("qcodes.configuration") / schema_file_name)
+    schema_default_file_name = str(files(_PARENT_MODULE) / schema_file_name)
     """Filename of default schema"""
 
     # home dir, os independent

--- a/qcodes/configuration/config.py
+++ b/qcodes/configuration/config.py
@@ -1,17 +1,11 @@
 from __future__ import annotations
 
-import sys
-
-if sys.version_info >= (3, 9):
-    from importlib.resources import files
-else:
-    from importlib_resources import files
-
 import copy
 import json
 import logging
 import os
 from collections.abc import Mapping
+from importlib.resources import files
 from os.path import expanduser
 from pathlib import Path
 from typing import Any

--- a/qcodes/monitor/monitor.py
+++ b/qcodes/monitor/monitor.py
@@ -19,6 +19,13 @@ list of parameters to monitor:
 """
 from __future__ import annotations
 
+import sys
+
+if sys.version_info >= (3, 9):
+    from importlib.resources import as_file, files
+else:
+    from importlib_resources import as_file, files
+
 import asyncio
 import json
 import logging
@@ -266,15 +273,17 @@ def main() -> None:
 
     # If this file is run, create a simple webserver that serves a simple
     # website that can be used to view monitored parameters.
-    static_dir = os.path.join(os.path.dirname(__file__), "dist")
-    os.chdir(static_dir)
+    static_dir = files("qcodes.monitor.dist")
     try:
-        log.info("Starting HTTP Server at http://localhost:%i", SERVER_PORT)
-        with socketserver.TCPServer(("", SERVER_PORT),
-                                    http.server.SimpleHTTPRequestHandler) as httpd:
-            log.debug("serving directory %s", static_dir)
-            webbrowser.open(f"http://localhost:{SERVER_PORT}")
-            httpd.serve_forever()
+        with as_file(static_dir) as extracted_dir:
+            os.chdir(extracted_dir)
+            log.info("Starting HTTP Server at http://localhost:%i", SERVER_PORT)
+            with socketserver.TCPServer(
+                ("", SERVER_PORT), http.server.SimpleHTTPRequestHandler
+            ) as httpd:
+                log.debug("serving directory %s", static_dir)
+                webbrowser.open(f"http://localhost:{SERVER_PORT}")
+                httpd.serve_forever()
     except KeyboardInterrupt:
         log.info("Shutting Down HTTP Server")
 

--- a/qcodes/monitor/monitor.py
+++ b/qcodes/monitor/monitor.py
@@ -267,7 +267,8 @@ def main() -> None:
 
     # If this file is run, create a simple webserver that serves a simple
     # website that can be used to view monitored parameters.
-    parent_module = ".".join(__loader__.name.split(".")[:-1])
+    # # https://github.com/python/mypy/issues/4182
+    parent_module = ".".join(__loader__.name.split(".")[:-1])  # type: ignore[name-defined]
 
     static_dir = files(parent_module).joinpath("dist")
     try:

--- a/qcodes/monitor/monitor.py
+++ b/qcodes/monitor/monitor.py
@@ -19,13 +19,6 @@ list of parameters to monitor:
 """
 from __future__ import annotations
 
-import sys
-
-if sys.version_info >= (3, 9):
-    from importlib.resources import as_file, files
-else:
-    from importlib_resources import as_file, files
-
 import asyncio
 import json
 import logging
@@ -37,6 +30,7 @@ from asyncio import CancelledError
 from collections import defaultdict
 from collections.abc import Awaitable, Sequence
 from contextlib import suppress
+from importlib.resources import as_file, files
 from threading import Event, Thread
 from typing import Any, Callable
 

--- a/qcodes/monitor/monitor.py
+++ b/qcodes/monitor/monitor.py
@@ -273,7 +273,9 @@ def main() -> None:
 
     # If this file is run, create a simple webserver that serves a simple
     # website that can be used to view monitored parameters.
-    static_dir = files("qcodes.monitor.dist")
+    parent_module = ".".join(__loader__.name.split(".")[:-1])
+
+    static_dir = files(parent_module).joinpath("dist")
     try:
         with as_file(static_dir) as extracted_dir:
             os.chdir(extracted_dir)


### PR DESCRIPTION
This replaces the remaining use of `__file__` with `files` from `imporlib.resources` in qcodes outside of the tests.

Note that there is a trade off here as we now have hardcoded the path to config and monitor dist files in the python file rather than the relative path to that file. I think its cleaner to hardcode the full path but I could see the argument the other way around too.