### PR TITLE
Rework config fixtures

### DIFF
--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -275,7 +275,7 @@ def start_logger() -> None:
         logging.getLogger(name).setLevel(level)
 
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.DEBUG)
+    root_logger.setLevel(logging.NOTSET)
 
     # remove previously set handlers
     for handler in (console_handler, file_handler, telemetry_handler):
@@ -484,7 +484,7 @@ class LogCapture:
     def __init__(self, logger: logging.Logger = logging.getLogger(),
                  level: Optional[LevelType] = None) -> None:
         self.logger = logger
-        self.level = level or logging.DEBUG
+        self.level = level or logging.NOTSET
 
         self.stashed_handlers = copy(self.logger.handlers)
         for h in self.stashed_handlers:

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -185,11 +185,3 @@ def _make_standalone_parameters_dataset(
     )
     dataset.mark_completed()
     yield dataset
-
-
-@pytest.fixture(name="set_default_station_to_none")
-def _make_set_default_station_to_none():
-    """Makes sure that after startup and teardown there is no default station"""
-    Station.default = None
-    yield
-    Station.default = None

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -18,6 +18,7 @@ from qcodes.dataset.data_set import DataSet
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.experiment_container import Experiment, new_experiment
+from qcodes.instrument import Instrument
 from qcodes.station import Station
 
 settings.register_profile("ci", deadline=1000)
@@ -90,10 +91,12 @@ def default_session_config(
 
 
 @pytest.fixture(scope="function", autouse=True)
-def reset_config_on_exit() -> Generator[None, None, None]:
+def reset_state_on_exit() -> Generator[None, None, None]:
     """
-    Fixture to clean any modification of the in memory config on exit
+    Fixture to clean any shared state on exit
 
+    Currently this resets the config to the default config
+    and closes all instruments.
     """
     default_config_obj: DotDict | None = copy.deepcopy(qc.config.current_config)
 
@@ -101,6 +104,7 @@ def reset_config_on_exit() -> Generator[None, None, None]:
         yield
     finally:
         qc.config.current_config = default_config_obj
+        Instrument.close_all()
 
 
 @pytest.fixture(scope="function", name="empty_temp_db")

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -54,7 +54,7 @@ def disable_telemetry() -> Generator[None, None, None]:
         qc.config.telemetry.enabled = original_state
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(scope="function")
 def default_config(tmp_path: Path) -> Generator[None, None, None]:
     """
     Fixture to temporarily establish default config settings.
@@ -97,7 +97,7 @@ def default_config(tmp_path: Path) -> Generator[None, None, None]:
         qc.config.current_config = default_config_obj
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", autouse=True)
 def reset_config_on_exit() -> Generator[None, None, None]:
 
     """

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -54,7 +54,7 @@ def disable_telemetry() -> Generator[None, None, None]:
         qc.config.telemetry.enabled = original_state
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="function", autouse=True)
 def default_config(tmp_path: Path) -> Generator[None, None, None]:
     """
     Fixture to temporarily establish default config settings.

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -39,30 +39,13 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def disable_telemetry() -> Generator[None, None, None]:
+def default_session_config(
+    tmpdir_factory: pytest.TempdirFactory,
+) -> Generator[None, None, None]:
     """
