### PR TITLE
Use StrEnum from std lib when avilable

### DIFF
--- a/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
+++ b/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
@@ -1,5 +1,6 @@
 import logging
 import struct
+import sys
 import warnings
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Sequence, Tuple
@@ -17,6 +18,13 @@ from qcodes.parameters import (
     ParamRawDataType,
     create_on_off_val_mapping,
 )
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+
+    class StrEnum(str, Enum):
+        pass
 
 log = logging.getLogger(__name__)
 
@@ -198,10 +206,6 @@ class TimeAxis(Parameter):
         npts = self.instrument.timetrace_npts()
         dt = self.instrument.timetrace_dt()
         return np.linspace(0, dt * npts, npts, endpoint=False)
-
-
-class StrEnum(str, Enum):
-    pass
 
 
 class Keithley2600MeasurementStatus(StrEnum):

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/constants.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/constants.py
@@ -1,9 +1,13 @@
+import sys
 from enum import Enum, IntEnum, IntFlag
 from typing import Sequence, Union
 
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
 
-class StrEnum(str, Enum):
-    pass
+    class StrEnum(str, Enum):
+        pass
 
 class ChannelName(StrEnum):
     A = 'CH1'

--- a/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
+++ b/qcodes/instrument_drivers/tektronix/Keithley_2600_channels.py
@@ -3,19 +3,27 @@ Alias left for backwards compatibility.
 Keithly drivers have moved to the Keithley module
 """
 import logging
+import sys
+from enum import Enum
 
 from qcodes.instrument_drivers.Keithley._Keithley_2600 import (
     Keithley2600,
     Keithley2600Channel,
     LuaSweepParameter,
     MeasurementStatus,
-    StrEnum,
     TimeAxis,
     TimeTrace,
     _MeasurementCurrentParameter,
     _MeasurementVoltageParameter,
     _ParameterWithStatus,
 )
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+
+    class StrEnum(str, Enum):
+        pass
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Python 3.11 added StrEnum to the std library so lets use that when available rather than rolling out our own