### PR TITLE
fix(Keithley3706A): Fix interlock status dictionary

### DIFF
--- a/docs/changes/newsfragments/5013.improved_driver
+++ b/docs/changes/newsfragments/5013.improved_driver
@@ -1,6 +1,6 @@
 Fixed a bug in interlock status querying for Keithley 3706A. Originally, not all
-potential responses from the system were accounted for when querying for interlock 
-status. A dictionary is used to map the response from the system to a string describing 
+potential responses from the system were accounted for when querying for interlock
+status. A dictionary is used to map the response from the system to a string describing
 the interlock status. When the system returns a response that was not accounted for, this
 resulted in a KeyError being raised. Now, this dictionary accounts for all potential responses
 from the system.

--- a/docs/changes/newsfragments/5013.improved_driver
+++ b/docs/changes/newsfragments/5013.improved_driver
@@ -1,0 +1,6 @@
+Fixed a bug in interlock status querying for Keithley 3706A. Originally, not all
+potential responses from the system were accounted for when querying for interlock 
+status. A dictionary is used to map the response from the system to a string describing 
+the interlock status. When the system returns a response that was not accounted for, this
+resulted in a KeyError being raised. Now, this dictionary accounts for all potential responses
+from the system.

--- a/qcodes/instrument/sims/Keithley_3706A.yaml
+++ b/qcodes/instrument/sims/Keithley_3706A.yaml
@@ -68,7 +68,7 @@ devices:
       - q: "print(slot[6].idn)"
         r: "Empty Slot"
       - q: "print(slot[1].interlock.state)"
-        r: 0
+        r: "nil"
         type: int
       - q: "print(slot[2].interlock.state)"
         r: 0

--- a/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
+++ b/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
@@ -794,7 +794,8 @@ class Keithley3706A(VisaInstrument):
         """
         slot_id = self._get_slot_ids()
         interlock_status = {
-            None: "No card is installed or the installed card does not support interlocks",
+            None: ("No card is installed or the installed card does "
+                "not support interlocks"),
             0: "Interlocks 1 and 2 are disengaged on the card",
             1: "Interlock 1 is engaged, interlock 2 (if it exists) is disengaged",
             2: "Interlock 2 in engaged, interlock 1 is disengaged",

--- a/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
+++ b/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
@@ -812,7 +812,7 @@ class Keithley3706A(VisaInstrument):
         if state == "nil":
             return None
         else:
-            return int(state)
+            return int(float(state))
 
     def get_ip_address(self) -> str:
         """

--- a/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
+++ b/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
@@ -793,7 +793,13 @@ class Keithley3706A(VisaInstrument):
         cannot be energized.
         """
         slot_id = self._get_slot_ids()
-        interlock_status = {0: "Interlock is disengaged", 1: "Interlock is engaged"}
+        interlock_status = {
+            None: "No card is installed or the installed card does not support interlocks",
+            0: "Interlocks 1 and 2 are disengaged on the card", 
+            1: "Interlock 1 is engaged, interlock 2 (if it exists) is disengaged",
+            2: "Interlock 2 in engaged, interlock 1 is disengaged",
+            3: "Both interlock 1 and 2 are engaged",
+        }
         states: List[Dict[str, str]] = []
         for i in slot_id:
             state = self.get_interlock_state_by_slot(i)
@@ -801,7 +807,11 @@ class Keithley3706A(VisaInstrument):
         return tuple(states)
 
     def get_interlock_state_by_slot(self, slot: Union[str, int]) -> int:
-        return int(float(self.ask(f"slot[{int(slot)}].interlock.state")))
+        state = self.ask(f"slot[{int(slot)}].interlock.state")
+        if state == "nil":
+            return None
+        else:
+            return int(state)
 
     def get_ip_address(self) -> str:
         """

--- a/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
+++ b/qcodes/instrument_drivers/Keithley/Keithley_3706A.py
@@ -806,7 +806,7 @@ class Keithley3706A(VisaInstrument):
             states.append({"slot_no": i, "state": interlock_status[state]})
         return tuple(states)
 
