### PR TITLE
Driver Keithley add union type

### DIFF
--- a/qcodes/calibrations/keithley.py
+++ b/qcodes/calibrations/keithley.py
@@ -7,8 +7,7 @@ from qcodes.instrument import Instrument
 from qcodes.parameters import Parameter
 
 if TYPE_CHECKING:
-    from qcodes.instrument_drivers.tektronix.Keithley_2600_channels import Keithley_2600
-
+    from qcodes.instrument_drivers.Keithley import Keithley26xx
 
 src_FS_map = {
     "200e-3": 180e-3, "2": 1.8, "20": 18, "200": 180,
@@ -22,7 +21,7 @@ def setup_dmm(dmm: Instrument) -> None:
     dmm.autorange("OFF")
 
 
-def save_calibration(smu: Keithley_2600) -> None:
+def save_calibration(smu: Keithley26xx) -> None:
     calibration_date = int(time.time())
     for smu_channel in smu.channels:
         smu.write(f"{smu_channel.channel}.cal.adjustdate = {calibration_date}")
@@ -30,7 +29,7 @@ def save_calibration(smu: Keithley_2600) -> None:
 
 
 def calibrate_keithley_smu_v(
-    smu: Keithley_2600,
+    smu: Keithley26xx,
     dmm: Instrument,
     src_Z: float = 1e-30,
     time_delay: float = 3.0,
@@ -66,7 +65,7 @@ def calibrate_keithley_smu_v(
 
 
 def calibrate_keithley_smu_v_single(
-    smu: Keithley_2600,
+    smu: Keithley26xx,
     channel: str,
     dmm_param_volt: Parameter,
     v_range: str,

--- a/qcodes/instrument_drivers/Keithley/__init__.py
+++ b/qcodes/instrument_drivers/Keithley/__init__.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from ._Keithley_2600 import Keithley2600MeasurementStatus
 from .Keithley_2000 import Keithley2000
 from .Keithley_2400 import Keithley2400
@@ -35,6 +37,22 @@ from .Keithley_s46 import (
     KeithleyS46RelayLock,
 )
 
+Keithley26xx = Union[
+    Keithley2601B,
+    Keithley2602A,
+    Keithley2602B,
+    Keithley2604B,
+    Keithley2611B,
+    Keithley2612B,
+    Keithley2614B,
+    Keithley2634B,
+    Keithley2635B,
+    Keithley2636B,
+]
+"""
+All Keithley 26xx SMUs supported by QCoDeS.
+"""
+
 __all__ = [
     "Keithley2000",
     "Keithley2400",
@@ -43,6 +61,7 @@ __all__ = [
     "Keithley2450Sense",
     "Keithley2450Source",
     "Keithley2600MeasurementStatus",
+    "Keithley26xx",
     "Keithley2601B",
     "Keithley2602A",
     "Keithley2602B",


### PR DESCRIPTION
I wanted to update the types in the calibration module to use the official api but noticed that there were no good way of saying give me any of the supported 26xx drivers. This fixes that by adding a Union type