-    We do not want the tests to send up telemetric information, so we disable
-    that with this fixture.
-    """
-
-    original_state = qc.config.telemetry.enabled
-
-    try:
-        qc.config.telemetry.enabled = False
-        yield
-    finally:
-        qc.config.telemetry.enabled = original_state
-
-
-@pytest.fixture(scope="function")
-def default_config(tmp_path: Path) -> Generator[None, None, None]:
-    """
-    Fixture to temporarily establish default config settings.
-    This is achieved by overwriting the config paths of the user-,
-    environment-, and current directory-config files with the path of the
-    config file in the qcodes repository,
-    additionally the current config object `qcodes.config` gets copied and
-    reestablished.
+    Set the config for the test session to be the default config.
+    Making sure that that user config does not influence the tests and
+    that tests cannot write to the user config.
     """
     home_file_name = Config.home_file_name
     schema_home_file_name = Config.schema_home_file_name
@@ -71,35 +54,43 @@ def default_config(tmp_path: Path) -> Generator[None, None, None]:
     cwd_file_name = Config.cwd_file_name
     schema_cwd_file_name = Config.schema_cwd_file_name
 
+    old_config: DotDict | None = copy.deepcopy(qc.config.current_config)
+    qc.config.current_config = copy.deepcopy(qc.config.defaults)
+
+    tmp_path = tmpdir_factory.mktemp("qcodes_tests")
+
     file_name = str(tmp_path / "user_config.json")
     file_name_schema = str(tmp_path / "user_config_schema.json")
 
-    Config.home_file_name = file_name
-    Config.schema_home_file_name = file_name_schema
-    Config.env_file_name = ""
-    Config.schema_env_file_name = ""
-    Config.cwd_file_name = ""
-    Config.schema_cwd_file_name = ""
+    qc.config.home_file_name = file_name
+    qc.config.schema_home_file_name = file_name_schema
+    qc.config.env_file_name = ""
+    qc.config.schema_env_file_name = ""
+    qc.config.cwd_file_name = ""
+    qc.config.schema_cwd_file_name = ""
 
-    default_config_obj: DotDict | None = copy.deepcopy(qc.config.current_config)
-    qc.config = Config()
+    # set any config that we want to be different from the default
+    # for the test session here
+    # also set the default db path here
+    qc.config.telemetry.enabled = False
+    qc.config.subscription.default_subscribers = []
+    qc.config.core.db_location = str(tmp_path / "temp.db")
 
     try:
         yield
     finally:
-        Config.home_file_name = home_file_name
-        Config.schema_home_file_name = schema_home_file_name
-        Config.env_file_name = env_file_name
-        Config.schema_env_file_name = schema_env_file_name
-        Config.cwd_file_name = cwd_file_name
-        Config.schema_cwd_file_name = schema_cwd_file_name
+        qc.config.home_file_name = home_file_name
+        qc.config.schema_home_file_name = schema_home_file_name
+        qc.config.env_file_name = env_file_name
+        qc.config.schema_env_file_name = schema_env_file_name
+        qc.config.cwd_file_name = cwd_file_name
+        qc.config.schema_cwd_file_name = schema_cwd_file_name
 
-        qc.config.current_config = default_config_obj
+        qc.config.current_config = old_config
 
 
 @pytest.fixture(scope="function", autouse=True)
 def reset_config_on_exit() -> Generator[None, None, None]:
-
     """
     Fixture to clean any modification of the in memory config on exit
 
@@ -110,22 +101,6 @@ def reset_config_on_exit() -> Generator[None, None, None]:
         yield
     finally:
         qc.config.current_config = default_config_obj
-
-
-@pytest.fixture(scope="session", autouse=True)
-def disable_config_subscriber() -> Generator[None, None, None]:
-    """
-    We do not want the tests to send generate subscription events unless specifically
-    enabled in the test. So disable any default subscriber defined.
-    """
-
-    original_state = qc.config.subscription.default_subscribers
-
-    try:
-        qc.config.subscription.default_subscribers = []
-        yield
-    finally:
-        qc.config.subscription.default_subscribers = original_state
 
 
 @pytest.fixture(scope="function", name="empty_temp_db")

--- a/qcodes/tests/conftest.py
+++ b/qcodes/tests/conftest.py
@@ -95,8 +95,8 @@ def reset_state_on_exit() -> Generator[None, None, None]:
     """
     Fixture to clean any shared state on exit
 
-    Currently this resets the config to the default config
-    and closes all instruments.
+    Currently this resets the config to the default config,
+    closes the default station and closes all instruments.
     """
     default_config_obj: DotDict | None = copy.deepcopy(qc.config.current_config)
 
@@ -105,6 +105,7 @@ def reset_state_on_exit() -> Generator[None, None, None]:
     finally:
         qc.config.current_config = default_config_obj
         Instrument.close_all()
+        Station.default = None
 
 
 @pytest.fixture(scope="function", name="empty_temp_db")

