### PR TITLE
Revert ipython to 8.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ importlib-resources~=5.9.0; python_version < '3.9'
 incremental~=22.10.0
 iniconfig~=1.1.1
 ipykernel~=6.17.1
-ipython~=8.7.0
+ipython~=8.6.0
 ipython-genutils==0.2.0
 ipywidgets~=8.0.2
 jedi~=0.18.1


### PR DESCRIPTION
The new version causes a huge number of warnings. Not caught due to #4830 

Warnings are due to https://github.com/ipython/ipython/issues/13845