### PR TITLE
Dataset: change default guid type to use a random str

### DIFF
--- a/docs/changes/newsfragments/5031.breaking
+++ b/docs/changes/newsfragments/5031.breaking
@@ -1,0 +1,8 @@
+The default configuration of QCoDeS dataset ``GUID_components.GUID_type`` has changed from ``explicit_sample`` to ``random_sample``.
+This means that QCoDeS GUIDs will no longer start with ``aaaaaaaa`` but with a random string. This significantly reduces the risk
+of duplicate GUIDs.
+This also means that that the ability to set a sample_id as part of the dataset GUID is disabled by default. With
+the default config its therefor an error to set ``GUID_components.sample`` to anything but the default value. The original
+behavior can be restored by setting ``GUID_components.GUID_type`` to ``explicit_sample`` in the config file but is not recommended.
+Users should make use of the ``sample_name`` attached to an experiment as an alternative. Note that if you have already created
+a local config you will need to update this for the changes to take effect.

--- a/qcodes/configuration/qcodesrc.json
+++ b/qcodes/configuration/qcodesrc.json
@@ -59,7 +59,7 @@
         "use_monitor": false
     },
     "GUID_components": {
-        "GUID_type": "explicit_sample",
+        "GUID_type": "random_sample",
         "location": 0,
         "work_station": 0,
         "sample": 0

--- a/qcodes/configuration/qcodesrc_schema.json
+++ b/qcodes/configuration/qcodesrc_schema.json
@@ -279,7 +279,7 @@
                 "GUID_type": {
                     "type": "string",
                     "enum": ["explicit_sample", "random_sample"],
-                    "default": "explicit_sample",
+                    "default": "random_sample",
                     "description": "Type of GUID to use. Currently possible to chose between an explicitly assigned 'Sample identification code' and a random string as the first part of the GUID."
                 },
                 "location": {

--- a/qcodes/dataset/guids.py
+++ b/qcodes/dataset/guids.py
@@ -75,10 +75,10 @@ def generate_guid(timeint: int | None = None, sampleint: int | None = None) -> s
     elif sampleint == 0:
         sampleint = 0xAA_AAA_AAA
 
-    loc_str = f'{location:02x}'
-    stat_str = f'{station:06x}'
-    smpl_str = f'{sampleint:08x}'
-    time_str = f'{timeint:016x}'
+    smpl_str = f"{sampleint:08x}"
+    loc_str = f"{location:02x}"
+    stat_str = f"{station:06x}"
+    time_str = f"{timeint:016x}"
 
     guid = (f'{smpl_str}-{loc_str}{stat_str[:2]}-{stat_str[2:]}-'
             f'{time_str[:4]}-{time_str[4:]}')
@@ -105,6 +105,30 @@ def parse_guid(guid: str) -> dict[str, int]:
     components['time'] = int(guid[16:], base=16)
 
     return components
+
+
+def build_guid_from_components(components: dict[str, int]) -> str:
+    """
+    Build a guid from a dict of its components
+
+    Args:
+        components: A dict with keys 'location', 'work_station', 'sample',
+          and 'time' as integer values
+
+    Returns:
+        A valid guid string
+    """
+    work_station_hex = f'{components["work_station"]:06x}'
+
+    guid = (
+        f'{components["sample"]:08x}-'
+        f'{components["location"]:02x}'
+        f"{work_station_hex[:2]}-"
+        f"{work_station_hex[2:]}-"
+        f'{components["time"]:016x}'
+    )
+
+    return guid
 
 
 def set_guid_location_code() -> None:

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -550,7 +550,7 @@ def test_perform_upgrade_v3_to_v4() -> None:
         assert p5.unit == "unit 5"
 
 
-@pytest.mark.usefixtures("empty_temp_db")
+@pytest.mark.usefixtures("default_config", "empty_temp_db")
 def test_update_existing_guids(caplog) -> None:
 
     old_loc = 101

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -293,9 +293,23 @@ def test_random_sample_and_sample_int_in_guid_raises() -> None:
 
 
 @pytest.mark.usefixtures("default_config")
-def test_sample_int_in_guid_warns() -> None:
+def test_sample_int_in_guid_warns_with_old_config() -> None:
+    cfg = qc.config
+    cfg["GUID_components"]["GUID_type"] = "explicit_sample"
     with pytest.warns(
         expected_warning=Warning,
         match=re.escape("Setting a non default GUID_components.sample"),
+    ):
+        generate_guid(sampleint=10)
+
+
+@pytest.mark.usefixtures("default_config")
+def test_sample_int_in_guid_raises():
+    with pytest.raises(
+        RuntimeError,
+        match=re.escape(
+            "QCoDeS is configured to disregard GUID_components.sample "
+            "from config file but this"
+        ),
     ):
         generate_guid(sampleint=10)

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -162,6 +162,10 @@ def test_filter_guid(locs, stats, smpls) -> None:
         cfg["GUID_components"]["location"] = loc
         cfg["GUID_components"]["work_station"] = stat
         cfg["GUID_components"]["sample"] = smpl
+        # even thou setting the sample name is no longer supported
+        # by default it makes sense to still be able to filter
+        # old dataset on that since they already exist
+        cfg["GUID_components"]["GUID_type"] = "explicit_sample"
 
         if smpl in (0, 0xAAAAAAAA):
             guid = generate_guid()


### PR DESCRIPTION
As earlier suggested this switches the default to replace sample by a random string eliminating duplicate guids. That was especially likely if generating lots of guids on the same system rapidly after each other on a system with low time resolution