### PR TITLE
Add ability to lookup component in station by full name

### DIFF
--- a/docs/changes/newsfragments/5028.new
+++ b/docs/changes/newsfragments/5028.new
@@ -1,0 +1,3 @@
+The QCoDeS ``Station`` ``Instrument`` and ``InstrumentModule`` classes gained a method ``get_component``
+which allows the user to get a component by name. Allowing the user to go from
+the full name of a component to the component itself.

--- a/docs/examples/Station.ipynb
+++ b/docs/examples/Station.ipynb
@@ -18,7 +18,23 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Logging hadn't been started.\n",
+      "Activating auto-logging. Current session state plus future input saved.\n",
+      "Filename       : C:\\Users\\jenielse\\.qcodes\\logs\\command_history.log\n",
+      "Mode           : append\n",
+      "Output logging : True\n",
+      "Raw input log  : False\n",
+      "Timestamping   : True\n",
+      "State          : active\n",
+      "Qcodes Logfile : C:\\Users\\jenielse\\.qcodes\\logs\\230221-10976-qcodes.log\n"
+     ]
+    }
+   ],
    "source": [
     "# Useful imports:\n",
     "\n",
@@ -128,7 +144,7 @@
     {
      "data": {
       "text/plain": [
-       "{'p': <qcodes.instrument.parameter.Parameter: p at 2330718811616>,\n",
+       "{'p': <qcodes.parameters.parameter.Parameter: p at 2344293461648>,\n",
        " 'instr': <DummyInstrument: instr>}"
       ]
      },
@@ -181,6 +197,44 @@
     "# Let's confirm that station's `p` is \n",
     "# actually the `p` parameter defined above\n",
     "assert station.p is p"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also possible to access a component or a sub component of a instrument directly via its name. For example, if we want to access the parameter ``input`` of the instrument ``instr``, we can do the following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "instr_input\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "input_name = station.instr.input.full_name\n",
+    "print(input_name)\n",
+    "param = station.get_component(input_name)\n",
+    "param is instr.input"
    ]
   },
   {
@@ -674,7 +728,7 @@
  "metadata": {
   "file_extension": ".py",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "qcodespip311",
    "language": "python",
    "name": "python3"
   },
@@ -688,13 +742,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.11.0"
   },
   "mimetype": "text/x-python",
   "name": "python",
   "npconvert_exporter": "python",
   "pygments_lexer": "ipython3",
   "version": 3,
+  "vscode": {
+   "interpreter": {
+    "hash": "7ac3e91929df5618782934af11c3fa566d637713ed5d04bf73eff1f535fb8e06"
+   }
+  },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
     "state": {},

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -266,10 +266,10 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
         if potential_top_level_name in self.parameters:
             component = self.parameters[potential_top_level_name]
         elif potential_top_level_name in self.functions:
-            component =  self.functions[potential_top_level_name]
+            component = self.functions[potential_top_level_name]
         elif potential_top_level_name in self.submodules:
             # recursive call on found component
-            component =  self.submodules[potential_top_level_name]
+            component = self.submodules[potential_top_level_name]
             if len(remaining_name_parts) > 0:
                 remaining_name_parts.reverse()
                 remaining_name = "_".join(remaining_name_parts)
@@ -289,8 +289,8 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
 
             remaining_name_parts.reverse()
             raise KeyError(
-                    f"Found component {component.full_name} but could not match "
-                    f"{'_'.join(remaining_name_parts)} part."
+                f"Found component {component.full_name} but could not match "
+                f"{'_'.join(remaining_name_parts)} part."
             )
         else:
             if len(remaining_name_parts) == 0:
@@ -308,7 +308,6 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
             )
 
         return component
