### PR TITLE
Reduce overhead in parameter validation

### DIFF
--- a/docs/changes/newsfragments/4887.underthehood
+++ b/docs/changes/newsfragments/4887.underthehood
@@ -1,0 +1,1 @@
+Improve performance of parameter validator.

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -419,8 +419,7 @@ class InstrumentBase(Metadatable, DelegateAttributes):
         A list of all the parts of the instrument name from :meth:`root_instrument`
         to the current :class:`InstrumentModule`.
         """
-        name_parts = [self.short_name]
-        return name_parts
+        return [self.short_name]
 
     @property
     def full_name(self) -> str:


### PR DESCRIPTION
The parameter validator spends a large amount of time in generating the validation context (only used if the validation fails), instead of the actual parameter validation. Profiling results with snakeviz:

![validate](https://user-images.githubusercontent.com/17724047/209675062-8a0354d3-a98d-462b-8923-c442fb7473bc.PNG)

This PR reduces the overhead by using a `cached_propery` decorator. This is possible since the instrument and parameter name are immutable in qcodes.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->

@jenshnielsen 