-    def get_interlock_state_by_slot(self, slot: Union[str, int]) -> int:
+    def get_interlock_state_by_slot(self, slot: Union[str, int]) -> Union[int, None]:
         state = self.ask(f"slot[{int(slot)}].interlock.state")
         if state == "nil":
             return None

--- a/qcodes/tests/drivers/test_keithley_3706A.py
+++ b/qcodes/tests/drivers/test_keithley_3706A.py
@@ -82,7 +82,8 @@ def test_get_interlock_state(driver):
     dict_list = (
         {
             "slot_no": "1",
-            "state": "No card is installed or the installed card does not support interlocks",
+            "state":("No card is installed or the installed card does "
+            "not support interlocks"),
         },
         {"slot_no": "2", "state": "Interlocks 1 and 2 are disengaged on the card"},
         {

--- a/qcodes/tests/drivers/test_keithley_3706A.py
+++ b/qcodes/tests/drivers/test_keithley_3706A.py
@@ -80,9 +80,12 @@ def test_slot_names(driver):
 
 def test_get_interlock_state(driver):
     dict_list = (
-        {'slot_no': '1', 'state': 'Interlock is disengaged'},
-        {'slot_no': '2', 'state': 'Interlock is disengaged'},
-        {'slot_no': '3', 'state': 'Interlock is engaged'},
+        {'slot_no': '1', 'state': 
+            'No card is installed or the installed card does not support interlocks'},
+        {'slot_no': '2', 'state': 
+            'Interlocks 1 and 2 are disengaged on the card'},
+        {'slot_no': '3', 'state': 
+            'Interlock 1 is engaged, interlock 2 (if it exists) is disengaged'},
     )
     assert dict_list == driver.get_interlock_state()
 

--- a/qcodes/tests/drivers/test_keithley_3706A.py
+++ b/qcodes/tests/drivers/test_keithley_3706A.py
@@ -80,12 +80,15 @@ def test_slot_names(driver):
 
 def test_get_interlock_state(driver):
     dict_list = (
-        {'slot_no': '1', 'state': 
-            'No card is installed or the installed card does not support interlocks'},
-        {'slot_no': '2', 'state': 
-            'Interlocks 1 and 2 are disengaged on the card'},
-        {'slot_no': '3', 'state': 
-            'Interlock 1 is engaged, interlock 2 (if it exists) is disengaged'},
+        {
+            "slot_no": "1",
+            "state": "No card is installed or the installed card does not support interlocks",
+        },
+        {"slot_no": "2", "state": "Interlocks 1 and 2 are disengaged on the card"},
+        {
+            "slot_no": "3",
+            "state": "Interlock 1 is engaged, interlock 2 (if it exists) is disengaged",
+        },
     )
     assert dict_list == driver.get_interlock_state()
 


### PR DESCRIPTION
When instantiating an object of the class `Keithley3706A`, the interlock status is checked for each card that is installed in the unit. When querying the unit for the interlock status (for a specific slot), the unit can return any of the following values:

![image](https://user-images.githubusercontent.com/104776697/218807073-be92d88a-8f61-4b84-85f0-508e1a194140.png)

See page 742 of https://download.tek.com/manual/3700AS-901-01D_Jul_2018_Ref_0.pdf. The interlock state is mapped using a dictionary (`interlock_status` in the `get_interlock_state` method), where the returned value is used as the key to find the appropriate status string. However, this dictionary was initially defined using only two keys, `0` and `1`. When querying the interlock status, the possible return values are `nil`, `0`, `1`, `2`, and `3`. As some of these return values are not included as keys in the `interlock_status` dictionary, when the unit does not return `0` or `1`, a `KeyError` is raised, and the driver cannot be instantiated. This PR updates this `interlock_status` dictionary to include all possible return values as keys, and adds the associated status strings (taken directly from the reference manual). The unit test/`sim` file are both updated to reflect these changes.
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
