### PR TITLE
Pyright 1.1.292

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -64,7 +64,7 @@ jobs:
         pip install .[test] -c requirements.txt
     - uses: jakebailey/pyright-action@v1.4.2
       with:
-        version: 1.1.291
+        version: 1.1.292
     - name: Run Mypy
       run: mypy -p qcodes
     - name: Run parallel tests

--- a/qcodes/logger/logger.py
+++ b/qcodes/logger/logger.py
@@ -68,7 +68,7 @@ _opencensus_filter = logging.Filter(name="opencensus")
 _urllib3_connection_filter = logging.Filter(name="urllib3.connection")
 
 
-def filter_out_telemetry_log_records(record: logging.LogRecord) -> int:
+def filter_out_telemetry_log_records(record: logging.LogRecord) -> bool:
     """
     here we filter any message that is likely to be thrown from
     opencensus so it is not shown in the user console


### PR DESCRIPTION
Pyright 1.1.292 finds a new error in the log filter probably due to improvements to typeshed 

The filter should and does return a bool but the annotated return type was wrong