--- a/qcodes/tests/dataset/dond/test_do0d.py
+++ b/qcodes/tests/dataset/dond/test_do0d.py
@@ -20,7 +20,7 @@ from qcodes.tests.instrument_mocks import (
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("period", [None, 1])
 @pytest.mark.parametrize("plot", [None, True, False])
-@pytest.mark.parametrize("plot_config", [None, True, False])
+@pytest.mark.parametrize("plot_config", [True, None, False])
 def test_do0d_with_real_parameter(period, plot, plot_config) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
 

--- a/qcodes/tests/dataset/dond/test_doNd.py
+++ b/qcodes/tests/dataset/dond/test_doNd.py
@@ -858,7 +858,7 @@ def test_dond_2d_multi_datasets_output_type(
     assert isinstance(datasets[1], DataSet) is True
 
 
-@pytest.mark.usefixtures("plot_close")
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_2d_multi_datasets_multi_exp(
     _param, _param_complex, _param_set, _param_set_2, request: FixtureRequest
 ) -> None:
@@ -881,7 +881,7 @@ def test_dond_2d_multi_datasets_multi_exp(
     assert datasets[1].exp_id == exp2.exp_id
 
 
-@pytest.mark.usefixtures("plot_close")
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_2d_multi_datasets_multi_exp_inconsistent_raises(
     _param, _param_complex, _param_set, _param_set_2, request: FixtureRequest
 ) -> None:
@@ -1117,6 +1117,7 @@ def test_dond_together_sweep_sweeper(_param_set, _param_set_2, _param) -> None:
         assert output[1].delay == delay_2
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_sweeper_combined() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1150,6 +1151,7 @@ def test_dond_together_sweep_sweeper_combined() -> None:
     assert datasets[2].name == "ds3"
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_sweeper_combined_2_in_1() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1214,6 +1216,7 @@ def test_dond_together_sweep_sweeper_mixed_splitting() -> None:
         )
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_sweeper_combined_explict_names() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1248,6 +1251,7 @@ def test_dond_together_sweep_sweeper_combined_explict_names() -> None:
     assert datasets[2].name == "ds3"
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_sweeper_combined_explict_names_inconsistent() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1282,6 +1286,7 @@ def test_dond_together_sweep_sweeper_combined_explict_names_inconsistent() -> No
         )
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_sweeper_combined_explict_names_and_single_name() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1315,6 +1320,7 @@ def test_dond_together_sweep_sweeper_combined_explict_names_and_single_name() ->
         )
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_sweeper_combined_lists() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1373,6 +1379,7 @@ def test_empty_together_sweep_raises() -> None:
         TogetherSweep()
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_more_parameters() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1425,6 +1432,7 @@ def test_dond_together_sweep_sweeper_combined_missing_in_dataset_dependencies() 
         )
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_sweeper_wrong_sp_in_dataset_dependencies() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1448,6 +1456,7 @@ def test_dond_together_sweep_sweeper_wrong_sp_in_dataset_dependencies() -> None:
         )
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_sweeper_wrong_mp_in_dataset_dependencies() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
@@ -1480,6 +1489,7 @@ def test_dond_together_sweep_sweeper_wrong_mp_in_dataset_dependencies() -> None:
         )
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_parameter_with_setpoints(dummyinstrument) -> None:
 
     outer_shape = 10
@@ -1532,6 +1542,7 @@ def test_dond_together_sweep_parameter_with_setpoints(dummyinstrument) -> None:
     ] == (outer_shape, inner_shape, n_points_b)
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping(
     dummyinstrument,
 ) -> None:
@@ -1587,6 +1598,7 @@ def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping(
     ] == (outer_shape, inner_shape, n_points_b)
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping_and_callable(
     dummyinstrument,
 ) -> None:
@@ -1644,6 +1656,7 @@ def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping_and_calla
     ] == (outer_shape, inner_shape, n_points_b)
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_sweeper_combinations(_param_set, _param_set_2, _param) -> None:
     outer_shape = 10
     inner_shape = 15
@@ -1678,6 +1691,7 @@ def test_dond_sweeper_combinations(_param_set, _param_set_2, _param) -> None:
         assert g in sweep_groups
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_sweep_int_vs_float() -> None:
 
     float_param = ManualParameter("float_param", initial_value=0.0)
@@ -1689,6 +1703,7 @@ def test_sweep_int_vs_float() -> None:
     assert dataset.cache.data()["float_param"]["int_param"].dtype.kind == "i"
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_error_no_measured_parameters() -> None:
     float_param = ManualParameter("float_param", initial_value=0.0)
     int_param = ManualParameter("int_param", vals=Ints(0, 100))
@@ -1697,6 +1712,7 @@ def test_error_no_measured_parameters() -> None:
         dond(ArraySweep(int_param, [1, 2, 3]), ArraySweep(float_param, [1.0, 2.0, 3.0]))
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_error_measured_grouped_and_not_grouped() -> None:
     param_1 = ManualParameter("param_1", initial_value=0.0)
     param_2 = ManualParameter("param_2", initial_value=0.0)
@@ -1708,6 +1724,7 @@ def test_error_measured_grouped_and_not_grouped() -> None:
         dond(LinSweep(param_1, 0, 10, 10), param_2, [param_3])
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_post_action(mocker) -> None:
     param_1 = ManualParameter("param_1", initial_value=0.0)
     param_2 = ManualParameter("param_2", initial_value=0.0)