-
 
     def snapshot_base(
         self,

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from qcodes.logger import get_instrument_logger
-from qcodes.metadatable import Metadatable
+from qcodes.metadatable import Metadatable, MetadatableWithName
 from qcodes.parameters import Function, Parameter, ParameterBase
 from qcodes.utils import DelegateAttributes, full_class
 
@@ -23,7 +23,7 @@ from qcodes.utils import QCoDeSDeprecationWarning
 log = logging.getLogger(__name__)
 
 
-class InstrumentBase(Metadatable, DelegateAttributes):
+class InstrumentBase(MetadatableWithName, DelegateAttributes):
     """
     Base class for all QCodes instruments and instrument channels
 

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -286,26 +286,26 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
         if component is not None:
             if len(remaining_name_parts) == 0:
                 return component
-            else:
-                remaining_name_parts.reverse()
-                raise KeyError(
+
+            remaining_name_parts.reverse()
+            raise KeyError(
                     f"Found component {component.full_name} but could not match "
                     f"{'_'.join(remaining_name_parts)} part."
-                )
+            )
         else:
             if len(remaining_name_parts) == 0:
                 raise KeyError(
                     f"Found component {self.full_name} but could not "
                     f"match {potential_top_level_name} part."
                 )
-            else:
-                new_potential_top_level_name = (
-                    f"{potential_top_level_name}_{remaining_name_parts.pop()}"
-                )
-                remaining_name_parts.reverse()
-                component = self._get_component_by_name(
-                    new_potential_top_level_name, remaining_name_parts
-                )
+
+            new_potential_top_level_name = (
+                f"{potential_top_level_name}_{remaining_name_parts.pop()}"
+            )
+            remaining_name_parts.reverse()
+            component = self._get_component_by_name(
+                new_potential_top_level_name, remaining_name_parts
+            )
 
         return component
 

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -292,20 +292,20 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
                 f"Found component {component.full_name} but could not match "
                 f"{'_'.join(remaining_name_parts)} part."
             )
-        else:
-            if len(remaining_name_parts) == 0:
-                raise KeyError(
-                    f"Found component {self.full_name} but could not "
-                    f"match {potential_top_level_name} part."
-                )
 
-            new_potential_top_level_name = (
-                f"{potential_top_level_name}_{remaining_name_parts.pop()}"
+        if len(remaining_name_parts) == 0:
+            raise KeyError(
+                f"Found component {self.full_name} but could not "
+                f"match {potential_top_level_name} part."
             )
-            remaining_name_parts.reverse()
-            component = self._get_component_by_name(
-                new_potential_top_level_name, remaining_name_parts
-            )
+
+        new_potential_top_level_name = (
+            f"{potential_top_level_name}_{remaining_name_parts.pop()}"
+        )
+        remaining_name_parts.reverse()
+        component = self._get_component_by_name(
+            new_potential_top_level_name, remaining_name_parts
+        )
 
         return component
 

--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -234,6 +234,82 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
         else:
             self.instrument_modules[name] = submodule
 
+    def get_component(self, full_name: str) -> MetadatableWithName:
+        """
+        Recursively get a component of the instrument by full_name.
+
+        Args:
+            name: The name of the component to get.
+
+        Returns:
+            The component with the given name.
+
+        Raises:
+            KeyError: If the component does not exist.
+        """
+        name_parts = full_name.split("_")
+        name_parts.reverse()
+
+        component = self._get_component_by_name(name_parts.pop(), name_parts)
+        return component
+
+    def _get_component_by_name(
+        self, potential_top_level_name: str, remaining_name_parts: list[str]
+    ) -> MetadatableWithName:
+        component: MetadatableWithName | None = None
+
+        sub_component_name_map = {
+            sub_component.short_name: sub_component
+            for sub_component in self.submodules.values()
+        }
+
+        if potential_top_level_name in self.parameters:
+            component = self.parameters[potential_top_level_name]
+        elif potential_top_level_name in self.functions:
+            component =  self.functions[potential_top_level_name]
+        elif potential_top_level_name in self.submodules:
+            # recursive call on found component
+            component =  self.submodules[potential_top_level_name]
+            if len(remaining_name_parts) > 0:
+                remaining_name_parts.reverse()
+                remaining_name = "_".join(remaining_name_parts)
+                component = component.get_component(remaining_name)
+                remaining_name_parts = []
+        elif potential_top_level_name in sub_component_name_map:
+            component = sub_component_name_map[potential_top_level_name]
+            if len(remaining_name_parts) > 0:
+                remaining_name_parts.reverse()
+                remaining_name = "_".join(remaining_name_parts)
+                component = component.get_component(remaining_name)
+                remaining_name_parts = []
+
+        if component is not None:
+            if len(remaining_name_parts) == 0:
+                return component
+            else:
+                remaining_name_parts.reverse()
+                raise KeyError(
+                    f"Found component {component.full_name} but could not match "
+                    f"{'_'.join(remaining_name_parts)} part."
+                )
+        else:
+            if len(remaining_name_parts) == 0:
+                raise KeyError(
+                    f"Found component {self.full_name} but could not "
+                    f"match {potential_top_level_name} part."
+                )
+            else:
+                new_potential_top_level_name = (
+                    f"{potential_top_level_name}_{remaining_name_parts.pop()}"
+                )
+                remaining_name_parts.reverse()
+                component = self._get_component_by_name(
+                    new_potential_top_level_name, remaining_name_parts
+                )
+
+        return component
+
+
     def snapshot_base(
         self,
         update: bool | None = False,

--- a/qcodes/metadatable/__init__.py
+++ b/qcodes/metadatable/__init__.py
@@ -1,3 +1,3 @@
-from .metadatable_base import Metadatable
+from .metadatable_base import Metadatable, MetadatableWithName
 
-__all__ = ["Metadatable"]
+__all__ = ["Metadatable", "MetadatableWithName"]

--- a/qcodes/metadatable/metadatable_base.py
+++ b/qcodes/metadatable/metadatable_base.py
@@ -61,12 +61,23 @@ class Metadatable:
 
 
 class MetadatableWithName(Metadatable):
+    """Add short_name and full_name properties to Metadatable.
+    This is used as a base class for all components in QCoDeS that
+    are members of a station to ensure that they have a name and
+    consistent interface."""
+
     @property
     @abstractmethod
     def short_name(self) -> str:
+        """
+        Name excluding name of any parent that this object is bound to.
+        """
         ...
 
     @property
     @abstractmethod
     def full_name(self) -> str:
+        """
+        Name including name of any parent that this object is bound to separated by '_'.
+        """
         ...

--- a/qcodes/metadatable/metadatable_base.py
+++ b/qcodes/metadatable/metadatable_base.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from typing import Any, Dict, Mapping, Optional, Sequence
 
 from qcodes.utils import deep_update
@@ -57,3 +58,15 @@ class Metadatable:
         Override this with the primary information for a subclass.
         """
         return {}
+
+
+class MetadatableWithName(Metadatable):
+    @property
+    @abstractmethod
+    def short_name(self) -> str:
+        ...
+
+    @property
+    @abstractmethod
+    def full_name(self) -> str:
+        ...

--- a/qcodes/metadatable/metadatable_base.py
+++ b/qcodes/metadatable/metadatable_base.py
@@ -72,7 +72,6 @@ class MetadatableWithName(Metadatable):
         """
         Name excluding name of any parent that this object is bound to.
         """
-        ...
 
     @property
     @abstractmethod
@@ -80,4 +79,3 @@ class MetadatableWithName(Metadatable):
         """
         Name including name of any parent that this object is bound to separated by '_'.
         """
-        ...

--- a/qcodes/parameters/parameter_base.py
+++ b/qcodes/parameters/parameter_base.py
@@ -10,7 +10,7 @@ from functools import cached_property, wraps
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, overload
 
-from qcodes.metadatable import Metadatable
+from qcodes.metadatable import Metadatable, MetadatableWithName
 from qcodes.utils import DelegateAttributes, full_class, qcodes_abstractmethod
 from qcodes.validators import Enum, Ints, Validator
 
@@ -83,7 +83,7 @@ def invert_val_mapping(val_mapping: Mapping[Any, Any]) -> dict[Any, Any]:
     return {v: k for k, v in val_mapping.items()}
 
 
-class ParameterBase(Metadatable):
+class ParameterBase(MetadatableWithName):
     """
     Shared behavior for all parameters. Not intended to be used
     directly, normally you should use ``Parameter``, ``ArrayParameter``,

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -40,7 +40,7 @@ import qcodes.instrument_drivers
 from qcodes import validators
 from qcodes.instrument.base import Instrument, InstrumentBase
 from qcodes.instrument.channel import ChannelTuple
-from qcodes.metadatable import Metadatable
+from qcodes.metadatable import Metadatable, MetadatableWithName
 from qcodes.monitor.monitor import Monitor
 from qcodes.parameters import (
     DelegateParameter,
@@ -139,7 +139,7 @@ class Station(Metadatable, DelegateAttributes):
 
     def __init__(
         self,
-        *components: Metadatable,
+        *components: MetadatableWithName,
         config_file: str | Sequence[str] | None = None,
         use_monitor: bool | None = None,
         default: bool = True,
@@ -157,7 +157,7 @@ class Station(Metadatable, DelegateAttributes):
         if default:
             Station.default = self
 
-        self.components: dict[str, Metadatable] = {}
+        self.components: dict[str, MetadatableWithName] = {}
         for item in components:
             self.add_component(item, update_snapshot=update_snapshot)
 
@@ -234,7 +234,7 @@ class Station(Metadatable, DelegateAttributes):
 
     def add_component(
         self,
-        component: Metadatable,
+        component: MetadatableWithName,
         name: str | None = None,
         update_snapshot: bool = True,
     ) -> str:
@@ -267,7 +267,7 @@ class Station(Metadatable, DelegateAttributes):
         self.components[namestr] = component
         return namestr
 
-    def remove_component(self, name: str) -> Metadatable | None:
+    def remove_component(self, name: str) -> MetadatableWithName | None:
         """
         Remove a component with a given name from this Station.
 

--- a/qcodes/station.py
+++ b/qcodes/station.py
@@ -337,7 +337,10 @@ class Station(Metadatable, DelegateAttributes):
         if isinstance(toplevel_component, InstrumentBase):
             component = toplevel_component.get_component(remaining_name)
         else:
-            raise KeyError(f"Component {full_name} is not part of the station")
+            raise KeyError(
+                f"Found component {toplevel_component} but this has no "
+                f"sub-component {remaining_name}."
+            )
 
         return component
 

--- a/qcodes/tests/common.py
+++ b/qcodes/tests/common.py
@@ -15,7 +15,7 @@ from typing_extensions import ParamSpec
 
 import qcodes
 from qcodes.configuration import Config, DotDict
-from qcodes.metadatable import Metadatable
+from qcodes.metadatable import MetadatableWithName
 from qcodes.utils import deprecate
 
 if TYPE_CHECKING:
@@ -154,14 +154,13 @@ def skip_if_no_fixtures(dbname: str | Path) -> None:
         )
 
 
