### PR TITLE
Move DriverTestCase to the test module

### DIFF
--- a/docs/changes/newsfragments/4922.breaking
+++ b/docs/changes/newsfragments/4922.breaking
@@ -1,0 +1,1 @@
+DriverTestCase has been moved from `qcodes.instrument_drivers.test` to `qcodes.tests.driver_test_case`.

--- a/qcodes/tests/driver_test_case.py
+++ b/qcodes/tests/driver_test_case.py
@@ -36,24 +36,26 @@ class DriverTestCase(unittest.TestCase):
             return
 
         if cls.driver is None:
-            raise TypeError('you must set a driver for ' + cls.__name__)
+            raise TypeError("you must set a driver for " + cls.__name__)
 
         instances = cls.driver.instances()
         name = cls.driver.__name__
 
         if not instances:
-            msg = f'no instances of {name} found'
-            if getattr(cls, 'noskip', False):
+            msg = f"no instances of {name} found"
+            if getattr(cls, "noskip", False):
                 # just to test this class, we need to disallow skipping
                 raise ValueError(msg)
             else:
                 raise unittest.SkipTest(msg)
 
         if len(instances) == 1:
-            print(f'***** found one {name}, testing *****')
+            print(f"***** found one {name}, testing *****")
         else:
-            print('***** found {} instances of {}; '
-                  'testing the last one *****'.format(len(instances), name))
+            print(
+                "***** found {} instances of {}; "
+                "testing the last one *****".format(len(instances), name)
+            )
 
         cls.instrument = instances[-1]
 
@@ -70,7 +72,8 @@ def test_instruments(verbosity=1):
 
     driver_path = qcdrivers.__path__[0]
     suite = unittest.defaultTestLoader.discover(
-        driver_path, top_level_dir=qcodes.__path__[0])
+        driver_path, top_level_dir=qcodes.__path__[0]
+    )
     unittest.TextTestRunner(verbosity=verbosity).run(suite)
 
 

--- a/qcodes/tests/drivers/test_Agilent_E8257D.py
+++ b/qcodes/tests/drivers/test_Agilent_E8257D.py
@@ -1,5 +1,5 @@
 from qcodes.instrument_drivers.agilent import AgilentE8257D
-from qcodes.instrument_drivers.test import DriverTestCase
+from qcodes.tests.driver_test_case import DriverTestCase
 
 
 class TestAgilentE8257D(DriverTestCase):

--- a/qcodes/tests/drivers/test_weinchel.py
+++ b/qcodes/tests/drivers/test_weinchel.py
@@ -1,5 +1,5 @@
-from qcodes.instrument_drivers.test import DriverTestCase
 from qcodes.instrument_drivers.weinschel import Weinschel8320
+from qcodes.tests.driver_test_case import DriverTestCase
 
 
 class TestWeinschel8320(DriverTestCase):


### PR DESCRIPTION
This has no good reason to live in the test module. This is a breaking change but I don't expect this to be used in a way where this is important enough for a shim to be added