@@ -1718,6 +1735,7 @@ def test_post_action(mocker) -> None:
     post_actions[0].assert_called_with()
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_extra_log_info(caplog: LogCaptureFixture) -> None:
 
     param_1 = ManualParameter("param_1", initial_value=0.0)
@@ -1730,6 +1748,7 @@ def test_extra_log_info(caplog: LogCaptureFixture) -> None:
     assert log_message in caplog.text
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_default_log_info(caplog: LogCaptureFixture) -> None:
 
     param_1 = ManualParameter("param_1", initial_value=0.0)
@@ -1741,6 +1760,7 @@ def test_default_log_info(caplog: LogCaptureFixture) -> None:
     assert "Using 'qcodes.dataset.dond'" in caplog.text
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_get_after_set(_param_set, _param_set_2, _param) -> None:
 
     n_points = 10
@@ -1764,6 +1784,7 @@ def test_dond_get_after_set(_param_set, _param_set_2, _param) -> None:
     assert b.set_count == 0
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_no_get_after_set(_param_set, _param_set_2, _param) -> None:
 
     n_points = 10
@@ -1787,6 +1808,7 @@ def test_dond_no_get_after_set(_param_set, _param_set_2, _param) -> None:
     assert b.set_count == 0
 
 
+@pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_get_after_set_stores_get_value(_param_set, _param_set_2, _param) -> None:
 
     n_points = 11

--- a/qcodes/tests/dataset/dond/test_doNd.py
+++ b/qcodes/tests/dataset/dond/test_doNd.py
@@ -94,7 +94,6 @@ def test_linear_sweep_get_setpoints(_param) -> None:
 
 
 @pytest.mark.usefixtures("experiment")
-@pytest.mark.usefixtures("default_config")
 @pytest.mark.parametrize("cache_config", [True, False])
 @pytest.mark.parametrize("cache_setting", [True, False, None])
 def test_cache_config(_param, _param_2, cache_config, cache_setting) -> None:

--- a/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
@@ -321,7 +321,6 @@ def test_setting_write_period(wp) -> None:
 @given(wp=hst.one_of(hst.integers(), hst.floats(allow_nan=False),
                      hst.text()))
 @pytest.mark.usefixtures("experiment")
-@pytest.mark.usefixtures("reset_config_on_exit")
 def test_setting_write_period_from_config(wp) -> None:
     qc.config.dataset.write_period = wp
 
@@ -341,7 +340,6 @@ def test_setting_write_period_from_config(wp) -> None:
 
 @pytest.mark.parametrize("write_in_background", [True, False])
 @pytest.mark.usefixtures("experiment")
-@pytest.mark.usefixtures("reset_config_on_exit")
 def test_setting_write_in_background_from_config(write_in_background) -> None:
     qc.config.dataset.write_in_background = write_in_background
 

--- a/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
@@ -607,7 +607,6 @@ def test_subscribers_called_for_all_data_points(experiment, DAC, DMM, N) -> None
     set_values=hst.lists(elements=hst.floats(), min_size=20, max_size=20),
     get_values=hst.lists(elements=hst.floats(), min_size=20, max_size=20),
 )
-@pytest.mark.usefixtures("set_default_station_to_none")
 def test_datasaver_scalars(
     experiment, DAC, DMM, set_values, get_values, breakpoint, write_period
 ) -> None:
