### PR TITLE
Add support for 2 simulated keysight dmms

### DIFF
--- a/qcodes/instrument/sims/Keysight_34465A.yaml
+++ b/qcodes/instrument/sims/Keysight_34465A.yaml
@@ -209,3 +209,6 @@ devices:
 resources:
   GPIB::1::INSTR:
      device: device 1
+
+  GPIB::2::INSTR:
+    device: device 1


### PR DESCRIPTION
Similar to https://github.com/QCoDeS/Qcodes/pull/4949 its nice to have the option to use 2 dmms in a mock experiment