### PR TITLE
Move VoltageDivider into parameters and deprecate

### DIFF
--- a/docs/changes/newsfragments/4923.breaking
+++ b/docs/changes/newsfragments/4923.breaking
@@ -1,0 +1,3 @@
+`qcodes.instrument_drivers.VoltageDivider` and `qcodes.instrument_drivers.devices.VoltageDivider` has
+been deprecated. Its functionality is better implemented in `qcodes.parameters.DelegateParameter` which
+is also significantly better tested and more general.

--- a/qcodes/instrument_drivers/__init__.py
+++ b/qcodes/instrument_drivers/__init__.py
@@ -1,1 +1,5 @@
-from .devices import VoltageDivider
+from qcodes.parameters.voltage_divider import VoltageDivider
+
+"""
+Deprecated alias will be removed
+"""

--- a/qcodes/instrument_drivers/devices.py
+++ b/qcodes/instrument_drivers/devices.py
@@ -1,0 +1,5 @@
+"""
+Alias for backwards compatiblility. Will be deprecated and removed in a future version of QCoDeS
+"""
+
+from qcodes.parameters.voltage_divider import VoltageDivider

--- a/qcodes/instrument_drivers/devices.py
+++ b/qcodes/instrument_drivers/devices.py
@@ -1,8 +1,11 @@
-from typing import Optional, Union
+from __future__ import annotations
 
-from qcodes.instrument import Instrument
+from typing import TYPE_CHECKING, Optional, Union
+
 from qcodes.parameters import Parameter
 
+if TYPE_CHECKING:
+    from qcodes.instrument import Instrument
 
 class VoltageDivider(Parameter):
     """
@@ -44,12 +47,14 @@ class VoltageDivider(Parameter):
             but attaches _attenuated
     """
 
-    def __init__(self,
-                 v1: Parameter,
-                 division_value: Union[int, float],
-                 name: Optional[str] = None,
-                 label: Optional[str] = None,
-                 instrument: Union[None, Instrument] = None) -> None:
+    def __init__(
+        self,
+        v1: Parameter,
+        division_value: int | float,
+        name: str | None = None,
+        label: str | None = None,
+        instrument: None | Instrument = None,
+    ) -> None:
         self.v1 = v1
         self.division_value = division_value
         if label:
@@ -72,11 +77,11 @@ class VoltageDivider(Parameter):
         # extend metadata
         self._meta_attrs.extend(["division_value"])
 
-    def set_raw(self, value: Union[int, float]) -> None:
+    def set_raw(self, value: int | float) -> None:
         instrument_value = value * self.division_value
         self.v1.set(instrument_value)
 
-    def get_raw(self) -> Union[int, float]:
+    def get_raw(self) -> int | float:
         """
         Returns:
             value at which was set at the sample
@@ -84,7 +89,7 @@ class VoltageDivider(Parameter):
         value = self.v1.get() / self.division_value
         return value
 
-    def get_instrument_value(self) -> Union[int, float]:
+    def get_instrument_value(self) -> int | float:
         """
         Returns:
             value at which the attached parameter is (i.e. does

--- a/qcodes/parameters/voltage_divider.py
+++ b/qcodes/parameters/voltage_divider.py
@@ -7,6 +7,7 @@ from qcodes.parameters import Parameter
 if TYPE_CHECKING:
     from qcodes.instrument import Instrument
 
+
 class VoltageDivider(Parameter):
     """
     Resitive voltage divider
@@ -72,7 +73,8 @@ class VoltageDivider(Parameter):
             instrument=instrument,
             label=self.label,
             unit=self.v1.unit,
-            metadata=self.v1.metadata)
+            metadata=self.v1.metadata,
+        )
 
         # extend metadata
         self._meta_attrs.extend(["division_value"])

--- a/qcodes/parameters/voltage_divider.py
+++ b/qcodes/parameters/voltage_divider.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from qcodes.parameters import Parameter
+from qcodes.utils import deprecate
 
 if TYPE_CHECKING:
     from qcodes.instrument import Instrument
 
 
+@deprecate(alternative="DelegateParameter")
 class VoltageDivider(Parameter):
     """
     Resitive voltage divider


### PR DESCRIPTION
This is not an instrument but a Parameter so it makes more sense for it to live there. 
Since DelegateParamerer does the same more general and better deprecate this one