### PR TITLE
Switch docs build to Sphinx 5.3.0 + bugfix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -132,7 +132,7 @@ slack-sdk~=3.19.1
 snowballstemmer~=2.2.0
 sortedcontainers~=2.4.0
 soupsieve~=2.3.2.post1
-Sphinx @ git+https://github.com/jenshnielsen/sphinx.git@fix_9884_50branch
+Sphinx @ git+https://github.com/jenshnielsen/sphinx.git@fix_9884_5_3
 sphinx-favicon~=0.2
 sphinx-issues~=3.0.1
 sphinx-jsonschema~=1.19.1


### PR DESCRIPTION
This simply switches our docs build to a branch that is the latest release of sphinx + my two commits to fix attribute documentation