### PR TITLE
Allow two simulated keysight 2600 smu's

### DIFF
--- a/qcodes/instrument/sims/Keithley_2600.yaml
+++ b/qcodes/instrument/sims/Keithley_2600.yaml
@@ -189,3 +189,6 @@ devices:
 resources:
   GPIB::1::INSTR:
     device: Keithley
+    
+  GPIB::2::INSTR:
+    device: Keithley

--- a/qcodes/instrument/sims/Keithley_2600.yaml
+++ b/qcodes/instrument/sims/Keithley_2600.yaml
@@ -189,6 +189,6 @@ devices:
 resources:
   GPIB::1::INSTR:
     device: Keithley
-    
+
   GPIB::2::INSTR:
     device: Keithley


### PR DESCRIPTION
Adding extra address to pyvisa sim yaml on the Keysight 2600 SMU to fix bug when instantiating two simulated SMU's. 