### PR TITLE
Configure basic ruff linter as precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,8 @@ repos:
           additional_dependencies: [pyupgrade]
         - id: nbqa-isort
           additional_dependencies: [isort]
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    # Ruff version.
+    rev: 'v0.0.244'
+    hooks:
+      - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,9 @@ filterwarnings = [
 ]
 
 [tool.ruff]
+# initially enable this single
+# error code.
+select = ["PT025"]
 # darker will fix this as code is
 # reformatted when it is changed.
 ignore = ["E501"]


### PR DESCRIPTION
Only checks for issues like https://github.com/QCoDeS/Qcodes/pull/4999 for now. That pr should be merged first and then rebased away from this pr