### PR TITLE
Attach default experiment to a measurement

### DIFF
--- a/qcodes/dataset/measurements.py
+++ b/qcodes/dataset/measurements.py
@@ -48,10 +48,11 @@ from qcodes.dataset.descriptions.dependencies import (
     InterDependencies_,
 )
 from qcodes.dataset.descriptions.param_spec import ParamSpec, ParamSpecBase
-from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
-from qcodes.dataset.experiment_container import Experiment
+from qcodes.dataset.experiment_container import Experiment, load_experiment
+from qcodes.dataset.experiment_settings import get_default_experiment_id
 from qcodes.dataset.export_config import get_data_export_automatic
+from qcodes.dataset.sqlite.database import conn_from_dbpath_or_conn
 from qcodes.dataset.sqlite.query_helpers import VALUE
 from qcodes.parameters import (
     ArrayParameter,
@@ -709,6 +710,8 @@ class Measurement:
         self.enteractions: list[ActionType] = []
         self.subscribers: list[SubscriberType] = []
 
+        if not exp:
+            exp = load_experiment(get_default_experiment_id(conn_from_dbpath_or_conn(None, None)))
         self.experiment = exp
         self.station = station
         self.name = name


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
This PR finds a default experiment and attach it to a measurement when it is created.
This behavior matches the document of [`Measurement` class ](https://github.com/QCoDeS/Qcodes/blob/master/qcodes/dataset/measurements.py#L687), which states 
```
...

    Args:
        exp: Specify the experiment to use. If not given
            the default one is used. The default experiment
            is the latest one created.
...
```