### PR TITLE
Update scale transformation in pyqtgraph plot

### DIFF
--- a/docs/changes/newsfragments/4886.improved
+++ b/docs/changes/newsfragments/4886.improved
@@ -1,0 +1,1 @@
+Update the pyqtgraph plot backend for upstream changes in pyqtgraph.

--- a/qcodes/plots/pyqtgraph.py
+++ b/qcodes/plots/pyqtgraph.py
@@ -317,8 +317,11 @@ class QtPlot(BasePlot):
 
         if scales_changed:
             img.resetTransform()
-            img.translate(scales['x'].translate, scales['y'].translate)
-            img.scale(scales['x'].scale, scales['y'].scale)
+            tr = QtGui.QTransform.fromTranslate(
+                scales["x"].translate, scales["y"].translate
+            )
+            tr_scale = QtGui.QTransform.fromScale(scales["x"].scale, scales["y"].scale)
+            img.setTransform(tr_scale * tr)
 
     def _update_cmap(self, plot_object):
         gradient = plot_object['hist'].gradient


### PR DESCRIPTION
Update the scale transformation in qcodes.plots.pyqtgraph to use the modern interface. I think the old interface was deprecated a very long time ago (see commnent in https://github.com/pyqtgraph/pyqtgraph/pull/1533).

Fixes #4756. @rsokolewicz Could you check this PR with the quantify plotting?

@jenshnielsen 

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
