### PR TITLE
log.warning instead of raise exception if measurement has been interrupted.

### DIFF
--- a/docs/changes/newsfragments/4801.improved
+++ b/docs/changes/newsfragments/4801.improved
@@ -1,0 +1,2 @@
+dond functions now return the dataset after `KeyboardInterrupt` or `BreakConditionInterrupt`.
+Instead of raising the interrupts, they are now logged as warning.

--- a/qcodes/dataset/dond/do_nd_utils.py
+++ b/qcodes/dataset/dond/do_nd_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
@@ -23,6 +24,8 @@ from qcodes.parameters import MultiParameter, ParameterBase
 
 if TYPE_CHECKING:
     from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
+
+log = logging.getLogger(__name__)
 
 ActionsT = Sequence[Callable[[], None]]
 BreakConditionT = Callable[[], bool]
@@ -102,7 +105,9 @@ def _handle_plotting(
         res = data, [None], [None]
 
     if interrupted:
-        raise interrupted
+        log.warning(
+            f"Measurement has been interrupted, data may be incomplete: {interrupted}"
+        )
 
     return res
 

--- a/qcodes/tests/dataset/dond/test_do1d.py
+++ b/qcodes/tests/dataset/dond/test_do1d.py
@@ -1,3 +1,5 @@
+import logging
+
 import hypothesis.strategies as hst
 import matplotlib
 import matplotlib.pyplot as plt
@@ -304,3 +306,32 @@ def test_do1d_additional_setpoints_shape(
         "simple_parameter": (num_points_p1, 1, 1),
     }
     assert results[0].description.shapes == expected_shapes
+
+
+@pytest.mark.usefixtures("plot_close", "experiment")
+def test_do1d_break_condition(caplog, _param_set, _param):
+
+    start = 0
+    stop = 1
+    num_points = 5
+    delay = 0
+
+    def break_condition():
+        return True
+
+    data = do1d(
+        _param_set,
+        start,
+        stop,
+        num_points,
+        delay,
+        _param,
+        break_condition=break_condition,
+    )
+
+    assert isinstance(data[0], DataSet) is True
+    assert (
+        "qcodes.dataset.dond.do_nd_utils",
+        logging.WARNING,
+        "Measurement has been interrupted, data may be incomplete: Break condition was met.",
+    ) in caplog.record_tuples


### PR DESCRIPTION
Pull request for #4800