### PR TITLE
Fix #5007 Handle version str with extra info 

### DIFF
--- a/docs/changes/newsfragments/5007.improved_driver
+++ b/docs/changes/newsfragments/5007.improved_driver
@@ -1,0 +1,2 @@
+Fixed a bug in version parsing for Keysight 344XXA and Keysight E4980A which
+would result in incompatibility with packaging>21 under certain circumstances.

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -14,20 +14,20 @@ from qcodes.utils import (
 # but we can at least test that they execute without errors
 
 
-def test_get_qcodes_version():
+def test_get_qcodes_version() -> None:
     with pytest.warns(QCoDeSDeprecationWarning):
         version = ii.get_qcodes_version()
 
     assert version == qc.__version__
 
 
-def test_is_qcodes_installed_editably():
+def test_is_qcodes_installed_editably() -> None:
     answer = is_qcodes_installed_editably()
 
     assert isinstance(answer, bool)
 
 
-def test_get_all_installed_package_versions():
+def test_get_all_installed_package_versions() -> None:
     ipvs = get_all_installed_package_versions()
 
     assert isinstance(ipvs, dict)
@@ -38,7 +38,7 @@ def test_get_all_installed_package_versions():
         assert isinstance(v, str)
 
 
-def test_convert_legacy_version_to_supported_version():
+def test_convert_legacy_version_to_supported_version() -> None:
     def assert_version_str(legacy_verstr: str, expected_converted_ver_str: str) -> None:
         converted_version_str = convert_legacy_version_to_supported_version(
             legacy_verstr

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -1,4 +1,5 @@
 import pytest
+from packaging import version
 
 import qcodes as qc
 import qcodes.utils.installation_info as ii
@@ -38,11 +39,28 @@ def test_get_all_installed_package_versions():
 
 
 def test_convert_legacy_version_to_supported_version():
+    def assert_version_str(legacy_verstr: str, expected_converted_ver_str: str) -> None:
+        converted_version_str = convert_legacy_version_to_supported_version(
+            legacy_verstr
+        )
+        assert converted_version_str == expected_converted_ver_str
+        version.parse(converted_version_str) == version.parse(
+            expected_converted_ver_str
+        )
+
     legacy_verstr = "a.1.4"
-    assert convert_legacy_version_to_supported_version(legacy_verstr) == "65.1.4"
+    expected_converted_ver_str = "65.1.4"
+    assert_version_str(legacy_verstr, expected_converted_ver_str)
+
 
     legacy_verstr = "10.4.7"
-    assert convert_legacy_version_to_supported_version(legacy_verstr) == "10.4.7"
+    expected_converted_ver_str = "10.4.7"
+    assert_version_str(legacy_verstr, expected_converted_ver_str)
 
     legacy_verstr = "C.2.1"
-    assert convert_legacy_version_to_supported_version(legacy_verstr) == "67.2.1"
+    expected_converted_ver_str = "67.2.1"
+    assert_version_str(legacy_verstr, expected_converted_ver_str)
+
+    legacy_verstr = "A.02.17-02.40-02.17-00.52-04-01"
+    expected_converted_ver_str = "65.02.17"
+    assert_version_str(legacy_verstr, expected_converted_ver_str)

--- a/qcodes/tests/test_installation_info.py
+++ b/qcodes/tests/test_installation_info.py
@@ -44,7 +44,7 @@ def test_convert_legacy_version_to_supported_version():
             legacy_verstr
         )
         assert converted_version_str == expected_converted_ver_str
-        version.parse(converted_version_str) == version.parse(
+        assert version.parse(converted_version_str) == version.parse(
             expected_converted_ver_str
         )
 

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -68,7 +68,7 @@ def convert_legacy_version_to_supported_version(ver: str) -> str:
     by its ASCII code (using ``ord``). This assumes that the version number
     only uses at most a single char per level and only ASCII chars.
 
-    It also splits off anything that comes after the first ``_`` in the version str.
+    It also splits off anything that comes after the first ``-`` in the version str.
 
     This is meant to pass versions like ``'A.02.17-02.40-02.17-00.52-04-01'``
     primarily used by Keysight instruments.

--- a/qcodes/utils/installation_info.py
+++ b/qcodes/utils/installation_info.py
@@ -67,6 +67,11 @@ def convert_legacy_version_to_supported_version(ver: str) -> str:
     numbers to a regular version string. This is done by replacing a char
     by its ASCII code (using ``ord``). This assumes that the version number
     only uses at most a single char per level and only ASCII chars.
+
+    It also splits off anything that comes after the first ``_`` in the version str.
+
+    This is meant to pass versions like ``'A.02.17-02.40-02.17-00.52-04-01'``
+    primarily used by Keysight instruments.
     """
 
     temp_list = []
@@ -75,4 +80,5 @@ def convert_legacy_version_to_supported_version(ver: str) -> str:
             temp_list.append(str(ord(v.upper())))
         else:
             temp_list.append(v)
-    return "".join(temp_list)
+    temp_str = "".join(temp_list)
+    return temp_str.split("-")[0]


### PR DESCRIPTION
Packaging 22 dropped LegacyVersion. We mostly handled this by converting any letters in the version str to a number using ord. However, the version str for keysight also contained extra info and looks something like this "A.02.17-02.40-02.17-00.52-04-01"

From packaging 22 and upwards this is an error. We fix that by splitting on `-` and only using the first part. The converter is only used for Keysight versions so adding it there seems safe. 

This was not caught in the Keysight 34xxx driver tests since the test only runs for a simulated instrument that has the dig option marked installed and this path in the code is only taken if the dig option is not present in the options str. 

Extend the tests for the converter to 
* include this type of version field
* Ensure what comes out of the converter can be parsed by packaing.

- [x] Add changelog

fixes #5007