-class DumyPar(Metadatable):
+class DummyComponent(MetadatableWithName):
 
-    """Docstring for DumyPar. """
+    """Docstring for DummyComponent."""
 
     def __init__(self, name: str):
         super().__init__()
         self.name = name
-        self.full_name = name
 
     def __str__(self) -> str:
         return self.full_name
@@ -169,6 +168,14 @@ class DumyPar(Metadatable):
     def set(self, value: float) -> float:
         value = value * 2
         return value
+
+    @property
+    def short_name(self) -> str:
+        return self.name
+
+    @property
+    def full_name(self) -> str:
+        return self.full_name
 
 
 @deprecate(reason="Unused internally", alternative="default_config fixture")

--- a/qcodes/tests/parameter/test_function.py
+++ b/qcodes/tests/parameter/test_function.py
@@ -1,0 +1,19 @@
+from typing import Iterator
+
+import pytest
+
+from qcodes.tests.instrument_mocks import DummyChannelInstrument
+
+
+@pytest.fixture(name="channel_instr")
+def _make_channel_instr() -> Iterator[DummyChannelInstrument]:
+    instr = DummyChannelInstrument("dummy")
+    try:
+        yield instr
+    finally:
+        instr.close()
+
+
+def test_function_name(channel_instr: DummyChannelInstrument) -> None:
+    assert channel_instr.A.log_my_name.short_name == "log_my_name"
+    assert channel_instr.A.log_my_name.full_name == "dummy_ChanA_log_my_name"

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -660,6 +660,11 @@ def test_channel_tuple_call_method_called_as_expected(dci, mocker):
         channel.turn_on.assert_called_with("bar")
 
 
