### PR TITLE
pin nbclient patch version to attempt to fix docs build issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ msal~=1.20.0
 msal-extensions~=1.0.0
 mypy==0.991
 mypy-extensions~=0.4.3
-nbclient~=0.7.0
+nbclient==0.7.0
 nbconvert~=7.2.2
 nbformat~=5.7.0
 nbsphinx~=0.8.9


### PR DESCRIPTION
This attempts to fix the docs build errors seen in https://github.com/QCoDeS/Qcodes/pull/4825 
