### PR TITLE
upgrade sphinx to 6.1.3 with patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -138,7 +138,7 @@ slack-sdk~=3.19.1
 snowballstemmer~=2.2.0
 sortedcontainers~=2.4.0
 soupsieve~=2.3.2.post1
-Sphinx @ git+https://github.com/jenshnielsen/sphinx.git@fix_9884_5_3
+Sphinx @ git+https://github.com/jenshnielsen/sphinx.git@fix_9884_6_1_3
 sphinx-favicon==0.2
 sphinx-issues~=3.0.1
 sphinx-jsonschema~=1.19.1


### PR DESCRIPTION
Now that rtd theme has support for sphinx 6 / docutils 0.18 this should be supported 