### PR TITLE
Add support for AimTTi QL355TP

### DIFF
--- a/docs/changes/newsfragments/5021.improved_driver
+++ b/docs/changes/newsfragments/5021.improved_driver
@@ -1,0 +1,2 @@
+Added support for AimTTi QL355TP power supply.
+Moved _numOutputChannels lookup table to the class body.

--- a/qcodes/instrument_drivers/AimTTi/Aim_TTi_QL355_TP.py
+++ b/qcodes/instrument_drivers/AimTTi/Aim_TTi_QL355_TP.py
@@ -1,0 +1,9 @@
+from ._AimTTi_PL_P import AimTTi
+
+
+class AimTTiQL355TP(AimTTi):
+    """
+    This is the QCoDeS driver for the Aim TTi QL355TP series power supply.
+    """
+
+    pass

--- a/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -213,6 +213,16 @@ class AimTTi(VisaInstrument):
     This is the QCoDeS driver for the Aim TTi PL-P series power supply.
     Tested with Aim TTi PL601-P equipped with a single output channel.
     """
+    
+    _numOutputChannels = {
+        "PL068-P": 1,
+        "PL155-P": 1,
+        "PL303-P": 1,
+        "PL601-P": 1,
+        "PL303QMD-P": 2,
+        "PL303QMT-P": 3,
+        "QL355TP": 3,
+    }
 
     def __init__(self, name: str, address: str, **kwargs: Any) -> None:
         """
@@ -226,20 +236,10 @@ class AimTTi(VisaInstrument):
 
         _model = self.get_idn()["model"]
 
-        _numOutputChannels = {
-            "PL068-P": 1,
-            "PL155-P": 1,
-            "PL303-P": 1,
-            "PL601-P": 1,
-            "PL303QMD-P": 2,
-            "PL303QMT-P": 3,
-            "QL355TP": 3,
-        }
-
-        if (_model not in _numOutputChannels.keys()) or (_model is None):
+        if (_model not in self._numOutputChannels.keys()) or (_model is None):
             raise NotKnownModel("Unknown model, connection cannot be " "established.")
 
-        self.numOfChannels = _numOutputChannels[_model]
+        self.numOfChannels = self._numOutputChannels[_model]
         for i in range(1, self.numOfChannels + 1):
             channel = AimTTiChannel(self, f"ch{i}", i)
             channels.append(channel)

--- a/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -213,7 +213,7 @@ class AimTTi(VisaInstrument):
     This is the QCoDeS driver for the Aim TTi PL-P series power supply.
     Tested with Aim TTi PL601-P equipped with a single output channel.
     """
-    
+
     _numOutputChannels = {
         "PL068-P": 1,
         "PL155-P": 1,

--- a/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -233,6 +233,7 @@ class AimTTi(VisaInstrument):
             "PL601-P": 1,
             "PL303QMD-P": 2,
             "PL303QMT-P": 3,
+            "QL355TP": 3,
         }
 
         if (_model not in _numOutputChannels.keys()) or (_model is None):

--- a/qcodes/instrument_drivers/AimTTi/__init__.py
+++ b/qcodes/instrument_drivers/AimTTi/__init__.py
@@ -5,6 +5,7 @@ from .Aim_TTi_PL303_P import AimTTiPL303P
 from .Aim_TTi_PL303QMD_P import AimTTiPL303QMDP
 from .Aim_TTi_PL303QMT_P import AimTTiPL303QMTP
 from .Aim_TTi_PL601_P import AimTTiPL601
+from .Aim_TTi_QL355_TP import AimTTiQL355TP
 
 __all__ = [
     "AimTTiChannel",
@@ -14,5 +15,6 @@ __all__ = [
     "AimTTiPL303QMDP",
     "AimTTiPL303QMTP",
     "AimTTiPL601",
+    "AimTTiQL355TP",
     "NotKnownModel",
 ]


### PR DESCRIPTION
Hi,
I have added AimTTi QL355TP power supply. 

I also moved the lookup table for other power supplies in case someone wants to easily add his device.


<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