@@ -645,7 +644,6 @@ def test_datasaver_scalars(
     # More assertions of setpoints, labels and units in the DB!
 
 
-@pytest.mark.usefixtures('set_default_station_to_none')
 def test_datasaver_inst_metadata(experiment, DAC_with_metadata, DMM) -> None:
     """
     Check that additional instrument metadata is captured into the dataset snapshot

--- a/qcodes/tests/dataset/measurement/test_shapes.py
+++ b/qcodes/tests/dataset/measurement/test_shapes.py
@@ -9,7 +9,6 @@ from pytest import LogCaptureFixture
 from qcodes.dataset.measurements import Measurement
 
 
-@pytest.mark.usefixtures("default_config")
 @given(n_points=hst.integers(min_value=1, max_value=100))
 @example(n_points=5)
 @settings(deadline=None, suppress_health_check=(HealthCheck.function_scoped_fixture,))
@@ -62,7 +61,6 @@ def test_datasaver_1d(
                                                           n_points_expected))
 
 
-@pytest.mark.usefixtures("default_config")
 @settings(deadline=None, suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n_points_1=hst.integers(min_value=1, max_value=50),
        n_points_2=hst.integers(min_value=1, max_value=50))

--- a/qcodes/tests/dataset/measurement/test_shapes.py
+++ b/qcodes/tests/dataset/measurement/test_shapes.py
@@ -2,7 +2,6 @@ import logging
 
 import hypothesis.strategies as hst
 import numpy as np
-import pytest
 from hypothesis import HealthCheck, example, given, settings
 from pytest import LogCaptureFixture
 

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -551,7 +551,7 @@ def test_perform_upgrade_v3_to_v4() -> None:
         assert p5.unit == "unit 5"
 
 
-@pytest.mark.usefixtures("default_config", "empty_temp_db")
+@pytest.mark.usefixtures("empty_temp_db")
 def test_update_existing_guids(caplog: LogCaptureFixture) -> None:
 
     old_loc = 101

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -636,7 +636,6 @@ def test_combine_runs(
         assert guid_comp["work_station"] == int(mydict["work_station"])
 
 
-@pytest.mark.usefixtures("default_config")
 def test_copy_datasets_and_add_new(
     two_empty_temp_db_connections, some_interdeps
 ) -> None:

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -551,7 +551,6 @@ def test_load_by_X_functions(two_empty_temp_db_connections, some_interdeps) -> N
     assert source_ds_2_2.the_same_dataset_as(test_ds)
 
 
-@pytest.mark.usefixtures("reset_config_on_exit")
 def test_combine_runs(
     two_empty_temp_db_connections, empty_temp_db_connection, some_interdeps
 ) -> None:

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -285,7 +285,6 @@ def test_load_by_id_for_none() -> None:
     ),
 )
 @pytest.mark.usefixtures("empty_temp_db")
-@pytest.mark.usefixtures("reset_config_on_exit")
 def test_add_experiments(experiment_name, sample_name, dataset_name) -> None:
     qc.config.GUID_components.GUID_type = "random_sample"
 

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -453,7 +453,6 @@ def test_export_netcdf_complex_data(tmp_path_factory, mock_dataset_complex) -> N
     assert df.y.values.tolist() == [1.0 + 1j]
 
 
-@pytest.mark.usefixtures("default_config")
 def test_export_no_or_nonexistent_type_specified(
     tmp_path_factory, mock_dataset
 ) -> None:

--- a/qcodes/tests/dataset/test_dataset_in_mem_import.py
+++ b/qcodes/tests/dataset/test_dataset_in_mem_import.py
@@ -10,7 +10,6 @@ from qcodes.dataset.experiment_container import Experiment
 from qcodes.dataset.sqlite.connection import path_to_dbfile
 
 
-@pytest.mark.usefixtures("default_config")
 def test_basic_roundtrip(
     two_empty_temp_db_connections, some_interdeps, tmp_path
 ) -> None:
@@ -69,7 +68,6 @@ def test_basic_roundtrip(
     )
 
 
-@pytest.mark.usefixtures("default_config")
 def test_roundtrip_to_db_with_existing_meas(
     two_empty_temp_db_connections, some_interdeps, tmp_path
 ) -> None:
@@ -154,7 +152,6 @@ def test_roundtrip_to_db_with_existing_meas(
     )
 
 
-@pytest.mark.usefixtures("default_config")
 def test_roundtrip_to_db_with_existing_meas_in_same_exp(
     two_empty_temp_db_connections, some_interdeps, tmp_path
 ) -> None:

--- a/qcodes/tests/dataset/test_dataset_in_mem_import.py
+++ b/qcodes/tests/dataset/test_dataset_in_mem_import.py
@@ -1,7 +1,6 @@
 import json
 
 import numpy as np
-import pytest
 
 from qcodes.dataset import load_by_guid, load_from_netcdf
 from qcodes.dataset.data_set import DataSet

--- a/qcodes/tests/dataset/test_dataset_in_memory.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory.py
@@ -261,7 +261,6 @@ def test_dataset_in_memory_no_export_warns(
     assert loaded_ds.cache.data() == {}
 
 
-@pytest.mark.usefixtures("default_config")
 def test_dataset_in_memory_missing_file_warns(
     meas_with_registered_param, DMM, DAC, tmp_path
 ) -> None:

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -29,7 +29,6 @@ from qcodes.utils import QCoDeSDeprecationWarning
 
 
 @pytest.mark.usefixtures("experiment")
-@pytest.mark.usefixtures("reset_config_on_exit")
 def test_load_by_id() -> None:
     qc.config.GUID_components.GUID_type = "random_sample"
     ds = new_data_set("test-dataset")

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -29,7 +29,6 @@ def _make_seed_random():
         random.setstate(state)
 
 
-@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=1000)
 @given(
     loc=hst.integers(0, 0xFF),
@@ -70,7 +69,6 @@ def test_generate_legacy_guid(loc, stat, smpl) -> None:
     assert comps["time"] - gen_time < 2
 
 
-@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=1000)
 @given(
     loc=hst.integers(0, 0xFF),
@@ -112,7 +110,6 @@ def test_generate_guid(loc, stat, smpl) -> None:
             _ = generate_guid()
 
 
-@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=None,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(loc=hst.integers(-10, 350))
@@ -130,7 +127,6 @@ def test_set_guid_location_code(loc, monkeypatch) -> None:
         assert cfg["GUID_components"]["location"] == original_loc
 
 
-@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=1000,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(ws=hst.integers(-10, 17000000))
@@ -150,7 +146,6 @@ def test_set_guid_workstation_code(ws, monkeypatch) -> None:
         assert cfg["GUID_components"]["work_station"] == original_ws
 
 
-@pytest.mark.usefixtures("default_config")
 @settings(max_examples=50, deadline=1000)
 @given(
     locs=hst.lists(hst.integers(0, 0xFF), min_size=2, max_size=2, unique=True),
@@ -269,7 +264,6 @@ def test_validation() -> None:
 
 
 @pytest.mark.usefixtures("seed_random")
-@pytest.mark.usefixtures("default_config")
 def test_random_sample_guid() -> None:
 
     cfg = qc.config
@@ -281,7 +275,6 @@ def test_random_sample_guid() -> None:
         assert guid.split("-")[0] == expected_guid_prefix
 
 
-@pytest.mark.usefixtures("default_config")
 def test_random_sample_and_sample_int_in_guid_raises() -> None:
 
     cfg = qc.config
@@ -296,7 +289,6 @@ def test_random_sample_and_sample_int_in_guid_raises() -> None:
         generate_guid(sampleint=10)
 
 
-@pytest.mark.usefixtures("default_config")
 def test_sample_int_in_guid_warns_with_old_config() -> None:
     cfg = qc.config
     cfg["GUID_components"]["GUID_type"] = "explicit_sample"
@@ -307,7 +299,6 @@ def test_sample_int_in_guid_warns_with_old_config() -> None:
         generate_guid(sampleint=10)
 
 
-@pytest.mark.usefixtures("default_config")
 def test_sample_int_in_guid_raises() -> None:
     with pytest.raises(
         RuntimeError,

--- a/qcodes/tests/dataset/test_snapshot.py
+++ b/qcodes/tests/dataset/test_snapshot.py
@@ -24,7 +24,6 @@ def dmm():
 
 
 @pytest.mark.parametrize("pass_station", (True, False))
-@pytest.mark.usefixtures("set_default_station_to_none")
 def test_station_snapshot_during_measurement(
     experiment, dac, dmm, pass_station
 ) -> None:
@@ -67,7 +66,6 @@ def test_station_snapshot_during_measurement(
     assert expected_snapshot == data_saver.dataset.snapshot
 
 
-@pytest.mark.usefixtures('set_default_station_to_none')
 def test_snapshot_creation_for_types_not_supported_by_builtin_json(experiment) -> None:
     """
     Test that `Measurement`/`Runner`/`DataSaver` infrastructure

--- a/qcodes/tests/dataset/test_string_data.py
+++ b/qcodes/tests/dataset/test_string_data.py
@@ -185,7 +185,6 @@ def test_list_of_strings(experiment) -> None:
         test_set.conn.close()  # type: ignore[attr-defined]
 
 
-@pytest.mark.usefixtures("default_config")
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,),
           deadline=None)
 @given(

--- a/qcodes/tests/dataset/test_subscribing.py
+++ b/qcodes/tests/dataset/test_subscribing.py
@@ -60,7 +60,7 @@ def basic_subscriber():
 
 
 @pytest.fixture(name="working_subscriber_config")
-def _make_working_subscriber_config(tmp_path, default_config):
+def _make_working_subscriber_config(tmp_path):
     # This string represents the config file in the home directory:
     config = """
     {
@@ -89,7 +89,7 @@ def _make_working_subscriber_config(tmp_path, default_config):
 
 
 @pytest.fixture(name="broken_subscriber_config")
-def _make_broken_subscriber_config(tmp_path, default_config):
+def _make_broken_subscriber_config(tmp_path):
     # This string represents the config file in the home directory:
     config = """
     {

--- a/qcodes/tests/delegate/conftest.py
+++ b/qcodes/tests/delegate/conftest.py
@@ -9,17 +9,17 @@ from qcodes.tests.instrument_mocks import MockDAC, MockField, MockLockin
 PARENT_DIR = pathlib.Path(__file__).parent.absolute()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def dac():
     return MockDAC('dac', num_channels=3)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def field_x():
     return MockField('field_x')
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def lockin():
     _lockin = MockLockin(
         name='lockin'

--- a/qcodes/tests/drivers/test_Keysight_33XXX.py
+++ b/qcodes/tests/drivers/test_Keysight_33XXX.py
@@ -5,7 +5,7 @@ from qcodes.instrument_drivers.Keysight.KeysightAgilent_33XXX import (
 )
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="function")
 def driver():
     kw_sim = WaveformGenerator_33XXX(
         "kw_sim", address="GPIB::1::INSTR", pyvisa_sim_file="Keysight_33xxx.yaml"

--- a/qcodes/tests/drivers/test_Keysight_N6705B.py
+++ b/qcodes/tests/drivers/test_Keysight_N6705B.py
@@ -3,7 +3,7 @@ import pytest
 import qcodes.instrument_drivers.Keysight.Keysight_N6705B as N6705B
 
 
-@pytest.fixture(scope="module", name="driver")
+@pytest.fixture(scope="function", name="driver")
 def _make_driver():
     driver = N6705B.N6705B(
         "N6705B", address="GPIB::1::INSTR", pyvisa_sim_file="Keysight_N6705B.yaml"

--- a/qcodes/tests/drivers/test_keithley_7510.py
+++ b/qcodes/tests/drivers/test_keithley_7510.py
@@ -1,12 +1,12 @@
 # pylint: disable=redefined-outer-name
 import hypothesis.strategies as st
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 
 from qcodes.instrument_drivers.Keithley import Keithley7510
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def dmm_7510_driver():
     inst = Keithley7510(
         "Keithley_7510_sim",
@@ -44,11 +44,8 @@ def test_change_sense_function(dmm_7510_driver) -> None:
     assert dmm_7510_driver.sense.function() == 'current'
 
 
-@settings(deadline=None)
-@given(
-    st.sampled_from((0.1, 1, 10, 100, 1000)),
-    st.floats(0.01, 10)
-)
+@settings(deadline=None, suppress_health_check=(HealthCheck.function_scoped_fixture,))
+@given(st.sampled_from((0.1, 1, 10, 100, 1000)), st.floats(0.01, 10))
 def test_set_range_and_nplc(dmm_7510_driver, upper_limit, nplc) -> None:
     """
     Test the ability of setting range and nplc value for sense function.

--- a/qcodes/tests/drivers/test_keysight_34934a.py
+++ b/qcodes/tests/drivers/test_keysight_34934a.py
@@ -7,7 +7,7 @@ from qcodes.instrument_drivers.Keysight.keysight_34934a import Keysight34934A
 from qcodes.instrument_drivers.Keysight.keysight_34980a import Keysight34980A
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def switch_driver():
     inst = Keysight34980A(
         "keysight_34980A_sim",

--- a/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
+++ b/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
@@ -6,7 +6,7 @@ import pytest
 from qcodes.instrument_drivers.tektronix.DPO7200xx import TektronixDPO7000xx
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="function")
 def tektronix_dpo():
     """
     A six channel-per-relay instrument

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -279,8 +279,6 @@ def test_update_and_validate_user_config(config, mocker) -> None:
     assert config.current_config == UPDATED_CONFIG
     assert config.current_schema == UPDATED_SCHEMA
 
-
-@pytest.mark.usefixtures("default_config")
 def test_update_from_path(path_to_config_file_on_disk) -> None:
     cfg = qcodes.config
 
@@ -310,7 +308,6 @@ def test_repr() -> None:
     assert rep == expected_rep
 
 
-@pytest.mark.usefixtures("default_config")
 def test_add_and_describe() -> None:
     """
     Test that a key can be added and described

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -2,7 +2,6 @@ import copy
 import json
 import os
 from functools import partial
-from pathlib import Path
 from unittest.mock import PropertyMock, mock_open
 
 import jsonschema
@@ -197,10 +196,6 @@ def test_missing_config_file(config) -> None:
         config.load_config("./missing.json")
 
 
-@pytest.mark.skipif(
-    Path.cwd() == Path.home(),
-    reason="This test requires that working dir is different from homedir.",
-)
 def test_default_config_files(config, load_config) -> None:
     load_config.side_effect = partial(side_effect, GOOD_CONFIG_MAP)
     # don't try to load custom schemas
@@ -212,9 +207,6 @@ def test_default_config_files(config, load_config) -> None:
     assert config == CONFIG
 
 
-@pytest.mark.skipif(Path.cwd() == Path.home(),
-                    reason="This test requires that "
-                           "working dir is different from homedir.")
 def test_bad_config_files(config, load_config) -> None:
 
     load_config.side_effect = partial(side_effect, BAD_CONFIG_MAP)
@@ -227,9 +219,6 @@ def test_bad_config_files(config, load_config) -> None:
         config.update_config()
 
 
-@pytest.mark.skipif(Path.cwd() == Path.home(),
-                    reason="This test requires that "
-                           "working dir is different from homedir.")
 def test_user_schema(config, load_config, mocker) -> None:
     mocker.patch("builtins.open", mock_open(read_data=USER_SCHEMA))
     load_config.side_effect = partial(side_effect, GOOD_CONFIG_MAP)

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -48,6 +48,7 @@ def awg5208():
 def model372():
     from qcodes.tests.drivers.test_lakeshore import Model_372_Mock
 
+    old_log_sep = logger.logger.LOGGING_SEPARATOR
     logger.logger.LOGGING_SEPARATOR = " - "
 
     logger.start_logger()
@@ -63,6 +64,7 @@ def model372():
     try:
         yield inst
     finally:
+        logger.logger.LOGGING_SEPARATOR = old_log_sep
         inst.close()
 
 

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -130,7 +130,7 @@ def test_start_logger() -> None:
     assert file_handler is not None
     assert file_handler.level == file_level
 
-    assert logging.getLogger().level == logger.get_level_code('DEBUG')
+    assert logging.getLogger().level == logger.get_level_code("NOTSET")
 
 
 @pytest.mark.usefixtures("remove_root_handlers")

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -220,6 +220,9 @@ def test_filter_without_started_logger_raises(AMI430_3D) -> None:
 @pytest.mark.usefixtures("remove_root_handlers")
 def test_capture_dataframe() -> None:
     root_logger = logging.getLogger()
+    # the logger must be started to set level
+    # debug on the rootlogger
+    logger.start_logger()
     with capture_dataframe() as (_, cb):
         root_logger.debug(TEST_LOG_MESSAGE)
         df = cb()

--- a/qcodes/tests/test_plot_utils.py
+++ b/qcodes/tests/test_plot_utils.py
@@ -50,7 +50,6 @@ def test_extend(dataset_with_outliers) -> None:
     plt.close()
 
 
-@pytest.mark.usefixtures("default_config")
 def test_defaults(dataset_with_outliers) -> None:
     run_id = dataset_with_outliers.run_id
 

--- a/qcodes/tests/test_plot_utils.py
+++ b/qcodes/tests/test_plot_utils.py
@@ -2,7 +2,6 @@
 Tests for `qcodes.utils.plotting`.
 """
 import matplotlib
-import pytest
 from pytest import fixture
 
 import qcodes

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -24,11 +24,6 @@ from .common import DummyComponent
 
 
 @pytest.fixture(autouse=True)
-def use_default_config(default_config):
-    yield
-
-
-@pytest.fixture(autouse=True)
 def set_default_station_to_none_automatically():
     """Makes sure that after startup and teardown there is no default station"""
     Station.default = None


### PR DESCRIPTION
Replace existing config fixtures with 2 auto use fixtures.

* A session fixture that makes sure that we load the default config and do not read / write config from any user folder. This makes sure that we dont fail tests due to config changes of the user or modify user configs. Also let this handle setting changes that we want to be different from the default. Disable telemetry, disable subscribers, set db path to a non existing file so test can't write to the default db if not using dataset / experiment fixtures.
* A function fixture that resets any modification that a test has made to the config, closes any instruments and resets the default station

Since these are auto use we can remove all explicit use of config fixtures.

In the process fix some issues.

* The old default_config fixture would replace qc.config with a new config object. This however will not work if the test had already imported the config object as `from qcodes import config` so instead patch the existing config object.
* some dond tests were not correctly using the experiment fixture. This is also fixed.
* remove deprecated function
* config tests no longer needs to be skipped when running from user home as we patch the location of user home automatically before the test runs
* Fix some logging tests that were leaking state or depending on leaked state


