### PR TITLE
Add just enough types to avoid mypy notes

### DIFF
--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -4,7 +4,7 @@ Live plotting using pyqtgraph
 import logging
 import warnings
 from collections import deque, namedtuple
-from typing import Deque, Dict, List, Optional, Union, cast
+from typing import Deque, Dict, List, Optional, Tuple, Union, cast
 
 import numpy as np
 import pyqtgraph as pg
@@ -66,10 +66,19 @@ class QtPlot(BasePlot):
     max_len = cast(int, max_len)
     plots: Deque['QtPlot'] = deque(maxlen=max_len)
 
-    def __init__(self, *args, figsize=(1000, 600), interval=0.25,
-                 window_title='', theme=((60, 60, 60), 'w'), show_window=True,
-                 remote=True, fig_x_position=None, fig_y_position=None,
-                 **kwargs):
+    def __init__(
+        self,
+        *args,
+        figsize: Tuple[int, int] = (1000, 600),
+        interval=0.25,
+        window_title="",
+        theme=((60, 60, 60), "w"),
+        show_window=True,
+        remote=True,
+        fig_x_position=None,
+        fig_y_position=None,
+        **kwargs,
+    ):
         super().__init__(interval)
 
         if 'windowTitle' in kwargs.keys():
@@ -88,6 +97,8 @@ class QtPlot(BasePlot):
             self.rpg = pg
             self.qc_helpers = qcodes.utils.qt_helpers
         try:
+            # _init_qt will set self.rpg so it cannot be None here
+            assert self.rpg is not None
             self.win = self.rpg.GraphicsLayoutWidget(title=window_title)
             self.win.show()
         except (ClosedError, ConnectionResetError) as err:
@@ -97,6 +108,8 @@ class QtPlot(BasePlot):
                 log.warning("Remote plot responded with {} \n"
                             "Restarting remote plot".format(err))
                 self._init_qt()
+                # _init_qt will set self.rpg so it cannot be None here
+                assert self.rpg is not None
                 self.win = self.rpg.GraphicsLayoutWidget(title=window_title)
                 self.win.show()
             else:
@@ -139,14 +152,14 @@ class QtPlot(BasePlot):
         cls.rpg = cls.proc._import("pyqtgraph")
         cls.qc_helpers = cls.proc._import("qcodes.utils.qt_helpers")
 
-    def clear(self):
+    def clear(self) -> None:
         """
         Clears the plot window and removes all subplots and traces
         so that the window can be reused.
         """
         self.win.clear()
         self.traces = []
-        self.subplots: List[Union[PlotItem, ObjectProxy]] = []
+        self.subplots = []
 
     def add_subplot(self):
         subplot_object = self.win.addPlot()

--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -5,7 +5,17 @@ import tempfile
 from contextlib import contextmanager
 from functools import wraps
 from time import sleep
-from typing import TYPE_CHECKING, Any, Callable, Dict, Hashable, Optional, Tuple, Type
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Generator,
+    Hashable,
+    Optional,
+    Tuple,
+    Type,
+)
 
 import pytest
 
@@ -216,7 +226,7 @@ def default_config(user_config: Optional[str] = None):
 
 @deprecate(reason="Unused internally", alternative="reset_config_on_exit fixture")
 @contextmanager
-def reset_config_on_exit():
+def reset_config_on_exit() -> Generator[None, None, None]:
     """
     Context manager to clean any modification of the in memory config on exit
 

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -5,7 +5,7 @@ import gc
 import os
 import sys
 import tempfile
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generator
 
 import pytest
 from hypothesis import settings
@@ -52,7 +52,7 @@ def disable_telemetry():
 
 
 @pytest.fixture(scope="function")
-def default_config(tmp_path):
+def default_config(tmp_path) -> Generator[None, None, None]:
     """
     Fixture to temporarily establish default config settings.
     This is achieved by overwriting the config paths of the user-,
@@ -95,7 +95,7 @@ def default_config(tmp_path):
 
 
 @pytest.fixture(scope="function")
-def reset_config_on_exit():
+def reset_config_on_exit() -> Generator[None, None, None]:
 
     """
     Fixture to clean any modification of the in memory config on exit

--- a/qcodes/tests/dataset/conftest.py
+++ b/qcodes/tests/dataset/conftest.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tempfile
 from contextlib import contextmanager
-from typing import Iterator
+from typing import Generator, Iterator
 
 import numpy as np
 import pytest
@@ -26,7 +26,7 @@ from qcodes.validators import Arrays, ComplexNumbers, Numbers
 
 
 @pytest.fixture(scope="function", name="non_created_db")
-def _make_non_created_db(tmp_path):
+def _make_non_created_db(tmp_path) -> Generator[None, None, None]:
     # set db location to a non existing file
     try:
         qc.config["core"]["db_location"] = str(tmp_path / "temp.db")

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -314,7 +314,7 @@ def test_add_experiments(experiment_name, sample_name, dataset_name):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_dependent_parameters():
+def test_dependent_parameters() -> None:
 
     pss: List[ParamSpecBase] = []
 

--- a/qcodes/tests/dataset/test_dataset_in_memory_bacis.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory_bacis.py
@@ -62,7 +62,7 @@ def test_no_interdeps_raises_in_prepare(experiment):
         ds.prepare(interdeps=InterDependencies_(), snapshot={})
 
 
-def test_prepare_twice_raises(experiment):
+def test_prepare_twice_raises(experiment) -> None:
     ds = DataSetInMem._create_new_run(name="foo")
 
     pss: List[ParamSpecBase] = []
@@ -78,7 +78,7 @@ def test_prepare_twice_raises(experiment):
         ds.prepare(interdeps=idps, snapshot={})
 
 
-def test_timestamps(experiment):
+def test_timestamps(experiment) -> None:
     ds = DataSetInMem._create_new_run(name="foo")
 
     assert ds.run_timestamp() is None

--- a/qcodes/tests/instrument_mocks.py
+++ b/qcodes/tests/instrument_mocks.py
@@ -228,7 +228,7 @@ class DmmExponentialParameter(Parameter):
 
 
 class DmmGaussParameter(Parameter):
-    def __init__(self, name, **kwargs):
+    def __init__(self, name: str, **kwargs: Any):
         super().__init__(name, **kwargs)
         self.x0 = 0.1
         self.y0 = 0.2


### PR DESCRIPTION
Mypy 0.990 has started triggering notes on annotations in functions that are not type checked. This is essentially because these type annotations have no effect since, they are not checked. This fixes that by adding partial type annotations to those functions.