### PR TITLE
Fix: usefixtures cannot be used in a new fixture

### DIFF
--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -24,8 +24,7 @@ from .common import DumyPar
 
 
 @pytest.fixture(autouse=True)
-@pytest.mark.usefixtures("default_config")
-def use_default_config():
+def use_default_config(default_config):
     yield
 
 


### PR DESCRIPTION
See warning here https://docs.pytest.org/en/7.1.x/how-to/fixtures.html#use-fixtures-in-classes-and-modules-with-usefixtures