+def test_channel_tuple_names(dci: DummyChannelInstrument) -> None:
+    assert dci.channels.short_name == "TempSensors"
+    assert dci.channels.full_name == "dci_TempSensors"
+
+
 def _verify_multiparam_data(data):
     assert 'multi_setpoint_param_this_setpoint_set' in data.arrays.keys()
     assert_array_equal(

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -917,6 +917,7 @@ def test_get_component_by_name() -> None:
     assert station.get_component("dummy") is instr
     assert station.get_component("dummy_A") is instr.A
     assert station.get_component("dummy_ChanA") is instr.A
+    assert station.get_component("dummy_A_temperature") is instr.A.temperature
     assert station.get_component("dummy_ChanA_temperature") is instr.A.temperature
 
     assert station.get_component("param") is param

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -949,6 +949,7 @@ def test_get_wrong_component_by_name_raises() -> None:
     ):
         _ = station.get_component("param_foo")
 
+
 def test_component_by_name_with_underscore_in_name() -> None:
     instr = DummyChannelInstrument(name="dum_my")
     station = Station(instr)

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -20,7 +20,7 @@ from qcodes.tests.instrument_mocks import DummyChannelInstrument, DummyInstrumen
 from qcodes.utils import NumpyJSONEncoder, QCoDeSDeprecationWarning, get_qcodes_path
 from qcodes.utils.deprecate import deprecation_message
 
