### PR TITLE
Extend export entry point event to take kwargs

### DIFF
--- a/docs/examples/DataSet/Exporting-data-to-other-file-formats.ipynb
+++ b/docs/examples/DataSet/Exporting-data-to-other-file-formats.ipynb
@@ -323,10 +323,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "QCoDeD will attempt to call any [EntryPoint](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins) registered for the group \"qcodes.dataset.on_export\". This will allow a user to setup a function that can trigger post processing such as backup to cloud, external drive, plotting or post process analysis. Functions registered for this entry point group are expected to take a Path to the file as input and return None. Please consult the [Setuptools docs](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins) for more information on the use of EntryPoints."
+    "QCoDeD will attempt to call any [EntryPoint](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins) registered for the group \"qcodes.dataset.on_export\". This will allow a user to setup a function that can trigger post processing such as backup to cloud, external drive, plotting or post process analysis. Functions registered for this entry point group are expected to take a Path to the file as input and return None. Please consult the [Setuptools docs](https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins) for more information on the use of EntryPoints. The entry point function must take the path to the exported file as a positional argument and take ``**kwargs`` for future compatibility. At the moment a single keyword argument ``automatic_export`` is passed to the function which indicates if the dataset was automatically or manually exported."
    ]
   },
   {
@@ -1182,7 +1183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.10.9 | packaged by conda-forge | (main, Jan 11 2023, 15:15:40) [MSC v.1916 64 bit (AMD64)]"
   },
   "toc": {
    "base_numbering": 1,

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -232,6 +232,7 @@ class DataSetProtocol(Protocol):
         export_type: DataExportType | str | None = None,
         path: str | None = None,
         prefix: str | None = None,
+        automatic_export: bool = False,
     ) -> None:
         ...
 
@@ -358,6 +359,7 @@ class BaseDataSet(DataSetProtocol, Protocol):
         export_type: DataExportType | str | None = None,
         path: str | Path | None = None,
         prefix: str | None = None,
+        automatic_export: bool = False,
     ) -> None:
         """Export data to disk with file name `{prefix}{name_elements}.{ext}`.
         Name elements are names of dataset object attributes that are taken
@@ -395,7 +397,10 @@ class BaseDataSet(DataSetProtocol, Protocol):
             )
 
         export_path = self._export_data(
-            export_type=parsed_export_type, path=path, prefix=prefix
+            export_type=parsed_export_type,
+            path=path,
+            prefix=prefix,
+            automatic_export=automatic_export,
         )
         export_info = self.export_info
         if export_path is not None:
@@ -410,6 +415,7 @@ class BaseDataSet(DataSetProtocol, Protocol):
         export_type: DataExportType,
         path: Path | None = None,
         prefix: str | None = None,
+        automatic_export: bool = False,
     ) -> Path | None:
         """Export data to disk with file name `{prefix}{name_elements}.{ext}`.
         Name elements are names of dataset object attributes that are taken
@@ -452,7 +458,7 @@ class BaseDataSet(DataSetProtocol, Protocol):
             try:
                 export_callback_function = export_callback.load()
                 LOG.info("Executing on_export callback %s", export_callback.name)
-                export_callback_function(export_path)
+                export_callback_function(export_path, automatic_export=automatic_export)
             except Exception:
                 LOG.exception("Exception during export callback function")
 

--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -469,7 +469,7 @@ class DataSaver:
         """Export data at end of measurement as per export_type
         specification in "dataset" section of qcodes config
         """
-        self.dataset.export()
+        self.dataset.export(automatic_export=True)
 
     @property
     def run_id(self) -> int:

--- a/qcodes/extensions/_log_export_info.py
+++ b/qcodes/extensions/_log_export_info.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 LOG = logging.getLogger(__name__)
 
 
-def log_dataset_export_info(path: Path | None) -> None:
-    LOG.info("Dataset has been exported to: %s", path)
+def log_dataset_export_info(path: Path | None, **kwargs: Any) -> None:
+    automatic = kwargs.get("automatic_export", False)
+    auto_str = "automatically" if automatic else "manually"
+    LOG.info("Dataset has been exported to: %s this was triggered %s.", path, auto_str)

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -202,6 +202,7 @@ def test_export_csv(tmp_path_factory, mock_dataset, caplog):
 
     assert "Executing on_export callback log_exported_ds" in caplog.messages
     assert any("Dataset has been exported to" in mes for mes in caplog.messages)
+    assert any("this was triggered manually" in mes for mes in caplog.messages)
 
     mock_dataset.add_metadata("metadata_added_after_export", 69)
 
@@ -221,6 +222,7 @@ def test_export_netcdf(tmp_path_factory, mock_dataset, caplog):
 
     assert "Executing on_export callback log_exported_ds" in caplog.messages
     assert any("Dataset has been exported to" in mes for mes in caplog.messages)
+    assert any("this was triggered manually" in mes for mes in caplog.messages)
 
     mock_dataset.add_metadata("metadata_added_after_export", 69)
 


### PR DESCRIPTION
This makes it future proof and should happen now since the functionality has not been in qcodes before this release to avoid it being an api break

By using **kwargs we ensure this is forwards compatible.

