### PR TITLE
remove non-working blueracer, replace with manual print of durations

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -61,7 +61,7 @@ jobs:
       run: mypy -p qcodes
     - name: Run parallel tests
       run: |
-        pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes
+        pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci  --durations=20 qcodes
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
     - name: Run serial tests
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -30,7 +30,6 @@ jobs:
       DISPLAY: ':99.0'
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
-      RUN_BLUERACER: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' }}
 
     steps:
     - uses: actions/checkout@v3.1.0
@@ -62,14 +61,8 @@ jobs:
       run: mypy -p qcodes
     - name: Run parallel tests
       run: |
-        pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes --csv test_durations.csv --csv-columns name,duration
+        pytest -m "not serial" --cov=qcodes --cov-report xml --hypothesis-profile ci qcodes
 # a subset of the tests fails when run in parallel on Windows so run those in serial here
-    - name: Compare test duration time on linux py311
-      uses: actions/upload-artifact@v3
-      with:
-        name: blueracer
-        path: test_durations.csv
-      if: ${{ fromJSON(env.RUN_BLUERACER) }}
     - name: Run serial tests
       run: |
         pytest -m "serial" -n 0 --dist no --cov=qcodes --cov-report xml --cov-append --hypothesis-profile ci qcodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ test = [
     "pytest>=6.1.0",
     "pytest-asyncio>=0.19.0",
     "pytest-cov>=3.0.0",
-    "pytest-csv>=3.0.0",
     "pytest-mock>=3.0.0",
     "pytest-rerunfailures>=10.0",
     "pytest-xdist>=2.0.0",


### PR DESCRIPTION
It seems like blueracer changed their integration but the documentation is unclear. This has never really worked correctly for us. We can come back to this when/if blueracer is more mature.

To get a little bit more feedback I have added ``--durations=20`` to print the run time of the slowest 20 tests to std out when running in CI