-from .common import DumyPar
+from .common import DummyComponent
 
 
 @pytest.fixture(autouse=True)
@@ -157,7 +157,7 @@ def test_close_all_registered_instruments():
         assert name not in Instrument._all_instruments
 
 
-def test_snapshot():
+def test_snapshot() -> None:
     station = Station()
 
     empty_snapshot = station.snapshot()
@@ -178,8 +178,8 @@ def test_snapshot():
     excluded_parameter = Parameter('excluded_parameter', snapshot_exclude=True)
     station.add_component(excluded_parameter)
 
-    component = DumyPar('component')
-    component.metadata['smth'] = 'in the way she moves'
+    component = DummyComponent("component")
+    component.metadata["smth"] = "in the way she moves"
     station.add_component(component)
     component_snapshot = component.snapshot()
 

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -943,4 +943,6 @@ def test_component_by_name_with_underscore_in_name() -> None:
     assert station.get_component("dum_my") is instr
     assert station.get_component("dum_my_A") is instr.A
     assert station.get_component("dum_my_ChanA") is instr.A
+    assert station.get_component("dum_my_A_temperature") is instr.A.temperature
     assert station.get_component("dum_my_ChanA_temperature") is instr.A.temperature
+    assert station.get_component("dum_my_ChanA_log_my_name") is instr.A.log_my_name

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -911,17 +911,22 @@ def test_station_config_created_with_multiple_config_files():
 
 def test_get_component_by_name() -> None:
     instr = DummyChannelInstrument(name="dummy")
-    station = Station(instr)
+    param = Parameter(name="param", set_cmd=None, get_cmd=None)
+    station = Station(instr, param)
 
     assert station.get_component("dummy") is instr
     assert station.get_component("dummy_A") is instr.A
     assert station.get_component("dummy_ChanA") is instr.A
     assert station.get_component("dummy_ChanA_temperature") is instr.A.temperature
 
+    assert station.get_component("param") is param
+
 
 def test_get_wrong_component_by_name_raises() -> None:
     instr = DummyChannelInstrument(name="dummy")
-    station = Station(instr)
+    param = Parameter(name="param", set_cmd=None, get_cmd=None)
+    station = Station(instr, param)
+
     with pytest.raises(KeyError, match="Component notdummy is not part of the station"):
         _ = station.get_component("notdummy")
 
@@ -932,10 +937,17 @@ def test_get_wrong_component_by_name_raises() -> None:
 
     with pytest.raises(
         KeyError,
-        match="Found component dummy_ChanA_temperature but could not match parameter part",
+        match=(
+            "Found component dummy_ChanA_temperature but could "
+            "not match parameter part"
+        ),
     ):
         _ = station.get_component("dummy_ChanA_temperature_parameter")
 
+    with pytest.raises(
+        KeyError, match="Found component param but this has no sub-component foo."
+    ):
+        _ = station.get_component("param_foo")
 
 def test_component_by_name_with_underscore_in_name() -> None:
     instr = DummyChannelInstrument(name="dum_my")


### PR DESCRIPTION
This is handy since you can then look up any parameter from its name in the snapshot.

Slightly complicated by the fact that a name could it self contain `_` we handle that by trying to merge the next name_part into the name that we are trying to lookup if the name cannot be found but we do not try to handle all possibilities. E.g. it is possible for the complete name to not be unique

To make this possible change the baseclass of all components to have short_name and full_name properties

- [x] document
- [x] Test name handling for function and channeltuple



 