### PR TITLE
Add automactially generated return types to tests

### DIFF
--- a/qcodes/tests/dataset/dond/conftest.py
+++ b/qcodes/tests/dataset/dond/conftest.py
@@ -82,7 +82,7 @@ def _param_callable(_param):
     return _param_func(_param)
 
 
-def test_param_callable(_param_callable):
+def test_param_callable(_param_callable) -> None:
     _param_modified = _param_callable
     assert _param_modified.get() == 2
 

--- a/qcodes/tests/dataset/dond/test_do0d.py
+++ b/qcodes/tests/dataset/dond/test_do0d.py
@@ -21,7 +21,7 @@ from qcodes.tests.instrument_mocks import (
 @pytest.mark.parametrize("period", [None, 1])
 @pytest.mark.parametrize("plot", [None, True, False])
 @pytest.mark.parametrize("plot_config", [None, True, False])
-def test_do0d_with_real_parameter(period, plot, plot_config):
+def test_do0d_with_real_parameter(period, plot, plot_config) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
 
     if plot_config is not None:
@@ -39,7 +39,7 @@ def test_do0d_with_real_parameter(period, plot, plot_config):
 @pytest.mark.parametrize(
     "period, plot", [(None, True), (None, False), (1, True), (1, False)]
 )
-def test_do0d_with_complex_parameter(_param_complex, period, plot):
+def test_do0d_with_complex_parameter(_param_complex, period, plot) -> None:
     do0d(_param_complex, write_period=period, do_plot=plot)
 
 
@@ -47,7 +47,7 @@ def test_do0d_with_complex_parameter(_param_complex, period, plot):
 @pytest.mark.parametrize(
     "period, plot", [(None, True), (None, False), (1, True), (1, False)]
 )
-def test_do0d_with_a_callable(_param_callable, period, plot):
+def test_do0d_with_a_callable(_param_callable, period, plot) -> None:
     do0d(_param_callable, write_period=period, do_plot=plot)
 
 
@@ -55,7 +55,7 @@ def test_do0d_with_a_callable(_param_callable, period, plot):
 @pytest.mark.parametrize(
     "period, plot", [(None, True), (None, False), (1, True), (1, False)]
 )
-def test_do0d_with_2_parameters(_param, _param_complex, period, plot):
+def test_do0d_with_2_parameters(_param, _param_complex, period, plot) -> None:
     do0d(_param, _param_complex, write_period=period, do_plot=plot)
 
 
@@ -65,30 +65,30 @@ def test_do0d_with_2_parameters(_param, _param_complex, period, plot):
 )
 def test_do0d_with_parameter_and_a_callable(
     _param_complex, _param_callable, period, plot
-):
+) -> None:
     do0d(_param_callable, _param_complex, write_period=period, do_plot=plot)
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do0d_output_type_real_parameter(_param):
+def test_do0d_output_type_real_parameter(_param) -> None:
     data = do0d(_param)
     assert isinstance(data[0], DataSet) is True
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do0d_output_type_complex_parameter(_param_complex):
+def test_do0d_output_type_complex_parameter(_param_complex) -> None:
     data_complex = do0d(_param_complex)
     assert isinstance(data_complex[0], DataSet) is True
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do0d_output_type_callable(_param_callable):
+def test_do0d_output_type_callable(_param_callable) -> None:
     data_func = do0d(_param_callable)
     assert isinstance(data_func[0], DataSet) is True
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do0d_output_data(_param):
+def test_do0d_output_data(_param) -> None:
     exp = do0d(_param)
     data = exp[0]
     assert data.description.interdeps.names == (_param.name,)
@@ -105,7 +105,7 @@ def test_do0d_output_data(_param):
 @settings(deadline=None, suppress_health_check=(HealthCheck.function_scoped_fixture,))
 def test_do0d_verify_shape(
     _param, _param_complex, multiparamtype, dummyinstrument, n_points_pws
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     multiparam = multiparamtype(name="multiparam")
     paramwsetpoints = dummyinstrument.A.dummy_parameter_with_setpoints
@@ -131,13 +131,13 @@ def test_do0d_verify_shape(
 
     data = ds.get_parameter_data()
 
-    for name, data in data.items():
-        for param_data in data.values():
+    for name, data_inner in data.items():
+        for param_data in data_inner.values():
             assert param_data.shape == expected_shapes[name]
 
 
 @pytest.mark.usefixtures("experiment")
-def test_do0d_parameter_with_array_vals():
+def test_do0d_parameter_with_array_vals() -> None:
     param = ArrayshapedParam(
         name="paramwitharrayval", vals=validators.Arrays(shape=(10,))
     )
@@ -146,7 +146,7 @@ def test_do0d_parameter_with_array_vals():
     assert results[0].description.shapes == expected_shapes
 
 
-def test_do0d_explicit_experiment(_param, experiment):
+def test_do0d_explicit_experiment(_param, experiment) -> None:
     experiment_2 = new_experiment("new-exp", "no-sample")
 
     data1 = do0d(_param, do_plot=False, exp=experiment)
@@ -159,13 +159,13 @@ def test_do0d_explicit_experiment(_param, experiment):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_do0d_explicit_name(_param):
+def test_do0d_explicit_name(_param) -> None:
     data1 = do0d(_param, do_plot=False, measurement_name="my measurement")
     assert data1[0].name == "my measurement"
 
 
 @pytest.mark.usefixtures("experiment")
-def test_do0d_parameter_with_setpoints_2d(dummyinstrument):
+def test_do0d_parameter_with_setpoints_2d(dummyinstrument) -> None:
     dummyinstrument.A.dummy_start(0)
     dummyinstrument.A.dummy_stop(10)
     dummyinstrument.A.dummy_n_points(10)
@@ -182,7 +182,7 @@ def test_do0d_parameter_with_setpoints_2d(dummyinstrument):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_0d_output_type(_param, _param_complex, _param_callable):
+def test_dond_0d_output_type(_param, _param_complex, _param_callable) -> None:
     data_1 = do0d(_param)
     assert isinstance(data_1[0], DataSet) is True
 

--- a/qcodes/tests/dataset/dond/test_do1d.py
+++ b/qcodes/tests/dataset/dond/test_do1d.py
@@ -23,7 +23,7 @@ from qcodes.tests.instrument_mocks import (
 
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("delay", [0, 0.1, 1])
-def test_do1d_with_real_parameter(_param_set, _param, delay):
+def test_do1d_with_real_parameter(_param_set, _param, delay) -> None:
 
     start = 0
     stop = 1
@@ -35,7 +35,7 @@ def test_do1d_with_real_parameter(_param_set, _param, delay):
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("plot", [None, True, False])
 @pytest.mark.parametrize("plot_config", [None, True, False])
-def test_do1d_plot(_param_set, _param, plot, plot_config):
+def test_do1d_plot(_param_set, _param, plot, plot_config) -> None:
 
     if plot_config is not None:
         config.dataset.dond_plot = plot_config
@@ -54,7 +54,7 @@ def test_do1d_plot(_param_set, _param, plot, plot_config):
 
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("delay", [0, 0.1, 1])
-def test_do1d_with_complex_parameter(_param_set, _param_complex, delay):
+def test_do1d_with_complex_parameter(_param_set, _param_complex, delay) -> None:
 
     start = 0
     stop = 1
@@ -65,7 +65,7 @@ def test_do1d_with_complex_parameter(_param_set, _param_complex, delay):
 
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("delay", [0, 0.1, 1])
-def test_do1d_with_2_parameter(_param_set, _param, _param_complex, delay):
+def test_do1d_with_2_parameter(_param_set, _param, _param_complex, delay) -> None:
 
     start = 0
     stop = 1
@@ -76,7 +76,7 @@ def test_do1d_with_2_parameter(_param_set, _param, _param_complex, delay):
 
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("delay", [0, 0.1, 1])
-def test_do1d_output_type_real_parameter(_param_set, _param, delay):
+def test_do1d_output_type_real_parameter(_param_set, _param, delay) -> None:
 
     start = 0
     stop = 1
@@ -87,7 +87,7 @@ def test_do1d_output_type_real_parameter(_param_set, _param, delay):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do1d_output_data(_param, _param_set):
+def test_do1d_output_data(_param, _param_set) -> None:
 
     start = 0
     stop = 1
@@ -122,7 +122,7 @@ def test_do1d_verify_shape(
     dummyinstrument,
     num_points,
     n_points_pws,
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     multiparam = multiparamtype(name="multiparam")
     paramwsetpoints = dummyinstrument.A.dummy_parameter_with_setpoints
@@ -158,7 +158,7 @@ def test_do1d_verify_shape(
 
 
 @pytest.mark.usefixtures("experiment")
-def test_do1d_parameter_with_array_vals(_param_set):
+def test_do1d_parameter_with_array_vals(_param_set) -> None:
     param = ArrayshapedParam(
         name="paramwitharrayval", vals=validators.Arrays(shape=(10,))
     )
@@ -176,12 +176,12 @@ def test_do1d_parameter_with_array_vals(_param_set):
 
     data = ds.get_parameter_data()
 
-    for name, data in data.items():
-        for param_data in data.values():
+    for name, data_inner in data.items():
+        for param_data in data_inner.values():
             assert param_data.shape == expected_shapes[name]
 
 
-def test_do1d_explicit_experiment(_param_set, _param, experiment):
+def test_do1d_explicit_experiment(_param_set, _param, experiment) -> None:
     start = 0
     stop = 1
     num_points = 5
@@ -217,7 +217,7 @@ def test_do1d_explicit_experiment(_param_set, _param, experiment):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_do1d_explicit_name(_param_set, _param):
+def test_do1d_explicit_name(_param_set, _param) -> None:
     start = 0
     stop = 1
     num_points = 5
@@ -237,7 +237,7 @@ def test_do1d_explicit_name(_param_set, _param):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do1d_additional_setpoints(_param, _param_complex, _param_set):
+def test_do1d_additional_setpoints(_param, _param_complex, _param_set) -> None:
     additional_setpoints = [
         Parameter(f"additional_setter_parameter_{i}", set_cmd=None, get_cmd=None)
         for i in range(2)
@@ -274,7 +274,7 @@ def test_do1d_additional_setpoints(_param, _param_complex, _param_set):
 @pytest.mark.usefixtures("experiment")
 def test_do1d_additional_setpoints_shape(
     _param, _param_complex, _param_set, num_points_p1
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     array_shape = arrayparam.shape
     additional_setpoints = [
@@ -309,7 +309,7 @@ def test_do1d_additional_setpoints_shape(
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do1d_break_condition(caplog, _param_set, _param):
+def test_do1d_break_condition(caplog, _param_set, _param) -> None:
 
     start = 0
     stop = 1

--- a/qcodes/tests/dataset/dond/test_do2d.py
+++ b/qcodes/tests/dataset/dond/test_do2d.py
@@ -25,7 +25,7 @@ from qcodes.tests.instrument_mocks import (
 @pytest.mark.parametrize(
     "sweep, columns", [(False, False), (False, True), (True, False), (True, True)]
 )
-def test_do2d(_param, _param_complex, _param_set, _param_set_2, sweep, columns):
+def test_do2d(_param, _param_complex, _param_set, _param_set_2, sweep, columns) -> None:
 
     start_p1 = 0
     stop_p1 = 1
@@ -58,7 +58,7 @@ def test_do2d(_param, _param_complex, _param_set, _param_set_2, sweep, columns):
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("plot", [None, True, False])
 @pytest.mark.parametrize("plot_config", [None, True, False])
-def test_do2d_plot(_param_set, _param_set_2, _param, plot, plot_config):
+def test_do2d_plot(_param_set, _param_set_2, _param, plot, plot_config) -> None:
 
     if plot_config is not None:
         config.dataset.dond_plot = plot_config
@@ -96,7 +96,7 @@ def test_do2d_plot(_param_set, _param_set_2, _param, plot, plot_config):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do2d_output_type(_param, _param_complex, _param_set, _param_set_2):
+def test_do2d_output_type(_param, _param_complex, _param_set, _param_set_2) -> None:
 
     start_p1 = 0
     stop_p1 = 0.5
@@ -126,7 +126,7 @@ def test_do2d_output_type(_param, _param_complex, _param_set, _param_set_2):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do2d_output_data(_param, _param_complex, _param_set, _param_set_2):
+def test_do2d_output_data(_param, _param_complex, _param_set, _param_set_2) -> None:
 
     start_p1 = 0
     stop_p1 = 0.5
@@ -212,7 +212,7 @@ def test_do2d_verify_shape(
     num_points_p1,
     num_points_p2,
     n_points_pws,
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     multiparam = multiparamtype(name="multiparam")
     paramwsetpoints = dummyinstrument.A.dummy_parameter_with_setpoints
@@ -269,13 +269,15 @@ def test_do2d_verify_shape(
 
     data = ds.get_parameter_data()
 
-    for name, data in data.items():
-        for param_data in data.values():
+    for name, data_inner in data.items():
+        for param_data in data_inner.values():
             assert param_data.shape == expected_shapes[name]
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_do2d_additional_setpoints(_param, _param_complex, _param_set, _param_set_2):
+def test_do2d_additional_setpoints(
+    _param, _param_complex, _param_set, _param_set_2
+) -> None:
     additional_setpoints = [
         Parameter(f"additional_setter_parameter_{i}", set_cmd=None, get_cmd=None)
         for i in range(2)
@@ -321,7 +323,7 @@ def test_do2d_additional_setpoints(_param, _param_complex, _param_set, _param_se
 @pytest.mark.usefixtures("experiment")
 def test_do2d_additional_setpoints_shape(
     _param, _param_complex, _param_set, _param_set_2, num_points_p1, num_points_p2
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     array_shape = arrayparam.shape
     additional_setpoints = [
@@ -366,7 +368,7 @@ def test_do2d_additional_setpoints_shape(
     assert results[0].description.shapes == expected_shapes
 
 
-def test_do2d_explicit_experiment(_param_set, _param_set_2, _param, experiment):
+def test_do2d_explicit_experiment(_param_set, _param_set_2, _param, experiment) -> None:
     start_p1 = 0
     stop_p1 = 0.5
     num_points_p1 = 5
@@ -430,7 +432,7 @@ def test_do2d_explicit_experiment(_param_set, _param_set_2, _param, experiment):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_do2d_explicit_name(_param_set, _param_set_2, _param):
+def test_do2d_explicit_name(_param_set, _param_set_2, _param) -> None:
     start_p1 = 0
     stop_p1 = 0.5
     num_points_p1 = 5

--- a/qcodes/tests/dataset/dond/test_doNd.py
+++ b/qcodes/tests/dataset/dond/test_doNd.py
@@ -79,7 +79,7 @@ class GetReturnsCountParameter(Parameter):
         self.set_count = 0
 
 
-def test_linear_sweep_get_setpoints(_param):
+def test_linear_sweep_get_setpoints(_param) -> None:
     start = 0
     stop = 1
     num_points = 5
@@ -91,7 +91,7 @@ def test_linear_sweep_get_setpoints(_param):
     )
 
 
-def test_linear_sweep_properties(_param, _param_complex):
+def test_linear_sweep_properties(_param, _param_complex) -> None:
     start = 0
     stop = 1
     num_points = 5
@@ -107,7 +107,7 @@ def test_linear_sweep_properties(_param, _param_complex):
     assert sweep_2.delay == 0
 
 
-def test_linear_sweep_parameter_class(_param, _param_complex):
+def test_linear_sweep_parameter_class(_param, _param_complex) -> None:
     start = 0
     stop = 1
     num_points = 5
@@ -123,7 +123,7 @@ def test_linear_sweep_parameter_class(_param, _param_complex):
     assert isinstance(sweep_3.param, ParameterBase)
 
 
-def test_log_sweep_get_setpoints(_param):
+def test_log_sweep_get_setpoints(_param) -> None:
     start = 0
     stop = 1
     num_points = 5
@@ -135,7 +135,7 @@ def test_log_sweep_get_setpoints(_param):
     )
 
 
-def test_log_sweep_properties(_param, _param_complex):
+def test_log_sweep_properties(_param, _param_complex) -> None:
     start = 0
     stop = 1
     num_points = 5
@@ -151,7 +151,7 @@ def test_log_sweep_properties(_param, _param_complex):
     assert sweep_2.delay == 0
 
 
-def test_log_sweep_parameter_class(_param, _param_complex):
+def test_log_sweep_parameter_class(_param, _param_complex) -> None:
     start = 0
     stop = 1
     num_points = 5
@@ -167,7 +167,7 @@ def test_log_sweep_parameter_class(_param, _param_complex):
     assert isinstance(sweep_3.param, ParameterBase)
 
 
-def test_array_sweep_get_setpoints(_param):
+def test_array_sweep_get_setpoints(_param) -> None:
     array = np.linspace(0, 1, 5)
     delay = 1
     sweep = ArraySweep(_param, array, delay)
@@ -175,12 +175,12 @@ def test_array_sweep_get_setpoints(_param):
     np.testing.assert_array_equal(sweep.get_setpoints(), array)
 
     array2 = [1, 2, 3, 4, 5, 5.2]
-    sweep2 = ArraySweep(_param, array2)
+    sweep2: ArraySweep[np.floating] = ArraySweep(_param, array2)
 
     np.testing.assert_array_equal(sweep2.get_setpoints(), np.array(array2))
 
 
-def test_array_sweep_properties(_param):
+def test_array_sweep_properties(_param) -> None:
     array = np.linspace(0, 1, 5)
     delay = 1
     sweep = ArraySweep(_param, array, delay)
@@ -194,7 +194,7 @@ def test_array_sweep_properties(_param):
     assert sweep_2.delay == 0
 
 
-def test_array_sweep_parameter_class(_param, _param_complex):
+def test_array_sweep_parameter_class(_param, _param_complex) -> None:
     array = np.linspace(0, 1, 5)
 
     sweep = ArraySweep(_param, array)
@@ -208,7 +208,7 @@ def test_array_sweep_parameter_class(_param, _param_complex):
     assert isinstance(sweep_3.param, ParameterBase)
 
 
-def test_dond_explicit_exp_meas_sample(_param, experiment):
+def test_dond_explicit_exp_meas_sample(_param, experiment) -> None:
     experiment_2 = new_experiment("new-exp", "no-sample")
 
     data1 = dond(_param, do_plot=False, exp=experiment)
@@ -234,7 +234,7 @@ def test_dond_explicit_exp_meas_sample(_param, experiment):
 
 def test_dond_multi_datasets_explicit_exp_meas_sample(
     _param, _param_complex, experiment
-):
+) -> None:
     experiment_2 = new_experiment("new-exp", "no-sample")
 
     data1 = dond([_param], [_param_complex], do_plot=False, exp=experiment)
@@ -264,8 +264,9 @@ def test_dond_multi_datasets_explicit_exp_meas_sample(
     assert datasets3[1].exp_name == "new-exp"
 
 
-def test_dond_multi_datasets_explicit_meas_names(_param, _param_complex, experiment):
-
+def test_dond_multi_datasets_explicit_meas_names(
+    _param, _param_complex, experiment
+) -> None:
     data1 = dond(
         [_param],
         [_param_complex],
@@ -279,7 +280,7 @@ def test_dond_multi_datasets_explicit_meas_names(_param, _param_complex, experim
     assert datasets1[1].name == "bar"
 
 
-def test_dond_multi_datasets_meas_names_len_mismatch(_param, experiment):
+def test_dond_multi_datasets_meas_names_len_mismatch(_param, experiment) -> None:
 
     with pytest.raises(
         ValueError,
@@ -302,7 +303,7 @@ def test_dond_multi_datasets_meas_names_len_mismatch(_param, experiment):
 @settings(deadline=None, suppress_health_check=(HealthCheck.function_scoped_fixture,))
 def test_dond_0d_verify_shape(
     _param, _param_complex, multiparamtype, dummyinstrument, n_points_pws
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     multiparam = multiparamtype(name="multiparam")
     paramwsetpoints = dummyinstrument.A.dummy_parameter_with_setpoints
@@ -327,13 +328,13 @@ def test_dond_0d_verify_shape(
 
     data = ds.get_parameter_data()
 
-    for name, data in data.items():
-        for param_data in data.values():
+    for name, data_inner in data.items():
+        for param_data in data_inner.values():
             assert param_data.shape == expected_shapes[name]
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_0d_output_data(_param):
+def test_dond_0d_output_data(_param) -> None:
     exp = dond(_param)
     data = exp[0]
     assert isinstance(data, DataSetProtocol)
@@ -343,7 +344,7 @@ def test_dond_0d_output_data(_param):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_dond_0d_parameter_with_array_vals():
+def test_dond_0d_parameter_with_array_vals() -> None:
     param = ArrayshapedParam(
         name="paramwitharrayval", vals=validators.Arrays(shape=(10,))
     )
@@ -358,7 +359,7 @@ def test_dond_0d_parameter_with_array_vals():
 @pytest.mark.parametrize("period", [None, 1])
 @pytest.mark.parametrize("plot", [None, True, False])
 @pytest.mark.parametrize("plot_config", [None, True, False])
-def test_dond_0d_with_real_parameter(period, plot, plot_config):
+def test_dond_0d_with_real_parameter(period, plot, plot_config) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
 
     if plot_config is not None:
@@ -373,7 +374,7 @@ def test_dond_0d_with_real_parameter(period, plot, plot_config):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_0d_parameter_with_setpoints_2d(dummyinstrument):
+def test_dond_0d_parameter_with_setpoints_2d(dummyinstrument) -> None:
     dummyinstrument.A.dummy_start(0)
     dummyinstrument.A.dummy_stop(10)
     dummyinstrument.A.dummy_n_points(10)
@@ -390,7 +391,7 @@ def test_dond_0d_parameter_with_setpoints_2d(dummyinstrument):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_dond_1d_parameter_with_array_vals(_param_set):
+def test_dond_1d_parameter_with_array_vals(_param_set) -> None:
     param = ArrayshapedParam(
         name="paramwitharrayval", vals=validators.Arrays(shape=(10,))
     )
@@ -408,8 +409,8 @@ def test_dond_1d_parameter_with_array_vals(_param_set):
 
     data = ds.get_parameter_data()
 
-    for name, data in data.items():
-        for param_data in data.values():
+    for name, data_inner in data.items():
+        for param_data in data_inner.values():
             assert param_data.shape == expected_shapes[name]
 
 
@@ -431,7 +432,7 @@ def test_dond_1d_verify_shape(
     dummyinstrument,
     num_points,
     n_points_pws,
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     multiparam = multiparamtype(name="multiparam")
     paramwsetpoints = dummyinstrument.A.dummy_parameter_with_setpoints
@@ -467,7 +468,7 @@ def test_dond_1d_verify_shape(
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_1d_additional_setpoints(_param, _param_complex, _param_set):
+def test_dond_1d_additional_setpoints(_param, _param_complex, _param_set) -> None:
     additional_setpoints = [
         Parameter(f"additional_setter_parameter_{i}", set_cmd=None, get_cmd=None)
         for i in range(2)
@@ -494,7 +495,7 @@ def test_dond_1d_additional_setpoints(_param, _param_complex, _param_set):
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(num_points_p1=hst.integers(min_value=1, max_value=5))
 @pytest.mark.usefixtures("experiment")
-def test_dond_1d_additional_setpoints_shape(_param, _param_set, num_points_p1):
+def test_dond_1d_additional_setpoints_shape(_param, _param_set, num_points_p1) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     array_shape = arrayparam.shape
     additional_setpoints = [
@@ -529,7 +530,7 @@ def test_dond_1d_additional_setpoints_shape(_param, _param_set, num_points_p1):
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("plot", [None, True, False])
 @pytest.mark.parametrize("plot_config", [None, True, False])
-def test_dond_1d_plot(_param_set, _param, plot, plot_config):
+def test_dond_1d_plot(_param_set, _param, plot, plot_config) -> None:
 
     if plot_config is not None:
         config.dataset.dond_plot = plot_config
@@ -545,7 +546,7 @@ def test_dond_1d_plot(_param_set, _param, plot, plot_config):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_1d_output_data(_param, _param_complex, _param_set):
+def test_dond_1d_output_data(_param, _param_complex, _param_set) -> None:
 
     sweep_1 = LinSweep(_param_set, 0, 0.5, 5, 0)
 
@@ -577,7 +578,7 @@ def test_dond_1d_output_data(_param, _param_complex, _param_set):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_1d_output_type(_param, _param_complex, _param_set):
+def test_dond_1d_output_type(_param, _param_complex, _param_set) -> None:
 
     sweep_1 = LinSweep(_param_set, 0, 0.5, 2, 0)
 
@@ -606,7 +607,7 @@ def test_dond_2d_verify_shape(
     num_points_p1,
     num_points_p2,
     n_points_pws,
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     multiparam = multiparamtype(name="multiparam")
     paramwsetpoints = dummyinstrument.A.dummy_parameter_with_setpoints
@@ -655,13 +656,15 @@ def test_dond_2d_verify_shape(
 
     data = ds.get_parameter_data()
 
-    for name, data in data.items():
-        for param_data in data.values():
+    for name, data_inner in data.items():
+        for param_data in data_inner.values():
             assert param_data.shape == expected_shapes[name]
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_2d_additional_setpoints(_param, _param_complex, _param_set, _param_set_2):
+def test_dond_2d_additional_setpoints(
+    _param, _param_complex, _param_set, _param_set_2
+) -> None:
     additional_setpoints = [
         Parameter(f"additional_setter_parameter_{i}", set_cmd=None, get_cmd=None)
         for i in range(2)
@@ -704,7 +707,7 @@ def test_dond_2d_additional_setpoints(_param, _param_complex, _param_set, _param
 @pytest.mark.usefixtures("experiment")
 def test_dond_2d_additional_setpoints_shape(
     _param, _param_complex, _param_set, _param_set_2, num_points_p1, num_points_p2
-):
+) -> None:
     arrayparam = ArraySetPointParam(name="arrayparam")
     array_shape = arrayparam.shape
     additional_setpoints = [
@@ -748,7 +751,7 @@ def test_dond_2d_additional_setpoints_shape(
 @pytest.mark.usefixtures("plot_close", "experiment")
 @pytest.mark.parametrize("plot", [None, True, False])
 @pytest.mark.parametrize("plot_config", [None, True, False])
-def test_dond_2d_plot(_param_set, _param_set_2, _param, plot, plot_config):
+def test_dond_2d_plot(_param_set, _param_set_2, _param, plot, plot_config) -> None:
 
     if plot_config is not None:
         config.dataset.dond_plot = plot_config
@@ -766,7 +769,7 @@ def test_dond_2d_plot(_param_set, _param_set_2, _param, plot, plot_config):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_2d_output_type(_param, _param_complex, _param_set, _param_set_2):
+def test_dond_2d_output_type(_param, _param_complex, _param_set, _param_set_2) -> None:
 
     sweep_1 = LinSweep(_param_set, 0, 0.5, 2, 0)
     sweep_2 = LinSweep(_param_set_2, 0.5, 1, 2, 0)
@@ -776,7 +779,7 @@ def test_dond_2d_output_type(_param, _param_complex, _param_set, _param_set_2):
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_2d_output_data(_param, _param_complex, _param_set, _param_set_2):
+def test_dond_2d_output_data(_param, _param_complex, _param_set, _param_set_2) -> None:
     sweep_1 = LinSweep(_param_set, 0, 0.5, 5, 0)
     sweep_2 = LinSweep(_param_set_2, 0.5, 1, 5, 0)
     exp_2 = dond(sweep_1, sweep_2, _param, _param_complex)
@@ -821,7 +824,7 @@ def test_dond_2d_output_data(_param, _param_complex, _param_set, _param_set_2):
 @pytest.mark.usefixtures("plot_close", "experiment")
 def test_dond_2d_multi_datasets_output_type(
     _param, _param_complex, _param_set, _param_set_2
-):
+) -> None:
 
     sweep_1 = LinSweep(_param_set, 0, 0.5, 2, 0)
     sweep_2 = LinSweep(_param_set_2, 0.5, 1, 2, 0)
@@ -836,7 +839,7 @@ def test_dond_2d_multi_datasets_output_type(
 @pytest.mark.usefixtures("plot_close")
 def test_dond_2d_multi_datasets_multi_exp(
     _param, _param_complex, _param_set, _param_set_2, request
-):
+) -> None:
     exp1 = new_experiment("test-experiment-1", sample_name="test-sample-1")
     exp2 = new_experiment("test-experiment-2", sample_name="test-sample-2")
 
@@ -859,7 +862,7 @@ def test_dond_2d_multi_datasets_multi_exp(
 @pytest.mark.usefixtures("plot_close")
 def test_dond_2d_multi_datasets_multi_exp_inconsistent_raises(
     _param, _param_complex, _param_set, _param_set_2, request
-):
+) -> None:
     exp1 = new_experiment("test-experiment-1", sample_name="test-sample-1")
     exp2 = new_experiment("test-experiment-2", sample_name="test-sample-2")
     exp3 = new_experiment("test-experiment-3", sample_name="test-sample-3")
@@ -882,7 +885,7 @@ def test_dond_2d_multi_datasets_multi_exp_inconsistent_raises(
 @pytest.mark.parametrize("plot_config", [None, True, False])
 def test_dond_2d_multiple_datasets_plot(
     _param_set, _param_set_2, _param, _param_2, plot, plot_config
-):
+) -> None:
 
     if plot_config is not None:
         config.dataset.dond_plot = plot_config
@@ -917,7 +920,7 @@ def test_dond_2d_multi_datasets_with_callable_output_data(
     _param_set,
     _param_set_2,
     _string_callable,
-):
+) -> None:
     sweep_1 = LinSweep(_param_set, 0, 0.5, 5, 0)
     sweep_2 = LinSweep(_param_set_2, 0.5, 1, 5, 0)
     exp_1 = dond(
@@ -1008,7 +1011,7 @@ def test_dond_2d_multi_datasets_with_callable_output_data(
 
 
 @pytest.mark.usefixtures("plot_close", "experiment")
-def test_dond_together_sweep(_param_set, _param_set_2, _param, _param_2):
+def test_dond_together_sweep(_param_set, _param_set_2, _param, _param_2) -> None:
 
     sweep_1 = LinSweep(_param_set, 0, 1, 10, 0)
     sweep_2 = LinSweep(_param_set_2, 1, 2, 10, 0)
@@ -1092,7 +1095,7 @@ def test_dond_together_sweep_sweeper(_param_set, _param_set_2, _param) -> None:
         assert output[1].delay == delay_2
 
 
-def test_dond_together_sweep_sweeper_combined():
+def test_dond_together_sweep_sweeper_combined() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1125,7 +1128,7 @@ def test_dond_together_sweep_sweeper_combined():
     assert datasets[2].name == "ds3"
 
 
-def test_dond_together_sweep_sweeper_combined_2_in_1():
+def test_dond_together_sweep_sweeper_combined_2_in_1() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1155,7 +1158,7 @@ def test_dond_together_sweep_sweeper_combined_2_in_1():
     assert datasets[1].name == "ds2"
 
 
-def test_dond_together_sweep_sweeper_mixed_splitting():
+def test_dond_together_sweep_sweeper_mixed_splitting() -> None:
     with pytest.raises(
         ValueError,
         match=re.escape(
@@ -1189,7 +1192,7 @@ def test_dond_together_sweep_sweeper_mixed_splitting():
         )
 
 
-def test_dond_together_sweep_sweeper_combined_explict_names():
+def test_dond_together_sweep_sweeper_combined_explict_names() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1223,7 +1226,7 @@ def test_dond_together_sweep_sweeper_combined_explict_names():
     assert datasets[2].name == "ds3"
 
 
-def test_dond_together_sweep_sweeper_combined_explict_names_inconsistent():
+def test_dond_together_sweep_sweeper_combined_explict_names_inconsistent() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1257,7 +1260,7 @@ def test_dond_together_sweep_sweeper_combined_explict_names_inconsistent():
         )
 
 
-def test_dond_together_sweep_sweeper_combined_explict_names_and_single_name():
+def test_dond_together_sweep_sweeper_combined_explict_names_and_single_name() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1290,7 +1293,7 @@ def test_dond_together_sweep_sweeper_combined_explict_names_and_single_name():
         )
 
 
-def test_dond_together_sweep_sweeper_combined_lists():
+def test_dond_together_sweep_sweeper_combined_lists() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1327,7 +1330,7 @@ def test_dond_together_sweep_sweeper_combined_lists():
     n_points_1=hst.integers(min_value=1, max_value=500),
     n_points_2=hst.integers(min_value=1, max_value=500),
 )
-def test_together_sweep_validation(n_points_1, n_points_2):
+def test_together_sweep_validation(n_points_1, n_points_2) -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     sweepA = LinSweep(a, 0, 3, n_points_1)
@@ -1340,7 +1343,7 @@ def test_together_sweep_validation(n_points_1, n_points_2):
             TogetherSweep(sweepA, sweepB)
 
 
-def test_empty_together_sweep_raises():
+def test_empty_together_sweep_raises() -> None:
 
     with pytest.raises(
         ValueError, match="A TogetherSweep must contain at least one sweep."
@@ -1348,7 +1351,7 @@ def test_empty_together_sweep_raises():
         TogetherSweep()
 
 
-def test_dond_together_sweep_more_parameters():
+def test_dond_together_sweep_more_parameters() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1371,7 +1374,7 @@ def test_dond_together_sweep_more_parameters():
     assert set(dataset.description.interdeps.names) == {"a", "b", "c", "d", "e", "f"}
 
 
-def test_dond_together_sweep_sweeper_combined_missing_in_dataset_dependencies():
+def test_dond_together_sweep_sweeper_combined_missing_in_dataset_dependencies() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1400,7 +1403,7 @@ def test_dond_together_sweep_sweeper_combined_missing_in_dataset_dependencies():
         )
 
 
-def test_dond_together_sweep_sweeper_wrong_sp_in_dataset_dependencies():
+def test_dond_together_sweep_sweeper_wrong_sp_in_dataset_dependencies() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1423,7 +1426,7 @@ def test_dond_together_sweep_sweeper_wrong_sp_in_dataset_dependencies():
         )
 
 
-def test_dond_together_sweep_sweeper_wrong_mp_in_dataset_dependencies():
+def test_dond_together_sweep_sweeper_wrong_mp_in_dataset_dependencies() -> None:
     a = ManualParameter("a", initial_value=0)
     b = ManualParameter("b", initial_value=0)
     c = ManualParameter("c", initial_value=0)
@@ -1455,7 +1458,7 @@ def test_dond_together_sweep_sweeper_wrong_mp_in_dataset_dependencies():
         )
 
 
-def test_dond_together_sweep_parameter_with_setpoints(dummyinstrument):
+def test_dond_together_sweep_parameter_with_setpoints(dummyinstrument) -> None:
 
     outer_shape = 10
     inner_shape = 15
@@ -1507,8 +1510,9 @@ def test_dond_together_sweep_parameter_with_setpoints(dummyinstrument):
     ] == (outer_shape, inner_shape, n_points_b)
 
 
-def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping(dummyinstrument):
-
+def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping(
+    dummyinstrument,
+) -> None:
     outer_shape = 10
     inner_shape = 15
 
@@ -1563,7 +1567,7 @@ def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping(dummyinst
 
 def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping_and_callable(
     dummyinstrument,
-):
+) -> None:
 
     outer_shape = 10
     inner_shape = 15
@@ -1618,7 +1622,7 @@ def test_dond_together_sweep_parameter_with_setpoints_explicit_mapping_and_calla
     ] == (outer_shape, inner_shape, n_points_b)
 
 
-def test_dond_sweeper_combinations(_param_set, _param_set_2, _param):
+def test_dond_sweeper_combinations(_param_set, _param_set_2, _param) -> None:
     outer_shape = 10
     inner_shape = 15
 
@@ -1652,7 +1656,7 @@ def test_dond_sweeper_combinations(_param_set, _param_set_2, _param):
         assert g in sweep_groups
 
 
-def test_sweep_int_vs_float():
+def test_sweep_int_vs_float() -> None:
 
     float_param = ManualParameter("float_param", initial_value=0.0)
     int_param = ManualParameter("int_param", vals=Ints(0, 100))
@@ -1663,7 +1667,7 @@ def test_sweep_int_vs_float():
     assert dataset.cache.data()["float_param"]["int_param"].dtype.kind == "i"
 
 
-def test_error_no_measured_parameters():
+def test_error_no_measured_parameters() -> None:
     float_param = ManualParameter("float_param", initial_value=0.0)
     int_param = ManualParameter("int_param", vals=Ints(0, 100))
 
@@ -1671,7 +1675,7 @@ def test_error_no_measured_parameters():
         dond(ArraySweep(int_param, [1, 2, 3]), ArraySweep(float_param, [1.0, 2.0, 3.0]))
 
 
-def test_error_measured_grouped_and_not_grouped():
+def test_error_measured_grouped_and_not_grouped() -> None:
     param_1 = ManualParameter("param_1", initial_value=0.0)
     param_2 = ManualParameter("param_2", initial_value=0.0)
     param_3 = ManualParameter("param_3", initial_value=0.0)
@@ -1682,7 +1686,7 @@ def test_error_measured_grouped_and_not_grouped():
         dond(LinSweep(param_1, 0, 10, 10), param_2, [param_3])
 
 
-def test_post_action(mocker):
+def test_post_action(mocker) -> None:
     param_1 = ManualParameter("param_1", initial_value=0.0)
     param_2 = ManualParameter("param_2", initial_value=0.0)
 
@@ -1692,7 +1696,7 @@ def test_post_action(mocker):
     post_actions[0].assert_called_with()
 
 
-def test_extra_log_info(caplog):
+def test_extra_log_info(caplog) -> None:
 
     param_1 = ManualParameter("param_1", initial_value=0.0)
     param_2 = ManualParameter("param_2", initial_value=0.0)
@@ -1704,7 +1708,7 @@ def test_extra_log_info(caplog):
     assert log_message in caplog.text
 
 
-def test_default_log_info(caplog):
+def test_default_log_info(caplog) -> None:
 
     param_1 = ManualParameter("param_1", initial_value=0.0)
     param_2 = ManualParameter("param_2", initial_value=0.0)
@@ -1715,7 +1719,7 @@ def test_default_log_info(caplog):
     assert "Using 'qcodes.dataset.dond'" in caplog.text
 
 
-def test_dond_get_after_set(_param_set, _param_set_2, _param):
+def test_dond_get_after_set(_param_set, _param_set_2, _param) -> None:
 
     n_points = 10
 
@@ -1738,7 +1742,7 @@ def test_dond_get_after_set(_param_set, _param_set_2, _param):
     assert b.set_count == 0
 
 
-def test_dond_no_get_after_set(_param_set, _param_set_2, _param):
+def test_dond_no_get_after_set(_param_set, _param_set_2, _param) -> None:
 
     n_points = 10
 
@@ -1761,7 +1765,7 @@ def test_dond_no_get_after_set(_param_set, _param_set_2, _param):
     assert b.set_count == 0
 
 
-def test_dond_get_after_set_stores_get_value(_param_set, _param_set_2, _param):
+def test_dond_get_after_set_stores_get_value(_param_set, _param_set_2, _param) -> None:
 
     n_points = 11
 

--- a/qcodes/tests/dataset/measurement/test_load_legacy_data.py
+++ b/qcodes/tests/dataset/measurement/test_load_legacy_data.py
@@ -8,7 +8,7 @@ from qcodes.dataset.data_set import DataSet
 
 
 @pytest.mark.usefixtures("experiment")
-def test_load_legacy_files_2d():
+def test_load_legacy_files_2d() -> None:
     full_location = (
         Path(__file__).parent.parent
         / "fixtures"
@@ -46,7 +46,7 @@ def test_load_legacy_files_2d():
 
 
 @pytest.mark.usefixtures("experiment")
-def test_load_legacy_files_1d():
+def test_load_legacy_files_1d() -> None:
     full_location = (
         Path(__file__).parent.parent
         / "fixtures"
@@ -84,7 +84,7 @@ def test_load_legacy_files_1d():
 
 
 @pytest.mark.usefixtures("experiment")
-def test_load_legacy_files_1d_pathlib_path():
+def test_load_legacy_files_1d_pathlib_path() -> None:
     full_location = (
         Path(__file__).parent.parent
         / "fixtures"

--- a/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
+++ b/qcodes/tests/dataset/measurement/test_measurement_context_manager.py
@@ -3,6 +3,7 @@ import os
 import re
 import traceback
 from time import sleep
+from typing import Any, Dict, List, Tuple
 
 import hypothesis.strategies as hst
 import numpy as np
@@ -19,11 +20,12 @@ from qcodes.dataset.experiment_container import new_experiment
 from qcodes.dataset.export_config import DataExportType
 from qcodes.dataset.measurements import Measurement
 from qcodes.dataset.sqlite.connection import atomic_transaction
-from qcodes.parameters import Parameter, expand_setpoints_helper
+from qcodes.parameters import ManualParameter, Parameter, expand_setpoints_helper
+from qcodes.station import Station
 from qcodes.tests.common import retry_until_does_not_throw
 
 
-def test_log_messages(caplog, meas_with_registered_param):
+def test_log_messages(caplog, meas_with_registered_param) -> None:
     caplog.set_level(logging.INFO)
 
     with meas_with_registered_param.run():
@@ -34,7 +36,7 @@ def test_log_messages(caplog, meas_with_registered_param):
     assert "Finished measurement with guid" in caplog.text
 
 
-def test_log_includes_extra_info(caplog, meas_with_registered_param):
+def test_log_includes_extra_info(caplog, meas_with_registered_param) -> None:
     caplog.set_level(logging.INFO)
     meas_with_registered_param._extra_log_info = "some extra info"
     with meas_with_registered_param.run():
@@ -43,19 +45,19 @@ def test_log_includes_extra_info(caplog, meas_with_registered_param):
     assert "some extra info" in caplog.text
 
 
-def test_register_parameter_numbers(DAC, DMM):
+def test_register_parameter_numbers(DAC, DMM) -> None:
     """
     Test the registration of scalar QCoDeS parameters
     """
 
     parameters = [DAC.ch1, DAC.ch2, DMM.v1, DMM.v2]
-    not_parameters = ['', 'Parameter', 0, 1.1, Measurement]
+    not_parameters = ("", "Parameter", 0, 1.1, Measurement)
 
     meas = Measurement()
 
     for not_a_parameter in not_parameters:
         with pytest.raises(ValueError):
-            meas.register_parameter(not_a_parameter)
+            meas.register_parameter(not_a_parameter)  # type: ignore[arg-type]
 
     my_param = DAC.ch1
     meas.register_parameter(my_param)
@@ -114,7 +116,7 @@ def test_register_parameter_numbers(DAC, DMM):
         meas.register_parameter(DMM.v1, setpoints=(DAC.ch2,))
 
 
-def test_register_custom_parameter(DAC):
+def test_register_custom_parameter(DAC) -> None:
     """
     Test the registration of custom parameters
     """
@@ -167,7 +169,7 @@ def test_register_custom_parameter(DAC):
                                        'label', 'unit', setpoints=(name,))
 
 
-def test_unregister_parameter(DAC, DMM):
+def test_unregister_parameter(DAC, DMM) -> None:
     """
     Test the unregistering of parameters.
     """
@@ -212,7 +214,7 @@ def test_unregister_parameter(DAC, DMM):
 
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_mixing_array_and_numeric(DAC, bg_writing):
+def test_mixing_array_and_numeric(DAC, bg_writing) -> None:
     """
     Test that mixing array and numeric types is okay
     """
@@ -225,7 +227,7 @@ def test_mixing_array_and_numeric(DAC, bg_writing):
                              (DAC.ch2, np.array([DAC.ch2(), DAC.ch1()])))
 
 
-def test_measurement_name_default(experiment, DAC, DMM):
+def test_measurement_name_default(experiment, DAC, DMM) -> None:
     fmt = experiment.format_string
     exp_id = experiment.exp_id
 
@@ -246,7 +248,7 @@ def test_measurement_name_default(experiment, DAC, DMM):
         assert ds.name == default_name
 
 
-def test_measurement_name_changed_via_attribute(experiment, DAC, DMM):
+def test_measurement_name_changed_via_attribute(experiment, DAC, DMM) -> None:
     fmt = experiment.format_string
     exp_id = experiment.exp_id
 
@@ -267,7 +269,7 @@ def test_measurement_name_changed_via_attribute(experiment, DAC, DMM):
         assert ds.name == name
 
 
-def test_measurement_name_set_as_argument(experiment, DAC, DMM):
+def test_measurement_name_set_as_argument(experiment, DAC, DMM) -> None:
     fmt = experiment.format_string
     exp_id = experiment.exp_id
 
@@ -315,7 +317,7 @@ def test_setting_write_period(wp) -> None:
                      hst.text()))
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.usefixtures("reset_config_on_exit")
-def test_setting_write_period_from_config(wp):
+def test_setting_write_period_from_config(wp) -> None:
     qc.config.dataset.write_period = wp
 
     if isinstance(wp, str):
@@ -335,7 +337,7 @@ def test_setting_write_period_from_config(wp):
 @pytest.mark.parametrize("write_in_background", [True, False])
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.usefixtures("reset_config_on_exit")
-def test_setting_write_in_background_from_config(write_in_background):
+def test_setting_write_in_background_from_config(write_in_background) -> None:
     qc.config.dataset.write_in_background = write_in_background
 
     meas = Measurement()
@@ -347,7 +349,7 @@ def test_setting_write_in_background_from_config(write_in_background):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_method_chaining(DAC):
+def test_method_chaining(DAC) -> None:
     (
         Measurement()
             .register_parameter(DAC.ch1)
@@ -363,7 +365,7 @@ def test_method_chaining(DAC):
 @pytest.mark.usefixtures("experiment")
 @settings(deadline=None, suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(words=hst.lists(elements=hst.text(), min_size=4, max_size=10))
-def test_enter_and_exit_actions(DAC, words):
+def test_enter_and_exit_actions(DAC, words) -> None:
     # we use a list to check that the functions executed
     # in the correct order
 
@@ -373,7 +375,7 @@ def test_enter_and_exit_actions(DAC, words):
     meas = Measurement()
     meas.register_parameter(DAC.ch1)
 
-    testlist = []
+    testlist: List[str] = []
 
     splitpoint = round(len(words) / 2)
     for n in range(splitpoint):
@@ -397,7 +399,7 @@ def test_enter_and_exit_actions(DAC, words):
         meas.add_after_run(action, testlist)
 
 
-def test_subscriptions(experiment, DAC, DMM):
+def test_subscriptions(experiment, DAC, DMM) -> None:
     """
     Test that subscribers are called at the moment the data is flushed to
     database
@@ -433,8 +435,8 @@ def test_subscriptions(experiment, DAC, DMM):
 
     # key is the number of the result tuple,
     # value is the result tuple itself
-    all_results_dict = {}
-    values_larger_than_7 = []
+    all_results_dict: Dict[str, Any] = {}
+    values_larger_than_7: List[float] = []
 
     meas.add_subscriber(collect_all_results, state=all_results_dict)
     assert len(meas.subscribers) == 1
@@ -460,8 +462,9 @@ def test_subscriptions(experiment, DAC, DMM):
 
         for num in range(5):
             (dac_val, dmm_val) = dac_vals_and_dmm_vals[num]
-            values_larger_than_7__expected += \
-                [val for val in (dac_val, dmm_val) if val > 7]
+            values_larger_than_7__expected += [
+                val for val in (dac_val, dmm_val) if val > 7
+            ]
 
             datasaver.add_result((DAC.ch1, dac_val), (DMM.v1, dmm_val))
 
@@ -505,8 +508,9 @@ def test_subscriptions(experiment, DAC, DMM):
     assert len(triggers) == 0
 
 
-def test_subscribers_called_at_exiting_context_if_queue_is_not_empty(experiment,
-                                                                     DAC):
+def test_subscribers_called_at_exiting_context_if_queue_is_not_empty(
+    experiment, DAC
+) -> None:
     """
     Upon quitting the "run()" context, verify that in case the queue is
     not empty, the subscriber's callback is still called on that data.
@@ -524,7 +528,7 @@ def test_subscribers_called_at_exiting_context_if_queue_is_not_empty(experiment,
     meas = Measurement(exp=experiment)
     meas.register_parameter(DAC.ch1)
 
-    collected_x_vals = []
+    collected_x_vals: List[float] = []
 
     meas.add_subscriber(collect_x_vals, state=collected_x_vals)
 
@@ -554,7 +558,7 @@ def test_subscribers_called_at_exiting_context_if_queue_is_not_empty(experiment,
 @settings(deadline=None, max_examples=25,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(N=hst.integers(min_value=2000, max_value=3000))
-def test_subscribers_called_for_all_data_points(experiment, DAC, DMM, N):
+def test_subscribers_called_for_all_data_points(experiment, DAC, DMM, N) -> None:
     def sub_get_x_vals(results, length, state):
         """
         A list of all x values
@@ -570,8 +574,8 @@ def test_subscribers_called_for_all_data_points(experiment, DAC, DMM, N):
     meas = Measurement(exp=experiment)
     meas.register_parameter(DAC.ch1)
     meas.register_parameter(DMM.v1, setpoints=(DAC.ch1,))
-    xvals = []
-    yvals = []
+    xvals: List[float] = []
+    yvals: List[float] = []
 
     meas.add_subscriber(sub_get_x_vals, state=xvals)
     meas.add_subscriber(sub_get_y_vals, state=yvals)
@@ -589,18 +593,24 @@ def test_subscribers_called_for_all_data_points(experiment, DAC, DMM, N):
 
 # There is no way around it: this test is slow. We test that write_period
 # works and hence we must wait for some time to elapse. Sorry.
-@settings(max_examples=5, deadline=None,
-          suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(breakpoint=hst.integers(min_value=1, max_value=19),
-       write_period=hst.floats(min_value=0.1, max_value=1.5),
-       set_values=hst.lists(elements=hst.floats(), min_size=20, max_size=20),
-       get_values=hst.lists(elements=hst.floats(), min_size=20, max_size=20))
-@pytest.mark.usefixtures('set_default_station_to_none')
-def test_datasaver_scalars(experiment, DAC, DMM, set_values, get_values,
-                           breakpoint, write_period):
+@settings(
+    max_examples=5,
+    deadline=None,
+    suppress_health_check=(HealthCheck.function_scoped_fixture,),
+)
+@given(
+    breakpoint=hst.integers(min_value=1, max_value=19),
+    write_period=hst.floats(min_value=0.1, max_value=1.5),
+    set_values=hst.lists(elements=hst.floats(), min_size=20, max_size=20),
+    get_values=hst.lists(elements=hst.floats(), min_size=20, max_size=20),
+)
+@pytest.mark.usefixtures("set_default_station_to_none")
+def test_datasaver_scalars(
+    experiment, DAC, DMM, set_values, get_values, breakpoint, write_period
+) -> None:
     no_of_runs = len(experiment)
 
-    station = qc.Station(DAC, DMM)
+    station = Station(DAC, DMM)
 
     meas = Measurement(station=station)
     meas.write_period = write_period
@@ -633,12 +643,12 @@ def test_datasaver_scalars(experiment, DAC, DMM, set_values, get_values,
 
 
 @pytest.mark.usefixtures('set_default_station_to_none')
-def test_datasaver_inst_metadata(experiment, DAC_with_metadata, DMM):
+def test_datasaver_inst_metadata(experiment, DAC_with_metadata, DMM) -> None:
     """
     Check that additional instrument metadata is captured into the dataset snapshot
     """
 
-    station = qc.Station(DAC_with_metadata, DMM)
+    station = Station(DAC_with_metadata, DMM)
 
     meas = Measurement(station=station)
     meas.register_parameter(DAC_with_metadata.ch1)
@@ -654,7 +664,8 @@ def test_datasaver_inst_metadata(experiment, DAC_with_metadata, DMM):
 
 
 def test_exception_happened_during_measurement_is_stored_in_dataset_metadata(
-        experiment):
+    experiment,
+) -> None:
     meas = Measurement()
     meas.register_custom_parameter(name='nodata')
 
@@ -683,7 +694,7 @@ def test_exception_happened_during_measurement_is_stored_in_dataset_metadata(
 @settings(max_examples=10, deadline=None)
 @given(N=hst.integers(min_value=2, max_value=500))
 @pytest.mark.usefixtures("empty_temp_db")
-def test_datasaver_arrays_lists_tuples(bg_writing, N):
+def test_datasaver_arrays_lists_tuples(bg_writing, N) -> None:
     new_experiment('firstexp', sample_name='no sample')
 
     meas = Measurement()
@@ -726,11 +737,11 @@ def test_datasaver_arrays_lists_tuples(bg_writing, N):
     # save arrays
     with meas.run(write_in_background=bg_writing) as datasaver:
         freqax = np.linspace(1e6, 2e6, N)
-        signal = np.random.randn(N)
+        signal1 = np.random.randn(N)
 
-        datasaver.add_result(('freqax', freqax),
-                             ('signal', signal),
-                             ('gate_voltage', 0))
+        datasaver.add_result(
+            ("freqax", freqax), ("signal", signal1), ("gate_voltage", 0)
+        )
 
     assert datasaver.points_written == N
     ds = datasaver.dataset
@@ -739,23 +750,23 @@ def test_datasaver_arrays_lists_tuples(bg_writing, N):
 
     # save lists
     with meas.run(write_in_background=bg_writing) as datasaver:
-        freqax = list(np.linspace(1e6, 2e6, N))
-        signal = list(np.random.randn(N))
+        freqax2 = list(np.linspace(1e6, 2e6, N))
+        signal2 = list(np.random.randn(N))
 
-        datasaver.add_result(('freqax', freqax),
-                             ('signal', signal),
-                             ('gate_voltage', 0))
+        datasaver.add_result(
+            ("freqax", freqax2), ("signal", signal2), ("gate_voltage", 0)
+        )
 
     assert datasaver.points_written == N
 
     # save tuples
     with meas.run(write_in_background=bg_writing) as datasaver:
-        freqax = tuple(np.linspace(1e6, 2e6, N))
-        signal = tuple(np.random.randn(N))
+        freqax3 = tuple(np.linspace(1e6, 2e6, N))
+        signal3 = tuple(np.random.randn(N))
 
-        datasaver.add_result(('freqax', freqax),
-                             ('signal', signal),
-                             ('gate_voltage', 0))
+        datasaver.add_result(
+            ("freqax", freqax3), ("signal", signal3), ("gate_voltage", 0)
+        )
 
     assert datasaver.points_written == N
 
@@ -764,7 +775,7 @@ def test_datasaver_arrays_lists_tuples(bg_writing, N):
 @settings(max_examples=10, deadline=None)
 @given(N=hst.integers(min_value=2, max_value=500))
 @pytest.mark.usefixtures("empty_temp_db")
-def test_datasaver_numeric_and_array_paramtype(bg_writing, N):
+def test_datasaver_numeric_and_array_paramtype(bg_writing, N) -> None:
     """
     Test saving one parameter with 'numeric' paramtype and one parameter with
     'array' paramtype
@@ -799,7 +810,7 @@ def test_datasaver_numeric_and_array_paramtype(bg_writing, N):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("empty_temp_db")
-def test_datasaver_numeric_after_array_paramtype(bg_writing):
+def test_datasaver_numeric_after_array_paramtype(bg_writing) -> None:
     """
     Test that passing values for 'array' parameter in `add_result` before
     passing values for 'numeric' parameter works.
@@ -835,19 +846,19 @@ def test_datasaver_numeric_after_array_paramtype(bg_writing):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_foul_input(bg_writing):
+def test_datasaver_foul_input(bg_writing) -> None:
     meas = Measurement()
 
     meas.register_custom_parameter('foul',
                                    label='something unnatural',
                                    unit='Fahrenheit')
 
-    foul_stuff = [qc.Parameter('foul'), {1, 2, 3}]
+    foul_stuff = [Parameter("foul"), {1, 2, 3}]
 
     with meas.run(bg_writing) as datasaver:
         for ft in foul_stuff:
             with pytest.raises(ValueError):
-                datasaver.add_result(('foul', ft))
+                datasaver.add_result(("foul", ft))  # type: ignore[arg-type]
 
 
 @settings(max_examples=10, deadline=None)
@@ -855,7 +866,7 @@ def test_datasaver_foul_input(bg_writing):
 @pytest.mark.usefixtures("empty_temp_db")
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
-def test_datasaver_unsized_arrays(N, storage_type, bg_writing):
+def test_datasaver_unsized_arrays(N, storage_type, bg_writing) -> None:
     new_experiment('firstexp', sample_name='no sample')
 
     meas = Measurement()
@@ -907,11 +918,11 @@ def test_datasaver_unsized_arrays(N, storage_type, bg_writing):
        seed=hst.integers(min_value=0, max_value=np.iinfo(np.uint32).max))
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("bg_writing", [True, False])
-@pytest.mark.parametrize("param_type", ['np_array', 'tuple', 'list'])
-@pytest.mark.parametrize("storage_type", ['numeric', 'array'])
-def test_datasaver_arrayparams(SpectrumAnalyzer, DAC, N, M,
-                               param_type, storage_type,
-                               seed, bg_writing):
+@pytest.mark.parametrize("param_type", ["np_array", "tuple", "list"])
+@pytest.mark.parametrize("storage_type", ["numeric", "array"])
+def test_datasaver_arrayparams(
+    SpectrumAnalyzer, DAC, N, M, param_type, storage_type, seed, bg_writing
+) -> None:
     """
     test that data is stored correctly for array parameters that
     return numpy arrays, lists and tuples. Stored both as arrays and
@@ -989,9 +1000,9 @@ def test_datasaver_arrayparams(SpectrumAnalyzer, DAC, N, M,
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_array_parameters_channel(channel_array_instrument,
-                                            DAC, N, storage_type,
-                                            bg_writing):
+def test_datasaver_array_parameters_channel(
+    channel_array_instrument, DAC, N, storage_type, bg_writing
+) -> None:
     meas = Measurement()
 
     array_param = channel_array_instrument.A.dummy_array_parameter
@@ -1038,7 +1049,7 @@ def test_datasaver_array_parameters_channel(channel_array_instrument,
     loaded_data = ds.get_parameter_data()['dummy_channel_inst_ChanA_dummy_array_parameter']
     for param in expected_params:
         if storage_type == 'array':
-            expected_shape = (N, M)
+            expected_shape: Tuple[int, ...] = (N, M)
         else:
             expected_shape = (N*M, )
         assert loaded_data[param].shape == expected_shape
@@ -1050,9 +1061,9 @@ def test_datasaver_array_parameters_channel(channel_array_instrument,
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_parameter_with_setpoints(channel_array_instrument,
-                                            DAC, n, storage_type,
-                                            bg_writing):
+def test_datasaver_parameter_with_setpoints(
+    channel_array_instrument, DAC, n, storage_type, bg_writing
+) -> None:
     random_seed = 1
     chan = channel_array_instrument.A
     param = chan.dummy_parameter_with_setpoints
@@ -1125,9 +1136,9 @@ def test_datasaver_parameter_with_setpoints(channel_array_instrument,
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_parameter_with_setpoints_explicitly_expanded(channel_array_instrument,
-                                                     DAC, n, storage_type,
-                                                     bg_writing):
+def test_datasaver_parameter_with_setpoints_explicitly_expanded(
+    channel_array_instrument, DAC, n, storage_type, bg_writing
+) -> None:
     random_seed = 1
     chan = channel_array_instrument.A
     param = chan.dummy_parameter_with_setpoints
@@ -1195,7 +1206,9 @@ def test_datasaver_parameter_with_setpoints_explicitly_expanded(channel_array_in
 
 
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_parameter_with_setpoints_partially_expanded_raises(channel_array_instrument, DAC):
+def test_datasaver_parameter_with_setpoints_partially_expanded_raises(
+    channel_array_instrument, DAC
+) -> None:
     random_seed = 1
     chan = channel_array_instrument.A
     param = chan.dummy_parameter_with_setpoints_2d
@@ -1232,9 +1245,9 @@ def test_datasaver_parameter_with_setpoints_partially_expanded_raises(channel_ar
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n=hst.integers(min_value=5, max_value=500))
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_parameter_with_setpoints_complex(channel_array_instrument,
-                                                    DAC, n,
-                                                    bg_writing):
+def test_datasaver_parameter_with_setpoints_complex(
+    channel_array_instrument, DAC, n, bg_writing
+) -> None:
     random_seed = 1
     chan = channel_array_instrument.A
     param = chan.dummy_parameter_with_setpoints_complex
@@ -1286,9 +1299,9 @@ def test_datasaver_parameter_with_setpoints_complex(channel_array_instrument,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n=hst.integers(min_value=5, max_value=500))
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_parameter_with_setpoints_complex_explicitly_expanded(channel_array_instrument,
-                                                             DAC, n,
-                                                             bg_writing):
+def test_datasaver_parameter_with_setpoints_complex_explicitly_expanded(
+    channel_array_instrument, DAC, n, bg_writing
+) -> None:
     random_seed = 1
     chan = channel_array_instrument.A
     param = chan.dummy_parameter_with_setpoints_complex
@@ -1339,9 +1352,8 @@ def test_datasaver_parameter_with_setpoints_complex_explicitly_expanded(channel_
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @pytest.mark.usefixtures("experiment")
 def test_datasaver_parameter_with_setpoints_missing_reg_raises(
-        channel_array_instrument,
-        DAC, storage_type,
-        bg_writing):
+    channel_array_instrument, DAC, storage_type, bg_writing
+) -> None:
     """
     Test that if for whatever reason new setpoints are added after
     registering but before adding this raises correctly
@@ -1379,9 +1391,8 @@ def test_datasaver_parameter_with_setpoints_missing_reg_raises(
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @pytest.mark.usefixtures("experiment")
 def test_datasaver_parameter_with_setpoints_reg_but_missing_validator(
-        channel_array_instrument,
-        DAC, storage_type,
-        bg_writing):
+    channel_array_instrument, DAC, storage_type, bg_writing
+) -> None:
     """
     Test that if for whatever reason the setpoints are removed between
     registering and adding this raises correctly. This tests tests that
@@ -1433,9 +1444,8 @@ def test_datasaver_parameter_with_setpoints_reg_but_missing_validator(
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @pytest.mark.usefixtures("experiment")
 def test_datasaver_parameter_with_setpoints_reg_but_missing(
-        channel_array_instrument,
-        DAC, storage_type,
-        bg_writing):
+    channel_array_instrument, DAC, storage_type, bg_writing
+) -> None:
     """
     Test that if for whatever reason the setpoints of a QCoDeS parameter are
     removed between registering that parameter with the Measurement and adding
@@ -1474,9 +1484,9 @@ def test_datasaver_parameter_with_setpoints_reg_but_missing(
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_datasaver_array_parameters_array(channel_array_instrument, DAC, N,
-                                          storage_type,
-                                          bg_writing):
+def test_datasaver_array_parameters_array(
+    channel_array_instrument, DAC, N, storage_type, bg_writing
+) -> None:
     """
     Test that storing array parameters inside a loop works as expected
     """
@@ -1557,9 +1567,9 @@ def test_datasaver_array_parameters_array(channel_array_instrument, DAC, N,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(N=hst.integers(min_value=5, max_value=500))
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_complex_array_parameters_array(channel_array_instrument,
-                                                  DAC, N,
-                                                  bg_writing):
+def test_datasaver_complex_array_parameters_array(
+    channel_array_instrument, DAC, N, bg_writing
+) -> None:
     """
     Test that storing a complex array parameters inside a loop with the sqlite
     Array type works as expected
@@ -1617,7 +1627,7 @@ def test_datasaver_complex_array_parameters_array(channel_array_instrument,
 
 
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_datasaver_multidim_array(experiment, bg_writing):  # noqa: F811
+def test_datasaver_multidim_array(experiment, bg_writing) -> None:  # noqa: F811
     """
     Test that inserting multidim parameters as arrays works as expected
     """
@@ -1627,10 +1637,10 @@ def test_datasaver_multidim_array(experiment, bg_writing):  # noqa: F811
 
     {name: i for i, name in zip(range(4), ["x1", "x2", "y1", "y2"])}
 
-    x1 = qc.ManualParameter('x1')
-    x2 = qc.ManualParameter('x2')
-    y1 = qc.ManualParameter('y1')
-    y2 = qc.ManualParameter('y2')
+    x1 = ManualParameter("x1")
+    x2 = ManualParameter("x2")
+    y1 = ManualParameter("y1")
+    y2 = ManualParameter("y2")
 
     meas.register_parameter(x1, paramtype='array')
     meas.register_parameter(x2, paramtype='array')
@@ -1665,7 +1675,7 @@ def test_datasaver_multidim_array(experiment, bg_writing):  # noqa: F811
 @pytest.mark.parametrize("export_type", [DataExportType.CSV, DataExportType.NETCDF])
 def test_datasaver_export(
     experiment, bg_writing, tmp_path_factory, export, export_type, mocker
-):
+) -> None:
     """
     Test export data to csv after measurement ends
     """
@@ -1673,10 +1683,10 @@ def test_datasaver_export(
     size1 = 10
     size2 = 15
 
-    x1 = qc.ManualParameter('x1')
-    x2 = qc.ManualParameter('x2')
-    y1 = qc.ManualParameter('y1')
-    y2 = qc.ManualParameter('y2')
+    x1 = ManualParameter("x1")
+    x2 = ManualParameter("x2")
+    y1 = ManualParameter("y1")
+    y2 = ManualParameter("y2")
 
     meas.register_parameter(x1, paramtype='array')
     meas.register_parameter(x2, paramtype='array')
@@ -1723,17 +1733,17 @@ def test_datasaver_export(
 
 
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_datasaver_multidim_numeric(experiment, bg_writing):
+def test_datasaver_multidim_numeric(experiment, bg_writing) -> None:
     """
     Test that inserting multidim parameters as numeric works as expected
     """
     meas = Measurement(experiment)
     size1 = 10
     size2 = 15
-    x1 = qc.ManualParameter('x1')
-    x2 = qc.ManualParameter('x2')
-    y1 = qc.ManualParameter('y1')
-    y2 = qc.ManualParameter('y2')
+    x1 = ManualParameter("x1")
+    x2 = ManualParameter("x2")
+    y1 = ManualParameter("y1")
+    y2 = ManualParameter("y2")
 
     {name: i for i, name in zip(range(4), ["x1", "x2", "y1", "y2"])}
 
@@ -1761,8 +1771,9 @@ def test_datasaver_multidim_numeric(experiment, bg_writing):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_multidimarrayparameter_as_array(SpectrumAnalyzer,
-                                                   bg_writing):
+def test_datasaver_multidimarrayparameter_as_array(
+    SpectrumAnalyzer, bg_writing
+) -> None:
     """
     Test that inserting multidim Arrrayparameters as array works as expected
     """
@@ -1805,8 +1816,9 @@ def test_datasaver_multidimarrayparameter_as_array(SpectrumAnalyzer,
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_multidimarrayparameter_as_numeric(SpectrumAnalyzer,
-                                                     bg_writing):
+def test_datasaver_multidimarrayparameter_as_numeric(
+    SpectrumAnalyzer, bg_writing
+) -> None:
     """
     Test that storing a multidim Array parameter as numeric unravels the
     parameter as expected.
@@ -1850,8 +1862,9 @@ def test_datasaver_multidimarrayparameter_as_numeric(SpectrumAnalyzer,
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_multi_parameters_scalar(channel_array_instrument,
-                                           bg_writing):
+def test_datasaver_multi_parameters_scalar(
+    channel_array_instrument, bg_writing
+) -> None:
     """
     Test that we can register multiparameters that are scalar.
     """
@@ -1873,8 +1886,7 @@ def test_datasaver_multi_parameters_scalar(channel_array_instrument,
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_multi_parameters_array(channel_array_instrument,
-                                          bg_writing):
+def test_datasaver_multi_parameters_array(channel_array_instrument, bg_writing) -> None:
     """
     Test that we can register multiparameters that are array like.
     """
@@ -1910,8 +1922,9 @@ def test_datasaver_multi_parameters_array(channel_array_instrument,
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_2d_multi_parameters_array(channel_array_instrument,
-                                             bg_writing):
+def test_datasaver_2d_multi_parameters_array(
+    channel_array_instrument, bg_writing
+) -> None:
     """
     Test that we can register multiparameters that are array like and 2D.
     """
@@ -1946,8 +1959,12 @@ def test_datasaver_2d_multi_parameters_array(channel_array_instrument,
     ds = load_by_id(datasaver.run_id)
 
     # 30 points in each setpoint value list
-    this_sp_val = np.array(reduce(list.__add__, [[n]*3 for n in range(5, 10)], []))
-    that_sp_val = np.array(reduce(list.__add__, [[n] for n in range(9, 12)], []) * 5)
+    this_sp_val: np.ndarray = np.array(
+        reduce(list.__add__, [[n] * 3 for n in range(5, 10)], [])  # type: ignore[arg-type]
+    )
+    that_sp_val: np.ndarray = np.array(
+        reduce(list.__add__, [[n] for n in range(9, 12)], []) * 5  # type: ignore[arg-type]
+    )
 
     assert isinstance(ds, DataSet)
     np.testing.assert_array_equal(
@@ -1981,7 +1998,7 @@ def test_datasaver_2d_multi_parameters_array(channel_array_instrument,
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @settings(deadline=None)
 @given(Ns=hst.lists(hst.integers(2, 10), min_size=2, max_size=5))
-def test_datasaver_arrays_of_different_length(storage_type, Ns, bg_writing):
+def test_datasaver_arrays_of_different_length(storage_type, Ns, bg_writing) -> None:
     """
     Test that we can save arrays of different length in a single call to
     datasaver.add_result
@@ -2023,7 +2040,7 @@ def test_datasaver_arrays_of_different_length(storage_type, Ns, bg_writing):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_save_complex_num(complex_num_instrument, bg_writing):
+def test_save_complex_num(complex_num_instrument, bg_writing) -> None:
     """
     Test that we can save various parameters mixed with complex parameters
     """
@@ -2102,8 +2119,7 @@ def test_save_complex_num(complex_num_instrument, bg_writing):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_save_and_reload_complex_standalone(complex_num_instrument,
-                                            bg_writing):
+def test_save_and_reload_complex_standalone(complex_num_instrument, bg_writing) -> None:
     param = complex_num_instrument.complex_num
     complex_num_instrument.setpoint(1)
     Parameter("test", set_cmd=None, get_cmd=lambda: 1 + 1j, vals=vals.ComplexNumbers())
@@ -2122,7 +2138,7 @@ def test_save_and_reload_complex_standalone(complex_num_instrument,
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_save_complex_num_setpoints(complex_num_instrument, bg_writing):
+def test_save_complex_num_setpoints(complex_num_instrument, bg_writing) -> None:
     """
     Test that we can save a parameter with complex setpoints
     """
@@ -2151,7 +2167,7 @@ def test_save_complex_num_setpoints(complex_num_instrument, bg_writing):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_save_complex_num_setpoints_array(complex_num_instrument, bg_writing):
+def test_save_complex_num_setpoints_array(complex_num_instrument, bg_writing) -> None:
     """
     Test that we can save an array parameter with complex setpoints
     """
@@ -2187,7 +2203,7 @@ def test_save_complex_num_setpoints_array(complex_num_instrument, bg_writing):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_save_complex_as_num_raises(complex_num_instrument, bg_writing):
+def test_save_complex_as_num_raises(complex_num_instrument, bg_writing) -> None:
     setparam = complex_num_instrument.setpoint
     param = complex_num_instrument.complex_num
     meas = Measurement()
@@ -2207,7 +2223,7 @@ def test_save_complex_as_num_raises(complex_num_instrument, bg_writing):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_save_numeric_as_complex_raises(complex_num_instrument, bg_writing):
+def test_save_numeric_as_complex_raises(complex_num_instrument, bg_writing) -> None:
     setparam = complex_num_instrument.setpoint
     param = complex_num_instrument.complex_num
     meas = Measurement()
@@ -2224,7 +2240,7 @@ def test_save_numeric_as_complex_raises(complex_num_instrument, bg_writing):
                                  (param, setparam()))
 
 
-def test_parameter_inference(channel_array_instrument):
+def test_parameter_inference(channel_array_instrument) -> None:
     chan = channel_array_instrument.channels[0]
     # default values
     assert Measurement._infer_paramtype(chan.temperature, None) is None
@@ -2256,7 +2272,7 @@ def test_parameter_inference(channel_array_instrument):
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_adding_parents(bg_writing, DAC):
+def test_adding_parents(bg_writing, DAC) -> None:
     """
     Test that we can register a DataSet as the parent of another DataSet
     as created by the Measurement

--- a/qcodes/tests/dataset/measurement/test_shapes.py
+++ b/qcodes/tests/dataset/measurement/test_shapes.py
@@ -10,8 +10,7 @@ from qcodes.dataset.measurements import Measurement
 @given(n_points=hst.integers(min_value=1, max_value=100))
 @example(n_points=5)
 @settings(deadline=None, suppress_health_check=(HealthCheck.function_scoped_fixture,))
-def test_datasaver_1d(experiment, DAC, DMM, caplog,
-                      n_points):
+def test_datasaver_1d(experiment, DAC, DMM, caplog, n_points) -> None:
     meas = Measurement()
     meas.register_parameter(DAC.ch1)
     meas.register_parameter(DMM.v1, setpoints=(DAC.ch1,))
@@ -62,8 +61,7 @@ def test_datasaver_1d(experiment, DAC, DMM, caplog,
 @given(n_points_1=hst.integers(min_value=1, max_value=50),
        n_points_2=hst.integers(min_value=1, max_value=50))
 @example(n_points_1=5, n_points_2=10)
-def test_datasaver_2d(experiment, DAC, DMM, caplog,
-                      n_points_1, n_points_2):
+def test_datasaver_2d(experiment, DAC, DMM, caplog, n_points_1, n_points_2) -> None:
     meas = Measurement()
     meas.register_parameter(DAC.ch1)
     meas.register_parameter(DAC.ch2)

--- a/qcodes/tests/dataset/test__get_data_from_ds.py
+++ b/qcodes/tests/dataset/test__get_data_from_ds.py
@@ -4,15 +4,15 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 from numpy.testing import assert_allclose
 
-import qcodes as qc
 from qcodes.dataset.data_export import _get_data_from_ds, get_data_by_id
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 from qcodes.dataset.measurements import Measurement
+from qcodes.parameters import ManualParameter
 from qcodes.utils import QCoDeSDeprecationWarning
 
 
-def test_get_data_by_id_order(dataset):
+def test_get_data_by_id_order(dataset) -> None:
     """
     Test that the added values of setpoints end up associated with the correct
     setpoint parameter, irrespective of the ordering of those setpoint
@@ -59,7 +59,7 @@ def test_get_data_by_id_order(dataset):
 def test_datasaver_multidimarrayparameter_as_array(
         SpectrumAnalyzer,
         bg_writing
-):
+) -> None:
     array_param = SpectrumAnalyzer.multidimspectrum
     meas = Measurement()
     meas.register_parameter(array_param, paramtype='array')
@@ -75,7 +75,7 @@ def test_datasaver_multidimarrayparameter_as_array(
     for datadict_list in datadicts:
         assert len(datadict_list) == 4
         for datadict in datadict_list:
-            datadict["data"].shape = (np.prod(expected_shape),)
+            datadict["data"].shape = (int(np.prod(expected_shape)),)
             if datadict["name"] == "dummy_SA_Frequency0":
                 temp_data = np.linspace(
                     array_param.start, array_param.stop, array_param.npts[0]
@@ -106,8 +106,9 @@ def test_datasaver_multidimarrayparameter_as_array(
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_multidimarrayparameter_as_numeric(SpectrumAnalyzer,
-                                                     bg_writing):
+def test_datasaver_multidimarrayparameter_as_numeric(
+    SpectrumAnalyzer, bg_writing
+) -> None:
     """
     Test that storing a multidim Array parameter as numeric unravels the
     parameter as expected.
@@ -167,9 +168,9 @@ def test_datasaver_multidimarrayparameter_as_numeric(SpectrumAnalyzer,
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.parametrize("storage_type", ['numeric', 'array'])
 @pytest.mark.usefixtures("experiment")
-def test_datasaver_array_parameters_channel(channel_array_instrument,
-                                            DAC, N, storage_type,
-                                            bg_writing):
+def test_datasaver_array_parameters_channel(
+    channel_array_instrument, DAC, N, storage_type, bg_writing
+) -> None:
     array_param = channel_array_instrument.A.dummy_array_parameter
     meas = Measurement()
     meas.register_parameter(DAC.ch1)
@@ -184,9 +185,9 @@ def test_datasaver_array_parameters_channel(channel_array_instrument,
     datadicts = _get_data_from_ds(datasaver.dataset)
     # one dependent parameter
     assert len(datadicts) == 1
-    datadicts = datadicts[0]
-    assert len(datadicts) == len(meas.parameters)
-    for datadict in datadicts:
+    sub_datadicts = datadicts[0]
+    assert len(sub_datadicts) == len(meas.parameters)
+    for datadict in sub_datadicts:
         if storage_type == "array":
             assert datadict["data"].shape == (N, M)
         else:
@@ -198,8 +199,9 @@ def test_datasaver_array_parameters_channel(channel_array_instrument,
 @given(N=hst.integers(min_value=5, max_value=500))
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_datasaver_array_parameters_array(channel_array_instrument, DAC, N,
-                                          bg_writing):
+def test_datasaver_array_parameters_array(
+    channel_array_instrument, DAC, N, bg_writing
+) -> None:
     """
     Test that storing array parameters inside a loop works as expected
     """
@@ -226,9 +228,9 @@ def test_datasaver_array_parameters_array(channel_array_instrument, DAC, N,
     datadicts = _get_data_from_ds(datasaver.dataset)
     # one dependent parameter
     assert len(datadicts) == 1
-    datadicts = datadicts[0]
-    assert len(datadicts) == len(meas.parameters)
-    for datadict in datadicts:
+    sub_datadicts = datadicts[0]
+    assert len(sub_datadicts) == len(meas.parameters)
+    for datadict in sub_datadicts:
         if datadict['name'] == 'dummy_dac_ch1':
             expected_data = np.repeat(dac_datapoints, M).reshape(N, M)
         elif datadict["name"] == dependency_name:
@@ -244,7 +246,7 @@ def test_datasaver_array_parameters_array(channel_array_instrument, DAC, N,
 
 
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_datasaver_multidim_array(experiment, bg_writing):
+def test_datasaver_multidim_array(experiment, bg_writing) -> None:
     """
     Test that inserting multidim parameters as arrays works as expected
     """
@@ -255,10 +257,10 @@ def test_datasaver_multidim_array(experiment, bg_writing):
     data_mapping = {name: i for i, name in
                     zip(range(4), ['x1', 'x2', 'y1', 'y2'])}
 
-    x1 = qc.ManualParameter('x1')
-    x2 = qc.ManualParameter('x2')
-    y1 = qc.ManualParameter('y1')
-    y2 = qc.ManualParameter('y2')
+    x1 = ManualParameter("x1")
+    x2 = ManualParameter("x2")
+    y1 = ManualParameter("y1")
+    y2 = ManualParameter("y2")
 
     meas.register_parameter(x1, paramtype='array')
     meas.register_parameter(x2, paramtype='array')
@@ -288,17 +290,17 @@ def test_datasaver_multidim_array(experiment, bg_writing):
 
 
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_datasaver_multidim_numeric(experiment, bg_writing):
+def test_datasaver_multidim_numeric(experiment, bg_writing) -> None:
     """
     Test that inserting multidim parameters as numeric works as expected
     """
     meas = Measurement(experiment)
     size1 = 10
     size2 = 15
-    x1 = qc.ManualParameter('x1')
-    x2 = qc.ManualParameter('x2')
-    y1 = qc.ManualParameter('y1')
-    y2 = qc.ManualParameter('y2')
+    x1 = ManualParameter("x1")
+    x2 = ManualParameter("x2")
+    y1 = ManualParameter("y1")
+    y2 = ManualParameter("y2")
 
     data_mapping = {name: i for i, name in
                     zip(range(4), ['x1', 'x2', 'y1', 'y2'])}

--- a/qcodes/tests/dataset/test_concurrent_datasets.py
+++ b/qcodes/tests/dataset/test_concurrent_datasets.py
@@ -7,7 +7,7 @@ from qcodes.dataset import new_experiment
 from qcodes.dataset.data_set import DataSet
 
 
-def test_foreground_after_background_raises(empty_temp_db_connection):
+def test_foreground_after_background_raises(empty_temp_db_connection) -> None:
     new_experiment("test", "test1", conn=empty_temp_db_connection)
     ds1 = DataSet(conn=empty_temp_db_connection)
     ds1.mark_started(start_bg_writer=True)
@@ -17,7 +17,7 @@ def test_foreground_after_background_raises(empty_temp_db_connection):
         ds2.mark_started(start_bg_writer=False)
 
 
-def test_background_after_foreground_raises(empty_temp_db_connection):
+def test_background_after_foreground_raises(empty_temp_db_connection) -> None:
     new_experiment("test", "test1", conn=empty_temp_db_connection)
     ds1 = DataSet(conn=empty_temp_db_connection)
     ds1.mark_started(start_bg_writer=False)
@@ -27,7 +27,7 @@ def test_background_after_foreground_raises(empty_temp_db_connection):
         ds2.mark_started(start_bg_writer=True)
 
 
-def test_background_twice(empty_temp_db_connection):
+def test_background_twice(empty_temp_db_connection) -> None:
     new_experiment("test", "test1", conn=empty_temp_db_connection)
     ds1 = DataSet(conn=empty_temp_db_connection)
     ds1.mark_started(start_bg_writer=True)
@@ -36,7 +36,7 @@ def test_background_twice(empty_temp_db_connection):
     ds2.mark_started(start_bg_writer=True)
 
 
-def test_foreground_twice(empty_temp_db_connection):
+def test_foreground_twice(empty_temp_db_connection) -> None:
     new_experiment("test", "test1", conn=empty_temp_db_connection)
     ds1 = DataSet(conn=empty_temp_db_connection)
     ds1.mark_started(start_bg_writer=False)
@@ -45,7 +45,7 @@ def test_foreground_twice(empty_temp_db_connection):
     ds2.mark_started(start_bg_writer=False)
 
 
-def test_foreground_after_background_non_concurrent(empty_temp_db_connection):
+def test_foreground_after_background_non_concurrent(empty_temp_db_connection) -> None:
     new_experiment("test", "test1", conn=empty_temp_db_connection)
     ds1 = DataSet(conn=empty_temp_db_connection)
     ds1.mark_started(start_bg_writer=True)

--- a/qcodes/tests/dataset/test_converters.py
+++ b/qcodes/tests/dataset/test_converters.py
@@ -21,7 +21,7 @@ from qcodes.dataset.descriptions.versioning.serialization import from_dict_to_cu
 from qcodes.dataset.descriptions.versioning.v0 import InterDependencies
 
 
-def test_convert_v0_to_newer(some_paramspecs):
+def test_convert_v0_to_newer(some_paramspecs) -> None:
     pgroup1 = some_paramspecs[1]
 
     interdeps = InterDependencies(pgroup1['ps1'],
@@ -37,7 +37,7 @@ def test_convert_v0_to_newer(some_paramspecs):
     _assert_dicts_are_related_as_expected(v0, v1, v2)
 
 
-def test_convert_v1(some_interdeps):
+def test_convert_v1(some_interdeps) -> None:
     interdeps_ = some_interdeps[0]
 
     v1 = RunDescriberV1Dict(interdependencies=interdeps_._to_dict(),
@@ -47,7 +47,7 @@ def test_convert_v1(some_interdeps):
     _assert_dicts_are_related_as_expected(v0, v1, v2)
 
 
-def test_convert_v2(some_interdeps):
+def test_convert_v2(some_interdeps) -> None:
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -74,7 +74,7 @@ def _assert_dicts_are_related_as_expected(v0, v1, v2):
     assert len(v2) == 3
 
 
-def test_construct_current_rundescriber_from_v0(some_paramspecs):
+def test_construct_current_rundescriber_from_v0(some_paramspecs) -> None:
 
     pgroup1 = some_paramspecs[1]
 
@@ -100,7 +100,7 @@ def test_construct_current_rundescriber_from_v0(some_paramspecs):
                     ignore_order=True) == {}
 
 
-def test_construct_current_rundescriber_from_v1(some_interdeps):
+def test_construct_current_rundescriber_from_v1(some_interdeps) -> None:
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -119,7 +119,7 @@ def test_construct_current_rundescriber_from_v1(some_interdeps):
     assert rds_upgraded._to_dict() == expected_v3_dict
 
 
-def test_construct_current_rundescriber_from_v2(some_interdeps):
+def test_construct_current_rundescriber_from_v2(some_interdeps) -> None:
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 
@@ -140,7 +140,7 @@ def test_construct_current_rundescriber_from_v2(some_interdeps):
     assert rds_upgraded._to_dict() == expected_v3_dict
 
 
-def test_construct_current_rundescriber_from_v3(some_interdeps):
+def test_construct_current_rundescriber_from_v3(some_interdeps) -> None:
     interdeps_ = some_interdeps[0]
     interdeps = new_to_old(interdeps_)
 

--- a/qcodes/tests/dataset/test_data_set_cache.py
+++ b/qcodes/tests/dataset/test_data_set_cache.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from math import ceil
 from string import ascii_uppercase
-from typing import Dict
 
 import hypothesis.strategies as hst
 import numpy as np
@@ -28,7 +29,7 @@ def test_cache_standalone(
     channel_array_instrument,
     set_shape,
     in_memory_cache,
-):
+) -> None:
 
     meas1 = Measurement()
     meas1.register_parameter(DMM.v1)
@@ -194,10 +195,17 @@ def test_cache_standalone(
 @settings(deadline=None, max_examples=10,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n_points=hst.integers(min_value=1, max_value=11))
-def test_cache_1d(experiment, DAC, DMM, n_points, bg_writing,
-                  channel_array_instrument, setpoints_type,
-                  set_shape, in_memory_cache):
-
+def test_cache_1d(
+    experiment,
+    DAC,
+    DMM,
+    n_points,
+    bg_writing,
+    channel_array_instrument,
+    setpoints_type,
+    set_shape,
+    in_memory_cache,
+) -> None:
     setpoints_param, setpoints_values = _prepare_setpoints_1d(
         DAC, channel_array_instrument,
         n_points, setpoints_type
@@ -320,12 +328,19 @@ def test_cache_1d(experiment, DAC, DMM, n_points, bg_writing,
 @settings(deadline=None, max_examples=10,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n_points=hst.integers(min_value=1, max_value=101))
-def test_cache_1d_every_other_point(experiment, DAC, DMM, n_points, bg_writing,
-                                    channel_array_instrument, setpoints_type,
-                                    in_memory_cache):
-
-    setpoints_param, setpoints_values = _prepare_setpoints_1d(DAC, channel_array_instrument,
-                                                                                   n_points, setpoints_type)
+def test_cache_1d_every_other_point(
+    experiment,
+    DAC,
+    DMM,
+    n_points,
+    bg_writing,
+    channel_array_instrument,
+    setpoints_type,
+    in_memory_cache,
+) -> None:
+    setpoints_param, setpoints_values = _prepare_setpoints_1d(
+        DAC, channel_array_instrument, n_points, setpoints_type
+    )
 
     meas = Measurement()
 
@@ -373,13 +388,25 @@ def test_cache_1d_every_other_point(experiment, DAC, DMM, n_points, bg_writing,
 
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.parametrize("in_memory_cache", [True, False])
-@settings(deadline=None, max_examples=10,
-          suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(n_points_outer=hst.integers(min_value=1, max_value=11),
-       n_points_inner=hst.integers(min_value=1, max_value=11))
-def test_cache_2d(experiment, DAC, DMM, n_points_outer,
-                  n_points_inner, bg_writing, channel_array_instrument,
-                  in_memory_cache):
+@settings(
+    deadline=None,
+    max_examples=10,
+    suppress_health_check=(HealthCheck.function_scoped_fixture,),
+)
+@given(
+    n_points_outer=hst.integers(min_value=1, max_value=11),
+    n_points_inner=hst.integers(min_value=1, max_value=11),
+)
+def test_cache_2d(
+    experiment,
+    DAC,
+    DMM,
+    n_points_outer,
+    n_points_inner,
+    bg_writing,
+    channel_array_instrument,
+    in_memory_cache,
+) -> None:
     meas = Measurement()
 
     meas.register_parameter(DAC.ch1)
@@ -428,12 +455,25 @@ def test_cache_2d(experiment, DAC, DMM, n_points_outer,
 @pytest.mark.parametrize("bg_writing", [True, False])
 @pytest.mark.parametrize("storage_type", ['numeric', 'array', None])
 @pytest.mark.parametrize("in_memory_cache", [True, False])
-@settings(deadline=None, max_examples=10,
-          suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(n_points_outer=hst.integers(min_value=1, max_value=11),
-       n_points_inner=hst.integers(min_value=1, max_value=11))
-def test_cache_2d_num_with_multiple_storage_types(experiment, DAC, DMM, n_points_outer,
-                      n_points_inner, bg_writing, storage_type, in_memory_cache):
+@settings(
+    deadline=None,
+    max_examples=10,
+    suppress_health_check=(HealthCheck.function_scoped_fixture,),
+)
+@given(
+    n_points_outer=hst.integers(min_value=1, max_value=11),
+    n_points_inner=hst.integers(min_value=1, max_value=11),
+)
+def test_cache_2d_num_with_multiple_storage_types(
+    experiment,
+    DAC,
+    DMM,
+    n_points_outer,
+    n_points_inner,
+    bg_writing,
+    storage_type,
+    in_memory_cache,
+) -> None:
     meas = Measurement()
 
     meas.register_parameter(DAC.ch1, paramtype=storage_type)
@@ -456,7 +496,7 @@ def test_cache_2d_num_with_multiple_storage_types(experiment, DAC, DMM, n_points
                 n_rows_written += 1
                 data = dataset.cache.data()
                 if array_used:
-                    shape = (n_rows_written, 1)
+                    shape: tuple[int, ...] = (n_rows_written, 1)
                 else:
                     shape = (n_rows_written,)
                 assert data[DMM.v1.full_name][DMM.v1.full_name].shape == shape
@@ -473,8 +513,15 @@ def test_cache_2d_num_with_multiple_storage_types(experiment, DAC, DMM, n_points
 @settings(deadline=None, max_examples=10,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n_points=hst.integers(min_value=1, max_value=21))
-def test_cache_1d_array_in_1d(experiment, DAC, channel_array_instrument,
-                              n_points, bg_writing, storage_type, in_memory_cache):
+def test_cache_1d_array_in_1d(
+    experiment,
+    DAC,
+    channel_array_instrument,
+    n_points,
+    bg_writing,
+    storage_type,
+    in_memory_cache,
+) -> None:
     param = channel_array_instrument.A.dummy_array_parameter
     meas = Measurement()
     meas.register_parameter(DAC.ch1, paramtype=storage_type)
@@ -493,7 +540,7 @@ def test_cache_1d_array_in_1d(experiment, DAC, channel_array_instrument,
             data = dataset.cache.data()
             n_rows_written = i+1
             if array_used:
-                shape = (n_rows_written, param.shape[0])
+                shape: tuple[int, ...] = (n_rows_written, param.shape[0])
             else:
                 shape = (n_rows_written * param.shape[0],)
             assert data[param.full_name][DAC.ch1.full_name].shape == shape
@@ -511,8 +558,15 @@ def test_cache_1d_array_in_1d(experiment, DAC, channel_array_instrument,
 @settings(deadline=None, max_examples=10,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n_points=hst.integers(min_value=1, max_value=21))
-def test_cache_multiparam_in_1d(experiment, DAC, channel_array_instrument,
-                                n_points, bg_writing, storage_type, in_memory_cache):
+def test_cache_multiparam_in_1d(
+    experiment,
+    DAC,
+    channel_array_instrument,
+    n_points,
+    bg_writing,
+    storage_type,
+    in_memory_cache,
+) -> None:
     param = channel_array_instrument.A.dummy_2d_multi_parameter
     meas = Measurement()
     meas.register_parameter(DAC.ch1, paramtype=storage_type)
@@ -550,14 +604,21 @@ def test_cache_multiparam_in_1d(experiment, DAC, channel_array_instrument,
 @settings(deadline=None, max_examples=10,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n_points=hst.integers(min_value=1, max_value=21))
-def test_cache_complex_array_param_in_1d(experiment, DAC, channel_array_instrument,
-                                         n_points, bg_writing, storage_type, outer_param_type,
-                                         in_memory_cache):
+def test_cache_complex_array_param_in_1d(
+    experiment,
+    DAC,
+    channel_array_instrument,
+    n_points,
+    bg_writing,
+    storage_type,
+    outer_param_type,
+    in_memory_cache,
+) -> None:
     param = channel_array_instrument.A.dummy_complex_array_parameter
     meas = Measurement()
     if outer_param_type == 'numeric':
         outer_param = DAC.ch1
-        outer_setpoints = np.linspace(-1, 1, n_points)
+        outer_setpoints: np.ndarray | list[str] = np.linspace(-1, 1, n_points)
         outer_storage_type = storage_type
     else:
         outer_param = channel_array_instrument.A.dummy_text
@@ -596,10 +657,16 @@ def test_cache_complex_array_param_in_1d(experiment, DAC, channel_array_instrume
 @settings(deadline=None, max_examples=10,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(n_points=hst.integers(min_value=1, max_value=11))
-def test_cache_1d_shape(experiment, DAC, DMM, n_points, bg_writing,
-                  channel_array_instrument, setpoints_type,
-                  in_memory_cache):
-
+def test_cache_1d_shape(
+    experiment,
+    DAC,
+    DMM,
+    n_points,
+    bg_writing,
+    channel_array_instrument,
+    setpoints_type,
+    in_memory_cache,
+) -> None:
     setpoints_param, setpoints_values = _prepare_setpoints_1d(
         DAC, channel_array_instrument,
         n_points, setpoints_type
@@ -680,23 +747,28 @@ def test_cache_1d_shape(experiment, DAC, DMM, n_points, bg_writing,
 
 
 @pytest.mark.parametrize("bg_writing", [True, False])
-@pytest.mark.parametrize("cache_size", ["too_large",
-                                        "correct",
-                                        "too_small"])
-@settings(deadline=None, max_examples=10,
-          suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(n_points_outer=hst.integers(min_value=1, max_value=11),
-       n_points_inner=hst.integers(min_value=1, max_value=11),
-       pws_n_points=hst.integers(min_value=1, max_value=11))
-def test_cache_2d_shape(experiment,
-                        DAC,
-                        DMM,
-                        n_points_outer,
-                        n_points_inner,
-                        pws_n_points,
-                        bg_writing,
-                        channel_array_instrument,
-                        cache_size):
+@pytest.mark.parametrize("cache_size", ["too_large", "correct", "too_small"])
+@settings(
+    deadline=None,
+    max_examples=10,
+    suppress_health_check=(HealthCheck.function_scoped_fixture,),
+)
+@given(
+    n_points_outer=hst.integers(min_value=1, max_value=11),
+    n_points_inner=hst.integers(min_value=1, max_value=11),
+    pws_n_points=hst.integers(min_value=1, max_value=11),
+)
+def test_cache_2d_shape(
+    experiment,
+    DAC,
+    DMM,
+    n_points_outer,
+    n_points_inner,
+    pws_n_points,
+    bg_writing,
+    channel_array_instrument,
+    cache_size,
+) -> None:
     meas = Measurement()
 
     meas.register_parameter(DAC.ch1)
@@ -873,9 +945,9 @@ def _assert_partial_cache_is_as_expected(
 
 
 def _assert_parameter_data_is_identical(
-        expected: Dict[str, Dict[str, np.ndarray]],
-        actual: Dict[str, Dict[str, np.ndarray]],
-        shaped_partial: bool = False
+    expected: dict[str, dict[str, np.ndarray]],
+    actual: dict[str, dict[str, np.ndarray]],
+    shaped_partial: bool = False,
 ):
     assert expected.keys() == actual.keys()
     # there is a tiny round trip loss in accuracy

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -77,14 +77,14 @@ LATEST_VERSION_ARG = -1
 
 
 @pytest.mark.parametrize('ver', VERSIONS + (LATEST_VERSION_ARG,))
-def test_connect_upgrades_user_version(ver):
+def test_connect_upgrades_user_version(ver) -> None:
     expected_version = ver if ver != LATEST_VERSION_ARG else LATEST_VERSION
     conn = connect(':memory:', version=ver)
     assert expected_version == get_user_version(conn)
 
 
 @pytest.mark.parametrize('version', VERSIONS + (LATEST_VERSION_ARG,))
-def test_tables_exist(empty_temp_db, version):
+def test_tables_exist(empty_temp_db, version) -> None:
     conn = connect(
         qc.config["core"]["db_location"], qc.config["core"]["db_debug"], version=version
     )
@@ -101,7 +101,7 @@ def test_tables_exist(empty_temp_db, version):
     conn.close()
 
 
-def test_initialise_database_at_for_nonexisting_db(tmp_path):
+def test_initialise_database_at_for_nonexisting_db(tmp_path) -> None:
     db_location = str(tmp_path / 'temp.db')
     assert not os.path.exists(db_location)
 
@@ -111,7 +111,7 @@ def test_initialise_database_at_for_nonexisting_db(tmp_path):
     assert qc.config["core"]["db_location"] == db_location
 
 
-def test_initialise_database_at_for_nonexisting_db_pathlib_path(tmp_path):
+def test_initialise_database_at_for_nonexisting_db_pathlib_path(tmp_path) -> None:
     db_location = tmp_path / "temp.db"
     assert not db_location.exists()
 
@@ -121,7 +121,7 @@ def test_initialise_database_at_for_nonexisting_db_pathlib_path(tmp_path):
     assert qc.config["core"]["db_location"] == str(db_location)
 
 
-def test_initialise_database_at_for_existing_db(tmp_path):
+def test_initialise_database_at_for_existing_db(tmp_path) -> None:
     # Define DB location
     db_location = str(tmp_path / 'temp.db')
     assert not os.path.exists(db_location)
@@ -142,7 +142,7 @@ def test_initialise_database_at_for_existing_db(tmp_path):
     assert qc.config["core"]["db_location"] == db_location
 
 
-def test_perform_actual_upgrade_0_to_1():
+def test_perform_actual_upgrade_0_to_1() -> None:
     # we cannot use the empty_temp_db, since that has already called connect
     # and is therefore latest version already
 
@@ -170,7 +170,7 @@ def test_perform_actual_upgrade_0_to_1():
         assert len(c.fetchall()) == 0
 
 
-def test_perform_actual_upgrade_1_to_2():
+def test_perform_actual_upgrade_1_to_2() -> None:
 
     v1fixpath = os.path.join(fixturepath, 'db_files', 'version1')
 
@@ -198,7 +198,7 @@ def test_perform_actual_upgrade_1_to_2():
         assert len(c.fetchall()) == 2
 
 
-def test_perform_actual_upgrade_2_to_3_empty():
+def test_perform_actual_upgrade_2_to_3_empty() -> None:
 
     v2fixpath = os.path.join(fixturepath, 'db_files', 'version2')
 
@@ -225,7 +225,7 @@ def test_perform_actual_upgrade_2_to_3_empty():
         assert len(c.fetchall()) == 0
 
 
-def test_perform_actual_upgrade_2_to_3_empty_runs():
+def test_perform_actual_upgrade_2_to_3_empty_runs() -> None:
 
     v2fixpath = os.path.join(fixturepath, 'db_files', 'version2')
 
@@ -238,7 +238,7 @@ def test_perform_actual_upgrade_2_to_3_empty_runs():
         perform_db_upgrade_2_to_3(conn)
 
 
-def test_perform_actual_upgrade_2_to_3_some_runs():
+def test_perform_actual_upgrade_2_to_3_some_runs() -> None:
 
     v2fixpath = os.path.join(fixturepath, 'db_files', 'version2')
 
@@ -325,7 +325,7 @@ def test_perform_actual_upgrade_2_to_3_some_runs():
         assert p5.unit == "unit 5"
 
 
-def test_perform_upgrade_v2_v3_to_v4_fixes():
+def test_perform_upgrade_v2_v3_to_v4_fixes() -> None:
     """
     Test that a db that was upgraded from v2 to v3 with a buggy
     version will be corrected when upgraded to v4.
@@ -469,7 +469,7 @@ def test_perform_upgrade_v2_v3_to_v4_fixes():
         assert p5.unit == "unit 5"
 
 
-def test_perform_upgrade_v3_to_v4():
+def test_perform_upgrade_v3_to_v4() -> None:
     """
     Test that a db upgrade from v2 to v4 works correctly.
     """
@@ -551,7 +551,7 @@ def test_perform_upgrade_v3_to_v4():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_update_existing_guids(caplog):
+def test_update_existing_guids(caplog) -> None:
 
     old_loc = 101
     old_ws = 1200
@@ -637,7 +637,7 @@ def _assert_loc_station(ds, expected_loc, expected_station):
                          ['empty',
                           'with_runs_but_no_snapshots',
                           'with_runs_and_snapshots'])
-def test_perform_actual_upgrade_4_to_5(db_file):
+def test_perform_actual_upgrade_4_to_5(db_file) -> None:
     v4fixpath = os.path.join(fixturepath, 'db_files', 'version4')
 
     db_file += '.db'
@@ -659,7 +659,7 @@ def test_perform_actual_upgrade_4_to_5(db_file):
         assert is_column_in_table(conn, 'runs', 'snapshot')
 
 
-def test_perform_actual_upgrade_5_to_6():
+def test_perform_actual_upgrade_5_to_6() -> None:
     fixpath = os.path.join(fixturepath, 'db_files', 'version5')
 
     db_file = 'empty.db'
@@ -693,7 +693,7 @@ def test_perform_actual_upgrade_5_to_6():
             assert desc._version == 3
 
 
-def test_perform_upgrade_6_7():
+def test_perform_upgrade_6_7() -> None:
     fixpath = os.path.join(fixturepath, 'db_files', 'version6')
 
     db_file = 'empty.db'
@@ -706,7 +706,7 @@ def test_perform_upgrade_6_7():
         assert get_user_version(conn) == 7
 
 
-def test_perform_actual_upgrade_6_to_7():
+def test_perform_actual_upgrade_6_to_7() -> None:
 
     fixpath = os.path.join(fixturepath, 'db_files', 'version6')
 
@@ -758,7 +758,7 @@ def test_perform_actual_upgrade_6_to_7():
             assert ds2.counter == ds2.captured_counter
 
 
-def test_perform_actual_upgrade_6_to_newest_add_new_data():
+def test_perform_actual_upgrade_6_to_newest_add_new_data() -> None:
     """
     Insert new runs on top of existing runs upgraded and verify that they
     get the correct captured_run_id and captured_counter
@@ -857,7 +857,7 @@ def test_perform_actual_upgrade_6_to_newest_add_new_data():
 @pytest.mark.parametrize('db_file',
                          ['empty',
                           'some_runs'])
-def test_perform_actual_upgrade_7_to_8(db_file):
+def test_perform_actual_upgrade_7_to_8(db_file) -> None:
     v7fixpath = os.path.join(fixturepath, 'db_files', 'version7')
 
     db_file += '.db'
@@ -873,7 +873,7 @@ def test_perform_actual_upgrade_7_to_8(db_file):
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_cannot_connect_to_newer_db():
+def test_cannot_connect_to_newer_db() -> None:
     conn = connect(qc.config["core"]["db_location"],
                    qc.config["core"]["db_debug"])
     current_version = get_user_version(conn)
@@ -886,12 +886,12 @@ def test_cannot_connect_to_newer_db():
                        qc.config["core"]["db_debug"])
 
 
-def test_latest_available_version():
+def test_latest_available_version() -> None:
     assert _latest_available_version() == 9
 
 
 @pytest.mark.parametrize("version", VERSIONS[:-1])
-def test_getting_db_version(version):
+def test_getting_db_version(version) -> None:
 
     fixpath = os.path.join(fixturepath, 'db_files', f'version{version}')
 
@@ -908,7 +908,7 @@ def test_getting_db_version(version):
 @pytest.mark.parametrize('db_file',
                          ['empty',
                           'some_runs'])
-def test_perform_actual_upgrade_8_to_9(db_file):
+def test_perform_actual_upgrade_8_to_9(db_file) -> None:
     v8fixpath = os.path.join(fixturepath, 'db_files', 'version8')
 
     db_file += '.db'

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -5,6 +5,7 @@ import uuid
 from contextlib import contextmanager
 from os.path import getmtime
 from pathlib import Path
+from typing import Callable, Dict
 
 import numpy as np
 import pytest
@@ -64,7 +65,7 @@ def _make_inst():
     inst.close()
 
 
-def test_missing_runs_raises(two_empty_temp_db_connections, some_interdeps):
+def test_missing_runs_raises(two_empty_temp_db_connections, some_interdeps) -> None:
     """
     Test that an error is raised if we attempt to extract a run not present in
     the source DB
@@ -103,16 +104,17 @@ def test_missing_runs_raises(two_empty_temp_db_connections, some_interdeps):
         extract_runs_into_db(source_path, target_path, *run_ids)
 
 
-def test_basic_extraction(two_empty_temp_db_connections, some_interdeps):
+def test_basic_extraction(two_empty_temp_db_connections, some_interdeps) -> None:
     source_conn, target_conn = two_empty_temp_db_connections
 
     source_path = path_to_dbfile(source_conn)
     target_path = path_to_dbfile(target_conn)
 
-    type_casters = {'numeric': float,
-                    'array': (lambda x: np.array(x) if hasattr(x, '__iter__')
-                              else np.array([x])),
-                    'text': str}
+    type_casters: Dict[str, Callable] = {
+        "numeric": float,
+        "array": (lambda x: np.array(x) if hasattr(x, "__iter__") else np.array([x])),
+        "text": str,
+    }
 
     source_exp = Experiment(conn=source_conn)
     source_dataset = DataSet(conn=source_conn, name="basic_copy_paste_name")
@@ -184,7 +186,7 @@ def test_basic_extraction(two_empty_temp_db_connections, some_interdeps):
         extract_runs_into_db(source_path, target_path, source_dataset.run_id)
 
 
-def test_real_dataset_1d(two_empty_temp_db_connections, inst):
+def test_real_dataset_1d(two_empty_temp_db_connections, inst) -> None:
     source_conn, target_conn = two_empty_temp_db_connections
 
     source_path = path_to_dbfile(source_conn)
@@ -206,11 +208,13 @@ def test_real_dataset_1d(two_empty_temp_db_connections, inst):
     source_data = source_dataset.get_parameter_data()["extract_run_inst_plunger"]
     target_data = target_dataset.get_parameter_data()["extract_run_inst_plunger"]
 
-    for source_data, target_data in zip(source_data.values(), target_data.values()):
-        assert_array_equal(source_data, target_data)
+    for source_data_vals, target_data_vals in zip(
+        source_data.values(), target_data.values()
+    ):
+        assert_array_equal(source_data_vals, target_data_vals)
 
 
-def test_real_dataset_1d_pathlib_path(two_empty_temp_db_connections, inst):
+def test_real_dataset_1d_pathlib_path(two_empty_temp_db_connections, inst) -> None:
     source_conn, target_conn = two_empty_temp_db_connections
 
     source_path = Path(path_to_dbfile(source_conn))
@@ -232,11 +236,13 @@ def test_real_dataset_1d_pathlib_path(two_empty_temp_db_connections, inst):
     source_data = source_dataset.get_parameter_data()["extract_run_inst_plunger"]
     target_data = target_dataset.get_parameter_data()["extract_run_inst_plunger"]
 
-    for source_data, target_data in zip(source_data.values(), target_data.values()):
-        assert_array_equal(source_data, target_data)
+    for source_data_vals, target_data_vals in zip(
+        source_data.values(), target_data.values()
+    ):
+        assert_array_equal(source_data_vals, target_data_vals)
 
 
-def test_real_dataset_2d(two_empty_temp_db_connections, inst):
+def test_real_dataset_2d(two_empty_temp_db_connections, inst) -> None:
     source_conn, target_conn = two_empty_temp_db_connections
 
     source_path = path_to_dbfile(source_conn)
@@ -260,12 +266,15 @@ def test_real_dataset_2d(two_empty_temp_db_connections, inst):
     source_data = source_dataset.get_parameter_data()["extract_run_inst_cutter"]
     target_data = target_dataset.get_parameter_data()["extract_run_inst_cutter"]
 
-    for source_data, target_data in zip(source_data.values(), target_data.values()):
-        assert_array_equal(source_data, target_data)
+    for source_data_vals, target_data_vals in zip(
+        source_data.values(), target_data.values()
+    ):
+        assert_array_equal(source_data_vals, target_data_vals)
 
 
-def test_correct_experiment_routing(two_empty_temp_db_connections,
-                                    some_interdeps):
+def test_correct_experiment_routing(
+    two_empty_temp_db_connections, some_interdeps
+) -> None:
     """
     Test that existing experiments are correctly identified AND that multiple
     insertions of the same runs don't matter (run insertion is idempotent)
@@ -362,8 +371,9 @@ def test_correct_experiment_routing(two_empty_temp_db_connections,
                 np.testing.assert_array_equal(inval, target_data[outkey][inkey])
 
 
-def test_runs_from_different_experiments_raises(two_empty_temp_db_connections,
-                                                some_interdeps):
+def test_runs_from_different_experiments_raises(
+    two_empty_temp_db_connections, some_interdeps
+) -> None:
     """
     Test that inserting runs from multiple experiments raises
     """
@@ -420,7 +430,7 @@ def test_runs_from_different_experiments_raises(two_empty_temp_db_connections,
         extract_runs_into_db(source_path, target_path, *run_ids)
 
 
-def test_extracting_dataless_run(two_empty_temp_db_connections):
+def test_extracting_dataless_run(two_empty_temp_db_connections) -> None:
     """
     Although contrived, it could happen that a run with no data is extracted
     """
@@ -442,8 +452,9 @@ def test_extracting_dataless_run(two_empty_temp_db_connections):
     assert loaded_ds.the_same_dataset_as(source_ds)
 
 
-def test_result_table_naming_and_run_id(two_empty_temp_db_connections,
-                                        some_interdeps):
+def test_result_table_naming_and_run_id(
+    two_empty_temp_db_connections, some_interdeps
+) -> None:
     """
     Check that a correct result table name is given and that a correct run_id
     is assigned
@@ -490,8 +501,7 @@ def test_result_table_naming_and_run_id(two_empty_temp_db_connections,
     assert target_ds.the_same_dataset_as(source_ds_2_2)
 
 
-def test_load_by_X_functions(two_empty_temp_db_connections,
-                             some_interdeps):
+def test_load_by_X_functions(two_empty_temp_db_connections, some_interdeps) -> None:
     """
     Test some different loading functions
     """
@@ -542,9 +552,9 @@ def test_load_by_X_functions(two_empty_temp_db_connections,
 
 
 @pytest.mark.usefixtures("reset_config_on_exit")
-def test_combine_runs(two_empty_temp_db_connections,
-                      empty_temp_db_connection,
-                      some_interdeps):
+def test_combine_runs(
+    two_empty_temp_db_connections, empty_temp_db_connection, some_interdeps
+) -> None:
     """
     Test that datasets that are exported in random order from 2 datasets
     can be reloaded by the original captured_run_id and the experiment
@@ -606,9 +616,9 @@ def test_combine_runs(two_empty_temp_db_connections,
     # this could be split out into its own test
     # but the test above has the useful side effect of
     # setting up datasets for this test.
-    guids = [ds.guid for ds in source_all_datasets]
+    new_guids = [ds.guid for ds in source_all_datasets]
 
-    table = generate_dataset_table(guids, conn=target_conn)
+    table = generate_dataset_table(new_guids, conn=target_conn)
     lines = table.split('\n')
     headers = re.split(r'\s+', lines[0].strip())
 
@@ -618,17 +628,18 @@ def test_combine_runs(two_empty_temp_db_connections,
     for i in range(2, len(lines)):
         split_line = re.split(r'\s+', lines[i].strip())
         mydict = {headers[j]: split_line[j] for j in range(len(split_line))}
-        ds = load_by_guid(guids[i-2], conn=target_conn)
-        assert ds.captured_run_id == int(mydict['captured_run_id'])
-        assert ds.captured_counter == int(mydict['captured_counter'])
-        assert ds.exp_name == mydict['experiment_name']
-        assert ds.sample_name == mydict['sample_name']
-        assert guid_comp['location'] == int(mydict['location'])
-        assert guid_comp['work_station'] == int(mydict['work_station'])
+        ds2 = load_by_guid(new_guids[i - 2], conn=target_conn)
+        assert ds2.captured_run_id == int(mydict["captured_run_id"])
+        assert ds2.captured_counter == int(mydict["captured_counter"])
+        assert ds2.exp_name == mydict["experiment_name"]
+        assert ds2.sample_name == mydict["sample_name"]
+        assert guid_comp["location"] == int(mydict["location"])
+        assert guid_comp["work_station"] == int(mydict["work_station"])
 
 
-def test_copy_datasets_and_add_new(two_empty_temp_db_connections,
-                                   some_interdeps):
+def test_copy_datasets_and_add_new(
+    two_empty_temp_db_connections, some_interdeps
+) -> None:
     """
     Test that new runs get the correct captured_run_id and captured_counter
     when adding on top of a dataset with partial exports
@@ -666,15 +677,17 @@ def test_copy_datasets_and_add_new(two_empty_temp_db_connections,
     expected_counter = [1, 2, 3]
     expected_captured_counter = [3, 4, 5]
 
-    for ds, eri, ecri, ec, ecc in zip(loaded_datasets,
-                                      expected_run_ids,
-                                      expected_captured_run_ids,
-                                      expected_counter,
-                                      expected_captured_counter):
-        assert ds.run_id == eri
-        assert ds.captured_run_id == ecri
-        assert ds.counter == ec
-        assert ds.captured_counter == ecc
+    for ds2, eri, ecri, ec, ecc in zip(
+        loaded_datasets,
+        expected_run_ids,
+        expected_captured_run_ids,
+        expected_counter,
+        expected_captured_counter,
+    ):
+        assert ds2.run_id == eri
+        assert ds2.captured_run_id == ecri
+        assert ds2.counter == ec
+        assert ds2.captured_counter == ecc
 
     exp = load_experiment_by_name('exp2', conn=target_conn)
 
@@ -705,9 +718,9 @@ def test_copy_datasets_and_add_new(two_empty_temp_db_connections,
         assert ds.captured_counter == ecc
 
 
-def test_old_versions_not_touched(two_empty_temp_db_connections,
-                                  some_interdeps):
-
+def test_old_versions_not_touched(
+    two_empty_temp_db_connections, some_interdeps
+) -> None:
     source_conn, target_conn = two_empty_temp_db_connections
 
     target_path = path_to_dbfile(target_conn)
@@ -759,8 +772,9 @@ def test_old_versions_not_touched(two_empty_temp_db_connections,
             assert warning[0].message.args[0] == expected_mssg
 
 
-def test_experiments_with_NULL_sample_name(two_empty_temp_db_connections,
-                                           some_interdeps):
+def test_experiments_with_NULL_sample_name(
+    two_empty_temp_db_connections, some_interdeps
+) -> None:
     """
     In older API versions (corresponding to DB version 3),
     users could get away with setting the sample name to None
@@ -811,8 +825,9 @@ def test_experiments_with_NULL_sample_name(two_empty_temp_db_connections,
     assert len(Experiment(exp_id=1, conn=target_conn)) == 5
 
 
-def test_integration_station_and_measurement(two_empty_temp_db_connections,
-                                             inst):
+def test_integration_station_and_measurement(
+    two_empty_temp_db_connections, inst
+) -> None:
     """
     An integration test where the runs in the source DB file are produced
     with the Measurement object and there is a Station as well
@@ -845,7 +860,7 @@ def test_integration_station_and_measurement(two_empty_temp_db_connections,
     assert datasaver.dataset.the_same_dataset_as(target_ds)
 
 
-def test_atomicity(two_empty_temp_db_connections, some_interdeps):
+def test_atomicity(two_empty_temp_db_connections, some_interdeps) -> None:
     """
     Test the atomicity of the transaction by extracting and inserting two
     runs where the second one is not completed. The not completed error must
@@ -881,7 +896,7 @@ def test_atomicity(two_empty_temp_db_connections, some_interdeps):
             extract_runs_into_db(source_path, target_path, 1, 2)
 
 
-def test_column_mismatch(two_empty_temp_db_connections, some_interdeps, inst):
+def test_column_mismatch(two_empty_temp_db_connections, some_interdeps, inst) -> None:
     """
     Test insertion of runs with no metadata and no snapshot into a DB already
     containing a run that has both

--- a/qcodes/tests/dataset/test_datasaver.py
+++ b/qcodes/tests/dataset/test_datasaver.py
@@ -1,4 +1,5 @@
 import re
+from typing import Callable, List
 
 import numpy as np
 import pytest
@@ -32,7 +33,7 @@ def reset_callback_globals():
 
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_default_callback(bg_writing):
+def test_default_callback(bg_writing) -> None:
     """
     The Web UI needs to know the results of an experiment with the metadata.
     So a default_callback class variable is set by the Web UI with a callback
@@ -64,7 +65,7 @@ def test_default_callback(bg_writing):
 
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_numpy_types(bg_writing):
+def test_numpy_types(bg_writing) -> None:
     """
     Test that we can save numpy types in the data set
     """
@@ -82,8 +83,15 @@ def test_numpy_types(bg_writing):
     data_saver = DataSaver(
         dataset=test_set, write_period=0, interdeps=idps)
 
-    dtypes = [np.int8, np.int16, np.int32, np.int64, np.float16, np.float32,
-              np.float64]
+    dtypes: List[Callable] = [
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.float16,
+        np.float32,
+        np.float64,
+    ]
 
     for dtype in dtypes:
         data_saver.add_result(("p", dtype(2)))

--- a/qcodes/tests/dataset/test_dataset_basic.py
+++ b/qcodes/tests/dataset/test_dataset_basic.py
@@ -10,6 +10,7 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 
 import qcodes as qc
+import qcodes.dataset
 from qcodes.dataset import (
     experiments,
     load_by_counter,
@@ -50,7 +51,7 @@ def make_shadow_dataset(dataset: DataSet):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_has_attributes_after_init():
+def test_has_attributes_after_init() -> None:
     """
     Ensure that all attributes are populated after __init__ in BOTH cases
     (run_id is None / run_id is not None)
@@ -78,7 +79,7 @@ def test_has_attributes_after_init():
 
 
 @pytest.mark.usefixtures("experiment")
-def test_dataset_length():
+def test_dataset_length() -> None:
 
     path_to_db = get_DB_location()
     ds = DataSet(path_to_db, run_id=None)
@@ -97,7 +98,7 @@ def test_dataset_length():
     assert len(ds) == 1
 
 
-def test_dataset_location(empty_temp_db_connection):
+def test_dataset_location(empty_temp_db_connection) -> None:
     """
     Test that an dataset and experiment points to the correct db file when
     a connection is supplied.
@@ -111,7 +112,7 @@ def test_dataset_location(empty_temp_db_connection):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_dataset_states():
+def test_dataset_states() -> None:
     """
     Test the interplay between pristine, started, running, and completed
     """
@@ -176,7 +177,7 @@ def test_dataset_states():
 
 @pytest.mark.parametrize("start_bg_writer", (True, False))
 @pytest.mark.usefixtures('experiment')
-def test_mark_completed_twice(start_bg_writer):
+def test_mark_completed_twice(start_bg_writer) -> None:
     """
     Ensure that its not an error to call mark_completed
     on an already completed dataset
@@ -188,7 +189,7 @@ def test_mark_completed_twice(start_bg_writer):
 
 
 @pytest.mark.usefixtures('experiment')
-def test_timestamps_are_none():
+def test_timestamps_are_none() -> None:
     ds = DataSet()
 
     assert ds.run_timestamp_raw is None
@@ -201,7 +202,7 @@ def test_timestamps_are_none():
 
 
 @pytest.mark.usefixtures('experiment')
-def test_integer_timestamps_in_database_are_supported():
+def test_integer_timestamps_in_database_are_supported() -> None:
     ds = DataSet()
 
     ds.mark_started()
@@ -216,7 +217,7 @@ def test_integer_timestamps_in_database_are_supported():
     assert isinstance(ds.completed_timestamp(), str)
 
 
-def test_dataset_read_only_properties(dataset):
+def test_dataset_read_only_properties(dataset) -> None:
     read_only_props = ['run_id', 'path_to_db', 'name', 'table_name', 'guid',
                        'number_of_results', 'counter', 'parameters',
                        'paramspecs', 'exp_id', 'exp_name', 'sample_name',
@@ -235,14 +236,14 @@ def test_dataset_read_only_properties(dataset):
 
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("non_existing_run_id", (1, 0, -1, 'number#42'))
-def test_create_dataset_from_non_existing_run_id(non_existing_run_id):
+def test_create_dataset_from_non_existing_run_id(non_existing_run_id) -> None:
     with pytest.raises(ValueError, match=f"Run with run_id "
                                          f"{non_existing_run_id} does not "
                                          f"exist in the database"):
         _ = DataSet(run_id=non_existing_run_id)
 
 
-def test_create_dataset_pass_both_connection_and_path_to_db(experiment):
+def test_create_dataset_pass_both_connection_and_path_to_db(experiment) -> None:
     with pytest.raises(ValueError, match="Received BOTH conn and path_to_db. "
                                          "Please provide only one or "
                                          "the other."):
@@ -250,7 +251,7 @@ def test_create_dataset_pass_both_connection_and_path_to_db(experiment):
         _ = DataSet(path_to_db="some valid path", conn=some_valid_connection)
 
 
-def test_load_by_id(dataset):
+def test_load_by_id(dataset) -> None:
     ds = load_by_id(dataset.run_id)
     assert dataset.run_id == ds.run_id
     assert dataset.path_to_db == ds.path_to_db
@@ -258,7 +259,7 @@ def test_load_by_id(dataset):
 
 @pytest.mark.usefixtures('experiment')
 @pytest.mark.parametrize('non_existing_run_id', (1, 0, -1))
-def test_load_by_id_for_nonexisting_run_id(non_existing_run_id):
+def test_load_by_id_for_nonexisting_run_id(non_existing_run_id) -> None:
     with pytest.raises(ValueError, match=f'Run with run_id '
                                          f'{non_existing_run_id} does not '
                                          f'exist in the database'):
@@ -279,7 +280,7 @@ def test_load_by_id_for_none() -> None:
                              min_size=1))
 @pytest.mark.usefixtures("empty_temp_db")
 @pytest.mark.usefixtures("reset_config_on_exit")
-def test_add_experiments(experiment_name, sample_name, dataset_name):
+def test_add_experiments(experiment_name, sample_name, dataset_name) -> None:
     qc.config.GUID_components.GUID_type = "random_sample"
 
     global n_experiments
@@ -345,7 +346,7 @@ def test_dependent_parameters() -> None:
     assert ds.dependent_parameters == (pss[3], pss[0])
 
 
-def test_set_interdependencies(dataset):
+def test_set_interdependencies(dataset) -> None:
     exps = experiments()
     assert len(exps) == 1
     exp = exps[0]
@@ -382,7 +383,7 @@ def test_set_interdependencies(dataset):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_add_data_1d():
+def test_add_data_1d() -> None:
     exps = experiments()
     assert len(exps) == 1
     exp = exps[0]
@@ -430,7 +431,7 @@ def test_add_data_1d():
 
 
 @pytest.mark.usefixtures("experiment")
-def test_add_data_array():
+def test_add_data_array() -> None:
     exps = experiments()
     assert len(exps) == 1
     exp = exps[0]
@@ -466,7 +467,7 @@ def test_add_data_array():
 
 
 @pytest.mark.usefixtures("experiment")
-def test_adding_too_many_results():
+def test_adding_too_many_results() -> None:
     """
     This test really tests the "chunking" functionality of the
     insert_many_values function of the sqlite.query_helpers module
@@ -479,7 +480,7 @@ def test_adding_too_many_results():
     idps = InterDependencies_(dependencies={yparam: (xparam,)})
     dataset.set_interdependencies(idps)
     dataset.mark_started()
-    n_max = int(qc.SQLiteSettings.limits["MAX_VARIABLE_NUMBER"])
+    n_max = int(qcodes.dataset.SQLiteSettings.limits["MAX_VARIABLE_NUMBER"])
 
     vals = np.linspace(0, 1, int(n_max/2)+2)
     results = [{'x': val} for val in vals]
@@ -495,7 +496,7 @@ def test_adding_too_many_results():
 
 
 @pytest.mark.usefixtures("dataset")
-def test_load_by_counter():
+def test_load_by_counter() -> None:
     exps = experiments()
     assert len(exps) == 1
     exp = exps[0]
@@ -512,7 +513,7 @@ def test_load_by_counter():
 
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize('nonexisting_counter', (-1, 0, 1, None))
-def test_load_by_counter_for_nonexisting_counter(nonexisting_counter):
+def test_load_by_counter_for_nonexisting_counter(nonexisting_counter) -> None:
     exp_id = 1
     with pytest.raises(RuntimeError, match='Expected one row'):
         _ = load_by_counter(exp_id, nonexisting_counter)
@@ -520,24 +521,24 @@ def test_load_by_counter_for_nonexisting_counter(nonexisting_counter):
 
 @pytest.mark.usefixtures("empty_temp_db")
 @pytest.mark.parametrize('nonexisting_exp_id', (-1, 0, 1, None))
-def test_load_by_counter_for_nonexisting_experiment(nonexisting_exp_id):
+def test_load_by_counter_for_nonexisting_experiment(nonexisting_exp_id) -> None:
     with pytest.raises(RuntimeError, match='Expected one row'):
         _ = load_by_counter(nonexisting_exp_id, 1)
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_dataset_with_no_experiment_raises():
+def test_dataset_with_no_experiment_raises() -> None:
     with pytest.raises(ValueError):
         new_data_set("test-dataset")
 
 
-def test_guid(dataset):
+def test_guid(dataset) -> None:
     guid = dataset.guid
     assert len(guid) == 36
     parse_guid(guid)
 
 
-def test_numpy_ints(dataset):
+def test_numpy_ints(dataset) -> None:
     """
      Test that we can insert numpy integers in the data set
     """
@@ -553,7 +554,7 @@ def test_numpy_ints(dataset):
                                   "x"]["x"], expected_result)
 
 
-def test_numpy_floats(dataset):
+def test_numpy_floats(dataset) -> None:
     """
     Test that we can insert numpy floats in the data set
     """
@@ -569,7 +570,7 @@ def test_numpy_floats(dataset):
     assert np.allclose(data, expected_result, atol=1E-8)
 
 
-def test_numpy_complex(dataset):
+def test_numpy_complex(dataset) -> None:
     """
     Test that we can insert numpy complex in the data set
     """
@@ -585,7 +586,7 @@ def test_numpy_complex(dataset):
     np.testing.assert_array_equal(result["x"]["x"], expected_result)
 
 
-def test_numpy_nan(dataset):
+def test_numpy_nan(dataset) -> None:
     parameter_m = ParamSpecBase("m", "numeric")
     idps = InterDependencies_(standalones=(parameter_m,))
     dataset.set_interdependencies(idps)
@@ -597,7 +598,7 @@ def test_numpy_nan(dataset):
     assert np.isnan(retrieved[1])
 
 
-def test_numpy_inf(dataset):
+def test_numpy_inf(dataset) -> None:
     """
     Test that we can insert and retrieve numpy inf in the data set
     """
@@ -612,16 +613,16 @@ def test_numpy_inf(dataset):
     assert np.isinf(retrieved).all()
 
 
-def test_backward_compat__adapt_array_v0_33():
+def test_backward_compat__adapt_array_v0_33() -> None:
     for dtype in numpy_floats + complex_types:
-        arr = np.asarray([1.0], dtype=np.dtype(dtype))
+        arr: np.ndarray = np.asarray([1.0], dtype=np.dtype(dtype))
         out = io.BytesIO()
         np.save(out, arr)
         out.seek(0)
         assert arr == _convert_array(out.read())
 
 
-def test_missing_keys(dataset):
+def test_missing_keys(dataset) -> None:
     """
     Test that we can now have partial results with keys missing. This is for
     example handy when having an interleaved 1D and 2D sweep.
@@ -668,7 +669,7 @@ def test_missing_keys(dataset):
                                   np.array([fb(xv, yv) for xv in xvals for yv in yvals]))
 
 
-def test_get_description(experiment, some_interdeps):
+def test_get_description(experiment, some_interdeps) -> None:
 
     ds = DataSet()
 
@@ -696,7 +697,7 @@ def test_get_description(experiment, some_interdeps):
     assert loaded_ds.description == expected_desc
 
 
-def test_metadata(experiment, request):
+def test_metadata(experiment, request) -> None:
 
     metadata1 = {'number': 1, "string": "Once upon a time..."}
     metadata2 = {'more': 'meta'}
@@ -739,7 +740,7 @@ def test_metadata(experiment, request):
     assert error_caused_by(e2, none_value_msg)
 
 
-def test_the_same_dataset_as(some_interdeps, experiment):
+def test_the_same_dataset_as(some_interdeps, experiment) -> None:
 
     ds = DataSet()
     ds.set_interdependencies(some_interdeps[1])
@@ -776,7 +777,7 @@ def test_parent_dataset_links_invalid_input() -> None:
 
 
 @pytest.mark.usefixtures("experiment")
-def test_parent_dataset_links(some_interdeps):
+def test_parent_dataset_links(some_interdeps) -> None:
     """
     Test that we can set links and retrieve them when loading the dataset
     """
@@ -863,7 +864,9 @@ class TestGetData:
             (2, 4, xdata[(2-1):4]),
         ],
     )
-    def test_get_data_with_start_and_end_args(self, ds_with_vals, start, end, expected):
+    def test_get_data_with_start_and_end_args(
+        self, ds_with_vals, start, end, expected
+    ) -> None:
         data = ds_with_vals.get_parameter_data(self.x, start=start, end=end)["x"]
         data = data["x"]
         np.testing.assert_array_equal(data, expected)
@@ -872,17 +875,17 @@ class TestGetData:
 @settings(deadline=600, suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(start=hst.one_of(hst.integers(1, 10**3), hst.none()),
        end=hst.one_of(hst.integers(1, 10**3), hst.none()))
-def test_get_parameter_data(scalar_dataset, start, end):
-    input_names = ['param_3']
+def test_get_parameter_data(scalar_dataset, start, end) -> None:
+    input_names = ["param_3"]
 
     expected_names = {}
-    expected_names['param_3'] = ['param_3', 'param_0', 'param_1', 'param_2']
-    expected_shapes = {}
-    expected_shapes['param_3'] = [(10**3, )]*4
+    expected_names["param_3"] = ["param_3", "param_0", "param_1", "param_2"]
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
+    expected_shapes["param_3"] = [(10**3,)] * 4
     expected_values = {}
-    expected_values['param_3'] = [np.arange(30000, 31000)] + \
-                                 [np.arange(10000*a, 10000*a+1000)
-                                  for a in range(3)]
+    expected_values["param_3"] = [np.arange(30000, 31000)] + [
+        np.arange(10000 * a, 10000 * a + 1000) for a in range(3)
+    ]
 
     start, end = limit_data_to_start_end(start, end, input_names,
                                          expected_names, expected_shapes,
@@ -897,26 +900,27 @@ def test_get_parameter_data(scalar_dataset, start, end):
                           end)
 
 
-def test_get_scalar_parameter_data_no_nulls(scalar_dataset_with_nulls):
-
+def test_get_scalar_parameter_data_no_nulls(scalar_dataset_with_nulls) -> None:
     expected_names = {}
-    expected_names['first_value'] = ['first_value', 'setpoint']
-    expected_names['second_value'] = ['second_value', 'setpoint']
-    expected_shapes = {}
-    expected_shapes['first_value'] = [(1, ), (1,)]
-    expected_shapes['second_value'] = [(1, ), (1,)]
+    expected_names["first_value"] = ["first_value", "setpoint"]
+    expected_names["second_value"] = ["second_value", "setpoint"]
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
+    expected_shapes["first_value"] = [(1,), (1,)]
+    expected_shapes["second_value"] = [(1,), (1,)]
     expected_values = {}
-    expected_values['first_value'] = [np.array([1]), np.array([0])]
-    expected_values['second_value'] = [np.array([2]), np.array([0])]
+    expected_values["first_value"] = [np.array([1]), np.array([0])]
+    expected_values["second_value"] = [np.array([2]), np.array([0])]
 
-    parameter_test_helper(scalar_dataset_with_nulls,
-                          list(expected_names.keys()),
-                          expected_names,
-                          expected_shapes,
-                          expected_values)
+    parameter_test_helper(
+        scalar_dataset_with_nulls,
+        list(expected_names.keys()),
+        expected_names,
+        expected_shapes,
+        expected_values,
+    )
 
 
-def test_get_array_parameter_data_no_nulls(array_dataset_with_nulls):
+def test_get_array_parameter_data_no_nulls(array_dataset_with_nulls) -> None:
 
     types = [p.type for p in array_dataset_with_nulls.paramspecs.values()]
 
@@ -926,18 +930,19 @@ def test_get_array_parameter_data_no_nulls(array_dataset_with_nulls):
     expected_shapes = {}
     expected_values = {}
 
-    if 'array' in types:
-        shape = (1, 5)
+    if "array" in types:
+        shape: Tuple[int, ...] = (1, 5)
     else:
         shape = (5,)
 
-    expected_shapes['val1'] = [shape] * 3
-    expected_shapes['val2'] = [shape] * 2
-    expected_values['val1'] = [np.ones(shape),
-                               np.arange(0, 5).reshape(shape),
-                               np.arange(5, 10).reshape(shape)]
-    expected_values['val2'] = [np.zeros(shape),
-                               np.arange(0, 5).reshape(shape)]
+    expected_shapes["val1"] = [shape] * 3
+    expected_shapes["val2"] = [shape] * 2
+    expected_values["val1"] = [
+        np.ones(shape),
+        np.arange(0, 5).reshape(shape),
+        np.arange(5, 10).reshape(shape),
+    ]
+    expected_values["val2"] = [np.zeros(shape), np.arange(0, 5).reshape(shape)]
 
     parameter_test_helper(array_dataset_with_nulls,
                           list(expected_names.keys()),
@@ -946,7 +951,7 @@ def test_get_array_parameter_data_no_nulls(array_dataset_with_nulls):
                           expected_values)
 
 
-def test_get_array_parameter_data(array_dataset):
+def test_get_array_parameter_data(array_dataset) -> None:
     paramspecs = array_dataset.paramspecs
     types = [param.type for param in paramspecs.values()]
     par_name = "array_setpoint_param"
@@ -956,15 +961,16 @@ def test_get_array_parameter_data(array_dataset):
 
     expected_names = {}
     expected_names[par_name] = [par_name, setpoint_name]
-    expected_shapes = {}
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
     expected_len = 5
     expected_shapes[par_name] = [(expected_len,), (expected_len,)]
     expected_values = {}
-    expected_values[par_name] = [np.ones(expected_len) + 1,
-                                 np.linspace(5, 9, expected_len)]
-    if 'array' in types:
-        expected_shapes[par_name] = [(1, expected_len),
-                                     (1, expected_len)]
+    expected_values[par_name] = [
+        np.ones(expected_len) + 1,
+        np.linspace(5, 9, expected_len),
+    ]
+    if "array" in types:
+        expected_shapes[par_name] = [(1, expected_len), (1, expected_len)]
         for i in range(len(expected_values[par_name])):
             expected_values[par_name][i] = expected_values[par_name][i].reshape(
                 1, expected_len)
@@ -975,7 +981,7 @@ def test_get_array_parameter_data(array_dataset):
                           expected_values)
 
 
-def test_get_multi_parameter_data(multi_dataset):
+def test_get_multi_parameter_data(multi_dataset) -> None:
     paramspecs = multi_dataset.paramspecs
     types = [param.type for param in paramspecs.values()]
 
@@ -984,9 +990,9 @@ def test_get_multi_parameter_data(multi_dataset):
                 'multi_2d_setpoint_param_that_setpoint']
 
     expected_names = {}
-    expected_names['this'] = ['this'] + sp_names
-    expected_names['that'] = ['that'] + sp_names
-    expected_shapes = {}
+    expected_names["this"] = ["this"] + sp_names
+    expected_names["that"] = ["that"] + sp_names
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
     expected_values = {}
     shape_1 = 5
     shape_2 = 3
@@ -996,17 +1002,19 @@ def test_get_multi_parameter_data(multi_dataset):
     sp_1_data = np.tile(np.linspace(5, 9, shape_1).reshape(shape_1, 1),
                         (1, shape_2))
     sp_2_data = np.tile(np.linspace(9, 11, shape_2), (shape_1, 1))
-    if 'array' in types:
-        expected_shapes['this'] = [
-            (1, shape_1, shape_2), (1, shape_1, shape_2)]
-        expected_shapes['that'] = [
-            (1, shape_1, shape_2), (1, shape_1, shape_2)]
-        expected_values['this'] = [this_data.reshape(1, shape_1, shape_2),
-                                   sp_1_data.reshape(1, shape_1, shape_2),
-                                   sp_2_data.reshape(1, shape_1, shape_2)]
-        expected_values['that'] = [that_data.reshape(1, shape_1, shape_2),
-                                   sp_1_data.reshape(1, shape_1, shape_2),
-                                   sp_2_data.reshape(1, shape_1, shape_2)]
+    if "array" in types:
+        expected_shapes["this"] = [(1, shape_1, shape_2), (1, shape_1, shape_2)]
+        expected_shapes["that"] = [(1, shape_1, shape_2), (1, shape_1, shape_2)]
+        expected_values["this"] = [
+            this_data.reshape(1, shape_1, shape_2),
+            sp_1_data.reshape(1, shape_1, shape_2),
+            sp_2_data.reshape(1, shape_1, shape_2),
+        ]
+        expected_values["that"] = [
+            that_data.reshape(1, shape_1, shape_2),
+            sp_1_data.reshape(1, shape_1, shape_2),
+            sp_2_data.reshape(1, shape_1, shape_2),
+        ]
 
     else:
         expected_shapes['this'] = [(15,), (15,)]
@@ -1025,29 +1033,30 @@ def test_get_multi_parameter_data(multi_dataset):
 
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(start=hst.one_of(hst.integers(1, 9), hst.none()),
-       end=hst.one_of(hst.integers(1, 9), hst.none()))
-def test_get_array_in_scalar_param_data(array_in_scalar_dataset,
-                                        start, end):
+@given(
+    start=hst.one_of(hst.integers(1, 9), hst.none()),
+    end=hst.one_of(hst.integers(1, 9), hst.none()),
+)
+def test_get_array_in_scalar_param_data(array_in_scalar_dataset, start, end) -> None:
     par_name = "array_setpoint_param"
     setpoint_name = "array_setpoint_param_this_setpoint"
 
     input_names = [par_name]
 
     expected_names = {}
-    expected_names[par_name] = [par_name, 'scalarparam', setpoint_name]
-    expected_shapes = {}
+    expected_names[par_name] = [par_name, "scalarparam", setpoint_name]
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
 
     shape_1 = 9
     shape_2 = 5
 
-    test_parameter_values = np.tile((np.ones(shape_2) + 1).reshape(1, shape_2),
-                                    (shape_1, 1))
-    scalar_param_values = np.tile(np.arange(1, 10).reshape(shape_1, 1),
-                                  (1, shape_2))
-    setpoint_param_values = np.tile((np.linspace(5, 9, shape_2)).reshape(1, shape_2),
-                                    (shape_1, 1))
-    expected_shapes[par_name] = {}
+    test_parameter_values = np.tile(
+        (np.ones(shape_2) + 1).reshape(1, shape_2), (shape_1, 1)
+    )
+    scalar_param_values = np.tile(np.arange(1, 10).reshape(shape_1, 1), (1, shape_2))
+    setpoint_param_values = np.tile(
+        (np.linspace(5, 9, shape_2)).reshape(1, shape_2), (shape_1, 1)
+    )
     expected_shapes[par_name] = [(shape_1, shape_2), (shape_1, shape_2)]
     expected_values = {}
     expected_values[par_name] = [
@@ -1067,30 +1076,30 @@ def test_get_array_in_scalar_param_data(array_in_scalar_dataset,
                           end)
 
 
-def test_get_varlen_array_in_scalar_param_data(varlen_array_in_scalar_dataset):
+def test_get_varlen_array_in_scalar_param_data(varlen_array_in_scalar_dataset) -> None:
     par_name = "array_setpoint_param"
     setpoint_name = "array_setpoint_param_this_setpoint"
 
     input_names = [par_name]
 
     expected_names = {}
-    expected_names[par_name] = [par_name, 'scalarparam', setpoint_name]
-    expected_shapes = {}
+    expected_names[par_name] = [par_name, "scalarparam", setpoint_name]
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
 
     n = 9
-    n_points = (n*(n+1))//2
+    n_points = (n * (n + 1)) // 2
 
-    scalar_param_values = []
-    setpoint_param_values = []
+    scalar_param_values_list = []
+    setpoint_param_values_list = []
     for i in range(1, n + 1):
         for j in range(i):
-            setpoint_param_values.append(j)
-            scalar_param_values.append(i)
+            setpoint_param_values_list.append(j)
+            scalar_param_values_list.append(i)
 
     np.random.seed(0)
     test_parameter_values = np.random.rand(n_points)
-    scalar_param_values = np.array(scalar_param_values)
-    setpoint_param_values = np.array(setpoint_param_values)
+    scalar_param_values = np.array(scalar_param_values_list)
+    setpoint_param_values = np.array(setpoint_param_values_list)
 
     expected_shapes[par_name] = [(n_points,), (n_points,)]
     expected_values = {}
@@ -1107,29 +1116,32 @@ def test_get_varlen_array_in_scalar_param_data(varlen_array_in_scalar_dataset):
 
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(start=hst.one_of(hst.integers(1, 45), hst.none()),
-       end=hst.one_of(hst.integers(1, 45), hst.none()))
-def test_get_array_in_scalar_param_unrolled(array_in_scalar_dataset_unrolled,
-                                            start, end):
+@given(
+    start=hst.one_of(hst.integers(1, 45), hst.none()),
+    end=hst.one_of(hst.integers(1, 45), hst.none()),
+)
+def test_get_array_in_scalar_param_unrolled(
+    array_in_scalar_dataset_unrolled, start, end
+) -> None:
     par_name = "array_setpoint_param"
     setpoint_name = "array_setpoint_param_this_setpoint"
     input_names = [par_name]
 
     expected_names = {}
-    expected_names[par_name] = [par_name, 'scalarparam', setpoint_name]
-    expected_shapes = {}
+    expected_names[par_name] = [par_name, "scalarparam", setpoint_name]
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
 
     shape_1 = 9
     shape_2 = 5
 
-    test_parameter_values = np.tile((np.ones(shape_2) + 1).reshape(1, shape_2),
-                                    (shape_1, 1))
-    scalar_param_values = np.tile(np.arange(1, 10).reshape(shape_1, 1),
-                                  (1, shape_2))
-    setpoint_param_values = np.tile((np.linspace(5, 9, shape_2)).reshape(1, shape_2),
-                                    (shape_1, 1))
-    expected_shapes[par_name] = {}
-    expected_shapes[par_name] = [(shape_1*shape_2,), (shape_1*shape_2,)]
+    test_parameter_values = np.tile(
+        (np.ones(shape_2) + 1).reshape(1, shape_2), (shape_1, 1)
+    )
+    scalar_param_values = np.tile(np.arange(1, 10).reshape(shape_1, 1), (1, shape_2))
+    setpoint_param_values = np.tile(
+        (np.linspace(5, 9, shape_2)).reshape(1, shape_2), (shape_1, 1)
+    )
+    expected_shapes[par_name] = [(shape_1 * shape_2,), (shape_1 * shape_2,)]
     expected_values = {}
     expected_values[par_name] = [
         test_parameter_values.ravel(),
@@ -1148,7 +1160,7 @@ def test_get_array_in_scalar_param_unrolled(array_in_scalar_dataset_unrolled,
                           end)
 
 
-def test_get_array_in_str_param_data(array_in_str_dataset):
+def test_get_array_in_str_param_data(array_in_str_dataset) -> None:
     paramspecs = array_in_str_dataset.paramspecs
     types = [param.type for param in paramspecs.values()]
 
@@ -1158,22 +1170,24 @@ def test_get_array_in_str_param_data(array_in_str_dataset):
     input_names = [par_name]
 
     expected_names = {}
-    expected_names[par_name] = [par_name, 'textparam', setpoint_name]
-    expected_shapes = {}
+    expected_names[par_name] = [par_name, "textparam", setpoint_name]
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
 
     shape_1 = 3
     shape_2 = 5
 
-    test_parameter_values = np.tile((np.ones(shape_2) + 1).reshape(1, shape_2),
-                                    (shape_1, 1))
-    scalar_param_values = np.tile(np.array(['A', 'B', 'C']).reshape(shape_1, 1),
-                                  (1, shape_2))
-    setpoint_param_values = np.tile((np.linspace(5, 9, shape_2)).reshape(1, shape_2),
-                                    (shape_1, 1))
-    expected_shapes['array_setpoint_param'] = {}
+    test_parameter_values = np.tile(
+        (np.ones(shape_2) + 1).reshape(1, shape_2), (shape_1, 1)
+    )
+    scalar_param_values = np.tile(
+        np.array(["A", "B", "C"]).reshape(shape_1, 1), (1, shape_2)
+    )
+    setpoint_param_values = np.tile(
+        (np.linspace(5, 9, shape_2)).reshape(1, shape_2), (shape_1, 1)
+    )
     expected_values = {}
 
-    if 'array' in types:
+    if "array" in types:
         expected_shapes[par_name] = [(3, 5), (3, 5)]
         expected_values[par_name] = [
             test_parameter_values,
@@ -1192,7 +1206,9 @@ def test_get_array_in_str_param_data(array_in_str_dataset):
                           expected_values)
 
 
-def test_get_parameter_data_independent_parameters(standalone_parameters_dataset):
+def test_get_parameter_data_independent_parameters(
+    standalone_parameters_dataset,
+) -> None:
     ds = standalone_parameters_dataset
 
     paramspecs = ds.description.interdeps.non_dependencies
@@ -1202,14 +1218,14 @@ def test_get_parameter_data_independent_parameters(standalone_parameters_dataset
     assert params == expected_toplevel_params
 
     expected_names = {}
-    expected_names['param_1'] = ['param_1']
-    expected_names['param_2'] = ['param_2']
-    expected_names['param_3'] = ['param_3', 'param_0']
+    expected_names["param_1"] = ["param_1"]
+    expected_names["param_2"] = ["param_2"]
+    expected_names["param_3"] = ["param_3", "param_0"]
 
-    expected_shapes = {}
-    expected_shapes['param_1'] = [(10 ** 3,)]
-    expected_shapes['param_2'] = [(10 ** 3,)]
-    expected_shapes['param_3'] = [(10**3, )]*2
+    expected_shapes: Dict[str, List[Tuple[int, ...]]] = {}
+    expected_shapes["param_1"] = [(10**3,)]
+    expected_shapes["param_2"] = [(10**3,)]
+    expected_shapes["param_3"] = [(10**3,)] * 2
 
     expected_values = {}
     expected_values['param_1'] = [np.arange(10000, 10000 + 1000)]
@@ -1224,13 +1240,15 @@ def test_get_parameter_data_independent_parameters(standalone_parameters_dataset
                           expected_values)
 
 
-def parameter_test_helper(ds: DataSet,
-                          toplevel_names: Sequence[str],
-                          expected_names: Dict[str, Sequence[str]],
-                          expected_shapes: Dict[str, Sequence[Tuple[int, ...]]],
-                          expected_values: Dict[str, Sequence[np.ndarray]],
-                          start: Optional[int] = None,
-                          end: Optional[int] = None):
+def parameter_test_helper(
+    ds: DataSet,
+    toplevel_names: Sequence[str],
+    expected_names: Dict[str, List[str]],
+    expected_shapes: Dict[str, List[Tuple[int, ...]]],
+    expected_values: Dict[str, List[np.ndarray]],
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+):
     """
     A helper function to compare the data we actually read out of a given
     dataset with the expected data.
@@ -1313,7 +1331,7 @@ def limit_data_to_start_end(start, end, input_names, expected_names,
 
 
 @pytest.mark.usefixtures("experiment")
-def test_empty_ds_parameters():
+def test_empty_ds_parameters() -> None:
 
     ds = new_data_set("mydataset")
     assert ds.parameters is None

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -122,7 +122,7 @@ def _make_mock_dataset_inverted_coords(experiment):
 
 
 @pytest.mark.usefixtures('experiment')
-def test_write_data_to_text_file_save(tmp_path_factory):
+def test_write_data_to_text_file_save(tmp_path_factory) -> None:
     dataset = new_data_set("dataset")
     xparam = ParamSpecBase("x", 'numeric')
     yparam = ParamSpecBase("y", 'numeric')
@@ -141,7 +141,9 @@ def test_write_data_to_text_file_save(tmp_path_factory):
         assert f.readlines() == ['0.0\t1.0\n']
 
 
-def test_write_data_to_text_file_save_multi_keys(tmp_path_factory, mock_dataset):
+def test_write_data_to_text_file_save_multi_keys(
+    tmp_path_factory, mock_dataset
+) -> None:
     tmp_path = tmp_path_factory.mktemp("data_to_text_file_save_multi_keys")
     path = str(tmp_path)
     mock_dataset.write_data_to_text_file(path=path)
@@ -152,7 +154,9 @@ def test_write_data_to_text_file_save_multi_keys(tmp_path_factory, mock_dataset)
         assert f.readlines() == ['0.0\t2.0\n']
 
 
-def test_write_data_to_text_file_save_single_file(tmp_path_factory, mock_dataset):
+def test_write_data_to_text_file_save_single_file(
+    tmp_path_factory, mock_dataset
+) -> None:
     tmp_path = tmp_path_factory.mktemp("to_text_file_save_single_file")
     path = str(tmp_path)
     mock_dataset.write_data_to_text_file(path=path, single_file=True,
@@ -163,7 +167,7 @@ def test_write_data_to_text_file_save_single_file(tmp_path_factory, mock_dataset
 
 
 @pytest.mark.usefixtures('experiment')
-def test_write_data_to_text_file_length_exception(tmp_path):
+def test_write_data_to_text_file_length_exception(tmp_path) -> None:
     dataset = new_data_set("dataset")
     xparam = ParamSpecBase("x", 'numeric')
     yparam = ParamSpecBase("y", 'numeric')
@@ -187,14 +191,14 @@ def test_write_data_to_text_file_length_exception(tmp_path):
                                         single_file_name='yz')
 
 
-def test_write_data_to_text_file_name_exception(tmp_path, mock_dataset):
+def test_write_data_to_text_file_name_exception(tmp_path, mock_dataset) -> None:
     temp_dir = str(tmp_path)
     with pytest.raises(Exception, match='desired file name'):
         mock_dataset.write_data_to_text_file(path=temp_dir, single_file=True,
                                              single_file_name=None)
 
 
-def test_export_csv(tmp_path_factory, mock_dataset, caplog):
+def test_export_csv(tmp_path_factory, mock_dataset, caplog) -> None:
     tmp_path = tmp_path_factory.mktemp("export_csv")
     path = str(tmp_path)
     with caplog.at_level(logging.INFO):
@@ -243,7 +247,7 @@ def test_export_netcdf(tmp_path_factory, mock_dataset, caplog) -> None:
     assert mock_dataset.export_info.export_paths["nc"] == file_path
 
 
-def test_export_netcdf_default_dir(tmp_path_factory, mock_dataset):
+def test_export_netcdf_default_dir(tmp_path_factory, mock_dataset) -> None:
     qcodes.config.dataset.export_path = "{db_location}"
     mock_dataset.export(export_type="netcdf", prefix="qcodes_")
     export_path = Path(mock_dataset.export_info.export_paths["nc"])
@@ -258,7 +262,7 @@ def test_export_netcdf_default_dir(tmp_path_factory, mock_dataset):
     assert exported_dir == get_data_export_path()
 
 
-def test_export_netcdf_csv(tmp_path_factory, mock_dataset):
+def test_export_netcdf_csv(tmp_path_factory, mock_dataset) -> None:
 
     tmp_path = tmp_path_factory.mktemp("export_netcdf")
     path = str(tmp_path)
@@ -317,7 +321,9 @@ def test_export_netcdf_complex_data(tmp_path_factory, mock_dataset_complex) -> N
     assert df.y.values.tolist() == [1.0 + 1j]  # type: ignore[union-attr]
 
 
-def test_export_no_or_nonexistent_type_specified(tmp_path_factory, mock_dataset):
+def test_export_no_or_nonexistent_type_specified(
+    tmp_path_factory, mock_dataset
+) -> None:
     with pytest.raises(ValueError, match="No data export type specified"):
         mock_dataset.export()
 
@@ -325,7 +331,7 @@ def test_export_no_or_nonexistent_type_specified(tmp_path_factory, mock_dataset)
         mock_dataset.export(export_type="foo")
 
 
-def test_export_from_config(tmp_path_factory, mock_dataset, mocker):
+def test_export_from_config(tmp_path_factory, mock_dataset, mocker) -> None:
     tmp_path = tmp_path_factory.mktemp("export_from_config")
     path = str(tmp_path)
     mock_type = mocker.patch("qcodes.dataset.data_set_protocol.get_data_export_type")
@@ -338,7 +344,9 @@ def test_export_from_config(tmp_path_factory, mock_dataset, mocker):
     ]
 
 
-def test_export_from_config_set_name_elements(tmp_path_factory, mock_dataset, mocker):
+def test_export_from_config_set_name_elements(
+    tmp_path_factory, mock_dataset, mocker
+) -> None:
     tmp_path = tmp_path_factory.mktemp("export_from_config")
     path = str(tmp_path)
     mock_type = mocker.patch("qcodes.dataset.data_set_protocol.get_data_export_type")
@@ -361,7 +369,7 @@ def test_export_from_config_set_name_elements(tmp_path_factory, mock_dataset, mo
     ]
 
 
-def test_same_setpoint_warning_for_df_and_xarray(different_setpoint_dataset):
+def test_same_setpoint_warning_for_df_and_xarray(different_setpoint_dataset) -> None:
 
     warning_message = (
         "Independent parameter setpoints are not equal. "
@@ -381,7 +389,7 @@ def test_same_setpoint_warning_for_df_and_xarray(different_setpoint_dataset):
         different_setpoint_dataset.cache.to_xarray_dataset()
 
 
-def test_export_to_xarray_dataset_empty_ds(mock_empty_dataset):
+def test_export_to_xarray_dataset_empty_ds(mock_empty_dataset) -> None:
     ds = mock_empty_dataset.to_xarray_dataset()
     assert len(ds) == 2
     assert len(ds.coords) == 1
@@ -389,7 +397,7 @@ def test_export_to_xarray_dataset_empty_ds(mock_empty_dataset):
     _assert_xarray_metadata_is_as_expected(ds, mock_empty_dataset)
 
 
-def test_export_to_xarray_dataarray_empty_ds(mock_empty_dataset):
+def test_export_to_xarray_dataarray_empty_ds(mock_empty_dataset) -> None:
     dad = mock_empty_dataset.to_xarray_dataarray_dict()
     assert len(dad) == 2
     assert len(dad["y"].coords) == 1
@@ -398,7 +406,7 @@ def test_export_to_xarray_dataarray_empty_ds(mock_empty_dataset):
     assert "x" in dad["z"].coords
 
 
-def test_export_to_xarray(mock_dataset):
+def test_export_to_xarray(mock_dataset) -> None:
     ds = mock_dataset.to_xarray_dataset()
     assert len(ds) == 2
     assert "index" not in ds.coords
@@ -406,7 +414,9 @@ def test_export_to_xarray(mock_dataset):
     _assert_xarray_metadata_is_as_expected(ds, mock_dataset)
 
 
-def test_export_to_xarray_non_unique_dependent_parameter(mock_dataset_nonunique):
+def test_export_to_xarray_non_unique_dependent_parameter(
+    mock_dataset_nonunique,
+) -> None:
     """When x (the dependent parameter) contains non unique values it cannot be used
     as coordinates in xarray so check that we fall back to using an index"""
     ds = mock_dataset_nonunique.to_xarray_dataset()
@@ -419,7 +429,7 @@ def test_export_to_xarray_non_unique_dependent_parameter(mock_dataset_nonunique)
         assert "snapshot" not in ds[array_name].attrs.keys()
 
 
-def test_export_to_xarray_extra_metadata(mock_dataset):
+def test_export_to_xarray_extra_metadata(mock_dataset) -> None:
     mock_dataset.add_metadata("mytag", "somestring")
     mock_dataset.add_metadata("myothertag", 1)
     ds = mock_dataset.to_xarray_dataset()
@@ -430,7 +440,7 @@ def test_export_to_xarray_extra_metadata(mock_dataset):
         assert "snapshot" not in ds[array_name].attrs.keys()
 
 
-def test_export_to_xarray_ds_dict_extra_metadata(mock_dataset):
+def test_export_to_xarray_ds_dict_extra_metadata(mock_dataset) -> None:
     mock_dataset.add_metadata("mytag", "somestring")
     mock_dataset.add_metadata("myothertag", 1)
     da_dict = mock_dataset.to_xarray_dataarray_dict()
@@ -439,7 +449,7 @@ def test_export_to_xarray_ds_dict_extra_metadata(mock_dataset):
         _assert_xarray_metadata_is_as_expected(datarray, mock_dataset)
 
 
-def test_export_to_xarray_extra_metadata_can_be_stored(mock_dataset, tmp_path):
+def test_export_to_xarray_extra_metadata_can_be_stored(mock_dataset, tmp_path) -> None:
 
     nt_metadata = {
         "foo": {
@@ -476,7 +486,7 @@ def test_export_to_xarray_extra_metadata_can_be_stored(mock_dataset, tmp_path):
     assert loaded_data.attrs == data_as_xarray.attrs
 
 
-def test_to_xarray_ds_paramspec_metadata_is_preserved(mock_dataset_label_unit):
+def test_to_xarray_ds_paramspec_metadata_is_preserved(mock_dataset_label_unit) -> None:
     xr_ds = mock_dataset_label_unit.to_xarray_dataset()
     assert len(xr_ds.dims) == 1
     for param_name in xr_ds.dims:
@@ -489,7 +499,9 @@ def test_to_xarray_ds_paramspec_metadata_is_preserved(mock_dataset_label_unit):
         )
 
 
-def test_to_xarray_da_dict_paramspec_metadata_is_preserved(mock_dataset_label_unit):
+def test_to_xarray_da_dict_paramspec_metadata_is_preserved(
+    mock_dataset_label_unit,
+) -> None:
     xr_das = mock_dataset_label_unit.to_xarray_dataarray_dict()
 
     for outer_param_name, xr_da in xr_das.items():
@@ -506,7 +518,7 @@ def test_to_xarray_da_dict_paramspec_metadata_is_preserved(mock_dataset_label_un
 
 def test_inverted_coords_perserved_on_netcdf_roundtrip(
     tmp_path_factory, mock_dataset_inverted_coords
-):
+) -> None:
     tmp_path = tmp_path_factory.mktemp("export_netcdf")
     path = str(tmp_path)
     mock_dataset_inverted_coords.export(

--- a/qcodes/tests/dataset/test_dataset_in_memory.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory.py
@@ -20,7 +20,7 @@ from qcodes.station import Station
 
 def test_dataset_in_memory_reload_from_db(
     meas_with_registered_param, DMM, DAC, tmp_path
-):
+) -> None:
     with meas_with_registered_param.run(
         dataset_class=DataSetType.DataSetInMem
     ) as datasaver:
@@ -56,7 +56,7 @@ def test_dataset_in_memory_reload_from_db(
 )
 def test_dataset_in_memory_reload_from_db_2d(
     meas_with_registered_param_2d, DMM, DAC, tmp_path, shape1, shape2
-):
+) -> None:
     meas_with_registered_param_2d.set_shapes(
         {
             DMM.v1.full_name: (shape1, shape2),
@@ -114,7 +114,7 @@ def test_dataset_in_memory_reload_from_db_2d(
 )
 def test_dataset_in_memory_reload_from_db_3d(
     meas_with_registered_param_3d, DMM, DAC3D, tmp_path, shape1, shape2, shape3
-):
+) -> None:
     meas_with_registered_param_3d.set_shapes(
         {
             DMM.v1.full_name: (shape1, shape2, shape3),
@@ -169,7 +169,7 @@ def test_dataset_in_memory_reload_from_db_3d(
 
 def test_dataset_in_memory_without_cache_raises(
     meas_with_registered_param, DMM, DAC, tmp_path
-):
+) -> None:
 
     with pytest.raises(
         RuntimeError,
@@ -186,7 +186,7 @@ def test_dataset_in_memory_without_cache_raises(
 
 def test_dataset_in_memory_reload_from_db_complex(
     meas_with_registered_param_complex, DAC, complex_num_instrument, tmp_path
-):
+) -> None:
     with meas_with_registered_param_complex.run(
         dataset_class=DataSetType.DataSetInMem
     ) as datasaver:
@@ -210,7 +210,7 @@ def test_dataset_in_memory_reload_from_db_complex(
 
 def test_dataset_in_memory_reload_from_netcdf_complex(
     meas_with_registered_param_complex, DAC, complex_num_instrument, tmp_path
-):
+) -> None:
     with meas_with_registered_param_complex.run(
         dataset_class=DataSetType.DataSetInMem
     ) as datasaver:
@@ -236,7 +236,7 @@ def test_dataset_in_memory_reload_from_netcdf_complex(
 
 def test_dataset_in_memory_no_export_warns(
     meas_with_registered_param, DMM, DAC, tmp_path
-):
+) -> None:
     with meas_with_registered_param.run(
         dataset_class=DataSetType.DataSetInMem
     ) as datasaver:
@@ -263,7 +263,7 @@ def test_dataset_in_memory_no_export_warns(
 
 def test_dataset_in_memory_missing_file_warns(
     meas_with_registered_param, DMM, DAC, tmp_path
-):
+) -> None:
     with meas_with_registered_param.run(
         dataset_class=DataSetType.DataSetInMem
     ) as datasaver:
@@ -284,7 +284,9 @@ def test_dataset_in_memory_missing_file_warns(
     assert loaded_ds.cache.data() == {}
 
 
-def test_dataset_in_reload_from_netcdf(meas_with_registered_param, DMM, DAC, tmp_path):
+def test_dataset_in_reload_from_netcdf(
+    meas_with_registered_param, DMM, DAC, tmp_path
+) -> None:
     with meas_with_registered_param.run(
         dataset_class=DataSetType.DataSetInMem
     ) as datasaver:
@@ -310,7 +312,7 @@ def test_dataset_in_reload_from_netcdf(meas_with_registered_param, DMM, DAC, tmp
 
 def test_dataset_load_from_netcdf_and_db(
     meas_with_registered_param, DMM, DAC, tmp_path
-):
+) -> None:
     with meas_with_registered_param.run(
         dataset_class=DataSetType.DataSetInMem
     ) as datasaver:
@@ -348,7 +350,7 @@ def test_dataset_load_from_netcdf_and_db(
 
 def test_dataset_in_memory_does_not_create_runs_table(
     meas_with_registered_param, DMM, DAC, tmp_path
-):
+) -> None:
     with meas_with_registered_param.run(
         dataset_class=DataSetType.DataSetInMem
     ) as datasaver:
@@ -369,7 +371,7 @@ def test_dataset_in_memory_does_not_create_runs_table(
     assert all(ds.name not in table_name for table_name in tablenames)
 
 
-def test_load_from_netcdf_and_write_metadata_to_db(empty_temp_db):
+def test_load_from_netcdf_and_write_metadata_to_db(empty_temp_db) -> None:
     netcdf_file_path = (
         Path(__file__).parent / "fixtures" / "db_files" / "netcdf" / "qcodes_2.nc"
     )
@@ -402,7 +404,7 @@ def test_load_from_netcdf_and_write_metadata_to_db(empty_temp_db):
     compare_datasets(ds, loaded_ds)
 
 
-def test_load_from_netcdf_no_db_file(non_created_db):
+def test_load_from_netcdf_no_db_file(non_created_db) -> None:
     netcdf_file_path = (
         Path(__file__).parent / "fixtures" / "db_files" / "netcdf" / "qcodes_2.nc"
     )
@@ -417,7 +419,7 @@ def test_load_from_netcdf_no_db_file(non_created_db):
     compare_datasets(ds, loaded_ds)
 
 
-def test_load_from_db(meas_with_registered_param, DMM, DAC, tmp_path):
+def test_load_from_db(meas_with_registered_param, DMM, DAC, tmp_path) -> None:
     Station(DAC, DMM)
     with meas_with_registered_param.run(
         dataset_class=DataSetType.DataSetInMem
@@ -447,7 +449,7 @@ def test_load_from_db(meas_with_registered_param, DMM, DAC, tmp_path):
     compare_datasets(ds, loaded_ds)
 
 
-def test_load_from_netcdf_legacy_version(non_created_db):
+def test_load_from_netcdf_legacy_version(non_created_db) -> None:
     # Qcodes 0.26 exported netcdf files did not contain
     # the parent dataset links and used a different engine to write data
     # check that it still loads correctly
@@ -487,8 +489,9 @@ def compare_datasets(ds, loaded_ds):
     assert all(xds == loaded_xds)
 
 
-def test_load_from_db_dataset_moved(meas_with_registered_param, DMM, DAC, tmp_path):
-
+def test_load_from_db_dataset_moved(
+    meas_with_registered_param, DMM, DAC, tmp_path
+) -> None:
     Station(DAC, DMM)
     with meas_with_registered_param.run(
         dataset_class=DataSetType.DataSetInMem

--- a/qcodes/tests/dataset/test_dataset_in_memory_bacis.py
+++ b/qcodes/tests/dataset/test_dataset_in_memory_bacis.py
@@ -10,7 +10,7 @@ from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
 
 
-def test_create_dataset_in_memory_explicit_db(empty_temp_db):
+def test_create_dataset_in_memory_explicit_db(empty_temp_db) -> None:
     default_db_location = qc.config["core"]["db_location"]
 
     extra_db_location = str(Path(default_db_location).parent / "extra.db")
@@ -25,7 +25,7 @@ def test_create_dataset_in_memory_explicit_db(empty_temp_db):
     assert default_db_location != extra_db_location
 
 
-def test_empty_ds_parameters(experiment):
+def test_empty_ds_parameters(experiment) -> None:
 
     ds = DataSetInMem._create_new_run(name="foo")
 
@@ -39,7 +39,7 @@ def test_empty_ds_parameters(experiment):
     assert ds._parameters is None
 
 
-def test_write_metadata_to_explicit_db(empty_temp_db):
+def test_write_metadata_to_explicit_db(empty_temp_db) -> None:
     default_db_location = qc.config["core"]["db_location"]
     extra_db_location = str(Path(default_db_location).parent / "extra.db")
     load_or_create_experiment(experiment_name="myexp", sample_name="mysample")
@@ -56,7 +56,7 @@ def test_write_metadata_to_explicit_db(empty_temp_db):
     ds.the_same_dataset_as(loaded_ds)
 
 
-def test_no_interdeps_raises_in_prepare(experiment):
+def test_no_interdeps_raises_in_prepare(experiment) -> None:
     ds = DataSetInMem._create_new_run(name="foo")
     with pytest.raises(RuntimeError, match="No parameters supplied"):
         ds.prepare(interdeps=InterDependencies_(), snapshot={})
@@ -112,7 +112,7 @@ def test_timestamps(experiment) -> None:
     ds.mark_completed()
 
 
-def test_mark_pristine_completed_raises(experiment):
+def test_mark_pristine_completed_raises(experiment) -> None:
     ds = DataSetInMem._create_new_run(name="foo")
 
     with pytest.raises(
@@ -121,7 +121,7 @@ def test_mark_pristine_completed_raises(experiment):
         ds.mark_completed()
 
 
-def test_load_from_non_existing_guid(experiment):
+def test_load_from_non_existing_guid(experiment) -> None:
     guid = "This is not a guid"
     with pytest.raises(
         RuntimeError, match="Could not find the requested run with GUID"

--- a/qcodes/tests/dataset/test_dataset_loading.py
+++ b/qcodes/tests/dataset/test_dataset_loading.py
@@ -30,7 +30,7 @@ from qcodes.utils import QCoDeSDeprecationWarning
 
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.usefixtures("reset_config_on_exit")
-def test_load_by_id():
+def test_load_by_id() -> None:
     qc.config.GUID_components.GUID_type = "random_sample"
     ds = new_data_set("test-dataset")
     run_id = ds.run_id
@@ -63,7 +63,7 @@ def test_load_by_id():
 
 
 @pytest.mark.usefixtures("experiment")
-def test_get_guids_from_run_spec_warns():
+def test_get_guids_from_run_spec_warns() -> None:
     ds = new_data_set("test-dataset")
     run_id = ds.run_id
     ds.mark_started()
@@ -78,7 +78,7 @@ def test_get_guids_from_run_spec_warns():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_load_by_counter():
+def test_load_by_counter() -> None:
     exp = new_experiment(name="for_loading", sample_name="no_sample")
     ds = new_data_set("my_first_ds")
 
@@ -156,7 +156,7 @@ def test_get_run_attributes() -> None:
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_experiment_info_in_dataset():
+def test_experiment_info_in_dataset() -> None:
     exp = new_experiment(name="for_loading", sample_name="no_sample")
     ds = new_data_set("my_first_ds")
 
@@ -166,7 +166,7 @@ def test_experiment_info_in_dataset():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_run_timestamp():
+def test_run_timestamp() -> None:
     _ = new_experiment(name="for_loading", sample_name="no_sample")
 
     t_before_data_set = time.time()
@@ -181,7 +181,7 @@ def test_run_timestamp():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_run_timestamp_with_default_format():
+def test_run_timestamp_with_default_format() -> None:
     _ = new_experiment(name="for_loading", sample_name="no_sample")
 
     t_before_data_set = time.time()
@@ -204,7 +204,7 @@ def test_run_timestamp_with_default_format():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_completed_timestamp():
+def test_completed_timestamp() -> None:
     _ = new_experiment(name="for_loading", sample_name="no_sample")
     ds = new_data_set("my_first_ds")
 
@@ -220,7 +220,7 @@ def test_completed_timestamp():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_completed_timestamp_for_not_completed_dataset():
+def test_completed_timestamp_for_not_completed_dataset() -> None:
     _ = new_experiment(name="for_loading", sample_name="no_sample")
     ds = new_data_set("my_first_ds")
 
@@ -235,7 +235,7 @@ def test_completed_timestamp_for_not_completed_dataset():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_completed_timestamp_with_default_format():
+def test_completed_timestamp_with_default_format() -> None:
     _ = new_experiment(name="for_loading", sample_name="no_sample")
     ds = new_data_set("my_first_ds")
 
@@ -264,7 +264,7 @@ def test_completed_timestamp_with_default_format():
 
 
 @pytest.mark.usefixtures('experiment')
-def test_load_by_guid(some_interdeps):
+def test_load_by_guid(some_interdeps) -> None:
     ds = DataSet()
     ds.set_interdependencies(some_interdeps[1])
     ds.mark_started()
@@ -275,7 +275,7 @@ def test_load_by_guid(some_interdeps):
     assert loaded_ds.the_same_dataset_as(ds)
 
 
-def test_load_by_run_spec(empty_temp_db, some_interdeps):
+def test_load_by_run_spec(empty_temp_db, some_interdeps) -> None:
 
     def create_ds_with_exp_id(exp_id):
         ds = DataSet(exp_id=exp_id)

--- a/qcodes/tests/dataset/test_dependencies.py
+++ b/qcodes/tests/dataset/test_dependencies.py
@@ -15,17 +15,17 @@ from qcodes.dataset.descriptions.versioning.v0 import InterDependencies
 from qcodes.tests.common import error_caused_by
 
 
-def test_wrong_input_raises():
-
-    for pspecs in [['p1', 'p2', 'p3'],
-                   [ParamSpec('p1', paramtype='numeric'), 'p2'],
-                   ['p1', ParamSpec('p2', paramtype='text')]]:
-
+def test_wrong_input_raises() -> None:
+    for pspecs in (
+        ["p1", "p2", "p3"],
+        [ParamSpec("p1", paramtype="numeric"), "p2"],
+        ["p1", ParamSpec("p2", paramtype="text")],
+    ):
         with pytest.raises(ValueError):
-            InterDependencies(pspecs)
+            InterDependencies(pspecs)  # type: ignore[arg-type]
 
 
-def test_init(some_paramspecbases):
+def test_init(some_paramspecbases) -> None:
     """
     Assert that the init functions correctly sets up the object.
     Assert via the public-facing methods.
@@ -104,7 +104,8 @@ def test_init_validation_raises(some_paramspecbases) -> None:
                 inferences=inv["inffs"],  # type: ignore[arg-type]
             )
 
-def test_to_dict(some_paramspecbases):
+
+def test_to_dict(some_paramspecbases) -> None:
 
     def tester(idps):
         ser = idps._to_dict()
@@ -126,7 +127,7 @@ def test_to_dict(some_paramspecbases):
     tester(idps)
 
 
-def test_old_to_new_and_back(some_paramspecs):
+def test_old_to_new_and_back(some_paramspecs) -> None:
 
     idps_old = InterDependencies(*some_paramspecs[1].values())
     idps_new = old_to_new(idps_old)
@@ -134,7 +135,7 @@ def test_old_to_new_and_back(some_paramspecs):
     assert new_to_old(idps_new) == idps_old
 
 
-def test_old_to_new(some_paramspecs):
+def test_old_to_new(some_paramspecs) -> None:
 
     ps1 = some_paramspecs[1]['ps1']
     ps2 = some_paramspecs[1]['ps2']
@@ -170,8 +171,8 @@ def test_old_to_new(some_paramspecs):
     assert idps_new.inferences == {ps3_base: (ps1_base,),
                                    ps4_base: (ps2_base,)}
     assert idps_new.standalones == set()
-    paramspecs = (ps1_base, ps2_base, ps3_base, ps4_base, ps5_base, ps6_base)
-    assert idps_new._id_to_paramspec == {ps.name: ps for ps in paramspecs}
+    paramspecs2 = (ps1_base, ps2_base, ps3_base, ps4_base, ps5_base, ps6_base)
+    assert idps_new._id_to_paramspec == {ps.name: ps for ps in paramspecs2}
 
     idps_old = InterDependencies(ps1, ps2)
 
@@ -180,11 +181,11 @@ def test_old_to_new(some_paramspecs):
     assert idps_new.dependencies == {}
     assert idps_new.inferences == {}
     assert idps_new.standalones == {ps1_base, ps2_base}
-    paramspecs = (ps1_base, ps2_base)
-    assert idps_new._id_to_paramspec == {ps.name: ps for ps in paramspecs}
+    paramspecs3 = (ps1_base, ps2_base)
+    assert idps_new._id_to_paramspec == {ps.name: ps for ps in paramspecs3}
 
 
-def test_new_to_old(some_paramspecbases):
+def test_new_to_old(some_paramspecbases) -> None:
 
     (ps1, ps2, ps3, ps4) = some_paramspecbases
 
@@ -226,7 +227,7 @@ def test_new_to_old(some_paramspecbases):
 
 
 
-def test_extend_with_paramspec(some_paramspecs):
+def test_extend_with_paramspec(some_paramspecs) -> None:
     ps1 = some_paramspecs[1]['ps1']
     ps2 = some_paramspecs[1]['ps2']
     ps3 = some_paramspecs[1]['ps3']
@@ -267,7 +268,7 @@ def test_extend_with_paramspec(some_paramspecs):
             _extend_with_paramspec(ps6)) == idps_extended
 
 
-def test_validate_subset(some_paramspecbases):
+def test_validate_subset(some_paramspecbases) -> None:
 
     ps1, ps2, ps3, ps4 = some_paramspecbases
 
@@ -280,34 +281,34 @@ def test_validate_subset(some_paramspecbases):
     idps.validate_subset(())
     idps.validate_subset([])
 
-    with pytest.raises(DependencyError) as exc_info:
+    with pytest.raises(DependencyError) as exc_info1:
         idps.validate_subset((ps1,))
-    assert exc_info.value._param_name == 'psb1'
-    assert exc_info.value._missing_params == {'psb2', 'psb3'}
+    assert exc_info1.value._param_name == "psb1"
+    assert exc_info1.value._missing_params == {"psb2", "psb3"}
 
-    with pytest.raises(DependencyError) as exc_info:
+    with pytest.raises(DependencyError) as exc_info2:
         idps.validate_subset((ps1, ps2, ps4))
-    assert exc_info.value._param_name == 'psb1'
-    assert exc_info.value._missing_params == {'psb3'}
+    assert exc_info2.value._param_name == "psb1"
+    assert exc_info2.value._missing_params == {"psb3"}
 
-    with pytest.raises(InferenceError) as exc_info:
+    with pytest.raises(InferenceError) as exc_info3:
         idps.validate_subset((ps3,))
-    assert exc_info.value._param_name == 'psb3'
-    assert exc_info.value._missing_params == {'psb4'}
+    assert exc_info3.value._param_name == "psb3"
+    assert exc_info3.value._missing_params == {"psb4"}
 
-    with pytest.raises(InferenceError) as exc_info:
+    with pytest.raises(InferenceError) as exc_info4:
         idps2 = InterDependencies_(dependencies={ps1: (ps2, ps3)},
                                     inferences={ps3: (ps4,)})
         idps2.validate_subset((ps1, ps2, ps3))
-    assert exc_info.value._param_name == 'psb3'
-    assert exc_info.value._missing_params == {'psb4'}
+    assert exc_info4.value._param_name == "psb3"
+    assert exc_info4.value._missing_params == {"psb4"}
 
     with pytest.raises(ValueError, match='ps42'):
         ps42 = ParamSpecBase('ps42', paramtype='text', label='', unit='it')
         idps.validate_subset((ps2, ps42, ps4))
 
 
-def test_extend(some_paramspecbases):
+def test_extend(some_paramspecbases) -> None:
 
     ps1, ps2, ps3, _ = some_paramspecbases
 
@@ -355,7 +356,7 @@ def test_extend(some_paramspecbases):
         idps_ext = idps.extend(inferences={ps2: (ps1,)})
 
 
-def test_remove(some_paramspecbases):
+def test_remove(some_paramspecbases) -> None:
     ps1, ps2, ps3, ps4 = some_paramspecbases
 
     idps = InterDependencies_(dependencies={ps1: (ps2, ps3)},
@@ -390,7 +391,8 @@ def test_remove(some_paramspecbases):
     idps_expected = InterDependencies_(standalones=(ps2, ps3, ps4))
     assert idps_rem == idps_expected
 
-def test_equality_old(some_paramspecs):
+
+def test_equality_old(some_paramspecs) -> None:
 
     # TODO: make this more fancy with itertools
 
@@ -406,7 +408,7 @@ def test_equality_old(some_paramspecs):
     assert InterDependencies(ps4, ps5, ps3) == InterDependencies(ps3, ps4, ps5)
 
 
-def test_non_dependents():
+def test_non_dependents() -> None:
     ps1 = ParamSpecBase('ps1', paramtype='numeric', label='Raw Data 1',
                         unit='V')
     ps2 = ParamSpecBase('ps2', paramtype='array', label='Raw Data 2',

--- a/qcodes/tests/dataset/test_descriptions.py
+++ b/qcodes/tests/dataset/test_descriptions.py
@@ -9,15 +9,13 @@ from qcodes.dataset.descriptions.versioning import serialization as serial
 from qcodes.dataset.descriptions.versioning.converters import new_to_old
 
 
-def test_wrong_input_type_raises():
-
-    for interdeps in ['interdeps', ['p1', 'p2'], 0]:
-
+def test_wrong_input_type_raises() -> None:
+    for interdeps in ("interdeps", ["p1", "p2"], 0):
         with pytest.raises(ValueError):
-            RunDescriber(interdeps=interdeps)
+            RunDescriber(interdeps=interdeps)  # type: ignore[arg-type]
 
 
-def test_equality(some_paramspecbases):
+def test_equality(some_paramspecbases) -> None:
 
     (psb1, psb2, psb3, _) = some_paramspecbases
 
@@ -34,7 +32,7 @@ def test_equality(some_paramspecbases):
     assert desc_3 != desc_2
 
 
-def test_keys_of_result_of_to_dict(some_interdeps):
+def test_keys_of_result_of_to_dict(some_interdeps) -> None:
 
     for idps in some_interdeps:
         desc = RunDescriber(interdeps=idps)
@@ -46,7 +44,7 @@ def test_keys_of_result_of_to_dict(some_interdeps):
                                          'shapes']
 
 
-def test_to_and_from_dict_roundtrip(some_interdeps):
+def test_to_and_from_dict_roundtrip(some_interdeps) -> None:
 
     for idps in some_interdeps:
         desc = RunDescriber(interdeps=idps)
@@ -59,7 +57,7 @@ def test_to_and_from_dict_roundtrip(some_interdeps):
         assert desc == new_desc
 
 
-def test_yaml_creation_and_loading(some_interdeps):
+def test_yaml_creation_and_loading(some_interdeps) -> None:
 
     yaml = YAML()
 
@@ -79,7 +77,7 @@ def test_yaml_creation_and_loading(some_interdeps):
         assert new_desc == desc
 
 
-def test_jsonization_as_v0_for_storage(some_interdeps):
+def test_jsonization_as_v0_for_storage(some_interdeps) -> None:
     """
     Test that a RunDescriber can be json-dumped as version 0
     """
@@ -93,7 +91,7 @@ def test_jsonization_as_v0_for_storage(some_interdeps):
     assert serial.to_json_as_version(new_desc, 0) == old_json
 
 
-def test_default_jsonization_for_storage(some_interdeps):
+def test_default_jsonization_for_storage(some_interdeps) -> None:
     """
     Test that a RunDescriber is json-dumped as version 2
     """
@@ -109,7 +107,7 @@ def test_default_jsonization_for_storage(some_interdeps):
     assert serial.to_json_for_storage(new_desc) == expected_json
 
 
-def test_dictization_as_v0_for_storage(some_interdeps):
+def test_dictization_as_v0_for_storage(some_interdeps) -> None:
     """
     Test that a RunDescriber always gets converted to dict that represents
     an old style RunDescriber, even when given new style interdeps
@@ -124,7 +122,7 @@ def test_dictization_as_v0_for_storage(some_interdeps):
     assert serial.to_dict_as_version(new_desc, 0) == old_desc
 
 
-def test_default_dictization_for_storage(some_interdeps):
+def test_default_dictization_for_storage(some_interdeps) -> None:
     """
     Test that a RunDescriber always gets converted to dict that represents
     an old style RunDescriber, even when given new style interdeps
@@ -142,7 +140,7 @@ def test_default_dictization_for_storage(some_interdeps):
     assert serial.to_dict_for_storage(new_desc) == old_desc
 
 
-def test_dictization_of_current_version(some_interdeps):
+def test_dictization_of_current_version(some_interdeps) -> None:
     """
     Test conversion to dictionary of a RunDescriber
     """

--- a/qcodes/tests/dataset/test_detect_shape.py
+++ b/qcodes/tests/dataset/test_detect_shape.py
@@ -17,7 +17,7 @@ from .conftest import ArrayshapedParam
 
 
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
-def test_get_shape_for_parameter_from_len(loop_shape):
+def test_get_shape_for_parameter_from_len(loop_shape) -> None:
     a = Parameter(name='a', initial_cache_value=10)
     shape = detect_shape_of_measurement((a,), loop_shape)
     assert shape == {'a': tuple(loop_shape)}
@@ -26,7 +26,7 @@ def test_get_shape_for_parameter_from_len(loop_shape):
 @given(loop_shape=hst.lists(hst.integers(min_value=1, max_value=1000),
                             min_size=1, max_size=10))
 @pytest.mark.parametrize("range_func", [range, np.arange])
-def test_get_shape_for_parameter_from_sequence(loop_shape, range_func):
+def test_get_shape_for_parameter_from_sequence(loop_shape, range_func) -> None:
     a = Parameter(name='a', initial_cache_value=10)
     loop_sequence = tuple(range_func(x) for x in loop_shape)
     shape = detect_shape_of_measurement((a,), loop_sequence)
@@ -34,7 +34,7 @@ def test_get_shape_for_parameter_from_sequence(loop_shape, range_func):
 
 
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10))
-def test_get_shape_for_array_parameter_from_len(loop_shape):
+def test_get_shape_for_array_parameter_from_len(loop_shape) -> None:
     a = ArraySetPointParam(name='a')
     shape = detect_shape_of_measurement((a,), loop_shape)
     expected_shape = tuple(loop_shape) + tuple(a.shape)
@@ -44,7 +44,7 @@ def test_get_shape_for_array_parameter_from_len(loop_shape):
 @given(loop_shape=hst.lists(hst.integers(min_value=1, max_value=1000),
                             min_size=1, max_size=10))
 @pytest.mark.parametrize("range_func", [range, np.arange])
-def test_get_shape_for_array_parameter_from_shape(loop_shape, range_func):
+def test_get_shape_for_array_parameter_from_shape(loop_shape, range_func) -> None:
     a = ArraySetPointParam(name='a')
     loop_sequence = tuple(range_func(x) for x in loop_shape)
     shape = detect_shape_of_measurement((a,), loop_sequence)
@@ -56,7 +56,7 @@ def test_get_shape_for_array_parameter_from_shape(loop_shape, range_func):
 @pytest.mark.parametrize("multiparamtype", [MultiSetPointParam,
                                             Multi2DSetPointParam,
                                             Multi2DSetPointParam2Sizes])
-def test_get_shape_for_multiparam_from_len(loop_shape, multiparamtype):
+def test_get_shape_for_multiparam_from_len(loop_shape, multiparamtype) -> None:
     param = multiparamtype(name='meas_param')
     shapes = detect_shape_of_measurement((param,), loop_shape)
     expected_shapes = {}
@@ -75,7 +75,7 @@ def test_get_shape_for_multiparam_from_shape(
         loop_shape,
         multiparamtype,
         range_func
-):
+) -> None:
     param = multiparamtype(name='meas_param')
     loop_sequence = tuple(range_func(x) for x in loop_shape)
     shapes = detect_shape_of_measurement((param,), loop_sequence)
@@ -88,7 +88,7 @@ def test_get_shape_for_multiparam_from_shape(
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10),
        n_points=hst.integers(min_value=1, max_value=1000))
-def test_get_shape_for_pws_from_len(dummyinstrument, loop_shape, n_points):
+def test_get_shape_for_pws_from_len(dummyinstrument, loop_shape, n_points) -> None:
     param = dummyinstrument.A.dummy_parameter_with_setpoints
     dummyinstrument.A.dummy_n_points(n_points)
     shapes = detect_shape_of_measurement((param,), loop_shape)
@@ -110,8 +110,9 @@ def test_get_shape_for_pws_from_len(dummyinstrument, loop_shape, n_points):
     ),
     n_points=hst.integers(min_value=1, max_value=1000)
 )
-def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
-                                      n_points):
+def test_get_shape_for_pws_from_shape(
+    dummyinstrument, loop_shape, range_func, n_points
+) -> None:
     param = dummyinstrument.A.dummy_parameter_with_setpoints
     dummyinstrument.A.dummy_n_points(n_points)
     loop_sequence = tuple(range_func(x) for x in loop_shape)
@@ -130,9 +131,8 @@ def test_get_shape_for_pws_from_shape(dummyinstrument, loop_shape, range_func,
         max_size=10
     )
 )
-def test_get_shape_for_param_with_array_validator_from_shape(
-        loop_shape):
-    param = ArrayshapedParam(name='paramwitharrayval', vals=Arrays(shape=(10,)))
+def test_get_shape_for_param_with_array_validator_from_shape(loop_shape) -> None:
+    param = ArrayshapedParam(name="paramwitharrayval", vals=Arrays(shape=(10,)))
 
     shapes = detect_shape_of_measurement((param,), loop_shape)
     assert isinstance(param.vals, Arrays)
@@ -141,11 +141,14 @@ def test_get_shape_for_param_with_array_validator_from_shape(
 
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
-@given(loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10),
-       n_points_1=hst.integers(min_value=1, max_value=1000),
-       n_points_2=hst.integers(min_value=1, max_value=1000))
-def test_get_shape_for_multiple_parameters(dummyinstrument, loop_shape,
-                                           n_points_1, n_points_2):
+@given(
+    loop_shape=hst.lists(hst.integers(min_value=1), min_size=1, max_size=10),
+    n_points_1=hst.integers(min_value=1, max_value=1000),
+    n_points_2=hst.integers(min_value=1, max_value=1000),
+)
+def test_get_shape_for_multiple_parameters(
+    dummyinstrument, loop_shape, n_points_1, n_points_2
+) -> None:
     param1 = dummyinstrument.A.dummy_parameter_with_setpoints
     dummyinstrument.A.dummy_n_points(n_points_1)
     param2 = dummyinstrument.B.dummy_parameter_with_setpoints

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -28,7 +28,7 @@ def assert_experiments_equal(exp, exp_2):
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_run_loaded_experiment():
+def test_run_loaded_experiment() -> None:
     """
     Test that we can resume a measurement after loading by name
     """
@@ -44,7 +44,7 @@ def test_run_loaded_experiment():
         pass
 
 
-def test_last_data_set_from_experiment(dataset):
+def test_last_data_set_from_experiment(dataset) -> None:
     experiment = load_experiment(dataset.exp_id)
     ds = experiment.last_data_set()
 
@@ -58,14 +58,14 @@ def test_last_data_set_from_experiment(dataset):
     assert experiment.path_to_db == ds.path_to_db
 
 
-def test_last_data_set_from_experiment_with_no_datasets(experiment):
+def test_last_data_set_from_experiment_with_no_datasets(experiment) -> None:
     with pytest.raises(ValueError, match='There are no runs in this '
                                          'experiment'):
         _ = experiment.last_data_set()
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_load_or_create_experiment_loading():
+def test_load_or_create_experiment_loading() -> None:
     """Test that an experiment is correctly loaded"""
     exp = new_experiment("experiment_name", "sample_name")
     exp_2 = load_or_create_experiment("experiment_name", "sample_name")
@@ -73,7 +73,7 @@ def test_load_or_create_experiment_loading():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_load_or_create_experiment_different_sample_name():
+def test_load_or_create_experiment_different_sample_name() -> None:
     """
     Test that an experiment is created for the case when the experiment
     name is the same, but the sample name is different
@@ -89,7 +89,7 @@ def test_load_or_create_experiment_different_sample_name():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_load_or_create_experiment_creating():
+def test_load_or_create_experiment_creating() -> None:
     """Test that an experiment is correctly created"""
     exp = load_or_create_experiment("experiment_name", "sample_name")
     exp_2 = load_experiment_by_name("experiment_name", "sample_name")
@@ -97,7 +97,7 @@ def test_load_or_create_experiment_creating():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_load_or_create_experiment_creating_not_empty():
+def test_load_or_create_experiment_creating_not_empty() -> None:
     """Test that an experiment is correctly created when DB is not empty"""
     exp = load_or_create_experiment("experiment_name_1", "sample_name_1")
     exp_2 = load_or_create_experiment("experiment_name_2", "sample_name_2")
@@ -110,7 +110,7 @@ def test_load_or_create_experiment_creating_not_empty():
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_has_attributes_after_init():
+def test_has_attributes_after_init() -> None:
     """
     Ensure that all attributes are populated after __init__ in BOTH cases
     (exp_id is None / exp_id is not None)
@@ -132,7 +132,7 @@ def test_has_attributes_after_init():
             getattr(exp, attr)
 
 
-def test_experiment_read_only_properties(experiment):
+def test_experiment_read_only_properties(experiment) -> None:
     read_only_props = ['name', 'exp_id', 'sample_name', 'last_counter',
                        'path_to_db', 'started_at', 'finished_at',
                        'format_string']
@@ -149,26 +149,26 @@ def test_experiment_read_only_properties(experiment):
 
 @pytest.mark.usefixtures("empty_temp_db")
 @pytest.mark.parametrize("non_existing_id", (1, 0, -1, 'number#42'))
-def test_create_experiment_from_non_existing_id(non_existing_id):
+def test_create_experiment_from_non_existing_id(non_existing_id) -> None:
     with pytest.raises(ValueError, match="No such experiment in the database"):
         _ = Experiment(exp_id=non_existing_id)
 
 
 @pytest.mark.usefixtures("empty_temp_db")
 @pytest.mark.parametrize("non_existing_id", (1, 0, -1))
-def test_load_experiment_from_non_existing_id(non_existing_id):
+def test_load_experiment_from_non_existing_id(non_existing_id) -> None:
     with pytest.raises(ValueError, match="No such experiment in the database"):
         _ = load_experiment(non_existing_id)
 
 
 @pytest.mark.usefixtures("empty_temp_db")
 @pytest.mark.parametrize("bad_id", (None, 'number#42'))
-def test_load_experiment_from_bad_id(bad_id):
+def test_load_experiment_from_bad_id(bad_id) -> None:
     with pytest.raises(ValueError, match="Experiment ID must be an integer"):
         _ = load_experiment(bad_id)
 
 
-def test_format_string(empty_temp_db):
+def test_format_string(empty_temp_db) -> None:
     # default format string
     exp1 = Experiment(exp_id=None)
     assert "{}-{}-{}" == exp1.format_string
@@ -186,7 +186,7 @@ def test_format_string(empty_temp_db):
         _ = Experiment(exp_id=None, format_string=fmt_str)
 
 
-def test_load_experiment_by_name_defaults(empty_temp_db):
+def test_load_experiment_by_name_defaults(empty_temp_db) -> None:
     exp1 = Experiment(exp_id=None)
 
     exp2 = load_experiment_by_name('experiment_1')
@@ -196,7 +196,7 @@ def test_load_experiment_by_name_defaults(empty_temp_db):
     assert_experiments_equal(exp1, exp3)
 
 
-def test_load_experiment_by_name(empty_temp_db):
+def test_load_experiment_by_name(empty_temp_db) -> None:
     exp1 = Experiment(exp_id=None, name='myname')
 
     exp2 = load_experiment_by_name('myname')
@@ -214,7 +214,7 @@ def test_load_experiment_by_name(empty_temp_db):
     assert_experiments_equal(exp4, exp6)
 
 
-def test_load_experiment_by_name_bad_name(empty_temp_db):
+def test_load_experiment_by_name_bad_name(empty_temp_db) -> None:
     Experiment(exp_id=None, name='myname')
 
     with pytest.raises(ValueError, match='Experiment not found'):
@@ -227,7 +227,7 @@ def test_load_experiment_by_name_bad_name(empty_temp_db):
         _ = load_experiment_by_name('myname__', 'some_sample__')
 
 
-def test_load_experiment_by_name_bad_sample_name(empty_temp_db):
+def test_load_experiment_by_name_bad_sample_name(empty_temp_db) -> None:
     Experiment(exp_id=None, sample_name='mysample')
 
     with pytest.raises(ValueError, match='Experiment not found'):
@@ -240,7 +240,7 @@ def test_load_experiment_by_name_bad_sample_name(empty_temp_db):
         _ = load_experiment_by_name('experiment_1__', 'mysample__')
 
 
-def test_load_experiment_by_name_duplicate_name(empty_temp_db):
+def test_load_experiment_by_name_duplicate_name(empty_temp_db) -> None:
     exp1 = Experiment(exp_id=None, name="exp")
     exp2 = Experiment(exp_id=None, name="exp")
 
@@ -277,7 +277,7 @@ def test_load_experiment_by_name_duplicate_name(empty_temp_db):
     assert_experiments_equal(exp3, exp3_loaded)
 
 
-def test_load_experiment_by_name_duplicate_sample_name(empty_temp_db):
+def test_load_experiment_by_name_duplicate_sample_name(empty_temp_db) -> None:
     exp1 = Experiment(exp_id=None, name='exp1', sample_name='sss')
     exp2 = Experiment(exp_id=None, name='exp2', sample_name='sss')
 
@@ -294,7 +294,7 @@ def test_load_experiment_by_name_duplicate_sample_name(empty_temp_db):
     assert_experiments_equal(exp2, exp2_loaded_with_sample)
 
 
-def test_load_experiment_by_name_duplicate_name_and_sample_name(empty_temp_db):
+def test_load_experiment_by_name_duplicate_name_and_sample_name(empty_temp_db) -> None:
     exp1 = Experiment(exp_id=None, name='exp', sample_name='sss')
     exp2 = Experiment(exp_id=None, name='exp', sample_name='sss')
 
@@ -317,7 +317,7 @@ def test_load_experiment_by_name_duplicate_name_and_sample_name(empty_temp_db):
     assert last_exp.exp_id == 2
 
 
-def test_new_experiment_duplicate_name_and_sample_name(empty_temp_db, caplog):
+def test_new_experiment_duplicate_name_and_sample_name(empty_temp_db, caplog) -> None:
     """
     Test new_experiment to raise warning if it wants to create experiment
     with a duplicate experiment name and sample name.
@@ -349,7 +349,7 @@ def test_new_experiment_duplicate_name_and_sample_name(empty_temp_db, caplog):
     caplog.clear()
 
 
-def test_load_last_experiment(empty_temp_db):
+def test_load_last_experiment(empty_temp_db) -> None:
     # test in case of no experiments
     with pytest.raises(ValueError, match='There are no experiments in the '
                                          'database file'):
@@ -368,7 +368,7 @@ def test_load_last_experiment(empty_temp_db):
     assert last_exp.path_to_db == exp2.path_to_db
 
 
-def test_active_experiment(empty_temp_db):
+def test_active_experiment(empty_temp_db) -> None:
 
     conn = conn_from_dbpath_or_conn(conn=None, path_to_db=empty_temp_db)
     with pytest.raises(ValueError):

--- a/qcodes/tests/dataset/test_fix_functions.py
+++ b/qcodes/tests/dataset/test_fix_functions.py
@@ -22,7 +22,7 @@ fixturepath = os.sep.join(qcodes.tests.dataset.__file__.split(os.sep)[:-1])
 fixturepath = os.path.join(fixturepath, 'fixtures')
 
 
-def test_version_4a_bugfix():
+def test_version_4a_bugfix() -> None:
     v4fixpath = os.path.join(fixturepath, 'db_files', 'version4a')
 
     dbname_old = os.path.join(v4fixpath, 'some_runs.db')
@@ -50,7 +50,7 @@ def test_version_4a_bugfix():
         assert dd['runs_fixed'] == 0
 
 
-def test_version_4a_bugfix_raises():
+def test_version_4a_bugfix_raises() -> None:
 
     v3fixpath = os.path.join(fixturepath, 'db_files', 'version3')
     dbname_old = os.path.join(v3fixpath, 'some_runs_without_run_description.db')
@@ -62,7 +62,7 @@ def test_version_4a_bugfix_raises():
             fix_version_4a_run_description_bug(conn)
 
 
-def test_fix_wrong_run_descriptions():
+def test_fix_wrong_run_descriptions() -> None:
     v3fixpath = os.path.join(fixturepath, 'db_files', 'version3')
 
     dbname_old = os.path.join(v3fixpath, 'some_runs_without_run_description.db')
@@ -101,7 +101,7 @@ def test_fix_wrong_run_descriptions():
         assert desc == empty_description
 
 
-def test_fix_wrong_run_descriptions_raises():
+def test_fix_wrong_run_descriptions_raises() -> None:
 
     v4fixpath = os.path.join(fixturepath, 'db_files', 'version4a')
 

--- a/qcodes/tests/dataset/test_guids.py
+++ b/qcodes/tests/dataset/test_guids.py
@@ -36,7 +36,7 @@ def _make_seed_random():
     stat=hst.integers(0, 0xFFFF),
     smpl=hst.integers(0, 0xFF_FFF_FFF),
 )
-def test_generate_guid(loc, stat, smpl):
+def test_generate_guid(loc, stat, smpl) -> None:
     # update config to generate a particular guid. Read it back to verify
     cfg = qc.config
     cfg["GUID_components"]["location"] = loc
@@ -69,7 +69,7 @@ def test_generate_guid(loc, stat, smpl):
 @settings(max_examples=50, deadline=None,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(loc=hst.integers(-10, 350))
-def test_set_guid_location_code(loc, monkeypatch):
+def test_set_guid_location_code(loc, monkeypatch) -> None:
     monkeypatch.setattr('builtins.input', lambda x: str(loc))
     orig_cfg = qc.config
     original_loc = orig_cfg["GUID_components"]["location"]
@@ -87,7 +87,7 @@ def test_set_guid_location_code(loc, monkeypatch):
 @settings(max_examples=50, deadline=1000,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(ws=hst.integers(-10, 17000000))
-def test_set_guid_workstation_code(ws, monkeypatch):
+def test_set_guid_workstation_code(ws, monkeypatch) -> None:
     monkeypatch.setattr('builtins.input', lambda x: str(ws))
 
     orig_cfg = qc.config
@@ -110,7 +110,7 @@ def test_set_guid_workstation_code(ws, monkeypatch):
     stats=hst.lists(hst.integers(0, 0xFFFF), min_size=2, max_size=2, unique=True),
     smpls=hst.lists(hst.integers(0, 0xFF_FFF_FFF), min_size=2, max_size=2, unique=True),
 )
-def test_filter_guid(locs, stats, smpls):
+def test_filter_guid(locs, stats, smpls) -> None:
     def make_test_guid(cfg, loc: int, smpl: int, stat: int):
         cfg["GUID_components"]["location"] = loc
         cfg["GUID_components"]["work_station"] = stat
@@ -209,7 +209,7 @@ def test_filter_guid(locs, stats, smpls):
     assert filtered_guids[2] == guids[3]
 
 
-def test_validation():
+def test_validation() -> None:
     valid_guid = str(uuid4())
     validate_guid_format(valid_guid)
 
@@ -219,7 +219,7 @@ def test_validation():
 
 @pytest.mark.usefixtures("seed_random")
 @pytest.mark.usefixtures("default_config")
-def test_random_sample_guid():
+def test_random_sample_guid() -> None:
 
     cfg = qc.config
     cfg["GUID_components"]["GUID_type"] = "random_sample"
@@ -231,7 +231,7 @@ def test_random_sample_guid():
 
 
 @pytest.mark.usefixtures("default_config")
-def test_random_sample_and_sample_int_in_guid_raises():
+def test_random_sample_and_sample_int_in_guid_raises() -> None:
 
     cfg = qc.config
     cfg["GUID_components"]["GUID_type"] = "random_sample"
@@ -246,7 +246,7 @@ def test_random_sample_and_sample_int_in_guid_raises():
 
 
 @pytest.mark.usefixtures("default_config")
-def test_sample_int_in_guid_warns():
+def test_sample_int_in_guid_warns() -> None:
     with pytest.warns(
         expected_warning=Warning,
         match=re.escape("Setting a non default GUID_components.sample"),

--- a/qcodes/tests/dataset/test_links.py
+++ b/qcodes/tests/dataset/test_links.py
@@ -50,7 +50,7 @@ def generate_some_links(N: int) -> List[Link]:
     return links
 
 
-def test_link_construction_passes():
+def test_link_construction_passes() -> None:
     head_guid = generate_guid()
     tail_guid = generate_guid()
     edge_type = "fit"
@@ -70,7 +70,7 @@ def test_link_construction_passes():
 
 @settings(max_examples=20)
 @given(not_guid=hst.text())
-def test_link_construction_raises(not_guid):
+def test_link_construction_raises(not_guid) -> None:
     head_guid = generate_guid()
     tail_guid = generate_guid()
     edge_type = "fit"
@@ -88,7 +88,7 @@ def test_link_construction_raises(not_guid):
         Link(head_guid, not_guid, edge_type)
 
 
-def test_link_to_str():
+def test_link_to_str() -> None:
     head_guid = generate_guid()
     tail_guid = generate_guid()
     edge_type = "test"
@@ -104,7 +104,7 @@ def test_link_to_str():
     assert link_to_str(link) == expected_str
 
 
-def test_str_to_link():
+def test_str_to_link() -> None:
     head_guid = generate_guid()
     tail_guid = generate_guid()
     edge_type = "test"
@@ -121,7 +121,7 @@ def test_str_to_link():
     assert str_to_link(lstr) == expected_link
 
 
-def test_link_to_string_and_back():
+def test_link_to_string_and_back() -> None:
     head_guid = generate_guid()
     tail_guid = generate_guid()
     edge_type = "analysis"
@@ -137,7 +137,7 @@ def test_link_to_string_and_back():
 
 @settings(max_examples=5, deadline=1200)
 @given(N=hst.integers(min_value=0, max_value=25))
-def test_links_to_str_and_back(N):
+def test_links_to_str_and_back(N) -> None:
     links = generate_some_links(N)
 
     new_links = str_to_links(links_to_str(links))

--- a/qcodes/tests/dataset/test_metadata.py
+++ b/qcodes/tests/dataset/test_metadata.py
@@ -1,15 +1,15 @@
-def test_get_metadata_from_dataset(dataset):
+def test_get_metadata_from_dataset(dataset) -> None:
     dataset.add_metadata('something', 123)
     something = dataset.get_metadata('something')
     assert 123 == something
 
 
-def test_get_nonexisting_metadata(dataset):
+def test_get_nonexisting_metadata(dataset) -> None:
     data = dataset.get_metadata("something")
     assert data is None
 
 
-def test_get_metadata_lower_upper_case(dataset):
+def test_get_metadata_lower_upper_case(dataset) -> None:
     dataset.add_metadata("something", 123)
 
     something_lower = dataset.metadata.get("something", "didnt find lowercase")

--- a/qcodes/tests/dataset/test_nested_measurements.py
+++ b/qcodes/tests/dataset/test_nested_measurements.py
@@ -17,7 +17,7 @@ VALUE = Union[str, float, List, np.ndarray, bool]
 
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_nested_measurement_basic(DAC, DMM, bg_writing):
+def test_nested_measurement_basic(DAC, DMM, bg_writing) -> None:
     meas1 = Measurement()
     meas1.register_parameter(DAC.ch1)
     meas1.register_parameter(DMM.v1, setpoints=(DAC.ch1,))
@@ -53,7 +53,7 @@ def test_nested_measurement_basic(DAC, DMM, bg_writing):
 
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("bg_writing", [True, False])
-def test_nested_measurement(bg_writing):
+def test_nested_measurement(bg_writing) -> None:
     meas1 = Measurement()
     meas1.register_custom_parameter('foo1')
     meas1.register_custom_parameter('bar1', setpoints=('foo1',))
@@ -90,11 +90,14 @@ def test_nested_measurement(bg_writing):
 @pytest.mark.usefixtures("experiment")
 @pytest.mark.parametrize("bg_writing", [True, False])
 @settings(deadline=None, max_examples=25)
-@given(outer_len=hst.integers(min_value=1, max_value=100),
-       inner_len1=hst.integers(min_value=1, max_value=1000),
-       inner_len2=hst.integers(min_value=1, max_value=1000))
-def test_nested_measurement_array(bg_writing, outer_len, inner_len1,
-                                  inner_len2):
+@given(
+    outer_len=hst.integers(min_value=1, max_value=100),
+    inner_len1=hst.integers(min_value=1, max_value=1000),
+    inner_len2=hst.integers(min_value=1, max_value=1000),
+)
+def test_nested_measurement_array(
+    bg_writing, outer_len, inner_len1, inner_len2
+) -> None:
     meas1 = Measurement()
     meas1.register_custom_parameter('foo1', paramtype='numeric')
     meas1.register_custom_parameter('bar1spt', paramtype='array')
@@ -168,7 +171,7 @@ def basic_subscriber():
 
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.serial
-def test_subscription_on_dual_datasets(experiment, basic_subscriber):
+def test_subscription_on_dual_datasets(experiment, basic_subscriber) -> None:
     xparam = ParamSpecBase(name='x',
                            paramtype='numeric',
                            label='x parameter',

--- a/qcodes/tests/dataset/test_paramspec.py
+++ b/qcodes/tests/dataset/test_paramspec.py
@@ -73,12 +73,11 @@ def version_0_objects():
        paramtype=hst.lists(
            elements=hst.sampled_from(['numeric', 'array', 'text']),
            min_size=6, max_size=6))
-def test_creation(name, sp1, sp2, inff1, inff2, paramtype):
-    invalid_types = ['np.array', 'ndarray', 'lala', '', Number,
-                     ndarray, 0, None]
+def test_creation(name, sp1, sp2, inff1, inff2, paramtype) -> None:
+    invalid_types = ("np.array", "ndarray", "lala", "", Number, ndarray, 0, None)
     for inv_type in invalid_types:
         with pytest.raises(ValueError):
-            ParamSpec(name, inv_type)
+            ParamSpec(name, inv_type)  # type: ignore[arg-type]
 
     if not inff1.isidentifier():
         inff1 = 'inff1'
@@ -110,7 +109,7 @@ def test_creation(name, sp1, sp2, inff1, inff2, paramtype):
 
 
 @given(name=hst.text(min_size=1))
-def test_repr(name):
+def test_repr(name) -> None:
     okay_types = ['array', 'numeric', 'text']
 
     for okt in okay_types:
@@ -132,7 +131,7 @@ alphabet = "".join(chr(i) for i in range(ord("a"), ord("z")))
     name2=hst.text(min_size=4, max_size=100, alphabet=alphabet),
     name3=hst.text(min_size=4, max_size=100, alphabet=alphabet)
 )
-def test_depends_on(name1, name2, name3):
+def test_depends_on(name1, name2, name3) -> None:
     ps2 = ParamSpec(name2, "numeric")
     ps3 = ParamSpec(name3, "numeric")
 
@@ -152,7 +151,7 @@ def test_depends_on(name1, name2, name3):
     name2=hst.text(min_size=4, max_size=100, alphabet=alphabet),
     name3=hst.text(min_size=4, max_size=100, alphabet=alphabet)
 )
-def test_inferred_from(name1, name2, name3):
+def test_inferred_from(name1, name2, name3) -> None:
     ps2 = ParamSpec(name2, "numeric")
     ps3 = ParamSpec(name3, "numeric")
 
@@ -172,7 +171,7 @@ def test_inferred_from(name1, name2, name3):
     name1=hst.text(min_size=4, max_size=100, alphabet=alphabet),
     name2=hst.text(min_size=4, max_size=100, alphabet=alphabet)
 )
-def test_copy(name1, name2):
+def test_copy(name1, name2) -> None:
     ps_indep = ParamSpec(name1, "numeric")
     ps = ParamSpec(name2, "numeric", depends_on=[ps_indep, 'other_param'])
     ps_copy = ps.copy()
@@ -202,7 +201,7 @@ def test_copy(name1, name2):
     assert hash(ps_copy) != hash(ps)
 
 
-def test_convert_to_dict():
+def test_convert_to_dict() -> None:
     p1 = ParamSpec('p1', 'numeric', 'paramspec one', 'no unit',
                    depends_on=['some', 'thing'], inferred_from=['bab', 'bob'])
 
@@ -216,14 +215,14 @@ def test_convert_to_dict():
     assert ser['inferred_from'] == p1._inferred_from
 
 
-def test_from_dict(version_0_dicts, version_0_objects):
+def test_from_dict(version_0_dicts, version_0_objects) -> None:
     for sdict, ps in zip(version_0_dicts, version_0_objects):
         deps = ParamSpec._from_dict(sdict)
         assert ps == deps
 
 
 @given(paramspecs=hst.lists(valid_paramspec_kwargs, min_size=2, max_size=2))
-def test_hash(paramspecs):
+def test_hash(paramspecs) -> None:
     p1 = ParamSpec(**paramspecs[0])
     p2 = ParamSpec(**paramspecs[1])
 
@@ -250,7 +249,8 @@ def test_hash(paramspecs):
        add_to_2_dep=hst.booleans(),
        )
 def test_hash_with_deferred_and_inferred_as_paramspecs(
-        paramspecs, add_to_1_inf, add_to_1_dep, add_to_2_inf, add_to_2_dep):
+    paramspecs, add_to_1_inf, add_to_1_dep, add_to_2_inf, add_to_2_dep
+) -> None:
     """
     Test that hashing works if 'inferred_from' and/or 'depends_on' contain
     actual ParamSpec instances and not just strings.
@@ -288,7 +288,7 @@ def test_hash_with_deferred_and_inferred_as_paramspecs(
 
 
 @given(paramspecs=hst.lists(valid_paramspec_kwargs, min_size=1, max_size=1))
-def test_base_version(paramspecs):
+def test_base_version(paramspecs) -> None:
 
     kwargs = paramspecs[0]
 
@@ -301,7 +301,7 @@ def test_base_version(paramspecs):
     assert ps.base_version() == ps_base
 
 
-def test_not_eq_for_list_attr():
+def test_not_eq_for_list_attr() -> None:
     """
     test that two paramspecs that differ only
     in list attrs are different
@@ -316,7 +316,7 @@ def test_not_eq_for_list_attr():
     assert p1 != p2
 
 
-def test_not_eq_for_str_attr():
+def test_not_eq_for_str_attr() -> None:
     """
     test that two paramspecs that differ only
     in str attrs are different
@@ -333,7 +333,7 @@ def test_not_eq_for_str_attr():
     assert p1 != p2
 
 
-def test_not_eq_non_paramspec():
+def test_not_eq_non_paramspec() -> None:
     """
     test that two paramspecs that differ only
     in str attrs are different

--- a/qcodes/tests/dataset/test_plotting.py
+++ b/qcodes/tests/dataset/test_plotting.py
@@ -113,7 +113,7 @@ def test_rescaled_ticks_and_units(
         assert '2.12346' == ticks_formatter(2.123456789 / (10 ** (-scale)))
 
 
-def test_plot_by_id_line_and_heatmap(experiment, request):
+def test_plot_by_id_line_and_heatmap(experiment, request) -> None:
     """
     Test that line plots and heatmaps can be plotted together
     """
@@ -144,7 +144,7 @@ def test_plot_by_id_line_and_heatmap(experiment, request):
 
 @pytest.mark.parametrize("nan_setpoints", [True, False])
 @pytest.mark.parametrize("shifted", [True, False])
-def test_plot_dataset_2d_shaped(experiment, request, nan_setpoints, shifted):
+def test_plot_dataset_2d_shaped(experiment, request, nan_setpoints, shifted) -> None:
     """
     Test plotting of preshaped data on a grid that may or may not be shifted
     with and without nans in the set points.
@@ -217,7 +217,7 @@ def test_plot_dataset_2d_shaped(experiment, request, nan_setpoints, shifted):
         assert ylims[1] < 11
 
 
-def test_appropriate_kwargs():
+def test_appropriate_kwargs() -> None:
 
     kwargs = {'cmap': 'bone'}
     check = kwargs.copy()

--- a/qcodes/tests/dataset/test_snapshot.py
+++ b/qcodes/tests/dataset/test_snapshot.py
@@ -68,7 +68,7 @@ def test_station_snapshot_during_measurement(
 
 
 @pytest.mark.usefixtures('set_default_station_to_none')
-def test_snapshot_creation_for_types_not_supported_by_builtin_json(experiment):
+def test_snapshot_creation_for_types_not_supported_by_builtin_json(experiment) -> None:
     """
     Test that `Measurement`/`Runner`/`DataSaver` infrastructure
     successfully dumps station snapshots in JSON format in cases when the

--- a/qcodes/tests/dataset/test_sqlite_connection.py
+++ b/qcodes/tests/dataset/test_sqlite_connection.py
@@ -43,7 +43,7 @@ def conn_plus_is_idle(conn: ConnectionPlus, isolation=None):
     return True
 
 
-def test_connection_plus():
+def test_connection_plus() -> None:
     sqlite_conn = sqlite3.connect(':memory:')
     conn_plus = ConnectionPlus(sqlite_conn)
 
@@ -58,7 +58,7 @@ def test_connection_plus():
         ConnectionPlus(conn_plus)
 
 
-def test_make_connection_plus_from_sqlite3_connection():
+def test_make_connection_plus_from_sqlite3_connection() -> None:
     conn = sqlite3.connect(':memory:')
     conn_plus = make_connection_plus_from(conn)
 
@@ -68,7 +68,7 @@ def test_make_connection_plus_from_sqlite3_connection():
     assert conn_plus is not conn
 
 
-def test_make_connection_plus_from_connecton_plus():
+def test_make_connection_plus_from_connecton_plus() -> None:
     conn = ConnectionPlus(sqlite3.connect(':memory:'))
     conn_plus = make_connection_plus_from(conn)
 
@@ -108,7 +108,7 @@ def test_atomic() -> None:
     assert atomic_in_progress is atomic_conn.atomic_in_progress
 
 
-def test_atomic_with_exception():
+def test_atomic_with_exception() -> None:
     sqlite_conn = sqlite3.connect(':memory:')
     conn_plus = ConnectionPlus(sqlite_conn)
 
@@ -127,7 +127,7 @@ def test_atomic_with_exception():
     assert 25 == sqlite_conn.execute('PRAGMA user_version').fetchall()[0][0]
 
 
-def test_atomic_on_outmost_connection_that_is_in_transaction():
+def test_atomic_on_outmost_connection_that_is_in_transaction() -> None:
     conn = ConnectionPlus(sqlite3.connect(':memory:'))
 
     conn.execute('BEGIN')
@@ -142,7 +142,7 @@ def test_atomic_on_outmost_connection_that_is_in_transaction():
 
 
 @pytest.mark.parametrize('in_transaction', (True, False))
-def test_atomic_on_connection_plus_that_is_in_progress(in_transaction):
+def test_atomic_on_connection_plus_that_is_in_progress(in_transaction) -> None:
     sqlite_conn = sqlite3.connect(':memory:')
     conn_plus = ConnectionPlus(sqlite_conn)
 
@@ -175,7 +175,7 @@ def test_atomic_on_connection_plus_that_is_in_progress(in_transaction):
     assert in_transaction is atomic_conn.in_transaction
 
 
-def test_two_nested_atomics():
+def test_two_nested_atomics() -> None:
     sqlite_conn = sqlite3.connect(':memory:')
     conn_plus = ConnectionPlus(sqlite_conn)
 
@@ -210,7 +210,8 @@ def test_two_nested_atomics():
                          argvalues=(make_connection_plus_from, ConnectionPlus),
                          ids=('make_connection_plus_from', 'ConnectionPlus'))
 def test_that_use_of_atomic_commits_only_at_outermost_context(
-        tmp_path, create_conn_plus):
+    tmp_path, create_conn_plus
+) -> None:
     """
     This test tests the behavior of `ConnectionPlus` that is created from
     `sqlite3.Connection` with respect to `atomic` context manager and commits.
@@ -297,7 +298,7 @@ def test_that_use_of_atomic_commits_only_at_outermost_context(
     assert 3 == len(control_conn.execute(get_all_runs).fetchall())
 
 
-def test_atomic_transaction(tmp_path):
+def test_atomic_transaction(tmp_path) -> None:
     """Test that atomic_transaction works for ConnectionPlus"""
     dbfile = str(tmp_path / 'temp.db')
 
@@ -326,7 +327,7 @@ def test_atomic_transaction_on_sqlite3_connection_raises(tmp_path) -> None:
         atomic_transaction(conn, "whatever sql query")  # type: ignore[arg-type]
 
 
-def test_connect():
+def test_connect() -> None:
     conn = connect(':memory:')
 
     assert isinstance(conn, sqlite3.Connection)

--- a/qcodes/tests/dataset/test_sqlitesettings.py
+++ b/qcodes/tests/dataset/test_sqlitesettings.py
@@ -1,12 +1,12 @@
 # This is a minimal test that simply ensures that the object exists,
 # basically just to notify us if we do API changes
 
-import qcodes as qc
+import qcodes.dataset
 
 
-def test_settings_exist():
-    limits = qc.SQLiteSettings.limits
-    settings = qc.SQLiteSettings.settings
+def test_settings_exist() -> None:
+    limits = qcodes.dataset.SQLiteSettings.limits
+    settings = qcodes.dataset.SQLiteSettings.settings
 
     assert isinstance(limits, dict)
     assert isinstance(settings, dict)

--- a/qcodes/tests/dataset/test_string_data.py
+++ b/qcodes/tests/dataset/test_string_data.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 from hypothesis import HealthCheck, given, settings
 
-import qcodes as qc
 from qcodes.dataset import load_by_id, new_data_set
 from qcodes.dataset.descriptions.dependencies import InterDependencies_
 from qcodes.dataset.descriptions.param_spec import ParamSpecBase
@@ -14,13 +13,13 @@ from qcodes.dataset.measurements import DataSaver, Measurement
 from qcodes.parameters import Parameter
 
 
-def test_string_via_dataset(experiment):
+def test_string_via_dataset(experiment) -> None:
     """
     Test that we can save text into database via DataSet API
     """
     p = ParamSpecBase("p", "text")
 
-    test_set = qc.new_data_set("test-dataset")
+    test_set = new_data_set("test-dataset")
     idps = InterDependencies_(standalones=(p,))
     test_set.set_interdependencies(idps)
     test_set.mark_started()
@@ -32,13 +31,13 @@ def test_string_via_dataset(experiment):
     assert test_set.get_parameter_data()["p"]["p"] == [["some text"]]
 
 
-def test_string_via_datasaver(experiment):
+def test_string_via_datasaver(experiment) -> None:
     """
     Test that we can save text into database via DataSaver API
     """
     p = ParamSpecBase(name="p", paramtype="text")
 
-    test_set = qc.new_data_set("test-dataset")
+    test_set = new_data_set("test-dataset")
     idps = InterDependencies_(standalones=(p,))
     test_set.prepare(snapshot={}, interdeps=idps)
 
@@ -53,12 +52,18 @@ def test_string_via_datasaver(experiment):
     assert test_set.get_parameter_data()["p"]["p"] == np.array(["some text"])
 
 
-def test_string(experiment):
+def test_string(experiment) -> None:
     """
     Test that we can save text into database via Measurement API
     """
-    p = qc.Parameter('p', label='String parameter', unit='', get_cmd=None,
-                     set_cmd=None, initial_value='some text')
+    p = Parameter(
+        "p",
+        label="String parameter",
+        unit="",
+        get_cmd=None,
+        set_cmd=None,
+        initial_value="some text",
+    )
 
     meas = Measurement(experiment)
     meas.register_parameter(p, paramtype='text')
@@ -71,13 +76,19 @@ def test_string(experiment):
     assert test_set.get_parameter_data()["p"]["p"] == np.array(["some text"])
 
 
-def test_string_with_wrong_paramtype(experiment):
+def test_string_with_wrong_paramtype(experiment) -> None:
     """
     Test that an exception occurs when saving string data if when registering a
     string parameter the paramtype was not set to 'text'
     """
-    p = qc.Parameter('p', label='String parameter', unit='', get_cmd=None,
-                     set_cmd=None, initial_value='some text')
+    p = Parameter(
+        "p",
+        label="String parameter",
+        unit="",
+        get_cmd=None,
+        set_cmd=None,
+        initial_value="some text",
+    )
 
     meas = Measurement(experiment)
     # intentionally forget `paramtype='text'`, so that the default 'numeric'
@@ -187,9 +198,15 @@ def test_list_of_strings(experiment) -> None:
         shape=hypnumpy.array_shapes()
     )
 )
-def test_string_and_date_data_in_array(experiment, p_values):
-    p = qc.Parameter('p', label='String parameter', unit='', get_cmd=None,
-                     set_cmd=None, initial_value=p_values)
+def test_string_and_date_data_in_array(experiment, p_values) -> None:
+    p = Parameter(
+        "p",
+        label="String parameter",
+        unit="",
+        get_cmd=None,
+        set_cmd=None,
+        initial_value=p_values,
+    )
 
     meas = Measurement(experiment)
     meas.register_parameter(p, paramtype='array')

--- a/qcodes/tests/dataset/test_subscribing.py
+++ b/qcodes/tests/dataset/test_subscribing.py
@@ -120,7 +120,7 @@ def _make_broken_subscriber_config(tmp_path, default_config):
 
 @pytest.mark.flaky(reruns=5)
 @pytest.mark.serial
-def test_basic_subscription(dataset, basic_subscriber):
+def test_basic_subscription(dataset, basic_subscriber) -> None:
     xparam = ParamSpecBase(name='x',
                            paramtype='numeric',
                            label='x parameter',
@@ -166,7 +166,7 @@ def test_basic_subscription(dataset, basic_subscriber):
 
 
 @pytest.mark.usefixtures("working_subscriber_config")
-def test_subscription_from_config(dataset, basic_subscriber):
+def test_subscription_from_config(dataset, basic_subscriber) -> None:
     """
     This test is similar to `test_basic_subscription`, with the only
     difference that another subscriber from a config file is added.
@@ -204,7 +204,7 @@ def test_subscription_from_config(dataset, basic_subscriber):
 
 
 @pytest.mark.usefixtures("broken_subscriber_config")
-def test_subscription_from_config_wrong_name(dataset):
+def test_subscription_from_config_wrong_name(dataset) -> None:
     """
     This test checks that an exception is thrown if a wrong name for a
     subscriber is passed

--- a/qcodes/tests/delegate/test_delegate_instrument.py
+++ b/qcodes/tests/delegate/test_delegate_instrument.py
@@ -5,13 +5,13 @@ from numpy.testing import assert_almost_equal
 from qcodes.tests.instrument_mocks import MockField
 
 
-def test_mock_dac(dac):
+def test_mock_dac(dac) -> None:
     assert dac.ch01.voltage() == 0.
     dac.ch01.voltage(1.)
     assert dac.ch01.voltage() == 1.
 
 
-def test_mock_field_delegate(station, field_x, chip_config):
+def test_mock_field_delegate(station, field_x, chip_config) -> None:
     with patch.object(
         MockField, "set_field", wraps=field_x.set_field
     ) as mock_set_field:
@@ -35,7 +35,7 @@ def test_mock_field_delegate(station, field_x, chip_config):
         assert_almost_equal(field.ramp_X_field(), 0.0)
 
 
-def test_delegate_channel_instrument(station, chip_config):
+def test_delegate_channel_instrument(station, chip_config) -> None:
     station.load_config_file(chip_config)
     switch = station.load_switch(station=station)
 

--- a/qcodes/tests/delegate/test_device.py
+++ b/qcodes/tests/delegate/test_device.py
@@ -7,7 +7,7 @@ from qcodes.dataset import Measurement
 from qcodes.tests.instrument_mocks import DummyChannel, MockCustomChannel
 
 
-def test_device(station, chip_config, dac, lockin):
+def test_device(station, chip_config, dac, lockin) -> None:
     assert os.path.exists(chip_config)
     station.load_config_file(chip_config)
     chip = station.load_MockChip_123(station=station)
@@ -26,7 +26,7 @@ def test_device(station, chip_config, dac, lockin):
 
 
 @pytest.mark.usefixtures("experiment")
-def test_device_meas(station, chip):
+def test_device_meas(station, chip) -> None:
     meas = Measurement(station=station)
     device = chip.device1
     meas.register_parameter(device.gate)
@@ -43,7 +43,7 @@ def test_device_meas(station, chip):
             datasaver.dataset.to_pandas_dataframe_dict()["device1_drain"]) == 10
 
 
-def test_device_with_channels(chip, station):
+def test_device_with_channels(chip, station) -> None:
     device = chip.channel_device
 
     assert device.gate_1 == station.dac.ch01
@@ -63,7 +63,7 @@ def test_device_with_channels(chip, station):
     assert device.readout() == 30
 
 
-def test_device_with_custom_channels(chip, station):
+def test_device_with_custom_channels(chip, station) -> None:
     device = chip.channel_device_custom
 
     assert device.gate_1._dac_channel == station.dac.ch01
@@ -75,7 +75,7 @@ def test_device_with_custom_channels(chip, station):
     assert isinstance(device.fast_gate, DummyChannel)
 
 
-def test_chip_definition(chip_config_typo, station):
+def test_chip_definition(chip_config_typo, station) -> None:
     station.load_config_file(chip_config_typo)
     with pytest.raises(KeyError):
         _ = station.load_MockChip_123(station=station)

--- a/qcodes/tests/driver_test_case.py
+++ b/qcodes/tests/driver_test_case.py
@@ -32,6 +32,7 @@ Using `DriverTestCase` is pretty easy:
 class DriverTestCase(unittest.TestCase):
     # override this in a subclass
     driver: type[Instrument] | None = None
+    instrument: Instrument
 
     @classmethod
     def setUpClass(cls):
@@ -63,7 +64,7 @@ class DriverTestCase(unittest.TestCase):
         cls.instrument = instances[-1]
 
 
-def test_instruments(verbosity=1):
+def test_instruments(verbosity=1) -> None:
     """
     Discover available instruments and test them all
     Unlike test_instrument, this does NOT reload tests prior to running them
@@ -80,7 +81,7 @@ def test_instruments(verbosity=1):
     unittest.TextTestRunner(verbosity=verbosity).run(suite)
 
 
-def test_instrument(instrument_testcase, verbosity=2):
+def test_instrument(instrument_testcase, verbosity=2) -> None:
     """
     Runs one instrument testcase
     Reloads the test case before running it

--- a/qcodes/tests/drivers/AlazarTech/test_alazar_api.py
+++ b/qcodes/tests/drivers/AlazarTech/test_alazar_api.py
@@ -7,6 +7,7 @@ Alazar board installed.
 import gc
 import logging
 import os
+from weakref import WeakValueDictionary
 
 import pytest
 
@@ -50,25 +51,29 @@ def alazar_api():
     yield AlazarATSAPI(AlazarTech_ATS.dll_path)
 
 
-def test_alazar_api_singleton_behavior(caplog):
+def test_alazar_api_singleton_behavior(caplog) -> None:
     def using_msg(dll_path):
         return f"Using existing instance for DLL path {dll_path}."
 
     def creating_msg(dll_path):
         return f"Creating new instance for DLL path {dll_path}."
 
-    assert DllWrapperMeta._instances == {}
+    assert DllWrapperMeta._instances == WeakValueDictionary()
 
     with caplog.at_level(logging.DEBUG):
         api1 = AlazarATSAPI(AlazarTech_ATS.dll_path)
-    assert DllWrapperMeta._instances == {AlazarTech_ATS.dll_path: api1}
+    assert DllWrapperMeta._instances == WeakValueDictionary(
+        {AlazarTech_ATS.dll_path: api1}
+    )
     assert caplog.records[-1].message == creating_msg(AlazarTech_ATS.dll_path)
     caplog.clear()
 
     with caplog.at_level(logging.DEBUG):
         api2 = AlazarATSAPI(AlazarTech_ATS.dll_path)
     assert api2 is api1
-    assert DllWrapperMeta._instances == {AlazarTech_ATS.dll_path: api1}
+    assert DllWrapperMeta._instances == WeakValueDictionary(
+        {AlazarTech_ATS.dll_path: api1}
+    )
     assert caplog.records[-1].message == using_msg(AlazarTech_ATS.dll_path)
     caplog.clear()
 
@@ -83,33 +88,35 @@ def test_alazar_api_singleton_behavior(caplog):
         api3 = AlazarATSAPI(dll_path_3)
     assert api3 is not api1
     assert api3 is not api2
-    assert DllWrapperMeta._instances == {AlazarTech_ATS.dll_path: api1,
-                                         dll_path_3: api3}
+    assert DllWrapperMeta._instances == WeakValueDictionary(
+        {AlazarTech_ATS.dll_path: api1, dll_path_3: api3}
+    )
     assert caplog.records[-1].message == creating_msg(dll_path_3)
     caplog.clear()
 
     del api2
     gc.collect()
-    assert DllWrapperMeta._instances == {AlazarTech_ATS.dll_path: api1,
-                                         dll_path_3: api3}
+    assert DllWrapperMeta._instances == WeakValueDictionary(
+        {AlazarTech_ATS.dll_path: api1, dll_path_3: api3}
+    )
 
     del api1
     gc.collect()
-    assert DllWrapperMeta._instances == {dll_path_3: api3}
+    assert DllWrapperMeta._instances == WeakValueDictionary({dll_path_3: api3})
 
     del api3
     gc.collect()
-    assert DllWrapperMeta._instances == {}
+    assert DllWrapperMeta._instances == WeakValueDictionary()
 
 
-def test_find_boards():
+def test_find_boards() -> None:
     boards = AlazarTech_ATS.find_boards()
     assert len(boards) == 1
     assert boards[0]['system_id'] == SYSTEM_ID
     assert boards[0]['board_id'] == BOARD_ID
 
 
-def test_get_board_info(alazar_api):
+def test_get_board_info(alazar_api) -> None:
     info = AlazarTech_ATS.get_board_info(api=alazar_api,
                                          system_id=SYSTEM_ID,
                                          board_id=BOARD_ID)
@@ -119,7 +126,7 @@ def test_get_board_info(alazar_api):
     assert info['board_id'] == BOARD_ID
 
 
-def test_idn(alazar):
+def test_idn(alazar) -> None:
     idn = alazar.get_idn()
     assert {'firmware', 'model', 'serial', 'vendor', 'CPLD_version',
             'driver_version', 'SDK_version', 'latest_cal_date', 'memory_size',
@@ -130,7 +137,7 @@ def test_idn(alazar):
     assert idn['model'][:3] == 'ATS'
 
 
-def test_return_codes_are_correct(alazar_api):
+def test_return_codes_are_correct(alazar_api) -> None:
     """
     Test correctness of the coded return codes (success, failure, unknowns),
     and consistency with what `AlazarErrorToText` function returns.
@@ -148,37 +155,37 @@ def test_return_codes_are_correct(alazar_api):
     assert alazar_api.error_to_text(upper_unknown) == 'Unknown'
 
 
-def test_get_channel_info_convenient(alazar):
+def test_get_channel_info_convenient(alazar) -> None:
     bps, max_s = alazar.api.get_channel_info_(alazar._handle)
     assert isinstance(bps, int)
     assert isinstance(max_s, int)
 
 
-def test_get_cpld_version_convenient(alazar):
+def test_get_cpld_version_convenient(alazar) -> None:
     cpld_ver = alazar.api.get_cpld_version_(alazar._handle)
     assert isinstance(cpld_ver, str)
     assert len(cpld_ver.split('.')) == 2
 
 
-def test_get_driver_version_convenient(alazar_api):
+def test_get_driver_version_convenient(alazar_api) -> None:
     driver_ver = alazar_api.get_driver_version_()
     assert isinstance(driver_ver, str)
     assert len(driver_ver.split('.')) == 3
 
 
-def test_get_sdk_version_convenient(alazar_api):
+def test_get_sdk_version_convenient(alazar_api) -> None:
     sdk_ver = alazar_api.get_sdk_version_()
     assert isinstance(sdk_ver, str)
     assert len(sdk_ver.split('.')) == 3
 
 
-def test_query_capability_convenient(alazar):
+def test_query_capability_convenient(alazar) -> None:
     cap = Capability.GET_SERIAL_NUMBER
     cap_value = alazar.api.query_capability_(alazar._handle, cap)
     assert isinstance(cap_value, int)
 
 
-def test_writing_and_reading_registers(alazar):
+def test_writing_and_reading_registers(alazar) -> None:
     """
     The approach is to read the register that includes information about
     trigger holdoff parameter, and write the same value back to the board.
@@ -188,7 +195,7 @@ def test_writing_and_reading_registers(alazar):
     alazar._write_register(trigger_holdoff_register_offset, orig_val)
 
 
-def test_get_num_channels():
+def test_get_num_channels() -> None:
     assert 1 == AlazarTech_ATS.get_num_channels(1)
     assert 1 == AlazarTech_ATS.get_num_channels(8)
 

--- a/qcodes/tests/drivers/AlazarTech/test_alazar_buffer.py
+++ b/qcodes/tests/drivers/AlazarTech/test_alazar_buffer.py
@@ -5,7 +5,7 @@ import pytest
 from qcodes.instrument_drivers.AlazarTech.ATS import Buffer
 
 
-def test_buffer_is_allocated_when_initiated():
+def test_buffer_is_allocated_when_initiated() -> None:
     b = Buffer(ctypes.c_uint8, 25)
     assert b._allocated is True
 
@@ -13,5 +13,5 @@ def test_buffer_is_allocated_when_initiated():
 @pytest.mark.parametrize('ctype', (ctypes.c_uint8, ctypes.c_uint16,
                                    ctypes.c_uint32, ctypes.c_int32,
                                    ctypes.c_float))
-def test_supported_ctypes_for_sample(ctype):
+def test_supported_ctypes_for_sample(ctype) -> None:
     Buffer(ctype, 8)

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
@@ -26,7 +26,7 @@ from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1530A import (
 )
 
 
-def test_make_module_from_model_name(mainframe):
+def test_make_module_from_model_name(mainframe) -> None:
 
     with pytest.raises(NotImplementedError):
         KeysightB1500.from_model_name(model='unsupported_module', slot_nr=0,
@@ -53,34 +53,34 @@ def test_make_module_from_model_name(mainframe):
     assert isinstance(smu, KeysightB1511B)
 
 
-def test_init(b1500):
+def test_init(b1500) -> None:
     assert hasattr(b1500, 'smu1')
     assert hasattr(b1500, 'smu2')
     assert hasattr(b1500, 'cmu1')
     assert hasattr(b1500, 'wgfmu1')
 
 
-def test_snapshot_does_not_raise_warnings(b1500):
+def test_snapshot_does_not_raise_warnings(b1500) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         b1500.snapshot(update=True)
 
 
-def test_submodule_access_by_class(b1500):
+def test_submodule_access_by_class(b1500) -> None:
     assert b1500.smu1 in b1500.by_kind['SMU']
     assert b1500.smu2 in b1500.by_kind['SMU']
     assert b1500.cmu1 in b1500.by_kind['CMU']
     assert b1500.wgfmu1 in b1500.by_kind['WGFMU']
 
 
-def test_submodule_access_by_slot(b1500):
+def test_submodule_access_by_slot(b1500) -> None:
     assert b1500.smu1 is b1500.by_slot[SlotNr.SLOT01]
     assert b1500.smu2 is b1500.by_slot[SlotNr.SLOT02]
     assert b1500.cmu1 is b1500.by_slot[3]
     assert b1500.wgfmu1 is b1500.by_slot[6]
 
 
-def test_submodule_access_by_channel(b1500):
+def test_submodule_access_by_channel(b1500) -> None:
     assert b1500.smu1 is b1500.by_channel[ChNr.SLOT_01_CH1]
     assert b1500.smu2 is b1500.by_channel[ChNr.SLOT_02_CH1]
     assert b1500.cmu1 is b1500.by_channel[ChNr.SLOT_03_CH1]
@@ -89,7 +89,7 @@ def test_submodule_access_by_channel(b1500):
     assert b1500.wgfmu1 is b1500.by_channel[ChNr.SLOT_06_CH2]
 
 
-def test_enable_multiple_channels(b1500):
+def test_enable_multiple_channels(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -98,7 +98,7 @@ def test_enable_multiple_channels(b1500):
     mock_write.assert_called_once_with("CN 1,2,3")
 
 
-def test_disable_multiple_channels(b1500):
+def test_disable_multiple_channels(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -107,7 +107,7 @@ def test_disable_multiple_channels(b1500):
     mock_write.assert_called_once_with("CL 1,2,3")
 
 
-def test_use_nplc_for_high_speed_adc(b1500):
+def test_use_nplc_for_high_speed_adc(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -120,7 +120,7 @@ def test_use_nplc_for_high_speed_adc(b1500):
     mock_write.assert_called_once_with("AIT 0,2,3")
 
 
-def test_use_nplc_for_high_resolution_adc(b1500):
+def test_use_nplc_for_high_resolution_adc(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -133,7 +133,7 @@ def test_use_nplc_for_high_resolution_adc(b1500):
     mock_write.assert_called_once_with("AIT 1,2,8")
 
 
-def test_autozero_enabled(b1500):
+def test_autozero_enabled(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -150,7 +150,7 @@ def test_autozero_enabled(b1500):
     assert b1500.autozero_enabled() is False
 
 
-def test_use_manual_mode_for_high_speed_adc(b1500):
+def test_use_manual_mode_for_high_speed_adc(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -168,7 +168,7 @@ def test_use_manual_mode_for_high_speed_adc(b1500):
     mock_write.assert_called_once_with("AIT 0,1,8")
 
 
-def test_self_calibration_successful(b1500):
+def test_self_calibration_successful(b1500) -> None:
     mock_ask = MagicMock()
     b1500.ask = mock_ask
 
@@ -180,7 +180,7 @@ def test_self_calibration_successful(b1500):
     mock_ask.assert_called_once_with('*CAL?')
 
 
-def test_self_calibration_failed(b1500):
+def test_self_calibration_failed(b1500) -> None:
     mock_ask = MagicMock()
     b1500.ask = mock_ask
 
@@ -193,12 +193,12 @@ def test_self_calibration_failed(b1500):
     mock_ask.assert_called_once_with('*CAL?')
 
 
-def test_error_message(b1500):
+def test_error_message(b1500) -> None:
     response = b1500.error_message()
     assert '+0,"No Error."' == response
 
 
-def test_clear_timer_count(b1500):
+def test_clear_timer_count(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -211,7 +211,7 @@ def test_clear_timer_count(b1500):
     mock_write.assert_called_once_with('TSR 1')
 
 
-def test_set_measuremet_mode(b1500):
+def test_set_measuremet_mode(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -219,7 +219,7 @@ def test_set_measuremet_mode(b1500):
     mock_write.assert_called_once_with('MM 1,1,2')
 
 
-def test_get_measurement_mode(b1500):
+def test_get_measurement_mode(b1500) -> None:
     mock_ask = MagicMock()
     b1500.ask = mock_ask
 
@@ -229,7 +229,7 @@ def test_get_measurement_mode(b1500):
     assert measurement_mode['channels'] == [1, 2]
 
 
-def test_get_response_format_and_mode(b1500):
+def test_get_response_format_and_mode(b1500) -> None:
     mock_ask = MagicMock()
     b1500.ask = mock_ask
 
@@ -239,7 +239,7 @@ def test_get_response_format_and_mode(b1500):
     assert measurement_mode['mode'] == constants.FMT.Mode(1)
 
 
-def test_enable_smu_filters(b1500):
+def test_enable_smu_filters(b1500) -> None:
     mock_write = MagicMock()
     b1500.write = mock_write
 
@@ -261,7 +261,7 @@ def test_enable_smu_filters(b1500):
     mock_write.assert_called_once_with('FL 1,102,202,302')
 
 
-def test_error_message_is_called_after_setting_a_parameter(b1500):
+def test_error_message_is_called_after_setting_a_parameter(b1500) -> None:
     mock_ask = MagicMock()
     b1500.ask = mock_ask
     mock_ask.return_value = '+0,"No Error."'

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500_module.py
@@ -20,7 +20,7 @@ from qcodes.instrument_drivers.Keysight.keysightb1500.KeysightB1517A import (
 )
 
 
-def test_is_enabled():
+def test_is_enabled() -> None:
     mainframe = MagicMock()
 
     # Use concrete subclass because B1500Module does not assign channels
@@ -41,7 +41,7 @@ def test_is_enabled():
     mainframe.ask.assert_called_once_with('*LRN? 0')
 
 
-def test_enable_outputs():
+def test_enable_outputs() -> None:
     mainframe = MagicMock()
 
     slot_nr = 1
@@ -52,7 +52,7 @@ def test_enable_outputs():
     mainframe.write.assert_called_once_with(f'CN {slot_nr}')
 
 
-def test_disable_outputs():
+def test_disable_outputs() -> None:
     mainframe = MagicMock()
 
     slot_nr = 1
@@ -63,7 +63,7 @@ def test_disable_outputs():
     mainframe.write.assert_called_once_with(f'CL {slot_nr}')
 
 
-def test_parse_module_query_response():
+def test_parse_module_query_response() -> None:
     response = 'B1517A,0;B1517A,0;B1520A,0;0,0;0,0;0,0;0,0;0,0;0,0;0,0'
     expected = {SlotNr.SLOT01: 'B1517A',
                 SlotNr.SLOT02: 'B1517A',
@@ -74,7 +74,7 @@ def test_parse_module_query_response():
     assert actual == expected
 
 
-def test_format_dcorr_response():
+def test_format_dcorr_response() -> None:
     resp_str1 = format_dcorr_response(
         _DCORRResponse(mode=DCORR.Mode.Cp_G, primary=0.001, secondary=0.34))
     assert resp_str1 == 'Mode: Cp_G, Primary Cp: 0.001 F, Secondary G: 0.34 S'
@@ -84,7 +84,7 @@ def test_format_dcorr_response():
     assert resp_str2 == 'Mode: Ls_Rs, Primary Ls: 0.2 H, Secondary Rs: 3.0 Ω'
 
 
-def test_fixed_negative_float():
+def test_fixed_negative_float() -> None:
     assert fixed_negative_float('-0.-1') == -0.1
     assert fixed_negative_float('-1.-1') == -1.1
     assert fixed_negative_float('0.1') == 0.1
@@ -93,7 +93,7 @@ def test_fixed_negative_float():
     assert fixed_negative_float('-1') == -1.0
 
 
-def test_get_name_label_unit_of_impedance_model():
+def test_get_name_label_unit_of_impedance_model() -> None:
     model = IMP.MeasurementMode.Cp_D
     name, label, unit = get_name_label_unit_of_impedance_model(model)
     assert name == ('parallel_capacitance', 'dissipation_factor')
@@ -107,7 +107,7 @@ def test_get_name_label_unit_of_impedance_model():
     assert unit == ('S', 'degree')
 
 
-def test_convert_dummy_val_to_nan():
+def test_convert_dummy_val_to_nan() -> None:
     status = ['C', 'V', 'N', 'V', 'N', 'N']
     value = [0, 199.999e99, 1, 199.999e99, 2, 3]
     channel = [1, 1, 1, 1, 1, 1]

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1511b_smu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1511b_smu.py
@@ -18,7 +18,7 @@ def _make_smu(mainframe):
     yield smu
 
 
-def test_force_invalid_current_output_range_when_asu_not_present(smu):
+def test_force_invalid_current_output_range_when_asu_not_present(smu) -> None:
     msg = re.escape("Invalid Source Current Output Range")
     with pytest.raises(RuntimeError, match=msg):
         smu.asu_present = True
@@ -27,7 +27,8 @@ def test_force_invalid_current_output_range_when_asu_not_present(smu):
 
 
 def test_i_measure_range_config_raises_invalid_range_error_when_asu_not_present(
-        smu):
+    smu,
+) -> None:
     msg = re.escape("8 current measurement range")
     with pytest.raises(RuntimeError, match=msg):
         smu.asu_present = True

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1517a_smu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1517a_smu.py
@@ -59,7 +59,7 @@ def test_snapshot() -> None:
 
 
 @pytest.mark.filterwarnings("ignore:The function <measure_config>")
-def test_measure_config(smu):
+def test_measure_config(smu) -> None:
     smu.measure_config(VMeasRange.AUTO)
     s = smu.snapshot()
 
@@ -85,20 +85,20 @@ def test_measure_config(smu):
     assert s['_measure_config']['i_measure_range'] == 0
 
 
-def test_v_measure_range_config_raises_type_error(smu):
+def test_v_measure_range_config_raises_type_error(smu) -> None:
     msg = re.escape("Expected valid voltage measurement range, got 42.")
 
     with pytest.raises(TypeError, match=msg):
         smu.v_measure_range_config(v_measure_range=42)
 
 
-def test_v_measure_range_config_raises_invalid_range_error(smu):
+def test_v_measure_range_config_raises_invalid_range_error(smu) -> None:
     msg = re.escape("15000 voltage measurement range")
     with pytest.raises(RuntimeError, match=msg):
         smu.v_measure_range_config(VMeasRange.MIN_1500V)
 
 
-def test_v_measure_range_config_sets_range_correctly(smu):
+def test_v_measure_range_config_sets_range_correctly(smu) -> None:
     smu.v_measure_range_config(v_measure_range=VMeasRange.MIN_0V5)
     s = smu.snapshot()
 
@@ -106,7 +106,7 @@ def test_v_measure_range_config_sets_range_correctly(smu):
     assert s['_measure_config']['v_measure_range'] == 5
 
 
-def test_getting_voltage_after_calling_v_measure_range_config(smu):
+def test_getting_voltage_after_calling_v_measure_range_config(smu) -> None:
     mainframe = smu.parent
     mainframe.ask.return_value = "NAV-000.002E-01\r"
 
@@ -120,20 +120,20 @@ def test_getting_voltage_after_calling_v_measure_range_config(smu):
     assert s
 
 
-def test_i_measure_range_config_raises_type_error(smu):
+def test_i_measure_range_config_raises_type_error(smu) -> None:
     msg = re.escape("Expected valid current measurement range, got 99.")
 
     with pytest.raises(TypeError, match=msg):
         smu.i_measure_range_config(i_measure_range=99)
 
 
-def test_i_measure_range_config_raises_invalid_range_error(smu):
+def test_i_measure_range_config_raises_invalid_range_error(smu) -> None:
     msg = re.escape("-23 current measurement range")
     with pytest.raises(RuntimeError, match=msg):
         smu.i_measure_range_config(IMeasRange.FIX_40A)
 
 
-def test_i_measure_range_config_sets_range_correctly(smu):
+def test_i_measure_range_config_sets_range_correctly(smu) -> None:
     smu.i_measure_range_config(i_measure_range=IMeasRange.MIN_1nA)
     s = smu.snapshot()
 
@@ -141,7 +141,7 @@ def test_i_measure_range_config_sets_range_correctly(smu):
     assert s['_measure_config']['i_measure_range'] == 11
 
 
-def test_getting_current_after_calling_i_measure_range_config(smu):
+def test_getting_current_after_calling_i_measure_range_config(smu) -> None:
     mainframe = smu.parent
     mainframe.ask.return_value = "NAI+000.005E-06\r"
 
@@ -155,19 +155,19 @@ def test_getting_current_after_calling_i_measure_range_config(smu):
     assert s
 
 
-def test_force_invalid_voltage_output_range(smu):
+def test_force_invalid_voltage_output_range(smu) -> None:
     msg = re.escape("Invalid Source Voltage Output Range")
     with pytest.raises(RuntimeError, match=msg):
         smu.source_config(VOutputRange.MIN_1500V)
 
 
-def test_force_invalid_current_output_range(smu):
+def test_force_invalid_current_output_range(smu) -> None:
     msg = re.escape("Invalid Source Current Output Range")
     with pytest.raises(RuntimeError, match=msg):
         smu.source_config(IOutputRange.MIN_20A)
 
 
-def test_force_voltage_with_autorange(smu):
+def test_force_voltage_with_autorange(smu) -> None:
     mainframe = smu.parent
 
     smu.source_config(output_range=VOutputRange.AUTO)
@@ -176,7 +176,7 @@ def test_force_voltage_with_autorange(smu):
     mainframe.write.assert_called_once_with('DV 1,0,10')
 
 
-def test_force_voltage_autorange_and_compliance(smu):
+def test_force_voltage_autorange_and_compliance(smu) -> None:
     mainframe = smu.parent
 
     smu.source_config(output_range=VOutputRange.AUTO,
@@ -188,7 +188,7 @@ def test_force_voltage_autorange_and_compliance(smu):
     mainframe.write.assert_called_once_with('DV 1,0,20,1e-06,0,15')
 
 
-def test_new_source_config_should_invalidate_old_source_config(smu):
+def test_new_source_config_should_invalidate_old_source_config(smu) -> None:
     mainframe = smu.parent
 
     smu.source_config(output_range=VOutputRange.AUTO,
@@ -202,7 +202,7 @@ def test_new_source_config_should_invalidate_old_source_config(smu):
     mainframe.write.assert_called_once_with('DV 1,0,20')
 
 
-def test_unconfigured_source_defaults_to_autorange_v(smu):
+def test_unconfigured_source_defaults_to_autorange_v(smu) -> None:
     mainframe = smu.parent
 
     smu.voltage(10)
@@ -210,7 +210,7 @@ def test_unconfigured_source_defaults_to_autorange_v(smu):
     mainframe.write.assert_called_once_with('DV 1,0,10')
 
 
-def test_unconfigured_source_defaults_to_autorange_i(smu):
+def test_unconfigured_source_defaults_to_autorange_i(smu) -> None:
     mainframe = smu.parent
 
     smu.current(0.2)
@@ -218,7 +218,7 @@ def test_unconfigured_source_defaults_to_autorange_i(smu):
     mainframe.write.assert_called_once_with('DI 1,0,0.2')
 
 
-def test_force_current_with_autorange(smu):
+def test_force_current_with_autorange(smu) -> None:
     mainframe = smu.parent
 
     smu.source_config(output_range=IOutputRange.AUTO)
@@ -227,7 +227,7 @@ def test_force_current_with_autorange(smu):
     mainframe.write.assert_called_once_with('DI 1,0,0.1')
 
 
-def test_raise_warning_output_range_mismatches_output_command(smu):
+def test_raise_warning_output_range_mismatches_output_command(smu) -> None:
     smu.source_config(output_range=VOutputRange.AUTO)
     msg = re.escape("Asking to force current, but source_config contains a "
                     "voltage output range")
@@ -241,7 +241,7 @@ def test_raise_warning_output_range_mismatches_output_command(smu):
         smu.voltage(0.1)
 
 
-def test_measure_current(smu):
+def test_measure_current(smu) -> None:
     mainframe = smu.parent
     mainframe.ask.return_value = "NAI+000.005E-06\r"
 
@@ -251,7 +251,7 @@ def test_measure_current(smu):
     assert smu.current.measurement_status == constants.MeasurementStatus.N
 
 
-def test_measure_voltage(smu):
+def test_measure_voltage(smu) -> None:
     mainframe = smu.parent
     mainframe.ask.return_value = "NAV+000.123E-06\r"
 
@@ -264,7 +264,7 @@ def test_measure_voltage(smu):
     assert s
 
 
-def test_measure_current_shows_compliance_hit(smu):
+def test_measure_current_shows_compliance_hit(smu) -> None:
     mainframe = smu.parent
     mainframe.ask.return_value = "CAI+000.123E-06\r"
 
@@ -274,7 +274,7 @@ def test_measure_current_shows_compliance_hit(smu):
     assert smu.current.measurement_status == constants.MeasurementStatus.C
 
 
-def test_measured_voltage_with_V_status_returns_nan(smu):
+def test_measured_voltage_with_V_status_returns_nan(smu) -> None:
     mainframe = smu.parent
     mainframe.ask.return_value = "VAV+199.999E+99\r"
 
@@ -284,7 +284,7 @@ def test_measured_voltage_with_V_status_returns_nan(smu):
     assert smu.voltage.measurement_status == constants.MeasurementStatus.V
 
 
-def test_some_voltage_sourcing_and_current_measurement(smu):
+def test_some_voltage_sourcing_and_current_measurement(smu) -> None:
     mainframe = smu.parent
 
     smu.source_config(output_range=VOutputRange.MIN_0V5, compliance=1e-9)
@@ -302,7 +302,7 @@ def test_some_voltage_sourcing_and_current_measurement(smu):
     assert smu.current.measurement_status == constants.MeasurementStatus.N
 
 
-def test_use_high_resolution_adc(smu):
+def test_use_high_resolution_adc(smu) -> None:
     mainframe = smu.parent
 
     smu.use_high_resolution_adc()
@@ -310,7 +310,7 @@ def test_use_high_resolution_adc(smu):
     mainframe.write.assert_called_once_with('AAD 1,1')
 
 
-def test_use_high_speed_adc(smu):
+def test_use_high_speed_adc(smu) -> None:
     mainframe = smu.parent
 
     smu.use_high_speed_adc()
@@ -318,12 +318,12 @@ def test_use_high_speed_adc(smu):
     mainframe.write.assert_called_once_with('AAD 1,0')
 
 
-def test_measurement_mode_at_init(smu):
+def test_measurement_mode_at_init(smu) -> None:
     mode_at_init = smu.measurement_mode()
     assert mode_at_init == MM.Mode.SPOT
 
 
-def test_measurement_mode_to_enum_value(smu):
+def test_measurement_mode_to_enum_value(smu) -> None:
     mainframe = smu.parent
 
     smu.measurement_mode(MM.Mode.SAMPLING)
@@ -333,7 +333,7 @@ def test_measurement_mode_to_enum_value(smu):
     assert new_mode == MM.Mode.SAMPLING
 
 
-def test_measurement_mode_to_int_value(smu):
+def test_measurement_mode_to_int_value(smu) -> None:
     mainframe = smu.parent
 
     smu.measurement_mode(10)
@@ -343,7 +343,7 @@ def test_measurement_mode_to_int_value(smu):
     assert new_mode == MM.Mode.SAMPLING
 
 
-def test_setting_timing_parameters(smu):
+def test_setting_timing_parameters(smu) -> None:
     mainframe = smu.parent
 
     smu.timing_parameters(0.0, 0.42, 32)
@@ -355,7 +355,7 @@ def test_setting_timing_parameters(smu):
     mainframe.write.assert_called_once_with('MT 0.0,0.42,32,0.02')
 
 
-def test_set_average_samples_for_high_speed_adc(smu):
+def test_set_average_samples_for_high_speed_adc(smu) -> None:
     mainframe = smu.parent
 
     smu.set_average_samples_for_high_speed_adc(131, 2)
@@ -368,7 +368,7 @@ def test_set_average_samples_for_high_speed_adc(smu):
 
 
 
-def test_measurement_operation_mode(smu):
+def test_measurement_operation_mode(smu) -> None:
     mainframe = smu.parent
 
     smu.measurement_operation_mode(constants.CMM.Mode.COMPLIANCE_SIDE)
@@ -382,7 +382,7 @@ def test_measurement_operation_mode(smu):
                          constants.CMM.Mode.COMPLIANCE_SIDE)]
 
 
-def test_current_measurement_range(smu):
+def test_current_measurement_range(smu) -> None:
     mainframe = smu.parent
 
     smu.current_measurement_range(constants.IMeasRange.FIX_1A)
@@ -396,7 +396,7 @@ def test_current_measurement_range(smu):
                          constants.IMeasRange.FIX_1A)]
 
 
-def test_get_sweep_mode_range_start_end_steps(smu):
+def test_get_sweep_mode_range_start_end_steps(smu) -> None:
     mainframe = smu.parent
     mainframe.ask.return_value = 'WV1,1,50,+3.0E+00,-3.0E+00,201'
 
@@ -420,7 +420,8 @@ def test_get_sweep_mode_range_start_end_steps(smu):
     current_compliance = smu.iv_sweep.current_compliance()
     assert current_compliance is None
 
-def test_iv_sweep_delay(smu):
+
+def test_iv_sweep_delay(smu) -> None:
     mainframe = smu.root_instrument
 
     smu.iv_sweep.hold_time(43.12)
@@ -436,7 +437,7 @@ def test_iv_sweep_delay(smu):
                                       call("WT 43.12,34.01,0.01,0.1,15.4")])
 
 
-def test_iv_sweep_mode_start_end_steps_compliance(smu):
+def test_iv_sweep_mode_start_end_steps_compliance(smu) -> None:
     mainframe = smu.parent
 
     smu.iv_sweep.sweep_mode(constants.SweepMode.LINEAR_TWO_WAY)
@@ -457,7 +458,7 @@ def test_iv_sweep_mode_start_end_steps_compliance(smu):
                                      )
 
 
-def test_set_sweep_auto_abort(smu):
+def test_set_sweep_auto_abort(smu) -> None:
     mainframe = smu.parent
 
     smu.iv_sweep.sweep_auto_abort(constants.Abort.ENABLED)
@@ -465,7 +466,7 @@ def test_set_sweep_auto_abort(smu):
     mainframe.write.assert_called_once_with("WM 2")
 
 
-def test_get_sweep_auto_abort(smu):
+def test_get_sweep_auto_abort(smu) -> None:
     mainframe = smu.parent
 
     mainframe.ask.return_value = "WM2,2;WT1.0,0.0,0.0,0.0,0.0;"
@@ -473,7 +474,7 @@ def test_get_sweep_auto_abort(smu):
     assert condition == constants.Abort.ENABLED
 
 
-def test_set_post_sweep_voltage_cond(smu):
+def test_set_post_sweep_voltage_cond(smu) -> None:
     mainframe = smu.parent
     mainframe.ask.return_value = "WM2,2;WT1.0,0.0,0.0,0.0,0.0"
     smu.iv_sweep.post_sweep_voltage_condition(constants.WMDCV.Post.STOP)
@@ -481,7 +482,7 @@ def test_set_post_sweep_voltage_cond(smu):
     mainframe.write.assert_called_once_with("WM 2,2")
 
 
-def test_get_post_sweep_voltage_cond(smu):
+def test_get_post_sweep_voltage_cond(smu) -> None:
     mainframe = smu.parent
 
     mainframe.ask.return_value = "WM2,2;WT1.0,0.0,0.0,0.0,0.0"

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
@@ -21,7 +21,7 @@ def _make_cmu(mainframe):
     yield cmu
 
 
-def test_force_dc_voltage(cmu):
+def test_force_dc_voltage(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.voltage_dc(10)
@@ -29,7 +29,7 @@ def test_force_dc_voltage(cmu):
     mainframe.write.assert_called_once_with('DCV 3,10')
 
 
-def test_force_ac_voltage(cmu):
+def test_force_ac_voltage(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.voltage_ac(0.1)
@@ -37,7 +37,7 @@ def test_force_ac_voltage(cmu):
     mainframe.write.assert_called_once_with('ACV 3,0.1')
 
 
-def test_set_ac_frequency(cmu):
+def test_set_ac_frequency(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.frequency(100e3)
@@ -45,7 +45,7 @@ def test_set_ac_frequency(cmu):
     mainframe.write.assert_called_once_with('FC 3,100000.0')
 
 
-def test_get_dc_voltage(cmu):
+def test_get_dc_voltage(cmu) -> None:
     mainframe = cmu.parent
     mainframe.ask.return_value = 'DCV3,0.000;ACV3,0.0;FC3,1000.000'
     response = cmu.voltage_dc()
@@ -62,7 +62,7 @@ def test_get_dc_voltage(cmu):
     assert response == 13.051
 
 
-def test_get_ac_voltage(cmu):
+def test_get_ac_voltage(cmu) -> None:
     mainframe = cmu.parent
     mainframe.ask.return_value = 'DCV3,0.000;ACV3,0.000;FC3,1000.000'
     response = cmu.voltage_ac()
@@ -79,7 +79,7 @@ def test_get_ac_voltage(cmu):
     assert response == 3.045
 
 
-def test_get_frequency(cmu):
+def test_get_frequency(cmu) -> None:
     mainframe = cmu.parent
     mainframe.ask.return_value = 'DCV3,0.000;ACV3,0.000;FC3,100000.000'
     response = cmu.frequency()
@@ -96,7 +96,7 @@ def test_get_frequency(cmu):
     assert response == 1540.40
 
 
-def test_get_capacitance(cmu):
+def test_get_capacitance(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = "NCC-1.45713E-06,NCD-3.05845E-03"
@@ -109,7 +109,7 @@ def test_get_capacitance(cmu):
     assert pytest.approx((-1.55713E-06, -3.15845E-03)) == cmu.capacitance()
 
 
-def test_raise_error_on_unsupported_result_format(cmu):
+def test_raise_error_on_unsupported_result_format(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = "NCR-1.1234E-03,NCX-4.5677E-03,NCV+0.14235E-03"
@@ -118,7 +118,7 @@ def test_raise_error_on_unsupported_result_format(cmu):
         cmu.capacitance()
 
 
-def test_ranging_mode(cmu):
+def test_ranging_mode(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.ranging_mode(constants.RangingMode.AUTO)
@@ -126,7 +126,7 @@ def test_ranging_mode(cmu):
     mainframe.write.assert_called_once_with('RC 3,0')
 
 
-def test_set_sweep_auto_abort(cmu):
+def test_set_sweep_auto_abort(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.cv_sweep.sweep_auto_abort(constants.Abort.ENABLED)
@@ -134,7 +134,7 @@ def test_set_sweep_auto_abort(cmu):
     mainframe.write.assert_called_once_with("WMDCV 2")
 
 
-def test_get_sweep_auto_abort(cmu):
+def test_get_sweep_auto_abort(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = "WMDCV2,2;WTDCV1.0,0.0,0.0,0.0,0.0"
@@ -142,7 +142,7 @@ def test_get_sweep_auto_abort(cmu):
     assert condition == constants.Abort.ENABLED
 
 
-def test_set_post_sweep_voltage_cond(cmu):
+def test_set_post_sweep_voltage_cond(cmu) -> None:
     mainframe = cmu.parent
     mainframe.ask.return_value = "WMDCV2,2;WTDCV1.0,0.0,0.0,0.0,0.0"
     cmu.cv_sweep.post_sweep_voltage_condition.set(constants.WMDCV.Post.STOP)
@@ -150,7 +150,7 @@ def test_set_post_sweep_voltage_cond(cmu):
     mainframe.write.assert_called_once_with("WMDCV 2,2")
 
 
-def test_get_post_sweep_voltage_cond(cmu):
+def test_get_post_sweep_voltage_cond(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = "WMDCV2,2;WTDCV1.0,0.0,0.0,0.0,0.0"
@@ -166,7 +166,7 @@ def test_get_post_sweep_voltage_cond(cmu):
         cmu.cv_sweep.post_sweep_voltage_condition()
 
 
-def test_cv_sweep_delay(cmu):
+def test_cv_sweep_delay(cmu) -> None:
     mainframe = cmu.root_instrument
 
     mainframe.ask.return_value = "WTDCV0.0,0.0,0.0,0.0,0.0"
@@ -178,7 +178,7 @@ def test_cv_sweep_delay(cmu):
                                       call("WTDCV 1.0,1.0,0.0,0.0,0.0")])
 
 
-def test_cmu_sweep_steps(cmu):
+def test_cmu_sweep_steps(cmu) -> None:
     mainframe = cmu.root_instrument
     mainframe.ask.return_value = "WDCV3,1,0.0,0.0,1"
     cmu.cv_sweep.sweep_start(2.0)
@@ -188,7 +188,7 @@ def test_cmu_sweep_steps(cmu):
                                       call("WDCV 3,1,2.0,4.0,1")])
 
 
-def test_cv_sweep_voltages(cmu):
+def test_cv_sweep_voltages(cmu) -> None:
 
     mainframe = cmu.root_instrument
 
@@ -207,7 +207,7 @@ def test_cv_sweep_voltages(cmu):
                                        voltages)])
 
 
-def test_sweep_modes(cmu):
+def test_sweep_modes(cmu) -> None:
 
     mainframe = cmu.root_instrument
 
@@ -227,7 +227,7 @@ def test_sweep_modes(cmu):
     assert all([a == b for a, b in zip((-1.0, 0.0, 1.0, 0.0, -1.0), voltages)])
 
 
-def test_run_sweep(cmu):
+def test_run_sweep(cmu) -> None:
     mainframe = cmu.root_instrument
 
     start = -1.0
@@ -259,7 +259,7 @@ def test_run_sweep(cmu):
 
 
 
-def test_phase_compensation_mode(cmu):
+def test_phase_compensation_mode(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.phase_compensation_mode(constants.ADJ.Mode.MANUAL)
@@ -269,7 +269,7 @@ def test_phase_compensation_mode(cmu):
     assert constants.ADJ.Mode.MANUAL == cmu.phase_compensation_mode()
 
 
-def test_phase_compensation(cmu):
+def test_phase_compensation(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = 0
@@ -281,7 +281,7 @@ def test_phase_compensation(cmu):
     assert response == constants.ADJQuery.Response.PASSED
 
 
-def test_phase_compensation_with_mode(cmu):
+def test_phase_compensation_with_mode(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = 0
@@ -293,7 +293,7 @@ def test_phase_compensation_with_mode(cmu):
     assert response == constants.ADJQuery.Response.PASSED
 
 
-def test_enable_correction(cmu):
+def test_enable_correction(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.correction.enable(constants.CalibrationType.OPEN)
@@ -310,7 +310,7 @@ def test_enable_correction(cmu):
     mainframe.write.assert_called_once_with('CORRST 3,3,1')
 
 
-def test_disable_correction(cmu):
+def test_disable_correction(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.correction.disable(constants.CalibrationType.OPEN)
@@ -327,7 +327,7 @@ def test_disable_correction(cmu):
     mainframe.write.assert_called_once_with('CORRST 3,3,0')
 
 
-def test_correction_is_enabled(cmu):
+def test_correction_is_enabled(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = '1'
@@ -336,7 +336,7 @@ def test_correction_is_enabled(cmu):
     assert response == constants.CORRST.Response.ON
 
 
-def test_correction_set_reference_values(cmu):
+def test_correction_set_reference_values(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.correction.set_reference_values(
@@ -347,7 +347,7 @@ def test_correction_set_reference_values(cmu):
     mainframe.write.assert_called_once_with('DCORR 3,1,100,1,2')
 
 
-def test_correction_get_reference_values(cmu):
+def test_correction_get_reference_values(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = '100,0.001,2'
@@ -356,7 +356,7 @@ def test_correction_get_reference_values(cmu):
         constants.CalibrationType.OPEN)
 
 
-def test_clear_and_set_default_frequency_list_for_correction(cmu):
+def test_clear_and_set_default_frequency_list_for_correction(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.correction.frequency_list.clear_and_set_default()
@@ -364,7 +364,7 @@ def test_clear_and_set_default_frequency_list_for_correction(cmu):
     mainframe.write.assert_called_once_with('CLCORR 3,2')
 
 
-def test_clear_frequency_list_for_correction(cmu):
+def test_clear_frequency_list_for_correction(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.correction.frequency_list.clear()
@@ -372,7 +372,7 @@ def test_clear_frequency_list_for_correction(cmu):
     mainframe.write.assert_called_once_with('CLCORR 3,1')
 
 
-def test_add_frequency_for_correction(cmu):
+def test_add_frequency_for_correction(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.correction.frequency_list.add(1000)
@@ -380,7 +380,7 @@ def test_add_frequency_for_correction(cmu):
     mainframe.write.assert_called_once_with('CORRL 3,1000')
 
 
-def test_query_from_frequency_list_for_correction(cmu):
+def test_query_from_frequency_list_for_correction(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = '25'
@@ -389,7 +389,7 @@ def test_query_from_frequency_list_for_correction(cmu):
     mainframe.ask.assert_called_once_with('CORRL? 3')
 
 
-def test_query_at_index_from_frequency_list_for_correction(cmu):
+def test_query_at_index_from_frequency_list_for_correction(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = '1234.567'
@@ -399,7 +399,7 @@ def test_query_at_index_from_frequency_list_for_correction(cmu):
     mainframe.ask.assert_called_once_with('CORRL? 3,0')
 
 
-def test_perform_correction(cmu):
+def test_perform_correction(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.return_value = 0
@@ -409,7 +409,7 @@ def test_perform_correction(cmu):
     assert constants.CORR.Response.SUCCESSFUL == response
 
 
-def test_perform_and_enable_correction(cmu):
+def test_perform_and_enable_correction(cmu) -> None:
     mainframe = cmu.parent
 
     mainframe.ask.side_effect = [
@@ -427,7 +427,7 @@ def test_perform_and_enable_correction(cmu):
     assert response == expected_response
 
 
-def test_abort(cmu):
+def test_abort(cmu) -> None:
     mainframe = cmu.parent
 
     cmu.abort()

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_sampling_measurement.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_sampling_measurement.py
@@ -44,20 +44,19 @@ def smu_sampling_measurement(smu, smu_output):
     return smu_sm, status, channel, type_
 
 
-def test_timing_parameters_is_none_at_init(smu):
+def test_timing_parameters_is_none_at_init(smu) -> None:
     assert smu._timing_parameters['interval'] is None
     assert smu._timing_parameters['number'] is None
     assert smu._timing_parameters['h_bias'] is None
     assert smu._timing_parameters['h_base'] is None
 
 
-def test_measurement_requires_timing_parameters_to_be_set(smu):
+def test_measurement_requires_timing_parameters_to_be_set(smu) -> None:
     with pytest.raises(Exception, match='set timing parameters first'):
         smu.sampling_measurement_trace.get()
 
 
-def test_sampling_measurement(smu_sampling_measurement,
-                              smu_output):
+def test_sampling_measurement(smu_sampling_measurement, smu_output) -> None:
     smu_sampling_measurement, _, _, _ = smu_sampling_measurement
     n_samples, data_to_return = smu_output
     smu_sampling_measurement.timing_parameters(h_bias=0,
@@ -69,15 +68,14 @@ def test_sampling_measurement(smu_sampling_measurement,
     smu_sampling_measurement.root_instrument.ask.assert_called_with('XE')
 
 
-def test_compliance_needs_data_from_sampling_measurement(smu):
+def test_compliance_needs_data_from_sampling_measurement(smu) -> None:
     with pytest.raises(MeasurementNotTaken,
                        match='First run sampling_measurement method '
                              'to generate the data'):
         smu.sampling_measurement_trace.compliance()
 
 
-def test_compliance(smu_sampling_measurement,
-                    smu_output):
+def test_compliance(smu_sampling_measurement, smu_output) -> None:
     n_samples, _ = smu_output
     smu_sampling_measurement, status, _, _ = smu_sampling_measurement
     smu_sampling_measurement.timing_parameters(h_bias=0,
@@ -93,8 +91,9 @@ def test_compliance(smu_sampling_measurement,
     np.testing.assert_array_equal(smu_compliance, compliance_list)
 
 
-def test_output_data_type_and_data_channel(smu_sampling_measurement,
-                                           smu_output):
+def test_output_data_type_and_data_channel(
+    smu_sampling_measurement, smu_output
+) -> None:
     n_samples, _ = smu_output
     smu_sampling_measurement, _, channel, type_ = smu_sampling_measurement
     smu_sampling_measurement.timing_parameters(h_bias=0,

--- a/qcodes/tests/drivers/keysight_b1500/test_MessageBuilder.py
+++ b/qcodes/tests/drivers/keysight_b1500/test_MessageBuilder.py
@@ -13,7 +13,7 @@ def mb():
     yield MessageBuilder()
 
 
-def test_as_csv():
+def test_as_csv() -> None:
     from qcodes.instrument_drivers.Keysight.keysightb1500.message_builder import as_csv
 
     assert '1' == as_csv([1])
@@ -27,17 +27,17 @@ def _skip():
     pytest.skip("not implemented yet")
 
 
-def test_cmd(mb):
+def test_cmd(mb) -> None:
     cmd = mb.aad(1, 0).ach(1, 5).ab()
     assert 'AAD 1,0;ACH 1,5;AB' == cmd.message
 
 
-def test_raise_error_on_appending_command_after_final_command(mb):
+def test_raise_error_on_appending_command_after_final_command(mb) -> None:
     with pytest.raises(ValueError):
         mb.aad(1, 0).ab().ach(1, 5)
 
 
-def test_exception_on_too_long_message(mb):
+def test_exception_on_too_long_message(mb) -> None:
     length = 0
     while length < 250:
         mb.os()
@@ -52,7 +52,7 @@ def test_exception_on_too_long_message(mb):
         _ = mb.message
 
 
-def test_clear_message_queue(mb):
+def test_clear_message_queue(mb) -> None:
     mb.aad(1, 0)
     assert mb.message == 'AAD 1,0'
 
@@ -61,7 +61,7 @@ def test_clear_message_queue(mb):
     assert mb.message == ''
 
 
-def test_aad(mb):
+def test_aad(mb) -> None:
     assert 'AAD 1,0' == \
            mb.aad(c.ChNr.SLOT_01_CH1,
                   c.AAD.Type.HIGH_SPEED).message
@@ -73,11 +73,11 @@ def test_aad(mb):
                   adc_type=c.AAD.Type.HIGH_RESOLUTION).message
 
 
-def test_ab(mb):
+def test_ab(mb) -> None:
     assert 'AB' == mb.ab().message
 
 
-def test_ach(mb):
+def test_ach(mb) -> None:
     assert 'ACH 1,5' == mb.ach(c.ChNr.SLOT_01_CH1,
                                c.ChNr.SLOT_05_CH1).message
 
@@ -90,7 +90,7 @@ def test_ach(mb):
     assert 'ACH' == mb.ach().message
 
 
-def test_act(mb):
+def test_act(mb) -> None:
     assert 'ACT 0,1' == mb.act(c.ACT.Mode.AUTO, 1).message
 
     mb.clear_message_queue()
@@ -98,17 +98,17 @@ def test_act(mb):
     assert 'ACT 2' == mb.act(c.ACT.Mode.PLC).message
 
 
-def test_acv(mb):
+def test_acv(mb) -> None:
     assert 'ACV 7,0.01' == \
            mb.acv(c.ChNr.SLOT_07_CH1, 0.01).message
 
 
-def test_adj(mb):
+def test_adj(mb) -> None:
     assert 'ADJ 9,1' == mb.adj(c.ChNr.SLOT_09_CH1,
                                c.ADJ.Mode.MANUAL).message
 
 
-def test_adj_query(mb):
+def test_adj_query(mb) -> None:
     assert 'ADJ? 1' == mb.adj_query(c.ChNr.SLOT_01_CH1).message
 
     mb.clear_message_queue()
@@ -117,7 +117,7 @@ def test_adj_query(mb):
                                       c.ADJQuery.Mode.MEASURE).message
 
 
-def test_ait(mb):
+def test_ait(mb) -> None:
     assert 'AIT 2,3,0.001' == mb.ait(c.AIT.Type.HIGH_SPEED_PULSED,
                                      c.AIT.Mode.MEAS_TIME_MODE,
                                      0.001).message
@@ -126,33 +126,33 @@ def test_ait(mb):
                                c.AIT.Mode.MEAS_TIME_MODE).message
 
 
-def test_aitm(mb):
+def test_aitm(mb) -> None:
     assert 'AITM 0' == mb.aitm(c.APIVersion.B1500).message
 
 
-def test_aitm_query(mb: MessageBuilder):
+def test_aitm_query(mb: MessageBuilder) -> None:
     assert 'AITM?' == mb.aitm_query().message
 
 
-def test_als(mb):
+def test_als(mb) -> None:
     with pytest.raises(NotImplementedError):
         mb.als(c.ChNr.SLOT_01_CH1, 1, b'a')
 
 
-def test_als_query(mb):
+def test_als_query(mb) -> None:
     assert 'ALS? 1' == mb.als_query(c.ChNr.SLOT_01_CH1).message
 
 
-def test_alw(mb):
+def test_alw(mb) -> None:
     with pytest.raises(NotImplementedError):
         mb.alw(c.ChNr.SLOT_01_CH1, 1, b'a')
 
 
-def test_alw_query(mb):
+def test_alw_query(mb) -> None:
     assert 'ALW? 1' == mb.alw_query(c.ChNr.SLOT_01_CH1).message
 
 
-def test_av(mb):
+def test_av(mb) -> None:
     assert 'AV 10' == mb.av(10).message
     mb.clear_message_queue()
     assert 'AV -50' == mb.av(-50).message
@@ -160,33 +160,33 @@ def test_av(mb):
     assert 'AV 100,1' == mb.av(100, c.AV.Mode.MANUAL).message
 
 
-def test_az(mb):
+def test_az(mb) -> None:
     assert 'AZ 0' == mb.az(False).message
     mb.clear_message_queue()
     assert 'AZ 1' == mb.az(True).message
 
 
-def test_bc(mb):
+def test_bc(mb) -> None:
     assert 'BC' == mb.bc().message
 
 
-def test_bdm(mb: MessageBuilder):
+def test_bdm(mb: MessageBuilder) -> None:
     assert 'BDM 0,1' == mb.bdm(c.BDM.Interval.SHORT,
                                c.BDM.Mode.CURRENT).message
 
 
-def test_bdt(mb: MessageBuilder):
+def test_bdt(mb: MessageBuilder) -> None:
     assert 'BDT 0.1,0.001' == mb.bdt(hold=0.1, delay=1e-3).message
 
 
-def test_bdv(mb):
+def test_bdv(mb) -> None:
     assert 'BDV 1,0,0,100,0.01' == mb.bdv(chnum=c.ChNr.SLOT_01_CH1,
                                           v_range=c.VOutputRange.AUTO,
                                           start=0, stop=100,
                                           i_comp=0.01).message
 
 
-def test_bgi(mb):
+def test_bgi(mb) -> None:
     assert 'BGI 1,0,1e-08,14,1e-06' == \
            mb.bgi(chnum=c.ChNr.SLOT_01_CH1,
                   searchmode=c.BinarySearchMode.LIMIT,
@@ -195,102 +195,102 @@ def test_bgi(mb):
                   target=1e-6).message
 
 
-def test_bgv(mb):
+def test_bgv(mb) -> None:
     assert 'BGV 1,0,0.1,12,5' == mb.bgv(1, 0, 0.1, 12, 5).message
 
 
-def test_bsi(mb):
+def test_bsi(mb) -> None:
     assert 'BSI 1,0,1e-12,1e-06,10' == mb.bsi(1, 0, 1e-12, 1e-6,
                                               10).message
 
 
-def test_bsm(mb):
+def test_bsm(mb) -> None:
     assert 'BSM 1,2,3' == mb.bsm(1, 2, 3).message
 
 
-def test_bssi(mb):
+def test_bssi(mb) -> None:
     assert 'BSSI 1,0,1e-06,10' == mb.bssi(1, 0, 1e-6, 10).message
 
 
-def test_bssv(mb):
+def test_bssv(mb) -> None:
     assert 'BSSV 1,0,5,1e-06' == mb.bssv(1, 0, 5, 1e-6).message
 
 
-def test_bst(mb):
+def test_bst(mb) -> None:
     assert 'BST 5,0.1' == mb.bst(5, 0.1).message
 
 
-def test_bsv(mb):
+def test_bsv(mb) -> None:
     assert 'BSV 1,0,0,20,1e-06' == mb.bsv(1, 0, 0, 20, 1e-6).message
 
 
-def test_bsvm(mb):
+def test_bsvm(mb) -> None:
     assert 'BSVM 1' == mb.bsvm(1).message
 
 
-def test_ca(mb):
+def test_ca(mb) -> None:
     assert 'CA' == mb.ca().message
 
 
-def test_cal_query(mb):
+def test_cal_query(mb) -> None:
     assert '*CAL?' == mb.cal_query().message
 
 
-def test_cl(mb):
+def test_cl(mb) -> None:
     assert 'CL' == mb.cl().message
     mb.clear_message_queue()
     assert 'CL 1,2,3,5' == mb.cl([1, 2, 3, 5]).message
 
 
-def test_clcorr(mb):
+def test_clcorr(mb) -> None:
     assert 'CLCORR 9,1' == mb.clcorr(9, 1).message
 
 
-def test_cm(mb):
+def test_cm(mb) -> None:
     assert 'CM 0' == mb.cm(False).message
 
 
-def test_cmm(mb):
+def test_cmm(mb) -> None:
     assert 'CMM 1,2' == mb.cmm(1, 2).message
 
 
-def test_cn(mb):
+def test_cn(mb) -> None:
     assert 'CN' == mb.cn().message
     mb.clear_message_queue()
     assert 'CN 1,2,3,5' == mb.cn([1, 2, 3, 5]).message
 
 
-def test_cnx(mb):
+def test_cnx(mb) -> None:
     assert 'CNX' == mb.cnx().message
     mb.clear_message_queue()
     assert 'CNX 1,2,3,5' == mb.cnx([1, 2, 3, 5]).message
 
 
-def test_corr_query(mb):
+def test_corr_query(mb) -> None:
     assert 'CORR? 9,3' == mb.corr_query(9, 3).message
 
 
-def test_corrdt(mb):
+def test_corrdt(mb) -> None:
     assert 'CORRDT 9,3000000,0,0,0,0,0,0' == mb.corrdt(9, 3000000, 0,
                                                        0, 0, 0, 0,
                                                        0).message
 
 
-def test_corrdt_query(mb):
+def test_corrdt_query(mb) -> None:
     assert 'CORRDT? 9,1' == mb.corrdt_query(9, 1).message
 
 
-def test_corrl(mb):
+def test_corrl(mb) -> None:
     assert 'CORRL 9,3000000' == mb.corrl(9, 3000000).message
 
 
-def test_corrl_query(mb):
+def test_corrl_query(mb) -> None:
     assert 'CORRL? 9' == mb.corrl_query(9).message
     mb.clear_message_queue()
     assert 'CORRL? 9,2' == mb.corrl_query(9, 2).message
 
 
-def test_corrser_query(mb: MessageBuilder):
+def test_corrser_query(mb: MessageBuilder) -> None:
     assert 'CORRSER? 101,1,1e-07,1e-08,10' == \
            mb.corrser_query(101,
                             True,
@@ -299,384 +299,384 @@ def test_corrser_query(mb: MessageBuilder):
                             10).message
 
 
-def test_corrst(mb):
+def test_corrst(mb) -> None:
     assert 'CORRST 3,1,1' == mb.corrst(3, 1, 1).message
 
 
-def test_corrst_query(mb):
+def test_corrst_query(mb) -> None:
     assert 'CORRST? 1,2' == mb.corrst_query(1, 2).message
 
 
-def test_dcorr(mb):
+def test_dcorr(mb) -> None:
     assert 'DCORR 3,1,100,0.1,0.2' == mb.dcorr(3, 1, 100, 0.1, 0.2).message
 
 
-def test_dcorr_query(mb):
+def test_dcorr_query(mb) -> None:
     assert 'DCORR? 3,1' == mb.dcorr_query(3, 1).message
 
 
-def test_dcv(mb):
+def test_dcv(mb) -> None:
     assert 'DCV 3,2.5' == mb.dcv(3, 2.5).message
 
 
-def test_di(mb):
+def test_di(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_diag_query(mb):
+def test_diag_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_do(mb):
+def test_do(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_dsmplarm(mb):
+def test_dsmplarm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_dsmplflush(mb):
+def test_dsmplflush(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_dsmplsetup(mb):
+def test_dsmplsetup(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_dv(mb):
+def test_dv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_dz(mb):
+def test_dz(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_emg_query(mb):
+def test_emg_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_end(mb):
+def test_end(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erc(mb):
+def test_erc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ercmaa(mb):
+def test_ercmaa(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ercmaa_query(mb):
+def test_ercmaa_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ercmagrd(mb):
+def test_ercmagrd(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ercmagrd_query(mb):
+def test_ercmagrd_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ercmaio(mb):
+def test_ercmaio(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ercmaio_query(mb):
+def test_ercmaio_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ercmapfgd(mb):
+def test_ercmapfgd(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpa(mb):
+def test_erhpa(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpa_query(mb):
+def test_erhpa_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpe(mb):
+def test_erhpe(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpe_query(mb):
+def test_erhpe_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpl(mb):
+def test_erhpl(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpl_query(mb):
+def test_erhpl_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpp(mb):
+def test_erhpp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpp_query(mb):
+def test_erhpp_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpqg(mb):
+def test_erhpqg(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpqg_query(mb):
+def test_erhpqg_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpr(mb):
+def test_erhpr(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhpr_query(mb):
+def test_erhpr_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhps(mb):
+def test_erhps(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhps_query(mb):
+def test_erhps_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhvca(mb):
+def test_erhvca(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhvca_query(mb):
+def test_erhvca_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhvctst_query(mb):
+def test_erhvctst_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhvp(mb):
+def test_erhvp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhvp_query(mb):
+def test_erhvp_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhvpv(mb):
+def test_erhvpv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhvs(mb):
+def test_erhvs(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erhvs_query(mb):
+def test_erhvs_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erm(mb):
+def test_erm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ermod(mb):
+def test_ermod(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ermod_query(mb):
+def test_ermod_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfda(mb):
+def test_erpfda(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfda_query(mb):
+def test_erpfda_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfdp(mb):
+def test_erpfdp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfdp_query(mb):
+def test_erpfdp_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfds(mb):
+def test_erpfds(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfds_query(mb):
+def test_erpfds_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfga(mb):
+def test_erpfga(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfga_query(mb):
+def test_erpfga_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfgp(mb):
+def test_erpfgp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfgp_query(mb):
+def test_erpfgp_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfgr(mb):
+def test_erpfgr(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfgr_query(mb):
+def test_erpfgr_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfqg(mb):
+def test_erpfqg(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfqg_query(mb):
+def test_erpfqg_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpftemp_query(mb):
+def test_erpftemp_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfuhca(mb):
+def test_erpfuhca(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfuhca_query(mb):
+def test_erpfuhca_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfuhccal_query(mb):
+def test_erpfuhccal_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfuhcmax_query(mb):
+def test_erpfuhcmax_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erpfuhctst(mb):
+def test_erpfuhctst(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_err_query(mb):
+def test_err_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_errx_query(mb):
+def test_errx_query(mb) -> None:
     assert 'ERRX?' == mb.errx_query().message
     mb.clear_message_queue()
     assert 'ERRX? 0' == mb.errx_query(mode=c.ERRX.Mode.CODE_AND_MESSAGE
                                       ).message
 
 
-def test_ers_query(mb):
+def test_ers_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erssp(mb):
+def test_erssp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_erssp_query(mb):
+def test_erssp_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_eruhva(mb):
+def test_eruhva(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_eruhva_query(mb):
+def test_eruhva_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_fc(mb):
+def test_fc(mb) -> None:
     assert 'FC 3,1000' == mb.fc(3, 1000).message
 
 
 
-def test_fl(mb):
+def test_fl(mb) -> None:
     assert 'FL 1' == mb.fl(True).message
     mb.clear_message_queue()
     assert 'FL 0,1,3,5' == mb.fl(False, [1, 3, 5]).message
@@ -688,7 +688,7 @@ def test_fl(mb):
         _ = mb.fl(False, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]).message
 
 
-def test_fmt(mb):
+def test_fmt(mb) -> None:
     assert 'FMT 1' == \
            mb.fmt(c.FMT.Format.ASCII_12_DIGITS_WITH_HEADER_CRLF_EOI
                   ).message
@@ -698,161 +698,161 @@ def test_fmt(mb):
                   c.FMT.Mode.PRIMARY_SOURCE_OUTPUT_DATA).message
 
 
-def test_hvsmuop(mb):
+def test_hvsmuop(mb) -> None:
     _skip()
 
 
-def test_hvsmuop_query(mb):
+def test_hvsmuop_query(mb) -> None:
     assert 'HVSMUOP?' == \
            mb.hvsmuop_query().message
 
 
-def test_idn_query(mb):
+def test_idn_query(mb) -> None:
     assert 'IN' == mb.in_().message
     mb.clear_message_queue()
     assert 'IN 1,2,3,5,6' == mb.in_([1, 2, 3, 5, 6]).message
 
 
-def test_imp(mb):
+def test_imp(mb) -> None:
     assert 'IMP 10' == mb.imp(c.IMP.MeasurementMode.Z_THETA_RAD).message
 
 
-def test_in_(mb):
+def test_in_(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_intlkvth(mb):
+def test_intlkvth(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_intlkvth_query(mb):
+def test_intlkvth_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lgi(mb):
+def test_lgi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lgv(mb):
+def test_lgv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lim(mb):
+def test_lim(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lim_query(mb):
+def test_lim_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lmn(mb):
+def test_lmn(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lop_query(mb):
+def test_lop_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lrn_query(mb):
+def test_lrn_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lsi(mb):
+def test_lsi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lsm(mb):
+def test_lsm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lssi(mb):
+def test_lssi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lssv(mb):
+def test_lssv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lst_query(mb):
+def test_lst_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lstm(mb):
+def test_lstm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lsv(mb):
+def test_lsv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_lsvm(mb):
+def test_lsvm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mcc(mb):
+def test_mcc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mcpnt(mb):
+def test_mcpnt(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mcpnx(mb):
+def test_mcpnx(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mcpt(mb):
+def test_mcpt(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mcpws(mb):
+def test_mcpws(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mcpwnx(mb):
+def test_mcpwnx(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mdcv(mb):
+def test_mdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mi(mb):
+def test_mi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ml(mb):
+def test_ml(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mm(mb):
+def test_mm(mb) -> None:
     assert 'MM 1,1' == \
            mb.mm(mode=c.MM.Mode.SPOT,
                  channels=[c.ChNr.SLOT_01_CH1]).message
@@ -862,183 +862,183 @@ def test_mm(mb):
                                          c.ChNr.SLOT_03_CH1]).message
 
 
-def test_msc(mb):
+def test_msc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_msp(mb):
+def test_msp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mt(mb):
+def test_mt(mb) -> None:
     assert 'MT 0.0,0.42,32' == mb.mt(0.0, 0.42, 32).message
     mb.clear_message_queue()
     assert 'MT 0.0,0.42,32,0.12' == mb.mt(0.0, 0.42, 32, 0.12).message
 
 
-def test_mtdcv(mb):
+def test_mtdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_mv(mb):
+def test_mv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_nub_query(mb):
+def test_nub_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_odsw(mb):
+def test_odsw(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_odsw_query(mb):
+def test_odsw_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_opc_query(mb):
+def test_opc_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_os(mb):
+def test_os(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_osx(mb):
+def test_osx(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pa(mb):
+def test_pa(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pad(mb):
+def test_pad(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pax(mb):
+def test_pax(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pch(mb):
+def test_pch(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pch_query(mb):
+def test_pch_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pdcv(mb):
+def test_pdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pi(mb):
+def test_pi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pt(mb):
+def test_pt(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ptdcv(mb):
+def test_ptdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pv(mb):
+def test_pv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pwdcv(mb):
+def test_pwdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pwi(mb):
+def test_pwi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_pwv(mb):
+def test_pwv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_qsc(mb):
+def test_qsc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_qsl(mb):
+def test_qsl(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_qsm(mb):
+def test_qsm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_qso(mb):
+def test_qso(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_qsr(mb):
+def test_qsr(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_qst(mb):
+def test_qst(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_qsv(mb):
+def test_qsv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_qsz(mb):
+def test_qsz(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_rc(mb):
+def test_rc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_rcv(mb):
+def test_rcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ri(mb):
+def test_ri(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_rm(mb):
+def test_rm(mb) -> None:
     assert 'RM 1,2' == mb.rm(1, c.RM.Mode.AUTO_UP).message
     mb.clear_message_queue()
     assert 'RM 2,3,60' == mb.rm(2, c.RM.Mode.AUTO_UP_DOWN, 60).message
@@ -1047,451 +1047,451 @@ def test_rm(mb):
         mb.rm(c.ChNr.SLOT_01_CH1, c.RM.Mode.DEFAULT, 22)
 
 
-def test_rst(mb):
+def test_rst(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ru(mb):
+def test_ru(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_rv(mb):
+def test_rv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_rz(mb):
+def test_rz(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sal(mb):
+def test_sal(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sap(mb):
+def test_sap(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sar(mb):
+def test_sar(mb) -> None:
     assert 'SAR 1,0' == mb.sar(1,
                                enable_picoamp_autoranging=True).message
 
 
-def test_scr(mb):
+def test_scr(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ser(mb):
+def test_ser(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ser_query(mb):
+def test_ser_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sim(mb):
+def test_sim(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sim_query(mb):
+def test_sim_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sopc(mb):
+def test_sopc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sopc_query(mb):
+def test_sopc_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sovc(mb):
+def test_sovc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sovc_query(mb):
+def test_sovc_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spm(mb):
+def test_spm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spm_query(mb):
+def test_spm_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spp(mb):
+def test_spp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spper(mb):
+def test_spper(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spper_query(mb):
+def test_spper_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sprm(mb):
+def test_sprm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sprm_query(mb):
+def test_sprm_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spst_query(mb):
+def test_spst_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spt(mb):
+def test_spt(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spt_query(mb):
+def test_spt_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spupd(mb):
+def test_spupd(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spv(mb):
+def test_spv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_spv_query(mb):
+def test_spv_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sre(mb):
+def test_sre(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_sre_query(mb):
+def test_sre_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_srp(mb):
+def test_srp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ssl(mb):
+def test_ssl(mb) -> None:
     assert 'SSL 9,0' == mb.ssl(9, enable_indicator_led=False).message
 
 
-def test_ssp(mb):
+def test_ssp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ssr(mb):
+def test_ssr(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_st(mb):
+def test_st(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_stb_query(mb):
+def test_stb_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_stgp(mb):
+def test_stgp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_stgp_query(mb):
+def test_stgp_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tacv(mb):
+def test_tacv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tc(mb):
+def test_tc(mb) -> None:
     assert 'TC 3,0' == mb.tc(3, 0).message
 
 
-def test_tdcv(mb):
+def test_tdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tdi(mb):
+def test_tdi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tdv(mb):
+def test_tdv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tgmo(mb):
+def test_tgmo(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tgp(mb):
+def test_tgp(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tgpc(mb):
+def test_tgpc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tgsi(mb):
+def test_tgsi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tgso(mb):
+def test_tgso(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tgxo(mb):
+def test_tgxo(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ti(mb):
+def test_ti(mb) -> None:
     assert 'TI 1' == mb.ti(chnum=1).message
     mb.clear_message_queue()
     assert 'TI 1,-14' == mb.ti(chnum=1, i_range=c.IMeasRange.FIX_1uA).message
 
 
-def test_tiv(mb):
+def test_tiv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tm(mb):
+def test_tm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tmacv(mb):
+def test_tmacv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tmdcv(mb):
+def test_tmdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tsc(mb):
+def test_tsc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tsq(mb):
+def test_tsq(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tsr(mb):
+def test_tsr(mb) -> None:
     assert 'TSR' == mb.tsr().message
     mb.clear_message_queue()
     assert 'TSR 1' == mb.tsr(c.ChNr.SLOT_01_CH1).message
 
 
-def test_tst(mb):
+def test_tst(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ttc(mb):
+def test_ttc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tti(mb):
+def test_tti(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ttiv(mb):
+def test_ttiv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ttv(mb):
+def test_ttv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_tv(mb):
+def test_tv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_unt_query(mb):
+def test_unt_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_var(mb):
+def test_var(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_var_query(mb):
+def test_var_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wacv(mb):
+def test_wacv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wat(mb):
+def test_wat(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wdcv(mb):
+def test_wdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wfc(mb):
+def test_wfc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wi(mb):
+def test_wi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wm(mb):
+def test_wm(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wmacv(mb):
+def test_wmacv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wmdcv(mb):
+def test_wmdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wmfc(mb):
+def test_wmfc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wncc(mb):
+def test_wncc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wnu_query(mb):
+def test_wnu_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wnx(mb):
+def test_wnx(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_ws(mb):
+def test_ws(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wsi(mb):
+def test_wsi(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wsv(mb):
+def test_wsv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wt(mb):
+def test_wt(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wtacv(mb):
+def test_wtacv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wtdcv(mb):
+def test_wtdcv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wtfc(mb):
+def test_wtfc(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wv(mb):
+def test_wv(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_wz_query(mb):
+def test_wz_query(mb) -> None:
     # assert '' == mb.().message
     _skip()
 
 
-def test_xe(mb):
+def test_xe(mb) -> None:
     assert 'XE' == mb.xe().message
 
 
-def test_nplc_setting_for_high_speed_vs_high_resolution_mode(mb):
+def test_nplc_setting_for_high_speed_vs_high_resolution_mode(mb) -> None:
     msg = (mb
            .ait(adc_type=c.AIT.Type.HIGH_SPEED,
                 mode=c.AIT.Mode.NPLC,
@@ -1504,7 +1504,7 @@ def test_nplc_setting_for_high_speed_vs_high_resolution_mode(mb):
     assert msg == 'AIT 0,2,3;AIT 1,2,8'
 
 
-def test_set_resolution_mode_for_each_smu(mb):
+def test_set_resolution_mode_for_each_smu(mb) -> None:
     msg = (mb
            .aad(chnum=1, adc_type=c.AAD.Type.HIGH_SPEED)
            .aad(chnum=2, adc_type=c.AAD.Type.HIGH_RESOLUTION)

--- a/qcodes/tests/drivers/keysight_b1500/test_commandList.py
+++ b/qcodes/tests/drivers/keysight_b1500/test_commandList.py
@@ -8,14 +8,14 @@ def uut():
     yield CommandList()
 
 
-def test_append(uut: CommandList):
+def test_append(uut: CommandList) -> None:
     uut.append('a')
     uut.append('b')
 
     assert ['a', 'b'] == uut
 
 
-def test_set_final(uut):
+def test_set_final(uut) -> None:
     uut.append('a')
 
     uut.set_final()
@@ -24,7 +24,7 @@ def test_set_final(uut):
         uut.append('b')
 
 
-def test_clear(uut):
+def test_clear(uut) -> None:
     uut.append('a')
     uut.set_final()
 
@@ -34,7 +34,7 @@ def test_clear(uut):
     assert ['b'] == uut
 
 
-def test_string_representation(uut):
+def test_string_representation(uut) -> None:
     uut.append('a')
     uut.append('b')
 

--- a/qcodes/tests/drivers/test_AimTTi_PL601P.py
+++ b/qcodes/tests/drivers/test_AimTTi_PL601P.py
@@ -13,7 +13,7 @@ def _make_driver():
     driver.close()
 
 
-def test_idn(driver):
+def test_idn(driver) -> None:
     assert {'firmware': '3.05-4.06',
             'model': 'PL601-P',
             'serial': '514710',

--- a/qcodes/tests/drivers/test_Keithley_2450.py
+++ b/qcodes/tests/drivers/test_Keithley_2450.py
@@ -18,7 +18,7 @@ def k2450():
     driver.close()
 
 
-def test_wrong_mode(caplog):
+def test_wrong_mode(caplog) -> None:
     """
     Starting an instrument in the wrong mode should result in a warning. Additionally, no
     parameters should be available, other then the parameters "IDN" and "timeout" which
@@ -33,7 +33,7 @@ def test_wrong_mode(caplog):
         instrument.close()
 
 
-def test_change_source_function(k2450):
+def test_change_source_function(k2450) -> None:
     """
     The parameters available on the source sub-module depend on the function.
     """
@@ -51,7 +51,7 @@ def test_change_source_function(k2450):
     assert k2450.submodules["_source_current"] is not k2450.submodules["_source_voltage"]
 
 
-def test_source_change_error(k2450):
+def test_source_change_error(k2450) -> None:
     """
     If the sense function is in resistance mode, test that an error is generated
     when we change the source function
@@ -69,7 +69,7 @@ def test_source_change_error(k2450):
     k2450.source.function("current")
 
 
-def test_sense_current_mode(k2450):
+def test_sense_current_mode(k2450) -> None:
     """
     Test that when we are in a sense function, for example, 'current', that
     the sense property is returning to the correct submodule. We also test
@@ -87,7 +87,7 @@ def test_sense_current_mode(k2450):
             assert not hasattr(k2450.sense, other_sense_function)
 
 
-def test_setpoint_always_follows_source_function(k2450):
+def test_setpoint_always_follows_source_function(k2450) -> None:
     """
     Changing the source and/or sense functions should not confuse the setpoints. These
     should always follow the source module
@@ -105,7 +105,7 @@ def test_setpoint_always_follows_source_function(k2450):
         assert k2450.sense.sweep.setpoints == (k2450.source.sweep_axis,)
 
 
-def test_reset_sweep_on_source_change(k2450):
+def test_reset_sweep_on_source_change(k2450) -> None:
     """
     If we change the source function, we need to run the sweep setup again
     """
@@ -120,7 +120,7 @@ def test_reset_sweep_on_source_change(k2450):
         k2450.source.get_sweep_axis()
 
 
-def test_sweep(k2450):
+def test_sweep(k2450) -> None:
     """
     Verify that we can start sweeps
     """

--- a/qcodes/tests/drivers/test_Keysight_33XXX.py
+++ b/qcodes/tests/drivers/test_Keysight_33XXX.py
@@ -15,7 +15,7 @@ def driver():
     kw_sim.close()
 
 
-def test_init(driver):
+def test_init(driver) -> None:
 
     idn_dict = driver.IDN()
 
@@ -25,7 +25,7 @@ def test_init(driver):
     assert driver.num_channels == 2
 
 
-def test_sync(driver):
+def test_sync(driver) -> None:
 
     assert driver.sync.output() == 'OFF'
     driver.sync.output('ON')
@@ -37,14 +37,14 @@ def test_sync(driver):
     driver.sync.source(1)
     driver.sync.output('OFF')
 
-def test_channel(driver):
+def test_channel(driver) -> None:
     assert driver.ch1.function_type() == 'SIN'
     driver.ch1.function_type('SQU')
     assert driver.ch1.function_type() == 'SQU'
     driver.ch1.function_type('SIN')
 
 
-def test_burst(driver):
+def test_burst(driver) -> None:
     assert driver.ch1.burst_ncycles() == 1
     driver.ch1.burst_ncycles(10)
     assert driver.ch1.burst_ncycles() == 10

--- a/qcodes/tests/drivers/test_Keysight_N6705B.py
+++ b/qcodes/tests/drivers/test_Keysight_N6705B.py
@@ -12,14 +12,14 @@ def _make_driver():
     driver.close()
 
 
-def test_idn(driver):
+def test_idn(driver) -> None:
     assert {'firmware': 'D.01.08',
             'model': 'N6705B',
             'serial': 'MY50001897',
             'vendor': 'Agilent Technologies'} == driver.IDN()
 
 
-def test_channels(driver):
+def test_channels(driver) -> None:
     # Ensure each channel got instantiated
     assert len(driver.channels) == 4
     for (i, ch) in enumerate(driver.channels):

--- a/qcodes/tests/drivers/test_MercuryiPS.py
+++ b/qcodes/tests/drivers/test_MercuryiPS.py
@@ -60,11 +60,11 @@ def driver_cyl_lim():
     mips_cl.close()
 
 
-def test_idn(driver):
+def test_idn(driver) -> None:
     assert driver.IDN()['model'] == 'SIMULATED MERCURY iPS'
 
 
-def test_simple_setting(driver):
+def test_simple_setting(driver) -> None:
     """
     Some very simple setting of parameters. Mainly just to
     sanity-check the pyvisa-sim setup.
@@ -74,7 +74,7 @@ def test_simple_setting(driver):
     assert driver.GRPX.field_target() == 0.1
 
 
-def test_vector_setting(driver):
+def test_vector_setting(driver) -> None:
     assert driver.field_target().distance(FieldVector(0, 0, 0)) <= 1e-8
     driver.field_target(FieldVector(r=0.1, theta=0, phi=0))
     assert driver.field_target().distance(
@@ -82,7 +82,7 @@ def test_vector_setting(driver):
     ) <= 1e-8
 
 
-def test_vector_ramp_rate(driver):
+def test_vector_ramp_rate(driver) -> None:
     driver.field_ramp_rate(FieldVector(0.1, 0.1, 0.1))
     assert driver.field_ramp_rate().distance(
         FieldVector(0.1, 0.1, 0.1)
@@ -106,7 +106,7 @@ def test_wrong_field_limit_raises() -> None:
     y=hst.floats(min_value=-3, max_value=3),
     z=hst.floats(min_value=-3, max_value=3),
 )
-def test_field_limits(x, y, z, driver_spher_lim, driver_cyl_lim):
+def test_field_limits(x, y, z, driver_spher_lim, driver_cyl_lim) -> None:
     """
     Try with a few different field_limits functions and see if we get no-go
     exceptions when we expect them
@@ -152,7 +152,7 @@ def get_ramp_order(caplog_records):
     y=hst.floats(min_value=-3, max_value=3),
     z=hst.floats(min_value=-3, max_value=3),
 )
-def test_ramp_safely(driver, x, y, z, caplog):
+def test_ramp_safely(driver, x, y, z, caplog) -> None:
     """
     Test that we get the first-down-then-up order right
     """

--- a/qcodes/tests/drivers/test_Rigol_DS1074Z.py
+++ b/qcodes/tests/drivers/test_Rigol_DS1074Z.py
@@ -16,7 +16,7 @@ def driver():
     rigol.close()
 
 
-def test_initialize(driver):
+def test_initialize(driver) -> None:
     """
     Test that simple initialisation works
     """
@@ -24,32 +24,32 @@ def test_initialize(driver):
     assert idn_dict['vendor'] == 'QCoDeS'
 
 
-def test_gets_correct_waveform_xorigin(driver):
+def test_gets_correct_waveform_xorigin(driver) -> None:
     assert driver.waveform_xorigin() == 0
 
 
-def test_gets_correct_waveform_xincrem(driver):
+def test_gets_correct_waveform_xincrem(driver) -> None:
     assert driver.waveform_xincrem() == 0.1
 
 
-def test_sets_correct_waveform_npoints(driver):
+def test_sets_correct_waveform_npoints(driver) -> None:
     driver.waveform_npoints(1000)
     assert driver.waveform_npoints() == 1000
 
 
-def test_gets_correct_waveform_yorigin(driver):
+def test_gets_correct_waveform_yorigin(driver) -> None:
     assert driver.waveform_yorigin() == 0
 
 
-def test_gets_correct_waveform_yincrem(driver):
+def test_gets_correct_waveform_yincrem(driver) -> None:
     assert driver.waveform_yincrem() == 0.1
 
 
-def test_gets_correct_waveform_yref(driver):
+def test_gets_correct_waveform_yref(driver) -> None:
     assert driver.waveform_yref() == 0
 
 
-def test_sets_correct_trigger_mode(driver):
+def test_sets_correct_trigger_mode(driver) -> None:
     driver.trigger_mode('edge')
     assert driver.trigger_mode() == "edge"
     driver.trigger_mode('pattern')
@@ -60,7 +60,7 @@ def test_sets_correct_trigger_mode(driver):
     assert driver.trigger_mode() == "video"
 
 
-def test_get_data_source(driver):
+def test_get_data_source(driver) -> None:
     driver.data_source('ch1')
     assert driver.data_source() == "ch1"
     driver.data_source('ch2')

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -133,7 +133,7 @@ random_coordinates = {
 }
 
 
-def test_instantiation_from_names(magnet_axes_instances, request):
+def test_instantiation_from_names(magnet_axes_instances, request) -> None:
     """
     Instantiate AMI430_3D instrument from the three mock instruments
     representing current drivers for the x, y, and z directions by their
@@ -151,7 +151,7 @@ def test_instantiation_from_names(magnet_axes_instances, request):
 
 def test_instantiation_from_name_of_nonexistent_ami_instrument(
         magnet_axes_instances, request
-):
+) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
     request.addfinalizer(AMI430_3D.close_all)
 
@@ -168,7 +168,7 @@ def test_instantiation_from_name_of_nonexistent_ami_instrument(
 
 def test_instantiation_from_name_of_existing_non_ami_instrument(
         magnet_axes_instances, request
-):
+) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
     request.addfinalizer(AMI430_3D.close_all)
 
@@ -215,7 +215,7 @@ def test_instantiation_from_badly_typed_argument(
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_cartesian_sanity(current_driver, set_target):
+def test_cartesian_sanity(current_driver, set_target) -> None:
     """
     A sanity check to see if the driver remember vectors in any random
     configuration in cartesian coordinates
@@ -238,7 +238,7 @@ def test_cartesian_sanity(current_driver, set_target):
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_spherical_sanity(current_driver, set_target):
+def test_spherical_sanity(current_driver, set_target) -> None:
     """
     A sanity check to see if the driver remember vectors in any random
     configuration in spherical coordinates
@@ -261,7 +261,7 @@ def test_spherical_sanity(current_driver, set_target):
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_cylindrical_sanity(current_driver, set_target):
+def test_cylindrical_sanity(current_driver, set_target) -> None:
     """
     A sanity check to see if the driver remember vectors in any random
     configuration in cylindrical coordinates
@@ -284,7 +284,7 @@ def test_cylindrical_sanity(current_driver, set_target):
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_cartesian_setpoints(current_driver, set_target):
+def test_cartesian_setpoints(current_driver, set_target) -> None:
     """
     Check that the individual x, y, z instruments are getting the set
     points as intended. This test is very similar to the sanity test, but
@@ -309,7 +309,7 @@ def test_cartesian_setpoints(current_driver, set_target):
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_spherical_setpoints(current_driver, set_target):
+def test_spherical_setpoints(current_driver, set_target) -> None:
     """
     Check that the individual x, y, z instruments are getting the set
     points as intended. This test is very similar to the sanity test, but
@@ -335,7 +335,7 @@ def test_spherical_setpoints(current_driver, set_target):
     deadline=500,
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
 )
-def test_cylindrical_setpoints(current_driver, set_target):
+def test_cylindrical_setpoints(current_driver, set_target) -> None:
     """
     Check that the individual x, y, z instruments are getting the set
     points as intended. This test is very similar to the sanity test, but
@@ -358,7 +358,7 @@ def test_cylindrical_setpoints(current_driver, set_target):
 @given(set_target=random_coordinates["cartesian"])
 @settings(max_examples=10, deadline=500,
           suppress_health_check=(HealthCheck.function_scoped_fixture,))
-def test_measured(current_driver, set_target):
+def test_measured(current_driver, set_target) -> None:
     """
     Simply call the measurement methods and verify that no exceptions
     are raised.
@@ -417,7 +417,7 @@ def get_ramp_down_order(messages: List[str]) -> List[str]:
     return order
 
 
-def test_ramp_down_first(current_driver, caplog):
+def test_ramp_down_first(current_driver, caplog) -> None:
     """
     To prevent quenching of the magnets, we need the driver to always
     be within the field limits. Part of the strategy of making sure
@@ -453,7 +453,7 @@ def test_ramp_down_first(current_driver, caplog):
             assert order[0][0] == names[count]
 
 
-def test_field_limit_exception(current_driver):
+def test_field_limit_exception(current_driver) -> None:
     """
     Test that an exception is raised if we intentionally set the field
     beyond the limits. Together with the no_test_ramp_down_first test
@@ -484,7 +484,7 @@ def test_field_limit_exception(current_driver):
             assert belief
 
 
-def test_cylindrical_poles(current_driver):
+def test_cylindrical_poles(current_driver) -> None:
     """
     Test that the phi coordinate is remembered even if the resulting
     vector is equivalent to the null vector
@@ -502,7 +502,7 @@ def test_cylindrical_poles(current_driver):
     assert np.allclose([rho_m, phi_m, z_m], [rho, phi, z])
 
 
-def test_spherical_poles(current_driver):
+def test_spherical_poles(current_driver) -> None:
     """
     Test that the theta and phi coordinates are remembered even if the
     resulting vector is equivalent to the null vector
@@ -520,7 +520,7 @@ def test_spherical_poles(current_driver):
     assert np.allclose([field_m, theta_m, phi_m], [field, theta, phi])
 
 
-def test_ramp_rate_exception(current_driver):
+def test_ramp_rate_exception(current_driver) -> None:
     """
     Test that an exception is raised if we try to set the ramp rate
     to a higher value than is allowed
@@ -535,7 +535,7 @@ def test_ramp_rate_exception(current_driver):
 
 def test_simultaneous_ramp_mode_does_not_reset_individual_axis_ramp_rates_if_nonblocking_ramp(
     current_driver, caplog, request
-):
+) -> None:
     ami3d = current_driver
 
     ami3d.cartesian((0.0, 0.0, 0.0))
@@ -628,7 +628,7 @@ def test_simultaneous_ramp_mode_does_not_reset_individual_axis_ramp_rates_if_non
 
 def test_simultaneous_ramp_mode_resets_individual_axis_ramp_rates_if_blocking_ramp(
     current_driver, caplog, request
-):
+) -> None:
     ami3d = current_driver
 
     ami3d.cartesian((0.0, 0.0, 0.0))
@@ -697,7 +697,7 @@ def test_simultaneous_ramp_mode_resets_individual_axis_ramp_rates_if_blocking_ra
     ), f"found: {messages_with_unexpected_fragment}"
 
 
-def test_reducing_field_ramp_limit_reduces_a_higher_ramp_rate(ami430):
+def test_reducing_field_ramp_limit_reduces_a_higher_ramp_rate(ami430) -> None:
     """
     When reducing field_ramp_limit, the actual ramp_rate should also be
     reduced if the new field_ramp_limit is lower than the actual ramp_rate
@@ -719,7 +719,7 @@ def test_reducing_field_ramp_limit_reduces_a_higher_ramp_rate(ami430):
     assert ami430.ramp_rate() == ami430.field_ramp_limit()
 
 
-def test_reducing_current_ramp_limit_reduces_a_higher_ramp_rate(ami430):
+def test_reducing_current_ramp_limit_reduces_a_higher_ramp_rate(ami430) -> None:
     """
     When reducing current_ramp_limit, the actual ramp_rate should also be
     reduced if the new current_ramp_limit is lower than the actual ramp_rate
@@ -745,7 +745,7 @@ def test_reducing_current_ramp_limit_reduces_a_higher_ramp_rate(ami430):
     assert ami430.ramp_rate() == ami430.field_ramp_limit()
 
 
-def test_reducing_field_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430):
+def test_reducing_field_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430) -> None:
     """
     When reducing field_ramp_limit, the actual ramp_rate should remain
     if the new field_ramp_limit is higher than the actual ramp_rate now.
@@ -768,7 +768,7 @@ def test_reducing_field_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430):
     assert ami430.ramp_rate() == old_ramp_rate
 
 
-def test_reducing_current_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430):
+def test_reducing_current_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430) -> None:
     """
     When reducing current_ramp_limit, the actual ramp_rate should remain
     if the new current_ramp_limit is higher than the actual ramp_rate now
@@ -796,7 +796,7 @@ def test_reducing_current_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430):
     assert ami430.ramp_rate() == old_ramp_rate
 
 
-def test_blocking_ramp_parameter(current_driver, caplog):
+def test_blocking_ramp_parameter(current_driver, caplog) -> None:
 
     assert current_driver.block_during_ramp() is True
 
@@ -818,7 +818,7 @@ def test_blocking_ramp_parameter(current_driver, caplog):
         assert len([mssg for mssg in messages if 'blocking' in mssg]) == 0
 
 
-def test_current_and_field_params_interlink_at_init(ami430):
+def test_current_and_field_params_interlink_at_init(ami430) -> None:
     """
     Test that the values of the ``coil_constant``-dependent parameters
     are correctly proportional to each other at the initialization of the
@@ -838,7 +838,8 @@ def test_current_and_field_params_interlink_at_init(ami430):
 
 
 def test_current_and_field_params_interlink__change_current_ramp_limit(
-        ami430, factor=0.9):
+    ami430, factor=0.9
+) -> None:
     """
     Test that after changing ``current_ramp_limit``, the values of the
     ``field_*`` parameters change proportionally, ``coil__constant`` remains
@@ -886,7 +887,8 @@ def test_current_and_field_params_interlink__change_current_ramp_limit(
 
 
 def test_current_and_field_params_interlink__change_field_ramp_limit(
-        ami430, factor=0.9):
+    ami430, factor=0.9
+) -> None:
     """
     Test that after changing ``field_ramp_limit``, the values of the
     ``current_*`` parameters change proportionally, ``coil__constant`` remains
@@ -935,7 +937,7 @@ def test_current_and_field_params_interlink__change_field_ramp_limit(
 
 def test_current_and_field_params_interlink__change_coil_constant(
     ami430, factor: float = 3
-):
+) -> None:
     """
     Test that after changing ``change_coil_constant``, the values of the
     ``current_*`` parameters remain the same while the values of the
@@ -983,7 +985,7 @@ def test_current_and_field_params_interlink__change_coil_constant(
         field_limit, current_limit*coil_constant)
 
 
-def test_current_and_field_params_interlink__permutations_of_tests(ami430):
+def test_current_and_field_params_interlink__permutations_of_tests(ami430) -> None:
     """
     As per one of the user's request, the
     test_current_and_field_params_interlink__* tests are executed here with
@@ -1065,7 +1067,7 @@ def _parametrization_kwargs():
 
 
 @pytest.mark.parametrize('field_limit', **_parametrization_kwargs())
-def test_numeric_field_limit(magnet_axes_instances, field_limit, request):
+def test_numeric_field_limit(magnet_axes_instances, field_limit, request) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
     ami = AMI430_3D("AMI430_3D", mag_x, mag_y, mag_z, field_limit)
     request.addfinalizer(ami.close)
@@ -1081,7 +1083,7 @@ def test_numeric_field_limit(magnet_axes_instances, field_limit, request):
         ami.cartesian(target_outside_limit)
 
 
-def test_ramp_rate_units_and_field_units_at_init(ami430):
+def test_ramp_rate_units_and_field_units_at_init(ami430) -> None:
     """
     Test values of ramp_rate_units and field_units parameters at init,
     and the units of other parameters which depend on the
@@ -1102,11 +1104,14 @@ def test_ramp_rate_units_and_field_units_at_init(ami430):
     assert ami430.field_ramp_limit.unit == "T/s"
 
 
-@pytest.mark.parametrize(('new_value', 'unit_string', 'scale'),
-                         (('seconds', 's', 1), ('minutes', 'min', 1/60)),
-                         ids=('seconds', 'minutes'))
-def test_change_ramp_rate_units_parameter(ami430, new_value, unit_string,
-                                          scale):
+@pytest.mark.parametrize(
+    ("new_value", "unit_string", "scale"),
+    (("seconds", "s", 1), ("minutes", "min", 1 / 60)),
+    ids=("seconds", "minutes"),
+)
+def test_change_ramp_rate_units_parameter(
+    ami430, new_value, unit_string, scale
+) -> None:
     """
     Test that changing value of ramp_rate_units parameter is reflected in
     settings of other magnet parameters.
@@ -1147,7 +1152,7 @@ def test_change_ramp_rate_units_parameter(ami430, new_value, unit_string,
 @pytest.mark.parametrize(('new_value', 'unit_string'),
                          (('tesla', 'T'), ('kilogauss', 'kG')),
                          ids=('tesla', 'kilogauss'))
-def test_change_field_units_parameter(ami430, new_value, unit_string):
+def test_change_field_units_parameter(ami430, new_value, unit_string) -> None:
     """
     Test that changing value of field_units parameter is reflected in
     settings of other magnet parameters.
@@ -1183,7 +1188,7 @@ def test_change_field_units_parameter(ami430, new_value, unit_string):
     ami430.field_units("tesla")
 
 
-def test_switch_heater_enabled(ami430):
+def test_switch_heater_enabled(ami430) -> None:
     assert ami430.switch_heater.enabled() is False
     ami430.switch_heater.enabled(True)
     assert ami430.switch_heater.enabled() is True

--- a/qcodes/tests/drivers/test_ami430_visa.py
+++ b/qcodes/tests/drivers/test_ami430_visa.py
@@ -120,7 +120,7 @@ random_coordinates = {
 }
 
 
-def test_instantiation_from_names(magnet_axes_instances, request):
+def test_instantiation_from_names(magnet_axes_instances, request) -> None:
     """
     Instantiate AMI430_3D instrument from the three mock instruments
     representing current drivers for the x, y, and z directions by their
@@ -136,7 +136,7 @@ def test_instantiation_from_names(magnet_axes_instances, request):
     assert driver._instrument_z is mag_z
 
 
-def test_instantiation_compat_classes(request):
+def test_instantiation_compat_classes(request) -> None:
     """
     Test that we can instantiate drivers using the old names
     """
@@ -161,7 +161,7 @@ def test_instantiation_compat_classes(request):
 
 def test_instantiation_from_name_of_nonexistent_ami_instrument(
     magnet_axes_instances, request
-):
+) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
     request.addfinalizer(AMIModel4303D.close_all)
 
@@ -177,7 +177,7 @@ def test_instantiation_from_name_of_nonexistent_ami_instrument(
 
 def test_instantiation_from_name_of_existing_non_ami_instrument(
     magnet_axes_instances, request
-):
+) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
     request.addfinalizer(AMIModel4303D.close_all)
 
@@ -224,7 +224,7 @@ def test_instantiation_from_badly_typed_argument(
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_cartesian_sanity(current_driver, set_target):
+def test_cartesian_sanity(current_driver, set_target) -> None:
     """
     A sanity check to see if the driver remember vectors in any random
     configuration in cartesian coordinates
@@ -247,7 +247,7 @@ def test_cartesian_sanity(current_driver, set_target):
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_spherical_sanity(current_driver, set_target):
+def test_spherical_sanity(current_driver, set_target) -> None:
     """
     A sanity check to see if the driver remember vectors in any random
     configuration in spherical coordinates
@@ -270,7 +270,7 @@ def test_spherical_sanity(current_driver, set_target):
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_cylindrical_sanity(current_driver, set_target):
+def test_cylindrical_sanity(current_driver, set_target) -> None:
     """
     A sanity check to see if the driver remember vectors in any random
     configuration in cylindrical coordinates
@@ -293,7 +293,7 @@ def test_cylindrical_sanity(current_driver, set_target):
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_cartesian_setpoints(current_driver, set_target):
+def test_cartesian_setpoints(current_driver, set_target) -> None:
     """
     Check that the individual x, y, z instruments are getting the set
     points as intended. This test is very similar to the sanity test, but
@@ -318,7 +318,7 @@ def test_cartesian_setpoints(current_driver, set_target):
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
     deadline=None,
 )
-def test_spherical_setpoints(current_driver, set_target):
+def test_spherical_setpoints(current_driver, set_target) -> None:
     """
     Check that the individual x, y, z instruments are getting the set
     points as intended. This test is very similar to the sanity test, but
@@ -344,7 +344,7 @@ def test_spherical_setpoints(current_driver, set_target):
     deadline=500,
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
 )
-def test_cylindrical_setpoints(current_driver, set_target):
+def test_cylindrical_setpoints(current_driver, set_target) -> None:
     """
     Check that the individual x, y, z instruments are getting the set
     points as intended. This test is very similar to the sanity test, but
@@ -370,7 +370,7 @@ def test_cylindrical_setpoints(current_driver, set_target):
     deadline=500,
     suppress_health_check=(HealthCheck.function_scoped_fixture,),
 )
-def test_measured(current_driver, set_target):
+def test_measured(current_driver, set_target) -> None:
     """
     Simply call the measurement methods and verify that no exceptions
     are raised.
@@ -425,7 +425,7 @@ def get_ramp_down_order(messages: List[str]) -> List[str]:
     return order
 
 
-def test_ramp_down_first(current_driver, caplog):
+def test_ramp_down_first(current_driver, caplog) -> None:
     """
     To prevent quenching of the magnets, we need the driver to always
     be within the field limits. Part of the strategy of making sure
@@ -461,7 +461,7 @@ def test_ramp_down_first(current_driver, caplog):
             assert order[0][0] == names[count]
 
 
-def test_field_limit_exception(current_driver):
+def test_field_limit_exception(current_driver) -> None:
     """
     Test that an exception is raised if we intentionally set the field
     beyond the limits. Together with the no_test_ramp_down_first test
@@ -491,7 +491,7 @@ def test_field_limit_exception(current_driver):
             assert belief
 
 
-def test_cylindrical_poles(current_driver):
+def test_cylindrical_poles(current_driver) -> None:
     """
     Test that the phi coordinate is remembered even if the resulting
     vector is equivalent to the null vector
@@ -509,7 +509,7 @@ def test_cylindrical_poles(current_driver):
     assert np.allclose([rho_m, phi_m, z_m], [rho, phi, z])
 
 
-def test_spherical_poles(current_driver):
+def test_spherical_poles(current_driver) -> None:
     """
     Test that the theta and phi coordinates are remembered even if the
     resulting vector is equivalent to the null vector
@@ -527,7 +527,7 @@ def test_spherical_poles(current_driver):
     assert np.allclose([field_m, theta_m, phi_m], [field, theta, phi])
 
 
-def test_ramp_rate_exception(current_driver):
+def test_ramp_rate_exception(current_driver) -> None:
     """
     Test that an exception is raised if we try to set the ramp rate
     to a higher value than is allowed
@@ -542,7 +542,7 @@ def test_ramp_rate_exception(current_driver):
 
 def test_simultaneous_ramp_mode_does_not_reset_individual_axis_ramp_rates_if_nonblocking_ramp(
     current_driver, caplog, request
-):
+) -> None:
     ami3d = current_driver
 
     ami3d.cartesian((0.0, 0.0, 0.0))
@@ -635,7 +635,7 @@ def test_simultaneous_ramp_mode_does_not_reset_individual_axis_ramp_rates_if_non
 
 def test_simultaneous_ramp_mode_resets_individual_axis_ramp_rates_if_blocking_ramp(
     current_driver, caplog, request
-):
+) -> None:
     ami3d = current_driver
 
     ami3d.cartesian((0.0, 0.0, 0.0))
@@ -704,7 +704,7 @@ def test_simultaneous_ramp_mode_resets_individual_axis_ramp_rates_if_blocking_ra
     ), f"found: {messages_with_unexpected_fragment}"
 
 
-def test_reducing_field_ramp_limit_reduces_a_higher_ramp_rate(ami430):
+def test_reducing_field_ramp_limit_reduces_a_higher_ramp_rate(ami430) -> None:
     """
     When reducing field_ramp_limit, the actual ramp_rate should also be
     reduced if the new field_ramp_limit is lower than the actual ramp_rate
@@ -726,7 +726,7 @@ def test_reducing_field_ramp_limit_reduces_a_higher_ramp_rate(ami430):
     assert ami430.ramp_rate() == ami430.field_ramp_limit()
 
 
-def test_reducing_current_ramp_limit_reduces_a_higher_ramp_rate(ami430):
+def test_reducing_current_ramp_limit_reduces_a_higher_ramp_rate(ami430) -> None:
     """
     When reducing current_ramp_limit, the actual ramp_rate should also be
     reduced if the new current_ramp_limit is lower than the actual ramp_rate
@@ -749,7 +749,7 @@ def test_reducing_current_ramp_limit_reduces_a_higher_ramp_rate(ami430):
     assert ami430.ramp_rate() == ami430.field_ramp_limit()
 
 
-def test_reducing_field_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430):
+def test_reducing_field_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430) -> None:
     """
     When reducing field_ramp_limit, the actual ramp_rate should remain
     if the new field_ramp_limit is higher than the actual ramp_rate now.
@@ -772,7 +772,7 @@ def test_reducing_field_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430):
     assert ami430.ramp_rate() == old_ramp_rate
 
 
-def test_reducing_current_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430):
+def test_reducing_current_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430) -> None:
     """
     When reducing current_ramp_limit, the actual ramp_rate should remain
     if the new current_ramp_limit is higher than the actual ramp_rate now
@@ -797,7 +797,7 @@ def test_reducing_current_ramp_limit_keeps_a_lower_ramp_rate_as_is(ami430):
     assert ami430.ramp_rate() == old_ramp_rate
 
 
-def test_blocking_ramp_parameter(current_driver, caplog):
+def test_blocking_ramp_parameter(current_driver, caplog) -> None:
 
     assert current_driver.block_during_ramp() is True
 
@@ -818,7 +818,7 @@ def test_blocking_ramp_parameter(current_driver, caplog):
         assert len([mssg for mssg in messages if "blocking" in mssg]) == 0
 
 
-def test_current_and_field_params_interlink_at_init(ami430):
+def test_current_and_field_params_interlink_at_init(ami430) -> None:
     """
     Test that the values of the ``coil_constant``-dependent parameters
     are correctly proportional to each other at the initialization of the
@@ -837,7 +837,7 @@ def test_current_and_field_params_interlink_at_init(ami430):
 
 def test_current_and_field_params_interlink__change_current_ramp_limit(
     ami430, factor=0.9
-):
+) -> None:
     """
     Test that after changing ``current_ramp_limit``, the values of the
     ``field_*`` parameters change proportionally, ``coil__constant`` remains
@@ -879,7 +879,7 @@ def test_current_and_field_params_interlink__change_current_ramp_limit(
 
 def test_current_and_field_params_interlink__change_field_ramp_limit(
     ami430, factor=0.9
-):
+) -> None:
     """
     Test that after changing ``field_ramp_limit``, the values of the
     ``current_*`` parameters change proportionally, ``coil__constant`` remains
@@ -921,7 +921,7 @@ def test_current_and_field_params_interlink__change_field_ramp_limit(
 
 def test_current_and_field_params_interlink__change_coil_constant(
     ami430, factor: float = 3
-):
+) -> None:
     """
     Test that after changing ``change_coil_constant``, the values of the
     ``current_*`` parameters remain the same while the values of the
@@ -962,7 +962,7 @@ def test_current_and_field_params_interlink__change_coil_constant(
     np.testing.assert_almost_equal(field_limit, current_limit * coil_constant)
 
 
-def test_current_and_field_params_interlink__permutations_of_tests(ami430):
+def test_current_and_field_params_interlink__permutations_of_tests(ami430) -> None:
     """
     As per one of the user's request, the
     test_current_and_field_params_interlink__* tests are executed here with
@@ -1066,7 +1066,7 @@ def _parametrization_kwargs():
 
 
 @pytest.mark.parametrize("field_limit", **_parametrization_kwargs())
-def test_numeric_field_limit(magnet_axes_instances, field_limit, request):
+def test_numeric_field_limit(magnet_axes_instances, field_limit, request) -> None:
     mag_x, mag_y, mag_z = magnet_axes_instances
     ami = AMIModel4303D("AMI430_3D", mag_x, mag_y, mag_z, field_limit)
     request.addfinalizer(ami.close)
@@ -1083,7 +1083,7 @@ def test_numeric_field_limit(magnet_axes_instances, field_limit, request):
         ami.cartesian(target_outside_limit)
 
 
-def test_ramp_rate_units_and_field_units_at_init(ami430):
+def test_ramp_rate_units_and_field_units_at_init(ami430) -> None:
     """
     Test values of ramp_rate_units and field_units parameters at init,
     and the units of other parameters which depend on the
@@ -1109,7 +1109,9 @@ def test_ramp_rate_units_and_field_units_at_init(ami430):
     (("seconds", "s", 1), ("minutes", "min", 1 / 60)),
     ids=("seconds", "minutes"),
 )
-def test_change_ramp_rate_units_parameter(ami430, new_value, unit_string, scale):
+def test_change_ramp_rate_units_parameter(
+    ami430, new_value, unit_string, scale
+) -> None:
     """
     Test that changing value of ramp_rate_units parameter is reflected in
     settings of other magnet parameters.
@@ -1151,7 +1153,7 @@ def test_change_ramp_rate_units_parameter(ami430, new_value, unit_string, scale)
     (("tesla", "T"), ("kilogauss", "kG")),
     ids=("tesla", "kilogauss"),
 )
-def test_change_field_units_parameter(ami430, new_value, unit_string):
+def test_change_field_units_parameter(ami430, new_value, unit_string) -> None:
     """
     Test that changing value of field_units parameter is reflected in
     settings of other magnet parameters.
@@ -1186,7 +1188,7 @@ def test_change_field_units_parameter(ami430, new_value, unit_string):
     ami430.field_units("tesla")
 
 
-def test_switch_heater_enabled(ami430):
+def test_switch_heater_enabled(ami430) -> None:
     assert ami430.switch_heater.enabled() is False
     ami430.switch_heater.enabled(True)
     assert ami430.switch_heater.enabled() is True

--- a/qcodes/tests/drivers/test_keithley_26xx.py
+++ b/qcodes/tests/drivers/test_keithley_26xx.py
@@ -28,14 +28,14 @@ def _make_smus(driver):
                 for smu_name in smu_names)
 
 
-def test_idn(driver):
+def test_idn(driver) -> None:
     assert {'firmware': '3.0.0',
             'model': '2601B',
             'serial': '1398687',
             'vendor': 'Keithley Instruments Inc.'} == driver.IDN()
 
 
-def test_smu_channels_and_their_parameters(driver):
+def test_smu_channels_and_their_parameters(driver) -> None:
     assert {'smua', 'smub'} == set(list(driver.submodules.keys()))
 
     for smu_name in {'smua', 'smub'}:
@@ -141,7 +141,7 @@ def test_smu_channels_and_their_parameters(driver):
         assert smu.time_axis == smu.timetrace.setpoints[0]
 
 
-def test_setting_source_voltage_range_disables_autorange(smus):
+def test_setting_source_voltage_range_disables_autorange(smus) -> None:
     for smu in smus:
         smu.source_autorange_v_enabled(True)
         assert smu.source_autorange_v_enabled() is True
@@ -150,7 +150,7 @@ def test_setting_source_voltage_range_disables_autorange(smus):
         assert smu.source_autorange_v_enabled() is False
 
 
-def test_setting_measure_voltage_range_disables_autorange(smus):
+def test_setting_measure_voltage_range_disables_autorange(smus) -> None:
     for smu in smus:
         smu.measure_autorange_v_enabled(True)
         assert smu.measure_autorange_v_enabled() is True
@@ -159,7 +159,7 @@ def test_setting_measure_voltage_range_disables_autorange(smus):
         assert smu.measure_autorange_v_enabled() is False
 
 
-def test_setting_source_current_range_disables_autorange(smus):
+def test_setting_source_current_range_disables_autorange(smus) -> None:
     for smu in smus:
         smu.source_autorange_i_enabled(True)
         assert smu.source_autorange_i_enabled() is True
@@ -168,7 +168,7 @@ def test_setting_source_current_range_disables_autorange(smus):
         assert smu.source_autorange_i_enabled() is False
 
 
-def test_setting_measure_current_range_disables_autorange(smus):
+def test_setting_measure_current_range_disables_autorange(smus) -> None:
     for smu in smus:
         smu.measure_autorange_i_enabled(True)
         assert smu.measure_autorange_i_enabled() is True

--- a/qcodes/tests/drivers/test_keithley_3706A.py
+++ b/qcodes/tests/drivers/test_keithley_3706A.py
@@ -56,29 +56,29 @@ def matrix_channels():
     return m_channels
 
 
-def test_idn(driver):
+def test_idn(driver) -> None:
     assert {'firmware': '01.56a',
             'model': '3706A-SNFP',
             'serial': '04447336',
             'vendor': 'KEITHLEY INSTRUMENTS INC.'} == driver.get_idn()
 
 
-def test_switch_card_idn(driver):
+def test_switch_card_idn(driver) -> None:
     assert {'slot_no': "1", 'model': "3730",
             'mtype': "6x16 High Density Matrix",
             'firmware': "01.40h",
             'serial': "4447332"} == driver.get_switch_cards()[0]
 
 
-def test_installed_card_id(driver):
+def test_installed_card_id(driver) -> None:
     assert ['1', '2', '3'] == driver._get_slot_ids()
 
 
-def test_slot_names(driver):
+def test_slot_names(driver) -> None:
     assert ['slot1', 'slot2', 'slot3'] == driver._get_slot_names()
 
 
-def test_get_interlock_state(driver):
+def test_get_interlock_state(driver) -> None:
     dict_list = (
         {
             "slot_no": "1",
@@ -96,53 +96,53 @@ def test_get_interlock_state(driver):
     assert dict_list == driver.get_interlock_state()
 
 
-def test_get_number_of_rows(driver):
+def test_get_number_of_rows(driver) -> None:
     assert [6, 6, 6] == driver._get_number_of_rows()
 
 
-def test_get_number_of_columns(driver):
+def test_get_number_of_columns(driver) -> None:
     assert [16, 16, 16] == driver._get_number_of_columns()
 
 
 @pytest.mark.parametrize('val', [0, 1, 2])
-def test_get_rows(driver, val):
+def test_get_rows(driver, val) -> None:
     rows_in_a_slot = ['1', '2', '3', '4', '5', '6']
     assert rows_in_a_slot == driver._get_rows()[val]
 
 
 @pytest.mark.parametrize('val', [0, 1, 2])
-def test_get_columns(driver, val):
+def test_get_columns(driver, val) -> None:
     columns_in_a_slot = ['01', '02', '03', '04', '05', '06', '07', '08', '09',
                          '10', '11', '12', '13', '14', '15', '16']
     assert columns_in_a_slot == driver._get_columns()[val]
 
 
 @pytest.mark.parametrize('val', [1, 2, 3])
-def test_number_of_channels_by_slot(driver, val):
+def test_number_of_channels_by_slot(driver, val) -> None:
     assert 96 == len(driver.get_channels_by_slot(val))
 
 
-def test_total_number_of_channels(driver):
+def test_total_number_of_channels(driver) -> None:
     assert 3*96 == len(driver.get_channels())
 
 
-def test_channels_in_slot_one(driver, channels_in_slot_one):
+def test_channels_in_slot_one(driver, channels_in_slot_one) -> None:
     assert channels_in_slot_one == driver.get_channels_by_slot(1)
 
 
-def test_channels_in_slot_two(driver, channels_in_slot_two):
+def test_channels_in_slot_two(driver, channels_in_slot_two) -> None:
     assert channels_in_slot_two == driver.get_channels_by_slot(2)
 
 
-def test_channels_in_slot_three(driver, channels_in_slot_three):
+def test_channels_in_slot_three(driver, channels_in_slot_three) -> None:
     assert channels_in_slot_three == driver.get_channels_by_slot(3)
 
 
-def test_matrix_channels(driver, matrix_channels):
+def test_matrix_channels(driver, matrix_channels) -> None:
     assert matrix_channels == driver.get_channels()
 
 
-def test_analog_backplane_specifiers(driver):
+def test_analog_backplane_specifiers(driver) -> None:
     specifiers = ['1911', '1912', '1913', '1914', '1915', '1916',
                   '2911', '2912', '2913', '2914', '2915', '2916',
                   '3911', '3912', '3913', '3914', '3915', '3916']
@@ -151,11 +151,11 @@ def test_analog_backplane_specifiers(driver):
 
 @pytest.mark.parametrize('val', ['slot1', 'allslots', '3111', '3912',
                                  '2103:2116'])
-def test_validator_truth(driver, val):
+def test_validator_truth(driver, val) -> None:
     assert driver._validator(val) is True
 
 
 @pytest.mark.parametrize('val', ['slot12', 'alslots', '5111', '912', '123213',
                                  'QCoDeS'])
-def test_validator_falsehood(driver, val):
+def test_validator_falsehood(driver, val) -> None:
     assert driver._validator(val) is False

--- a/qcodes/tests/drivers/test_keithley_7510.py
+++ b/qcodes/tests/drivers/test_keithley_7510.py
@@ -20,7 +20,7 @@ def dmm_7510_driver():
         inst.close()
 
 
-def test_get_idn(dmm_7510_driver):
+def test_get_idn(dmm_7510_driver) -> None:
     assert dmm_7510_driver.IDN() == {
         'vendor': 'KEITHLEY INSTRUMENTS',
         'model': 'DMM7510',
@@ -29,7 +29,7 @@ def test_get_idn(dmm_7510_driver):
     }
 
 
-def test_change_sense_function(dmm_7510_driver):
+def test_change_sense_function(dmm_7510_driver) -> None:
     """
     Measurement should be the same as the sense function, e.g., only voltage
     measurement is allowed when the sense function is "voltage".
@@ -49,7 +49,7 @@ def test_change_sense_function(dmm_7510_driver):
     st.sampled_from((0.1, 1, 10, 100, 1000)),
     st.floats(0.01, 10)
 )
-def test_set_range_and_nplc(dmm_7510_driver, upper_limit, nplc):
+def test_set_range_and_nplc(dmm_7510_driver, upper_limit, nplc) -> None:
     """
     Test the ability of setting range and nplc value for sense function.
     "Voltage" is used as an example.

--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -5,7 +5,7 @@ import pytest
 from qcodes.instrument_drivers.tektronix.Keithley_s46 import S46, LockAcquisitionError
 
 
-def test_aliases_dict():
+def test_aliases_dict() -> None:
     """
     Test the class attribute 'aliases' which maps channel aliases
     (e.g. A1, B2, etc) to channel numbers.
@@ -52,7 +52,7 @@ def s46_four():
         driver.close()
 
 
-def test_runtime_error_on_bad_init(request):
+def test_runtime_error_on_bad_init(request) -> None:
     """
     If we initialize the driver from an instrument state with more then one
     channel per relay closed, raise a runtime error. An instrument can come to
@@ -71,7 +71,7 @@ def test_runtime_error_on_bad_init(request):
         )
 
 
-def test_query_close_once_at_init(caplog):
+def test_query_close_once_at_init(caplog) -> None:
     """
     Test that, during initialisation, we query the closed channels only once
     """
@@ -85,7 +85,7 @@ def test_query_close_once_at_init(caplog):
         inst.close()
 
 
-def test_init_six(s46_six, caplog):
+def test_init_six(s46_six, caplog) -> None:
     """
     Test that the six channel instrument initializes correctly.
     """
@@ -107,7 +107,7 @@ def test_init_six(s46_six, caplog):
         assert s46_six.C1._lock._locked_by is None
 
 
-def test_init_four(s46_four):
+def test_init_four(s46_four) -> None:
     """
     Test that the six channel instrument initializes correctly.
     """
@@ -125,7 +125,7 @@ def test_init_four(s46_four):
             assert not hasattr(s46_four, alias)
 
 
-def test_channel_number_invariance(s46_four, s46_six):
+def test_channel_number_invariance(s46_four, s46_six) -> None:
     """
     Regardless of the channel layout (that is, number of channels per relay),
     channel aliases should represent the same channel. See also page 2-5 of the
@@ -138,7 +138,7 @@ def test_channel_number_invariance(s46_four, s46_six):
             assert channel_four.channel_number == channel_six.channel_number
 
 
-def test_locking_mechanism(s46_six):
+def test_locking_mechanism(s46_six) -> None:
     """
     1) Test that the lock acquisition error is raised if we try to close
     more then once channel per replay
@@ -171,7 +171,7 @@ def test_locking_mechanism(s46_six):
     s46_six.C2("close")
 
 
-def test_is_closed(s46_six):
+def test_is_closed(s46_six) -> None:
     """
     Test the `is_closed` public method
     """

--- a/qcodes/tests/drivers/test_keysight_34465a.py
+++ b/qcodes/tests/drivers/test_keysight_34465a.py
@@ -43,25 +43,25 @@ def driver_with_read_and_fetch_mocked(val_volt):
         Keysight_34465A.close_all()
 
 
-def test_init(driver):
+def test_init(driver) -> None:
     idn = driver.IDN()
     assert idn['vendor'] == 'Keysight'
     assert idn['model'] == '34465A'
 
 
-def test_has_dig_option(driver):
+def test_has_dig_option(driver) -> None:
     assert True is driver.has_DIG
 
 
-def test_model_flag(driver):
+def test_model_flag(driver) -> None:
     assert True is driver.is_34465A_34470A
 
 
-def test_reset(driver):
+def test_reset(driver) -> None:
     driver.reset()
 
 
-def test_NPLC(driver):
+def test_NPLC(driver) -> None:
     assert driver.NPLC.get() == 10.0
     driver.NPLC.set(0.2)
     assert driver.NPLC.get() == 0.2
@@ -69,19 +69,19 @@ def test_NPLC(driver):
 
 
 @pytest.mark.parametrize("val_volt", ['100.0'])
-def test_get_voltage(driver_with_read_and_fetch_mocked, val_volt):
+def test_get_voltage(driver_with_read_and_fetch_mocked, val_volt) -> None:
     voltage = driver_with_read_and_fetch_mocked.volt.get()
     assert voltage == 100.0
 
 
 @pytest.mark.parametrize("val_volt", ['9.9e37'])
-def test_get_voltage_plus_inf(driver_with_read_and_fetch_mocked, val_volt):
+def test_get_voltage_plus_inf(driver_with_read_and_fetch_mocked, val_volt) -> None:
     voltage = driver_with_read_and_fetch_mocked.volt.get()
     assert voltage == np.inf
 
 
 @pytest.mark.parametrize("val_volt", ['-9.9e37'])
-def test_get_voltage_minus_inf(driver_with_read_and_fetch_mocked, val_volt):
+def test_get_voltage_minus_inf(driver_with_read_and_fetch_mocked, val_volt) -> None:
     voltage = driver_with_read_and_fetch_mocked.volt.get()
     assert voltage == -np.inf
 
@@ -91,14 +91,14 @@ def test_get_voltage_minus_inf(driver_with_read_and_fetch_mocked, val_volt):
                                      "fail. The problem is coming from "
                                      "timetrace().")
 @pytest.mark.parametrize("val_volt", ['10, 9.9e37, -9.9e37'])
-def test_get_timetrace(driver_with_read_and_fetch_mocked, val_volt):
+def test_get_timetrace(driver_with_read_and_fetch_mocked, val_volt) -> None:
     driver_with_read_and_fetch_mocked.timetrace_npts(3)
     assert driver_with_read_and_fetch_mocked.timetrace_npts() == 3
     voltage = driver_with_read_and_fetch_mocked.timetrace()
     assert (voltage == np.array([10.0, np.inf, -np.inf])).all()
 
 
-def test_set_get_autorange(driver):
+def test_set_get_autorange(driver) -> None:
     ar = driver.autorange.get()
     assert ar == 'OFF'
     driver.autorange.set('ON')
@@ -109,7 +109,7 @@ def test_set_get_autorange(driver):
     assert ar == 'OFF'
 
 
-def test_increase_decrease_range(driver):
+def test_increase_decrease_range(driver) -> None:
     driver_range_user = driver.ranges[2]
     driver.increase_range(driver_range_user)
     assert driver.range() == driver.ranges[3]
@@ -124,7 +124,7 @@ def test_increase_decrease_range(driver):
     assert driver.range() == driver.ranges[1]
 
 
-def test_display_text(driver):
+def test_display_text(driver) -> None:
 
     original_text = driver.display.text()
     assert original_text == ""

--- a/qcodes/tests/drivers/test_keysight_34934a.py
+++ b/qcodes/tests/drivers/test_keysight_34934a.py
@@ -21,14 +21,14 @@ def switch_driver():
         inst.close()
 
 
-def test_protection_mode(switch_driver):
+def test_protection_mode(switch_driver) -> None:
     """
     to check the protection mode (34934A module only)
     """
     assert switch_driver.module[1].protection_mode() == 'AUTO100'
 
 
-def test_connection(switch_driver):
+def test_connection(switch_driver) -> None:
     """
     to check if a channel is closed or open
     """
@@ -45,7 +45,7 @@ def test_connection(switch_driver):
     st.integers(1, 4),
     st.integers(1, 32)
 )
-def test_4x32(config, row, column):
+def test_4x32(config, row, column) -> None:
     f = Keysight34934A.get_numbering_function(4, 32, config)
     g = numbering_function_4x32(config)
     assert f(row, column) == g(row, column)
@@ -56,7 +56,7 @@ def test_4x32(config, row, column):
     st.integers(1, 4),
     st.integers(1, 64)
 )
-def test_4x64(config, row, column):
+def test_4x64(config, row, column) -> None:
     f = Keysight34934A.get_numbering_function(4, 64, config)
     g = numbering_function_4x64(config)
     assert f(row, column) == g(row, column)
@@ -66,7 +66,7 @@ def test_4x64(config, row, column):
     st.integers(1, 4),
     st.integers(1, 128)
 )
-def test_4x128(row, column):
+def test_4x128(row, column) -> None:
     f = Keysight34934A.get_numbering_function(4, 128)
     g = numbering_function_4x128()
     assert f(row, column) == g(row, column)
@@ -77,7 +77,7 @@ def test_4x128(row, column):
     st.integers(1, 8),
     st.integers(1, 32)
 )
-def test_8x32(config, row, column):
+def test_8x32(config, row, column) -> None:
     f = Keysight34934A.get_numbering_function(8, 32, config)
     g = numbering_function_8x32(config)
     assert f(row, column) == g(row, column)
@@ -87,7 +87,7 @@ def test_8x32(config, row, column):
     st.integers(1, 8),
     st.integers(1, 64)
 )
-def test_8x64(row, column):
+def test_8x64(row, column) -> None:
     f = Keysight34934A.get_numbering_function(8, 64)
     g = numbering_function_8x64()
     assert f(row, column) == g(row, column)
@@ -97,7 +97,7 @@ def test_8x64(row, column):
     st.integers(1, 16),
     st.integers(1, 32)
 )
-def test_16x32(row, column):
+def test_16x32(row, column) -> None:
     f = Keysight34934A.get_numbering_function(16, 32)
     g = numbering_function_16x32()
     assert f(row, column) == g(row, column)

--- a/qcodes/tests/drivers/test_keysight_34980a.py
+++ b/qcodes/tests/drivers/test_keysight_34980a.py
@@ -20,7 +20,7 @@ def switch_driver():
         inst.close()
 
 
-def test_safety_interlock_during_init(switch_driver, caplog):
+def test_safety_interlock_during_init(switch_driver, caplog) -> None:
     """
     to check if a warning would show when initialize the instrument with a
     module in safety interlock state. This test has to be placed first if
@@ -33,7 +33,7 @@ def test_safety_interlock_during_init(switch_driver, caplog):
     assert "safety interlock" in msg[0]
 
 
-def test_get_idn(switch_driver):
+def test_get_idn(switch_driver) -> None:
     """
     to check if the instrument attributes are set correctly after getting
     the IDN
@@ -46,7 +46,7 @@ def test_get_idn(switch_driver):
     }
 
 
-def test_scan_slots(switch_driver):
+def test_scan_slots(switch_driver) -> None:
     """
     to check if the submodule attributes are set correctly after scanning
     every slot
@@ -68,7 +68,7 @@ def test_scan_slots(switch_driver):
     }
 
 
-def test_safety_interlock(switch_driver, caplog):
+def test_safety_interlock(switch_driver, caplog) -> None:
     """
     to check if a warning would show when talk to a module that is in safety
     interlock state

--- a/qcodes/tests/drivers/test_keysight_b220x.py
+++ b/qcodes/tests/drivers/test_keysight_b220x.py
@@ -28,17 +28,17 @@ def uut():
     instance.close()
 
 
-def test_idn_command(uut):
+def test_idn_command(uut) -> None:
     assert "AGILENT" in uut.IDN()['vendor']
     assert 0 == uut.get_status()
 
 
-def test_connect(uut):
+def test_connect(uut) -> None:
     uut.connect(2, 48)
     assert 0 == uut.get_status()
 
 
-def test_connect_throws_at_invalid_channel_number(uut):
+def test_connect_throws_at_invalid_channel_number(uut) -> None:
     with pytest.raises(ValueError):
         uut.connect(2, 49)
     with pytest.raises(ValueError):
@@ -49,7 +49,7 @@ def test_connect_throws_at_invalid_channel_number(uut):
         uut.connect(15, 10)
 
 
-def test_connect_emits_warning_on_statusbyte_not_null(uut):
+def test_connect_emits_warning_on_statusbyte_not_null(uut) -> None:
     # some tricks are used to trigger an instrument error both in the
     # simulation as well as in the real instrument:
     # 1. with gnd mode enabled, it is illegal to connect to input channel 12,
@@ -69,7 +69,7 @@ def test_connect_emits_warning_on_statusbyte_not_null(uut):
         uut.gnd_mode(False)
 
 
-def test_disconnect_throws_at_invalid_channel_number(uut):
+def test_disconnect_throws_at_invalid_channel_number(uut) -> None:
     with pytest.raises(ValueError):
         uut.disconnect(2, 49)
     with pytest.raises(ValueError):
@@ -80,35 +80,35 @@ def test_disconnect_throws_at_invalid_channel_number(uut):
         uut.disconnect(15, 10)
 
 
-def test_connections(uut):
+def test_connections(uut) -> None:
     uut.connect(2, 48)
     uut.connect(10, 12)
     assert {(2, 48), (10, 12)} == uut.connections()
 
 
-def test_to_channel_list(uut):
+def test_to_channel_list(uut) -> None:
     assert '(@00345,01109)' == uut.to_channel_list([(3, 45), (11, 9)])
 
 
-def test_connect_paths(uut):
+def test_connect_paths(uut) -> None:
     uut.disconnect_all()
     uut.connect_paths([(3, 45), (11, 9)])
     assert 0 == uut.get_status()
 
 
-def test_disconnect_paths(uut):
+def test_disconnect_paths(uut) -> None:
     uut.connect_paths([(3, 45), (11, 9)])
     uut.disconnect_paths([(3, 45), (11, 9)])
     assert 0 == uut.get_status()
 
 
-def test_disconnect_all(uut):
+def test_disconnect_all(uut) -> None:
     uut.connect(2, 48)
     uut.disconnect_all()
     assert 0 == uut.get_status()
 
 
-def test_disconnect(uut):
+def test_disconnect(uut) -> None:
     uut.connect(2, 48)
     assert 0 == uut.get_status()
     uut.disconnect(2, 48)
@@ -118,14 +118,14 @@ def test_disconnect(uut):
 
 
 @pytest.mark.filterwarnings("ignore:When going")
-def test_connection_rule(uut):
+def test_connection_rule(uut) -> None:
     uut.connection_rule('single')
     assert 0 == uut.get_status()
     assert 'single' == uut.connection_rule()
     assert 0 == uut.get_status()
 
 
-def test_connection_rule_emits_warning_when_going_from_free_to_single(uut):
+def test_connection_rule_emits_warning_when_going_from_free_to_single(uut) -> None:
     uut.connection_rule(
         'free')  # uut should already be in free mode after reset
 
@@ -133,7 +133,7 @@ def test_connection_rule_emits_warning_when_going_from_free_to_single(uut):
         uut.connection_rule('single')
 
 
-def test_connection_sequence(uut):
+def test_connection_sequence(uut) -> None:
     assert 'bbm' == uut.connection_sequence()
     assert 0 == uut.get_status()
     uut.connection_sequence('mbb')
@@ -141,74 +141,74 @@ def test_connection_sequence(uut):
     assert 'mbb' == uut.connection_sequence()
 
 
-def test_bias_disable_all_outputs(uut):
+def test_bias_disable_all_outputs(uut) -> None:
     uut.bias_disable_all_outputs()
     assert 0 == uut.get_status()
 
 
-def test_bias_disable_ouput(uut):
+def test_bias_disable_ouput(uut) -> None:
     uut.bias_disable_output(1)
     assert 0 == uut.get_status()
 
 
-def test_bias_enable_all_outputs(uut):
+def test_bias_enable_all_outputs(uut) -> None:
     uut.bias_enable_all_outputs()
     assert 0 == uut.get_status()
 
 
-def test_bias_enable_output(uut):
+def test_bias_enable_output(uut) -> None:
     uut.bias_enable_output(1)
     assert 0 == uut.get_status()
 
 
-def test_bias_input_port(uut):
+def test_bias_input_port(uut) -> None:
     assert 10 == uut.bias_input_port()
     uut.bias_input_port(9)
     assert 9 == uut.bias_input_port()
     assert 0 == uut.get_status()
 
 
-def test_bias_mode(uut):
+def test_bias_mode(uut) -> None:
     uut.bias_mode(True)
     assert uut.bias_mode()
     assert 0 == uut.get_status()
 
 
-def test_gnd_disable_all_outputs(uut):
+def test_gnd_disable_all_outputs(uut) -> None:
     uut.gnd_disable_all_outputs()
     assert 0 == uut.get_status()
 
 
-def test_gnd_disable_output(uut):
+def test_gnd_disable_output(uut) -> None:
     uut.gnd_disable_output(1)
     assert 0 == uut.get_status()
 
 
-def test_gnd_enable_all_outputs(uut):
+def test_gnd_enable_all_outputs(uut) -> None:
     uut.gnd_enable_all_outputs()
     assert 0 == uut.get_status()
 
 
-def test_gnd_enable_output(uut):
+def test_gnd_enable_output(uut) -> None:
     uut.gnd_enable_output(1)
     assert 0 == uut.get_status()
 
 
-def test_gnd_input_port(uut):
+def test_gnd_input_port(uut) -> None:
     assert 12 == uut.gnd_input_port()
     uut.gnd_input_port(5)
     assert 5 == uut.gnd_input_port()
     assert 0 == uut.get_status()
 
 
-def test_gnd_mode(uut):
+def test_gnd_mode(uut) -> None:
     assert not uut.gnd_mode()
     uut.gnd_mode(True)
     assert uut.gnd_mode()
     assert 0 == uut.get_status()
 
 
-def test_unused_inputs(uut):
+def test_unused_inputs(uut) -> None:
     uut.unused_inputs()
     assert 0 == uut.get_status()
 
@@ -221,14 +221,14 @@ def test_unused_inputs(uut):
     assert [5, 6, 7, 8] == uut.unused_inputs()
 
 
-def test_couple_mode(uut):
+def test_couple_mode(uut) -> None:
     assert not uut.couple_mode()
     uut.couple_mode(True)
     assert uut.couple_mode()
     assert 0 == uut.get_status()
 
 
-def test_couple_ports(uut):
+def test_couple_ports(uut) -> None:
     assert not uut.couple_ports()
     assert 0 == uut.get_status()
 
@@ -246,25 +246,25 @@ def test_couple_ports(uut):
         uut.couple_ports([2, 3])
 
 
-def test_couple_port_autodetect(uut):
+def test_couple_port_autodetect(uut) -> None:
     uut.couple_port_autodetect()
     assert 0 == uut.get_status()
 
 
-def test_get_error(uut):
+def test_get_error(uut) -> None:
     uut.get_error()
     assert 0 == uut.get_status()
 
 
 class TestParseChannelList:
     @staticmethod
-    def test_parse_channel_list():
+    def test_parse_channel_list() -> None:
         channel_list = '(@10101,10202)'
         assert {(1, 1), (2, 2)} == KeysightB220X.parse_channel_list(
             channel_list)
 
     @staticmethod
-    def test_all_combinations_zero_padded():
+    def test_all_combinations_zero_padded() -> None:
         import itertools
         cards = range(5)
         inputs = range(1, 15)
@@ -278,7 +278,7 @@ class TestParseChannelList:
                 padded)
 
     @staticmethod
-    def test_all_combinations_unpadded():
+    def test_all_combinations_unpadded() -> None:
         import itertools
         cards = range(5)
         inputs = range(1, 15)

--- a/qcodes/tests/drivers/test_keysight_e4980a.py
+++ b/qcodes/tests/drivers/test_keysight_e4980a.py
@@ -14,14 +14,14 @@ def _make_driver():
     instr.close()
 
 
-def test_idn(driver):
+def test_idn(driver) -> None:
     assert {'firmware': 'A.02.10',
             'model': 'E4980A',
             'serial': 'MY46516036',
             'vendor': 'Keysight Technologies'} == driver.IDN()
 
 
-def test_raise_error_for_volt_level_query_when_signal_set_as_current(driver):
+def test_raise_error_for_volt_level_query_when_signal_set_as_current(driver) -> None:
     driver.current_level(0.01)
     msg = re.escape("Cannot get voltage level as signal is set with current "
                     "level parameter.")
@@ -29,12 +29,12 @@ def test_raise_error_for_volt_level_query_when_signal_set_as_current(driver):
         driver.voltage_level()
 
 
-def test_voltage_level_set_method(driver):
+def test_voltage_level_set_method(driver) -> None:
     driver.voltage_level(3)
     assert driver.voltage_level() == 3
 
 
-def test_signal_mode_parameter(driver):
+def test_signal_mode_parameter(driver) -> None:
     driver.voltage_level(2)
     assert driver.signal_mode() == "Voltage"
 
@@ -42,7 +42,7 @@ def test_signal_mode_parameter(driver):
     assert driver.signal_mode() == "Current"
 
 
-def test_raise_error_for_curr_level_query_when_signal_set_as_voltage(driver):
+def test_raise_error_for_curr_level_query_when_signal_set_as_voltage(driver) -> None:
     driver.voltage_level(1)
     msg = re.escape("Cannot get current level as signal is set with voltage "
                     "level parameter.")
@@ -50,6 +50,6 @@ def test_raise_error_for_curr_level_query_when_signal_set_as_voltage(driver):
         driver.current_level()
 
 
-def test_current_level_set_method(driver):
+def test_current_level_set_method(driver) -> None:
     driver.current_level(0.003)
     assert driver.current_level() == 0.003

--- a/qcodes/tests/drivers/test_keysight_n9030b.py
+++ b/qcodes/tests/drivers/test_keysight_n9030b.py
@@ -26,14 +26,14 @@ def _activate_log_plot_measurement(driver):
     yield driver.pn
 
 
-def test_idn(driver):
+def test_idn(driver) -> None:
     assert {'firmware': '0.1',
             'model': 'N9030B',
             'serial': '1000',
             'vendor': 'Keysight Technologies'} == driver.IDN()
 
 
-def test_swept_sa_setup(sa):
+def test_swept_sa_setup(sa) -> None:
     assert isinstance(sa, SpectrumAnalyzerMode)
 
     sa.setup_swept_sa_sweep(123, 11e3, 501)
@@ -45,7 +45,7 @@ def test_swept_sa_setup(sa):
     assert sa.npts() == 501
 
 
-def test_log_plot_setup(pn):
+def test_log_plot_setup(pn) -> None:
     assert isinstance(pn, PhaseNoiseMode)
 
     pn.setup_log_plot_sweep(1000, 1e7, 10001)

--- a/qcodes/tests/drivers/test_lakeshore.py
+++ b/qcodes/tests/drivers/test_lakeshore.py
@@ -320,7 +320,7 @@ def lakeshore_372():
     )
 
 
-def test_pid_set(lakeshore_372):
+def test_pid_set(lakeshore_372) -> None:
     ls = lakeshore_372
     P, I, D = 1, 2, 3  # noqa  E741
     for h in (ls.warmup_heater, ls.analog_heater, ls.sample_heater):
@@ -330,7 +330,7 @@ def test_pid_set(lakeshore_372):
         assert (h.P(), h.I(), h.D()) == (P, I, D)
 
 
-def test_output_mode(lakeshore_372):
+def test_output_mode(lakeshore_372) -> None:
     ls = lakeshore_372
     mode = 'off'
     input_channel = 1
@@ -353,7 +353,7 @@ def test_output_mode(lakeshore_372):
         assert h.delay() == delay
 
 
-def test_range(lakeshore_372):
+def test_range(lakeshore_372) -> None:
     ls = lakeshore_372
     output_range = '10mA'
     for h in (ls.warmup_heater, ls.analog_heater, ls.sample_heater):
@@ -361,7 +361,7 @@ def test_range(lakeshore_372):
         assert h.output_range() == output_range
 
 
-def test_tlimit(lakeshore_372):
+def test_tlimit(lakeshore_372) -> None:
     ls = lakeshore_372
     tlimit = 5.1
     for ch in ls.channels:
@@ -369,7 +369,7 @@ def test_tlimit(lakeshore_372):
         assert ch.t_limit() == tlimit
 
 
-def test_setpoint(lakeshore_372):
+def test_setpoint(lakeshore_372) -> None:
     ls = lakeshore_372
     setpoint = 5.1
     for h in (ls.warmup_heater, ls.analog_heater, ls.sample_heater):
@@ -377,7 +377,7 @@ def test_setpoint(lakeshore_372):
         assert h.setpoint() == setpoint
 
 
-def test_select_range_limits(lakeshore_372):
+def test_select_range_limits(lakeshore_372) -> None:
     h = lakeshore_372.sample_heater
     ranges = list(range(1, 9))
     h.range_limits(ranges)
@@ -390,14 +390,14 @@ def test_select_range_limits(lakeshore_372):
     assert h.output_range() == h.INVERSE_RANGES[len(ranges)]
 
 
-def test_set_and_wait_unit_setpoint_reached(lakeshore_372):
+def test_set_and_wait_unit_setpoint_reached(lakeshore_372) -> None:
     ls = lakeshore_372
     ls.sample_heater.setpoint(4)
     ls.start_heating()
     ls.sample_heater.wait_until_set_point_reached()
 
 
-def test_blocking_t(lakeshore_372):
+def test_blocking_t(lakeshore_372) -> None:
     ls = lakeshore_372
     h = lakeshore_372.sample_heater
     ranges = list(range(1, 9))
@@ -406,7 +406,7 @@ def test_blocking_t(lakeshore_372):
     h.blocking_t(4)
 
 
-def test_get_term_sum():
+def test_get_term_sum() -> None:
     available_terms = [0, 1, 2, 4, 8, 16, 32]
 
     assert [32, 8, 2, 1] == BaseSensorChannel._get_sum_terms(
@@ -420,7 +420,7 @@ def test_get_term_sum():
     assert [0] == BaseSensorChannel._get_sum_terms(available_terms, 0)
 
 
-def test_get_term_sum_with_some_powers_of_2_omitted():
+def test_get_term_sum_with_some_powers_of_2_omitted() -> None:
     available_terms = [0, 16, 32]
 
     assert [32, 16] == BaseSensorChannel._get_sum_terms(available_terms, 16 + 32)
@@ -430,13 +430,13 @@ def test_get_term_sum_with_some_powers_of_2_omitted():
     assert [0] == BaseSensorChannel._get_sum_terms(available_terms, 0)
 
 
-def test_get_term_sum_returns_empty_list():
+def test_get_term_sum_returns_empty_list() -> None:
     available_terms = [0, 16, 32]
 
     assert [] == BaseSensorChannel._get_sum_terms(available_terms, 15)
 
 
-def test_get_term_sum_when_zero_is_not_in_available_terms():
+def test_get_term_sum_when_zero_is_not_in_available_terms() -> None:
     available_terms = [16, 32]
 
     assert [] == BaseSensorChannel._get_sum_terms(available_terms, 3)

--- a/qcodes/tests/drivers/test_lakeshore_325.py
+++ b/qcodes/tests/drivers/test_lakeshore_325.py
@@ -17,7 +17,7 @@ from qcodes.instrument_drivers.Lakeshore import (
         sorted  # type: ignore[arg-type]
     )
 )
-def test_decode_sensor_status(list_of_codes):
+def test_decode_sensor_status(list_of_codes) -> None:
     """
     The sensor status is one of the status codes, or a sum thereof. Multiple
     status are possible as they are not necessarily mutually exclusive.

--- a/qcodes/tests/drivers/test_lakeshore_336.py
+++ b/qcodes/tests/drivers/test_lakeshore_336.py
@@ -174,7 +174,7 @@ def _make_lakeshore_336():
     )
 
 
-def test_pid_set(lakeshore_336):
+def test_pid_set(lakeshore_336) -> None:
     ls = lakeshore_336
     P, I, D = 1, 2, 3  # noqa  E741
     # Only current source outputs/heaters have PID parameters,
@@ -187,7 +187,7 @@ def test_pid_set(lakeshore_336):
         assert (h.P(), h.I(), h.D()) == (P, I, D)
 
 
-def test_output_mode(lakeshore_336):
+def test_output_mode(lakeshore_336) -> None:
     ls = lakeshore_336
     mode = 'off'
     input_channel = 'A'
@@ -202,7 +202,7 @@ def test_output_mode(lakeshore_336):
         assert h.powerup_enable() == powerup_enable
 
 
-def test_range(lakeshore_336):
+def test_range(lakeshore_336) -> None:
     ls = lakeshore_336
     output_range = 'medium'
     outputs = [getattr(ls, f'output_{n}') for n in range(1, 5)]
@@ -211,7 +211,7 @@ def test_range(lakeshore_336):
         assert h.output_range() == output_range
 
 
-def test_tlimit(lakeshore_336):
+def test_tlimit(lakeshore_336) -> None:
     ls = lakeshore_336
     tlimit = 5.1
     for ch in ls.channels:
@@ -219,7 +219,7 @@ def test_tlimit(lakeshore_336):
         assert ch.t_limit() == tlimit
 
 
-def test_setpoint(lakeshore_336):
+def test_setpoint(lakeshore_336) -> None:
     ls = lakeshore_336
     setpoint = 5.1
     outputs = [getattr(ls, f'output_{n}') for n in range(1, 5)]
@@ -228,7 +228,7 @@ def test_setpoint(lakeshore_336):
         assert h.setpoint() == setpoint
 
 
-def test_select_range_limits(lakeshore_336):
+def test_select_range_limits(lakeshore_336) -> None:
     h = lakeshore_336.output_1
     ranges = [1, 2, 3]
     h.range_limits(ranges)
@@ -242,14 +242,14 @@ def test_select_range_limits(lakeshore_336):
     assert h.output_range() == h.INVERSE_RANGES[len(ranges)]
 
 
-def test_set_and_wait_unit_setpoint_reached(lakeshore_336):
+def test_set_and_wait_unit_setpoint_reached(lakeshore_336) -> None:
     ls = lakeshore_336
     ls.output_1.setpoint(4)
     ls.start_heating()
     ls.output_1.wait_until_set_point_reached()
 
 
-def test_blocking_t(lakeshore_336):
+def test_blocking_t(lakeshore_336) -> None:
     ls = lakeshore_336
     h = ls.output_1
     ranges = [1.2, 2.4, 3.1]

--- a/qcodes/tests/drivers/test_lakeshore_336_legacy.py
+++ b/qcodes/tests/drivers/test_lakeshore_336_legacy.py
@@ -206,7 +206,7 @@ def lakeshore_336():
     )
 
 
-def test_pid_set(lakeshore_336):
+def test_pid_set(lakeshore_336) -> None:
     ls = lakeshore_336
     P, I, D = 1, 2, 3  # noqa  E741
     # Only current source outputs/heaters have PID parameters,
@@ -219,7 +219,7 @@ def test_pid_set(lakeshore_336):
         assert (h.P(), h.I(), h.D()) == (P, I, D)
 
 
-def test_output_mode(lakeshore_336):
+def test_output_mode(lakeshore_336) -> None:
     ls = lakeshore_336
     mode = "off"
     input_channel = "A"
@@ -234,7 +234,7 @@ def test_output_mode(lakeshore_336):
         assert h.powerup_enable() == powerup_enable
 
 
-def test_range(lakeshore_336):
+def test_range(lakeshore_336) -> None:
     ls = lakeshore_336
     output_range = "medium"
     outputs = [getattr(ls, f"output_{n}") for n in range(1, 5)]
@@ -243,7 +243,7 @@ def test_range(lakeshore_336):
         assert h.output_range() == output_range
 
 
-def test_tlimit(lakeshore_336):
+def test_tlimit(lakeshore_336) -> None:
     ls = lakeshore_336
     tlimit = 5.1
     for ch in ls.channels:
@@ -251,7 +251,7 @@ def test_tlimit(lakeshore_336):
         assert ch.t_limit() == tlimit
 
 
-def test_setpoint(lakeshore_336):
+def test_setpoint(lakeshore_336) -> None:
     ls = lakeshore_336
     setpoint = 5.1
     outputs = [getattr(ls, f"output_{n}") for n in range(1, 5)]
@@ -260,7 +260,7 @@ def test_setpoint(lakeshore_336):
         assert h.setpoint() == setpoint
 
 
-def test_select_range_limits(lakeshore_336):
+def test_select_range_limits(lakeshore_336) -> None:
     h = lakeshore_336.output_1
     ranges = [1, 2, 3]
     h.range_limits(ranges)
@@ -274,14 +274,14 @@ def test_select_range_limits(lakeshore_336):
     assert h.output_range() == h.INVERSE_RANGES[len(ranges)]
 
 
-def test_set_and_wait_unit_setpoint_reached(lakeshore_336):
+def test_set_and_wait_unit_setpoint_reached(lakeshore_336) -> None:
     ls = lakeshore_336
     ls.output_1.setpoint(4)
     ls.start_heating()
     ls.output_1.wait_until_set_point_reached()
 
 
-def test_blocking_t(lakeshore_336):
+def test_blocking_t(lakeshore_336) -> None:
     ls = lakeshore_336
     h = ls.output_1
     ranges = [1.2, 2.4, 3.1]

--- a/qcodes/tests/drivers/test_lakeshore_file_parser.py
+++ b/qcodes/tests/drivers/test_lakeshore_file_parser.py
@@ -31,7 +31,7 @@ def curve_file():
     yield io.StringIO(curve_file_content)
 
 
-def test_file_parser(curve_file):
+def test_file_parser(curve_file) -> None:
     file_data = _read_curve_file(curve_file)
 
     assert list(file_data.keys()) == ["metadata", "data"]
@@ -52,7 +52,7 @@ def test_file_parser(curve_file):
     }
 
 
-def test_sanitise_data(curve_file):
+def test_sanitise_data(curve_file) -> None:
 
     file_data = _read_curve_file(curve_file)
     data_dict = _get_sanitize_data(file_data)

--- a/qcodes/tests/drivers/test_rto_1000.py
+++ b/qcodes/tests/drivers/test_rto_1000.py
@@ -16,14 +16,14 @@ def driver():
     rto_sim.close()
 
 
-def test_init(driver):
+def test_init(driver) -> None:
 
     idn_dict = driver.IDN()
 
     assert idn_dict['vendor'] == 'QCoDeS'
 
 
-def test_trigger_source_level(driver):
+def test_trigger_source_level(driver) -> None:
     assert driver.trigger_source() == 'CH1'
     assert driver.trigger_level() == 0
     driver.trigger_level(1.0)

--- a/qcodes/tests/drivers/test_stahl.py
+++ b/qcodes/tests/drivers/test_stahl.py
@@ -18,7 +18,7 @@ def stahl_instrument():
         inst.close()
 
 
-def test_parse_idn_string():
+def test_parse_idn_string() -> None:
     """
     Test that we can parse IDN strings correctly
     """
@@ -37,7 +37,7 @@ def test_parse_idn_string():
         Stahl.parse_idn_string("HS123 005 16 bla b")
 
 
-def test_get_idn(stahl_instrument):
+def test_get_idn(stahl_instrument) -> None:
     """
     Instrument attributes are set correctly after getting the IDN
     """
@@ -53,7 +53,7 @@ def test_get_idn(stahl_instrument):
     assert stahl_instrument.output_type == "bipolar"
 
 
-def test_get_set_voltage(stahl_instrument, caplog):
+def test_get_set_voltage(stahl_instrument, caplog) -> None:
     """
     Test that we can correctly get/set voltages
     """
@@ -68,7 +68,7 @@ def test_get_set_voltage(stahl_instrument, caplog):
     )
 
 
-def test_get_set_voltage_assert_warning(stahl_instrument, caplog):
+def test_get_set_voltage_assert_warning(stahl_instrument, caplog) -> None:
     """
     On channel 2 we have deliberately introduced an error in the
     visa simulation; setting a voltage does not produce an acknowledge
@@ -81,7 +81,7 @@ def test_get_set_voltage_assert_warning(stahl_instrument, caplog):
     )
 
 
-def test_get_current(stahl_instrument):
+def test_get_current(stahl_instrument) -> None:
     """
     Test that we can read currents and that the unit is in Ampere
     """
@@ -89,7 +89,7 @@ def test_get_current(stahl_instrument):
     assert stahl_instrument.channel[0].current.unit == "A"
 
 
-def test_get_temperature(stahl_instrument):
+def test_get_temperature(stahl_instrument) -> None:
     """
     Due to limitations in pyvisa-sim, we cannot test this.
     Line 191 of pyvisa-sim/component.py  should read

--- a/qcodes/tests/drivers/test_tektronix_AWG5014C.py
+++ b/qcodes/tests/drivers/test_tektronix_AWG5014C.py
@@ -18,14 +18,14 @@ def awg():
     awg_sim.close()
 
 
-def test_init_awg(awg):
+def test_init_awg(awg) -> None:
 
     idn_dict = awg.IDN()
 
     assert idn_dict['vendor'] == 'QCoDeS'
 
 
-def test_pack_waveform(awg):
+def test_pack_waveform(awg) -> None:
 
     N = 25
 
@@ -38,7 +38,7 @@ def test_pack_waveform(awg):
     assert package is not None
 
 
-def test_make_awg_file(awg):
+def test_make_awg_file(awg) -> None:
 
     N = 25
 

--- a/qcodes/tests/drivers/test_tektronix_AWG5208.py
+++ b/qcodes/tests/drivers/test_tektronix_AWG5208.py
@@ -15,14 +15,14 @@ def awg():
     awg_sim.close()
 
 
-def test_init_awg(awg):
+def test_init_awg(awg) -> None:
 
     idn_dict = awg.IDN()
 
     assert idn_dict['vendor'] == 'QCoDeS'
 
 
-def test_channel_resolution_docstring(awg):
+def test_channel_resolution_docstring(awg) -> None:
 
     expected_docstring = ("12 bit resolution allows for four "
                           "markers, 13 bit resolution "

--- a/qcodes/tests/drivers/test_tektronix_AWG70000A.py
+++ b/qcodes/tests/drivers/test_tektronix_AWG70000A.py
@@ -103,7 +103,7 @@ def _make_forged_sequence():
     return seq
 
 
-def test_init_awg2(awg2):
+def test_init_awg2(awg2) -> None:
 
     idn_dict = awg2.IDN()
 
@@ -112,7 +112,7 @@ def test_init_awg2(awg2):
 
 @settings(deadline=2500, max_examples=7)
 @given(N=hst.integers(1, 100))
-def test_SML_successful_generation_vary_length(N):
+def test_SML_successful_generation_vary_length(N) -> None:
 
     tw = [0]*N
     nreps = [1]*N
@@ -133,7 +133,7 @@ def test_SML_successful_generation_vary_length(N):
 
 @given(num_samples=hst.integers(min_value=2400),
        markers_included=hst.booleans())
-def test_WFMXHeader_succesful(num_samples, markers_included):
+def test_WFMXHeader_succesful(num_samples, markers_included) -> None:
 
     xmlstr = AWG70000A._makeWFMXFileHeader(num_samples, markers_included)
     etree.parse(StringIO(xmlstr))
@@ -141,7 +141,7 @@ def test_WFMXHeader_succesful(num_samples, markers_included):
 
 @given(num_samples=hst.integers(max_value=2399),
        markers_included=hst.booleans())
-def test_WFMXHeader_failing(num_samples, markers_included):
+def test_WFMXHeader_failing(num_samples, markers_included) -> None:
     with pytest.raises(ValueError):
         AWG70000A._makeWFMXFileHeader(num_samples, markers_included)
 
@@ -181,7 +181,7 @@ def test_seqxfilefromfs_failing(forged_sequence) -> None:
                   channel_mapping={1: 10, 2: 8, 3: -1})
 
 
-def test_seqxfilefromfs_warns(forged_sequence, caplog):
+def test_seqxfilefromfs_warns(forged_sequence, caplog) -> None:
     """
     Test that a warning is logged when waveform is clipped
     """
@@ -196,7 +196,7 @@ def test_seqxfilefromfs_warns(forged_sequence, caplog):
         assert "Waveform exceeds specified channel range" in message
 
 
-def test_seqxfile_from_fs(forged_sequence):
+def test_seqxfile_from_fs(forged_sequence) -> None:
 
     # typing convenience
     make_seqx = AWG70000A.make_SEQX_from_forged_sequence
@@ -232,7 +232,7 @@ def test_seqxfile_from_fs(forged_sequence):
 # TODO: Add some failing tests for inproper input
 
 
-def test_makeSEQXFile(awg2, random_wfm_m1_m2_package):
+def test_makeSEQXFile(awg2, random_wfm_m1_m2_package) -> None:
     """
     Test that this function works (for some input)
     """

--- a/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
+++ b/qcodes/tests/drivers/test_tektronix_dpo7200xx.py
@@ -23,7 +23,7 @@ def tektronix_dpo():
 @pytest.mark.xfail(
     condition=sys.platform == "win32", reason="Time resolution is too low on windows"
 )
-def test_adjust_timer(tektronix_dpo):
+def test_adjust_timer(tektronix_dpo) -> None:
     """
     After adjusting the type of the measurement or the source of the
     measurement, we need wait at least 0.1 seconds
@@ -53,7 +53,7 @@ def test_adjust_timer(tektronix_dpo):
     # measurements slightly sooner then 'minimum_adjustment_time'
 
 
-def test_measurements_return_float(tektronix_dpo):
+def test_measurements_return_float(tektronix_dpo) -> None:
     amplitude = tektronix_dpo.measurement[0].amplitude()
     assert isinstance(amplitude, float)
 
@@ -61,6 +61,6 @@ def test_measurements_return_float(tektronix_dpo):
     assert isinstance(mean_amplitude, float)
 
 
-def test_measurement_sets_state(tektronix_dpo):
+def test_measurement_sets_state(tektronix_dpo) -> None:
     tektronix_dpo.measurement[1].frequency()
     assert tektronix_dpo.measurement[1].state() == 1

--- a/qcodes/tests/drivers/test_weinchel.py
+++ b/qcodes/tests/drivers/test_weinchel.py
@@ -11,11 +11,11 @@ class TestWeinschel8320(DriverTestCase):
 
     driver = Weinschel8320
 
-    def test_firmware_version(self):
+    def test_firmware_version(self) -> None:
         v = self.instrument.IDN.get()
         self.assertTrue(v.startswith('API Weinschel, 8320,'))
 
-    def test_attenuation(self):
+    def test_attenuation(self) -> None:
         curr_val = self.instrument.attenuation.get()
 
         for v in [0, 32, 60]:

--- a/qcodes/tests/drivers/test_yokogawa_gs200.py
+++ b/qcodes/tests/drivers/test_yokogawa_gs200.py
@@ -13,13 +13,13 @@ def _make_gs200():
     gs200.close()
 
 
-def test_basic_init(gs200):
+def test_basic_init(gs200) -> None:
 
     idn = gs200.get_idn()
     assert idn["vendor"] == "QCoDeS Yokogawa Mock"
 
 
-def test_current_raises_in_voltage_mode(gs200):
+def test_current_raises_in_voltage_mode(gs200) -> None:
     gs200.source_mode("VOLT")
 
     with pytest.raises(
@@ -33,7 +33,7 @@ def test_current_raises_in_voltage_mode(gs200):
         gs200.current(1)
 
 
-def test_voltage_raises_in_current_mode(gs200):
+def test_voltage_raises_in_current_mode(gs200) -> None:
     gs200.source_mode("CURR")
 
     with pytest.raises(

--- a/qcodes/tests/helpers/test_compare_dictionaries.py
+++ b/qcodes/tests/helpers/test_compare_dictionaries.py
@@ -4,7 +4,7 @@ import pytest
 from qcodes.tests.common import compare_dictionaries
 
 
-def test_same():
+def test_same() -> None:
     # NOTE(alexcjohnson): the numpy array and list compare equal,
     # even though a list and tuple would not. See TODO in
     # compare_dictionaries.
@@ -16,7 +16,7 @@ def test_same():
     assert err == ''
 
 
-def test_bad_dict():
+def test_bad_dict() -> None:
     # NOTE(alexcjohnson):
     # this is a valid dict, but not good JSON because the tuple key cannot
     # be converted into a string.
@@ -27,7 +27,7 @@ def test_bad_dict():
         compare_dictionaries(a, a)
 
 
-def test_key_diff():
+def test_key_diff() -> None:
     a = {'a': 1, 'c': 4}
     b = {'b': 1, 'c': 4}
 
@@ -45,7 +45,7 @@ def test_key_diff():
     assert 'Key b[b] not in a' in err
 
 
-def test_val_diff_simple():
+def test_val_diff_simple() -> None:
     a = {'a': 1}
     b = {'a': 2}
 
@@ -56,7 +56,7 @@ def test_val_diff_simple():
     assert '"d2[a]" ("2", type"<class \'int\'>")' in err
 
 
-def test_val_diff_seq():
+def test_val_diff_seq() -> None:
     # NOTE(alexcjohnson):
     # we don't dive recursively into lists at the moment.
     # Perhaps we want to? Seems like list equality does a deep comparison,
@@ -74,7 +74,7 @@ def test_val_diff_seq():
            err
 
 
-def test_nested_key_diff():
+def test_nested_key_diff() -> None:
     a = {'a': {'b': 'c'}}
     b = {'a': {'d': 'c'}}
 

--- a/qcodes/tests/helpers/test_delegate_attribues.py
+++ b/qcodes/tests/helpers/test_delegate_attribues.py
@@ -102,7 +102,7 @@ def test_delegate_object() -> None:
         assert dir(to_obj).count(attr) == 1
 
 
-def test_delegate_objects():
+def test_delegate_objects() -> None:
     class R1:
         a = 1
         b = 2
@@ -142,7 +142,7 @@ def test_delegate_objects():
         assert dir(to_objs).count(attr) == 1
 
 
-def test_delegate_both():
+def test_delegate_both() -> None:
     class Recipient:
         rock = 0
         paper = 1

--- a/qcodes/tests/helpers/test_json_encoder.py
+++ b/qcodes/tests/helpers/test_json_encoder.py
@@ -17,7 +17,7 @@ from qcodes.utils import NumpyJSONEncoder
 from qcodes.utils.types import numpy_complex, numpy_floats, numpy_ints
 
 
-def test_python_types():
+def test_python_types() -> None:
     e = NumpyJSONEncoder()
 
     # test basic python types
@@ -37,7 +37,7 @@ def test_python_types():
             assert v == r
 
 
-def test_complex_types():
+def test_complex_types() -> None:
     e = NumpyJSONEncoder()
     assert e.encode(complex(1, 2)) == \
            '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
@@ -46,27 +46,27 @@ def test_complex_types():
                '{"__dtype__": "complex", "re": 1.0, "im": 2.0}'
 
 
-def test_UFloat_type():
+def test_UFloat_type() -> None:
     e = NumpyJSONEncoder()
     assert e.encode(uncertainties.ufloat(1.0, 2.0)) == \
            '{"__dtype__": "UFloat", "nominal_value": 1.0, "std_dev": 2.0}'
 
 
-def test_numpy_int_types():
+def test_numpy_int_types() -> None:
     e = NumpyJSONEncoder()
 
     for int_type in numpy_ints:
         assert e.encode(int_type(3)) == '3'
 
 
-def test_numpy_float_types():
+def test_numpy_float_types() -> None:
     e = NumpyJSONEncoder()
 
     for float_type in numpy_floats:
         assert e.encode(float_type(2.5)) == '2.5'
 
 
-def test_numpy_bool_type():
+def test_numpy_bool_type() -> None:
     e = NumpyJSONEncoder()
 
     assert e.encode(np.bool_(True)) == 'true'
@@ -74,7 +74,7 @@ def test_numpy_bool_type():
     assert e.encode(np.array([8, 5]) == 5) == '[false, true]'
 
 
-def test_numpy_array():
+def test_numpy_array() -> None:
     e = NumpyJSONEncoder()
 
     assert e.encode(np.array([1, 0, 0])) == \
@@ -87,7 +87,7 @@ def test_numpy_array():
            '[[[1, 2], [1, 2]], [[3, 3], [4, 4]]]'
 
 
-def test_non_serializable():
+def test_non_serializable() -> None:
     """
     Test that non-serializable objects are serialzed to their
     string representation
@@ -102,7 +102,7 @@ def test_non_serializable():
            '"i am a dummy with \\\\ slashes /"'
 
 
-def test_object_with_serialization_method():
+def test_object_with_serialization_method() -> None:
     """
     Test that objects with `_JSONEncoder` method are serialized via
     calling that method
@@ -143,7 +143,7 @@ EXAMPLEMETADATA = {
 }
 
 
-def test_standard_encoder_fails_examplemetadata():
+def test_standard_encoder_fails_examplemetadata() -> None:
     with pytest.raises(TypeError):
         json.dumps(
             EXAMPLEMETADATA,
@@ -152,7 +152,7 @@ def test_standard_encoder_fails_examplemetadata():
             ensure_ascii=False)
 
 
-def test_numpy_encoder_examplemetadata():
+def test_numpy_encoder_examplemetadata() -> None:
     data = json.dumps(EXAMPLEMETADATA, sort_keys=True, indent=4,
                       ensure_ascii=False, cls=NumpyJSONEncoder)
     data_dict = json.loads(data)
@@ -173,7 +173,7 @@ def test_numpy_encoder_examplemetadata():
 
 
 @given(bytes_to_encode=hst.binary(max_size=100))
-def test_bytes(bytes_to_encode):
+def test_bytes(bytes_to_encode) -> None:
     e = NumpyJSONEncoder()
     v = e.encode(bytes_to_encode)
 
@@ -184,7 +184,7 @@ def test_bytes(bytes_to_encode):
 
 
 @given(bytes_to_encode=hst.binary(max_size=100))
-def test_bytes_array(bytes_to_encode):
+def test_bytes_array(bytes_to_encode) -> None:
     e = NumpyJSONEncoder()
     value = bytearray(bytes_to_encode)
     v = e.encode(value)

--- a/qcodes/tests/mockers/test_simulated_ats_api.py
+++ b/qcodes/tests/mockers/test_simulated_ats_api.py
@@ -44,7 +44,7 @@ def alazar_ctrl():
 
 
 @pytest.mark.win32
-def test_simulated_alazar(simulated_alazar, alazar_ctrl):
+def test_simulated_alazar(simulated_alazar, alazar_ctrl) -> None:
     alazar = simulated_alazar
     buffers_per_acquisition = 10
     data = alazar.acquire(

--- a/qcodes/tests/parameter/test_group_parameter.py
+++ b/qcodes/tests/parameter/test_group_parameter.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import Optional
+from typing import Any, Dict, Optional
 
 import pytest
 
@@ -65,7 +65,7 @@ class Dummy(Instrument):
         return ",".join(str(i) for i in [self._a, self._b])
 
 
-def test_sanity():
+def test_sanity() -> None:
     """
     Test that we can individually address parameters "a" and "b", which belong
     to the same group.
@@ -86,19 +86,20 @@ def test_sanity():
     assert dummy.b() == 10
 
 
-def test_raise_on_get_set_cmd():
+def test_raise_on_get_set_cmd() -> None:
 
     for arg in ["set_cmd", "get_cmd"]:
         kwarg = {arg: ""}
 
         with pytest.raises(ValueError) as e:
-            GroupParameter(name="a", **kwarg)
+            GroupParameter(name="a", **kwarg)  # type: ignore[arg-type]
 
-        assert str(e.value) == "A GroupParameter does not use 'set_cmd' or " \
-                               "'get_cmd' kwarg"
+        assert (
+            str(e.value) == "A GroupParameter does not use 'set_cmd' or 'get_cmd' kwarg"
+        )
 
 
-def test_raises_on_get_set_without_group():
+def test_raises_on_get_set_without_group() -> None:
     param = GroupParameter(name='b')
 
     with pytest.raises(RuntimeError) as e:
@@ -110,7 +111,7 @@ def test_raises_on_get_set_without_group():
     assert str(e.value) == "('Trying to set Group value but no group defined', 'setting b to 1')"
 
 
-def test_raises_runtime_error_on_update_if_get_cmd_is_none():
+def test_raises_runtime_error_on_update_if_get_cmd_is_none() -> None:
     dummy = Dummy("dummy", get_cmd=None)
     msg = ("Cannot update values in the group with "
            "parameters - dummy_a, dummy_b since it "
@@ -118,15 +119,15 @@ def test_raises_runtime_error_on_update_if_get_cmd_is_none():
     with pytest.raises(RuntimeError, match=msg):
         dummy.group.update()
 
-def test_raises_runtime_error_if_set_parameters_called_with_empty_dict():
+def test_raises_runtime_error_if_set_parameters_called_with_empty_dict() -> None:
     dummy = Dummy("dummy")
-    parameters_dict = dict()
+    parameters_dict: Dict[str, Any] = {}
     msg = ("Provide at least one group parameter and its value to be set.")
 
     with pytest.raises(RuntimeError, match=msg):
         dummy.group.set_parameters(parameters_dict)
 
-def test_set_parameters_called_for_one_parameter():
+def test_set_parameters_called_for_one_parameter() -> None:
     dummy = Dummy("dummy")
     parameters_dict = {"a": 7}
 
@@ -134,7 +135,8 @@ def test_set_parameters_called_for_one_parameter():
     assert dummy.a() == 7
     assert dummy.b() == 0
 
-def test_set_parameters_called_for_more_than_one_parameters():
+
+def test_set_parameters_called_for_more_than_one_parameters() -> None:
     dummy = Dummy("dummy")
     parameters_dict = {"a": 10, "b": 57}
 
@@ -142,7 +144,8 @@ def test_set_parameters_called_for_more_than_one_parameters():
     assert dummy.a() == 10
     assert dummy.b() == 57
 
-def test_set_parameters_when_parameter_value_not_equal_to_raw_value():
+
+def test_set_parameters_when_parameter_value_not_equal_to_raw_value() -> None:
     dummy = Dummy("dummy", scale_a=10)
     parameters_dict = {"a": 7}
 
@@ -151,7 +154,8 @@ def test_set_parameters_when_parameter_value_not_equal_to_raw_value():
     assert dummy.a.cache.raw_value == 70
     assert dummy.a() == 7
 
-def test_initial_values():
+
+def test_initial_values() -> None:
     initial_a = 42
     initial_b = 43
     dummy = Dummy("dummy", initial_a=initial_a, initial_b=initial_b)
@@ -160,7 +164,7 @@ def test_initial_values():
     assert dummy.b() == initial_b
 
 
-def test_raise_on_not_all_initial_values():
+def test_raise_on_not_all_initial_values() -> None:
     expected_err_msg = (r'Either none or all of the parameters in a group '
                         r'should have an initial value. Found initial values '
                         r'for \[.*\] but not for \[.*\].')
@@ -168,7 +172,7 @@ def test_raise_on_not_all_initial_values():
         Dummy("dummy", initial_a=42)
 
 
-def test_update_group_parameter_reflected_in_cache_of_all_params():
+def test_update_group_parameter_reflected_in_cache_of_all_params() -> None:
     dummy = Dummy("dummy")
     group = dummy.a.group
 
@@ -181,6 +185,7 @@ def test_update_group_parameter_reflected_in_cache_of_all_params():
     group.update()
     after = datetime.now()
 
+    assert dummy.a.cache.timestamp is not None
     assert before <= dummy.a.cache.timestamp
     assert after >= dummy.a.cache.timestamp
 
@@ -191,7 +196,7 @@ def test_update_group_parameter_reflected_in_cache_of_all_params():
     assert dummy.b.cache.get(get_if_invalid=False) == 0
 
 
-def test_get_group_param_updates_cache_of_other_param():
+def test_get_group_param_updates_cache_of_other_param() -> None:
     dummy = Dummy("dummy")
 
     assert dummy.a.cache.timestamp is None
@@ -203,6 +208,7 @@ def test_get_group_param_updates_cache_of_other_param():
     assert dummy.a.get() == 0
     after = datetime.now()
 
+    assert dummy.a.cache.timestamp is not None
     assert before <= dummy.a.cache.timestamp
     assert after >= dummy.a.cache.timestamp
 
@@ -213,7 +219,7 @@ def test_get_group_param_updates_cache_of_other_param():
     assert dummy.b.cache.get(get_if_invalid=False) == 0
 
 
-def test_set_group_param_updates_cache_of_other_param():
+def test_set_group_param_updates_cache_of_other_param() -> None:
     dummy = Dummy("dummy")
 
     assert dummy.a.cache.timestamp is None
@@ -225,6 +231,7 @@ def test_set_group_param_updates_cache_of_other_param():
     dummy.a.set(10)
     after = datetime.now()
 
+    assert dummy.a.cache.timestamp is not None
     assert before <= dummy.a.cache.timestamp
     assert after >= dummy.a.cache.timestamp
 
@@ -235,7 +242,7 @@ def test_set_group_param_updates_cache_of_other_param():
     assert dummy.b.cache.get(get_if_invalid=False) == 0
 
 
-def test_group_param_scale_is_handled():
+def test_group_param_scale_is_handled() -> None:
     dummy = Dummy("dummy", scale_a=10, initial_a=1, initial_b=5)
 
     assert dummy.a.cache.get(get_if_invalid=False) == 1

--- a/qcodes/tests/parameter/test_issequence.py
+++ b/qcodes/tests/parameter/test_issequence.py
@@ -40,15 +40,15 @@ no_sequence = [
 
 
 @pytest.mark.parametrize("val", yes_sequence)
-def test_yes(val):
+def test_yes(val) -> None:
     assert is_sequence(val)
 
 
 @pytest.mark.parametrize("val", no_sequence)
-def test_no(val):
+def test_no(val) -> None:
     assert not is_sequence(val)
 
 
-def test_open_file_is_not_sequence():
+def test_open_file_is_not_sequence() -> None:
     with open(__file__) as f:
         assert not is_sequence(f)

--- a/qcodes/tests/parameter/test_issequenceof.py
+++ b/qcodes/tests/parameter/test_issequenceof.py
@@ -20,7 +20,7 @@ simple_good: List[Tuple[Any, ...]] = [
 
 
 @pytest.mark.parametrize("args", simple_good)
-def test_simple_good(args):
+def test_simple_good(args) -> None:
     assert is_sequence_of(*args)
 
 
@@ -28,7 +28,7 @@ simple_bad = [(1,), (1, int), ([1, 2.0], int), ([1, 2], float), ([1, 2], (float,
 
 
 @pytest.mark.parametrize("args", simple_bad)
-def test_simple_bad(args):
+def test_simple_bad(args) -> None:
     assert not is_sequence_of(*args)
     # second arg, if provided, must be a type or tuple of types
     # failing this doesn't return False, it raises an error
@@ -51,7 +51,7 @@ good_depth = [
 
 
 @pytest.mark.parametrize("args", good_depth)
-def test_depth_good(args):
+def test_depth_good(args) -> None:
     assert is_sequence_of(*args)
 
 
@@ -59,7 +59,7 @@ bad_depth = [([1], int, 2), ([[1]], int, 1), ([[1]], float, 2)]
 
 
 @pytest.mark.parametrize("args", bad_depth)
-def test_depth_bad(args):
+def test_depth_bad(args) -> None:
     assert not is_sequence_of(*args)
 
 
@@ -77,7 +77,7 @@ good_shapes = [
 
 
 @pytest.mark.parametrize("args", good_shapes)
-def test_shape_good(args):
+def test_shape_good(args) -> None:
     obj, types, shape = args
     assert is_sequence_of(obj, types, shape=shape)
 
@@ -93,12 +93,12 @@ bad_shapes = [
 
 
 @pytest.mark.parametrize("args", bad_shapes)
-def test_shape_bad(args):
+def test_shape_bad(args) -> None:
     obj, types, shape = args
     assert not is_sequence_of(obj, types, shape=shape)
 
 
-def test_shape_depth():
+def test_shape_depth() -> None:
     # there's no reason to provide both shape and depth, but
     # we allow it if they are self-consistent
     with pytest.raises(ValueError):

--- a/qcodes/tests/parameter/test_make_sweep.py
+++ b/qcodes/tests/parameter/test_make_sweep.py
@@ -4,7 +4,7 @@ import pytest
 from qcodes.parameters.sweep_values import make_sweep
 
 
-def test_good_calls():
+def test_good_calls() -> None:
     swp = make_sweep(1, 3, num=6)
     assert swp == [1, 1.4, 1.8, 2.2, 2.6, 3]
 
@@ -22,7 +22,7 @@ def test_good_calls():
             assert swp[-1] == 1 + r
 
 
-def test_bad_calls():
+def test_bad_calls() -> None:
     with pytest.raises(AttributeError):
         make_sweep(1, 3, num=3, step=1)
 

--- a/qcodes/tests/parameter/test_parameter_ramp.py
+++ b/qcodes/tests/parameter/test_parameter_ramp.py
@@ -11,7 +11,7 @@ from qcodes.validators import Numbers
 from .conftest import MemoryParameter
 
 
-def test_step_ramp(caplog):
+def test_step_ramp(caplog) -> None:
     p = MemoryParameter(name='test_step')
     p(42)
     assert p.set_values == [42]
@@ -40,7 +40,7 @@ def test_step_ramp(caplog):
 
 @given(scale=hst.integers(1, 100),
        value=hst.floats(min_value=1e-9, max_value=10))
-def test_ramp_scaled(scale, value):
+def test_ramp_scaled(scale, value) -> None:
     start_point = 0.0
     p = MemoryParameter(name='p', scale=scale,
                         initial_value=start_point)
@@ -77,7 +77,7 @@ def test_ramp_scaled(scale, value):
 
 
 @given(value=hst.floats(min_value=1e-9, max_value=10))
-def test_ramp_parser(value):
+def test_ramp_parser(value) -> None:
     start_point = 0.0
     p = MemoryParameter(name='p',
                         set_parser=lambda x: -x,
@@ -120,7 +120,7 @@ def test_ramp_parser(value):
 @given(scale=hst.integers(1, 100),
        value=hst.floats(min_value=1e-9, max_value=10))
 @settings(deadline=None)
-def test_ramp_parsed_scaled(scale, value):
+def test_ramp_parsed_scaled(scale, value) -> None:
     start_point = 0.0
     p = MemoryParameter(name='p',
                         scale=scale,
@@ -154,7 +154,7 @@ def test_ramp_parsed_scaled(scale, value):
     assert p.raw_value == -scale * value
 
 
-def test_stepping_from_invalid_starting_point():
+def test_stepping_from_invalid_starting_point() -> None:
 
     the_value = -10
 

--- a/qcodes/tests/parameter/test_parameter_scale_offset.py
+++ b/qcodes/tests/parameter/test_parameter_scale_offset.py
@@ -7,7 +7,7 @@ from hypothesis import event, given, settings
 from qcodes.parameters import Parameter
 
 
-def test_scale_raw_value():
+def test_scale_raw_value() -> None:
     p = Parameter(name='test_scale_raw_value', set_cmd=None)
     p(42)
     assert p.raw_value == 42
@@ -65,7 +65,7 @@ def iterable_or_number(draw, values, size, values_scalar, is_values):
 @given(values=iterable_or_number(TestFloats, SharedSize, ValuesScalar, True),
        offsets=iterable_or_number(TestFloats, SharedSize, ValuesScalar, False),
        scales=iterable_or_number(TestFloats, SharedSize, ValuesScalar, False))
-def test_scale_and_offset_raw_value_iterable(values, offsets, scales):
+def test_scale_and_offset_raw_value_iterable(values, offsets, scales) -> None:
     p = Parameter(name='test_scale_and_offset_raw_value', set_cmd=None)
 
     # test that scale and offset does not change the default behaviour
@@ -123,16 +123,14 @@ def test_scale_and_offset_raw_value_iterable(values, offsets, scales):
 
 @settings(max_examples=300)
 @given(
-    values=iterable_or_number(
-        TestFloats, SharedSize, ValuesScalar, True),
-    offsets=iterable_or_number(
-        TestFloats, SharedSize, ValuesScalar, False),
-    scales=iterable_or_number(
-        TestFloats, SharedSize, ValuesScalar, False))
-def test_scale_and_offset_raw_value_iterable_for_set_cache(values,
-                                                           offsets,
-                                                           scales):
-    p = Parameter(name='test_scale_and_offset_raw_value', set_cmd=None)
+    values=iterable_or_number(TestFloats, SharedSize, ValuesScalar, True),
+    offsets=iterable_or_number(TestFloats, SharedSize, ValuesScalar, False),
+    scales=iterable_or_number(TestFloats, SharedSize, ValuesScalar, False),
+)
+def test_scale_and_offset_raw_value_iterable_for_set_cache(
+    values, offsets, scales
+) -> None:
+    p = Parameter(name="test_scale_and_offset_raw_value", set_cmd=None)
 
     # test that scale and offset does not change the default behaviour
     p.cache.set(values)
@@ -187,8 +185,9 @@ def test_scale_and_offset_raw_value_iterable_for_set_cache(values,
         event('Scale is array but not offset')
 
 
-def test_numpy_array_valued_parameter_preserves_type_if_scale_and_offset_are_set():
-
+def test_numpy_array_valued_parameter_preserves_type_if_scale_and_offset_are_set() -> (
+    None
+):
     def rands():
         return np.random.randn(5)
 
@@ -204,7 +203,7 @@ def test_numpy_array_valued_parameter_preserves_type_if_scale_and_offset_are_set
     assert isinstance(values, np.ndarray)
 
 
-def test_setting_numpy_array_valued_param_if_scale_and_offset_are_not_none():
+def test_setting_numpy_array_valued_param_if_scale_and_offset_are_not_none() -> None:
 
     param = Parameter(name='test_param',
                       set_cmd=None,

--- a/qcodes/tests/parameter/test_parameter_with_setpoints.py
+++ b/qcodes/tests/parameter/test_parameter_with_setpoints.py
@@ -26,7 +26,7 @@ def parameters():
            setpoints_1, setpoints_2, setpoints_3)
 
 
-def test_validation_shapes():
+def test_validation_shapes() -> None:
     """
     Test that various parameters with setpoints and shape combinations
     validate correctly.
@@ -108,7 +108,7 @@ def test_setpoints_non_parameter_raises() -> None:
         param_with_setpoints_1.setpoints = (lambda x: x,)  # type: ignore[assignment]
 
 
-def test_validation_inconsistent_shape():
+def test_validation_inconsistent_shape() -> None:
     """
     Parameters with shapes inconsistent with their setpoints should not
     validate
@@ -143,7 +143,7 @@ def test_validation_inconsistent_shape():
         param_with_diff_length.validate(param_with_diff_length.get())
 
 
-def test_validation_wrong_validator():
+def test_validation_wrong_validator() -> None:
     """
     If the validator does not match the actual content the validation should
     fail
@@ -175,7 +175,7 @@ def test_validation_wrong_validator():
         param_with_wrong_validator.validate(param_with_wrong_validator())
 
 
-def test_validation_no_validator():
+def test_validation_no_validator() -> None:
     """
     If a parameter does not use array validators it cannot be validated.
     """
@@ -197,7 +197,7 @@ def test_validation_no_validator():
         )
 
 
-def test_validation_sp_no_validator():
+def test_validation_sp_no_validator() -> None:
     """
     If the setpoints do not have an Arrays validator validation
     will fail.
@@ -225,7 +225,7 @@ def test_validation_sp_no_validator():
         param_sp_without_validator.validate(param_sp_without_validator.get())
 
 
-def test_validation_without_shape():
+def test_validation_without_shape() -> None:
     """
     If the Arrays validator does not have a shape the validation will fail
     """
@@ -251,7 +251,7 @@ def test_validation_without_shape():
         )
 
 
-def test_validation_without_sp_shape():
+def test_validation_without_sp_shape() -> None:
     """
     If the setpoints validator has no shape the validation will fail
     """
@@ -349,7 +349,7 @@ def test_validation_one_sp_dim_missing() -> None:
         param_sp_without_shape.validate(param_sp_without_shape.get())
 
 
-def test_expand_setpoints_1c(parameters):
+def test_expand_setpoints_1c(parameters) -> None:
     """
     Test that the setpoints expander helper function works correctly
     """
@@ -370,7 +370,7 @@ def test_expand_setpoints_1c(parameters):
     assert len(data[0][1]) == len(data[1][1])
 
 
-def test_expand_setpoints_2d(parameters):
+def test_expand_setpoints_2d(parameters) -> None:
 
     n_points_1, n_points_2, n_points_3, \
     setpoints_1, setpoints_2, setpoints_3 = parameters
@@ -400,7 +400,7 @@ def test_expand_setpoints_2d(parameters):
         np.testing.assert_array_equal(sp2[i, :], np.arange(sp1.shape[1]))
 
 
-def test_expand_setpoints_3d(parameters):
+def test_expand_setpoints_3d(parameters) -> None:
 
     n_points_1, n_points_2, n_points_3, \
         setpoints_1, setpoints_2, setpoints_3 = parameters

--- a/qcodes/tests/parameter/test_permissive_range.py
+++ b/qcodes/tests/parameter/test_permissive_range.py
@@ -23,13 +23,13 @@ good_args = [
 
 
 @pytest.mark.parametrize("args", bad_args)
-def test_bad_calls(args):
+def test_bad_calls(args) -> None:
     with pytest.raises(Exception):
         permissive_range(*args)
 
 
 @pytest.mark.parametrize("args,result", good_args)
-def test_good_calls(args, result):
+def test_good_calls(args, result) -> None:
     # TODO(giulioungaretti)
     # not sure what we are testing here.
     # in python 1.0 and 1 are actually the same

--- a/qcodes/tests/parameter/test_scaled_parameter.py
+++ b/qcodes/tests/parameter/test_scaled_parameter.py
@@ -114,7 +114,7 @@ def test_wrapped_parameter(instrument: DummyInstrument) -> None:
     assert instrument.scaler.wrapped_parameter == instrument.target_parameter
 
 
-def test_divider(instrument):
+def test_divider(instrument) -> None:
     test_division = 10
     test_value = 5
 

--- a/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
+++ b/qcodes/tests/sphinx_extension/test_parse_parameter_attr.py
@@ -70,7 +70,7 @@ class DummyDecoratedClassTestClass(InstrumentBase):
         """
 
 
-def test_extract_class_attr():
+def test_extract_class_attr() -> None:
     a = safe_getattr(DummyTestClass, "myattr")
     assert a == "ClassAttribute"
 
@@ -78,7 +78,7 @@ def test_extract_class_attr():
     assert b == "ClassAttribute"
 
 
-def test_extract_instance_attr():
+def test_extract_instance_attr() -> None:
     with pytest.raises(AttributeError):
         safe_getattr(DummyTestClass, "other_attr")
 
@@ -87,31 +87,31 @@ def test_extract_instance_attr():
     assert repr(b) == '"InstanceAttribute"'
 
 
-def test_instrument_base_get_attr():
+def test_instrument_base_get_attr() -> None:
     parameters = qcodes_parameter_attr_getter(InstrumentBase, "parameters")
     assert isinstance(parameters, ParameterProxy)
     assert repr(parameters) == "{}"
 
 
-def test_visa_instr_get_attr():
+def test_visa_instr_get_attr() -> None:
     parameters = qcodes_parameter_attr_getter(VisaInstrument, "parameters")
     assert isinstance(parameters, ParameterProxy)
     assert repr(parameters) == "{}"
 
 
-def test_decorated_init_func():
+def test_decorated_init_func() -> None:
     attr = qcodes_parameter_attr_getter(DummyDecoratedInitTestClass, "other_attr")
     assert isinstance(attr, ParameterProxy)
     assert repr(attr) == '"InstanceAttribute"'
 
 
-def test_decorated_class():
+def test_decorated_class() -> None:
     attr = qcodes_parameter_attr_getter(DummyDecoratedClassTestClass, "other_attr")
     assert isinstance(attr, ParameterProxy)
     assert repr(attr) == '"InstanceAttribute"'
 
 
-def test_no_init():
+def test_no_init() -> None:
     """Test that attribute can be found from a class without an init function."""
     attr = qcodes_parameter_attr_getter(DummyNoInitClass, "parameters")
     assert isinstance(attr, ParameterProxy)

--- a/qcodes/tests/test_abstract_instrument.py
+++ b/qcodes/tests/test_abstract_instrument.py
@@ -159,7 +159,7 @@ def _driver():
     drvr.close()
 
 
-def test_sanity(driver):
+def test_sanity(driver) -> None:
     """
     If all abstract parameters are implemented, we should be able
     to instantiate the instrument
@@ -168,7 +168,7 @@ def test_sanity(driver):
     assert driver.voltage() == 0.1
 
 
-def test_not_implemented_error():
+def test_not_implemented_error() -> None:
     """
     If not all abstract parameters are implemented, we should see
     an exception
@@ -180,7 +180,7 @@ def test_not_implemented_error():
     assert not VoltageSourceNotImplemented.instances()
 
 
-def test_unit_value_error():
+def test_unit_value_error() -> None:
     """
     Units should match between subclasses and base classes
     """
@@ -188,7 +188,7 @@ def test_unit_value_error():
         VoltageSourceBadUnit("abstract_instrument_driver_3")
 
 
-def test_unit_value_error_does_not_register_instrument():
+def test_unit_value_error_does_not_register_instrument() -> None:
     """
     Units should match between subclasses and base classes
     """
@@ -197,7 +197,7 @@ def test_unit_value_error_does_not_register_instrument():
     assert not VoltageSourceBadUnit.instances()
 
 
-def test_exception_in_init():
+def test_exception_in_init() -> None:
     """
     Verify that if the instrument raises in init it is not registered as an instance
     """
@@ -212,7 +212,7 @@ def test_exception_in_init():
     instance.close()
 
 
-def test_abstract_channel_raises():
+def test_abstract_channel_raises() -> None:
     """
     Creating an instrument with a channel with abstract parameters should raise
     """
@@ -222,7 +222,7 @@ def test_abstract_channel_raises():
         VoltageAbstractChannelSource("abstract_instrument_driver_7")
 
 
-def test_non_abstract_channel_does_not_raises(request):
+def test_non_abstract_channel_does_not_raises(request) -> None:
     """
     Creating an instrument with a channel that implements the interface.
     This should not raise
@@ -231,7 +231,7 @@ def test_non_abstract_channel_does_not_raises(request):
     request.addfinalizer(source.close)
 
 
-def test_abstract_channellist_raises():
+def test_abstract_channellist_raises() -> None:
     """
     Creating an instrument with a channel (in a ChannelList)
     with abstract parameters should raise
@@ -242,7 +242,7 @@ def test_abstract_channellist_raises():
         VoltageAbstractChannelListSource("abstract_instrument_driver_9")
 
 
-def test_non_abstract_channellist_does_not_raises(request):
+def test_non_abstract_channellist_does_not_raises(request) -> None:
     """
     Creating an instrument with a ChannelList that contains a
     channel that implements the interface. This should not raise

--- a/qcodes/tests/test_autoloadable_channels.py
+++ b/qcodes/tests/test_autoloadable_channels.py
@@ -211,7 +211,7 @@ def dummy_instrument():
     instrument.close()
 
 
-def test_sanity(dummy_instrument):
+def test_sanity(dummy_instrument) -> None:
     """
     Test the basic functionality of the auto-loadable channels, without using
     the auto-loadable channels list. Please note that the `channels_to_skip`
@@ -255,7 +255,7 @@ def test_sanity(dummy_instrument):
         # longer be available
 
 
-def test_channels_list(dummy_instrument):
+def test_channels_list(dummy_instrument) -> None:
     """
     Test the auto-loadable channels list
     """
@@ -283,7 +283,7 @@ def test_channels_list(dummy_instrument):
     assert len(dummy_instrument.channels) == 2
 
 
-def test_with_kwargs(dummy_instrument):
+def test_with_kwargs(dummy_instrument) -> None:
     """
     Test keyword arguments given to the add method
     """

--- a/qcodes/tests/test_channels.py
+++ b/qcodes/tests/test_channels.py
@@ -56,18 +56,18 @@ class EmptyChannel(InstrumentChannel):
     pass
 
 
-def test_instrument_channel_label():
+def test_instrument_channel_label() -> None:
     dci = DummyChannelInstrument(name="dci_with_labels", label="Instrument Label")
     channel = DummyChannel(dci, "A_with_label", "A_wl", label="A with f@ncy label")
     dci.add_submodule("A_with_label", channel)
-    channel = EmptyChannel(dci, "B_with_label", label="B with f@ncy label")
-    dci.add_submodule("B_with_label", channel)
+    channel_2 = EmptyChannel(dci, "B_with_label", label="B with f@ncy label")
+    dci.add_submodule("B_with_label", channel_2)
     assert dci.label == "Instrument Label"
     assert dci.A_with_label.label == "A with f@ncy label"
     assert dci.B_with_label.label == "B with f@ncy label"
 
 
-def test_channels_call_function(dci, caplog):
+def test_channels_call_function(dci, caplog) -> None:
     """
     Test that dci.channels.some_function() calls
     some_function on each of the channels
@@ -81,7 +81,7 @@ def test_channels_call_function(dci, caplog):
         assert mssgs == names
 
 
-def test_channels_get(dci):
+def test_channels_get(dci) -> None:
 
     temperatures = dci.channels.temperature.get()
     assert len(temperatures) == 6
@@ -89,7 +89,7 @@ def test_channels_get(dci):
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(value=hst.floats(0, 300), channel=hst.integers(0, 3))
-def test_channel_access_is_identical(dci, value, channel):
+def test_channel_access_is_identical(dci, value, channel) -> None:
     channel_to_label = {0: 'A', 1: 'B', 2: 'C', 3: "D"}
     label = channel_to_label[channel]
     channel_via_label = getattr(dci, label)
@@ -138,7 +138,7 @@ def test_invalid_multichan_type_raises(empty_instrument: Instrument) -> None:
         )
 
 
-def test_wrong_chan_type_raises(empty_instrument):
+def test_wrong_chan_type_raises(empty_instrument) -> None:
     with pytest.raises(TypeError, match="All items in this ChannelTuple must be of"):
         ChannelList(
             parent=empty_instrument,
@@ -148,7 +148,7 @@ def test_wrong_chan_type_raises(empty_instrument):
         )
 
 
-def test_append_channel(dci_with_list):
+def test_append_channel(dci_with_list) -> None:
     n_channels_pre = len(dci_with_list.channels)
     n_channels_post = n_channels_pre + 1
     chan_num = "11"
@@ -169,7 +169,7 @@ def test_append_channel(dci_with_list):
     assert len(dci_with_list.channels) == n_channels_post
 
 
-def test_append_channel_wrong_type_raises(dci_with_list):
+def test_append_channel_wrong_type_raises(dci_with_list) -> None:
     n_channels = len(dci_with_list.channels)
 
     channel = EmptyChannel(dci_with_list, "foo")
@@ -179,7 +179,7 @@ def test_append_channel_wrong_type_raises(dci_with_list):
     assert len(dci_with_list.channels) == n_channels
 
 
-def test_extend_channels_from_generator(dci_with_list):
+def test_extend_channels_from_generator(dci_with_list) -> None:
     n_channels = len(dci_with_list.channels)
     names = ("foo", "bar", "foobar")
     channels = (DummyChannel(dci_with_list, "Chan" + name, name) for name in names)
@@ -188,7 +188,7 @@ def test_extend_channels_from_generator(dci_with_list):
     assert len(dci_with_list.channels) == n_channels + len(names)
 
 
-def test_extend_channels_from_tuple(dci_with_list):
+def test_extend_channels_from_tuple(dci_with_list) -> None:
     n_channels = len(dci_with_list.channels)
     names = ("foo", "bar", "foobar")
     channels = tuple(DummyChannel(dci_with_list, "Chan" + name, name) for name in names)
@@ -197,7 +197,7 @@ def test_extend_channels_from_tuple(dci_with_list):
     assert len(dci_with_list.channels) == n_channels + len(names)
 
 
-def test_extend_wrong_type_raises(dci_with_list):
+def test_extend_wrong_type_raises(dci_with_list) -> None:
     names = ("foo", "bar", "foobar")
     channels = tuple(EmptyChannel(dci_with_list, "Chan" + name) for name in names)
     with pytest.raises(
@@ -206,7 +206,7 @@ def test_extend_wrong_type_raises(dci_with_list):
         dci_with_list.channels.extend(channels)
 
 
-def test_extend_locked_list_raises(dci_with_list):
+def test_extend_locked_list_raises(dci_with_list) -> None:
     dci_with_list.channels.lock()
     names = ("foo", "bar", "foobar")
     channels = tuple(EmptyChannel(dci_with_list, "Chan" + name) for name in names)
@@ -214,7 +214,7 @@ def test_extend_locked_list_raises(dci_with_list):
         dci_with_list.channels.extend(channels)
 
 
-def test_extend_then_remove(dci_with_list):
+def test_extend_then_remove(dci_with_list) -> None:
     n_channels = len(dci_with_list.channels)
     names = ("foo", "bar", "foobar")
     channels = [DummyChannel(dci_with_list, "Chan" + name, name) for name in names]
@@ -227,7 +227,7 @@ def test_extend_then_remove(dci_with_list):
     assert len(dci_with_list.channels) == n_channels + len(names) - 1
 
 
-def test_insert_channel(dci_with_list):
+def test_insert_channel(dci_with_list) -> None:
     n_channels_pre = len(dci_with_list.channels)
     name = "foo"
     channel = DummyChannel(dci_with_list, "Chan" + name, name)
@@ -249,18 +249,18 @@ def test_insert_channel(dci_with_list):
     assert len(dci_with_list.channels._channel_mapping) == n_channels_post
 
 
-def test_insert_channel_wrong_type_raises(dci_with_list):
+def test_insert_channel_wrong_type_raises(dci_with_list) -> None:
     with pytest.raises(TypeError, match="All items in a channel list"):
         dci_with_list.channels.insert(1, EmptyChannel(parent=dci_with_list, name="foo"))
 
 
-def test_add_none_channel_tuple_to_channel_tuple_raises(dci):
+def test_add_none_channel_tuple_to_channel_tuple_raises(dci) -> None:
 
     with pytest.raises(TypeError, match="Can't add objects of type"):
         _ = dci.channels + [1]
 
 
-def test_add_channel_tuples_of_different_types_raises(dci):
+def test_add_channel_tuples_of_different_types_raises(dci) -> None:
 
     extra_channels = [EmptyChannel(dci, f"chan{i}") for i in range(10)]
     extra_channel_list = ChannelList(
@@ -275,56 +275,56 @@ def test_add_channel_tuples_of_different_types_raises(dci):
         _ = dci.channels + extra_channel_list
 
 
-def test_add_channel_tuples_from_different_parents(dci, dci_with_list):
+def test_add_channel_tuples_from_different_parents(dci, dci_with_list) -> None:
 
     with pytest.raises(ValueError, match="Can only add channels from the same"):
         _ = dci.channels + dci_with_list.channels
 
 
-def test_chan_tuple_repr(dci):
+def test_chan_tuple_repr(dci) -> None:
 
     dci_repr = repr(dci.channels)
     assert dci_repr.startswith("ChannelTuple")
 
 
-def test_chan_list_repr(dci_with_list):
+def test_chan_list_repr(dci_with_list) -> None:
 
     dci_repr = repr(dci_with_list.channels)
     assert dci_repr.startswith("ChannelList")
 
 
-def test_channel_tuple_get_validator(dci):
+def test_channel_tuple_get_validator(dci) -> None:
 
     validator = dci.channels.get_validator()
     for chan in dci.channels:
         validator.validate(chan)
 
 
-def test_channel_list_get_validator(dci_with_list):
+def test_channel_list_get_validator(dci_with_list) -> None:
     dci_with_list.channels.lock()
     validator = dci_with_list.channels.get_validator()
     for chan in dci_with_list.channels:
         validator.validate(chan)
 
 
-def test_channel_list_get_validator_not_locked_raised(dci_with_list):
+def test_channel_list_get_validator_not_locked_raised(dci_with_list) -> None:
     with pytest.raises(AttributeError, match="Cannot create a validator"):
         dci_with_list.channels.get_validator()
 
 
-def test_channel_tuple_index(dci):
+def test_channel_tuple_index(dci) -> None:
 
     for i, chan in enumerate(dci.channels):
         assert dci.channels.index(chan) == i
 
 
-def test_channel_tuple_snapshot(dci):
+def test_channel_tuple_snapshot(dci) -> None:
     snapshot = dci.channels.snapshot()
     assert snapshot["snapshotable"] is False
     assert len(snapshot.keys()) == 2
 
 
-def test_channel_tuple_snapshot_enabled(empty_instrument):
+def test_channel_tuple_snapshot_enabled(empty_instrument) -> None:
 
     channels = ChannelList(
         empty_instrument, "ListElem", DummyChannel, snapshotable=True
@@ -340,7 +340,7 @@ def test_channel_tuple_snapshot_enabled(empty_instrument):
     assert "channels" in snapshot.keys()
 
 
-def test_channel_tuple_dir(dci):
+def test_channel_tuple_dir(dci) -> None:
 
     dir_list = dir(dci.channels)
 
@@ -351,13 +351,13 @@ def test_channel_tuple_dir(dci):
         assert param.short_name in dir_list
 
 
-def test_clear_channels(dci_with_list):
+def test_clear_channels(dci_with_list) -> None:
     channels = dci_with_list.channels
     channels.clear()
     assert len(channels) == 0
 
 
-def test_clear_locked_channels(dci_with_list):
+def test_clear_locked_channels(dci_with_list) -> None:
     channels = dci_with_list.channels
     original_length = len(channels)
     channels.lock()
@@ -366,7 +366,7 @@ def test_clear_locked_channels(dci_with_list):
     assert len(channels) == original_length
 
 
-def test_remove_channel(dci_with_list):
+def test_remove_channel(dci_with_list) -> None:
     channels = dci_with_list.channels
     chan_a = dci_with_list.A
     original_length = len(channels.temperature())
@@ -377,7 +377,7 @@ def test_remove_channel(dci_with_list):
     assert len(channels.temperature()) == original_length-1
 
 
-def test_remove_locked_channel(dci_with_list):
+def test_remove_locked_channel(dci_with_list) -> None:
     channels = dci_with_list.channels
     chan_a = dci_with_list.A
     channels.lock()
@@ -385,14 +385,14 @@ def test_remove_locked_channel(dci_with_list):
         channels.remove(chan_a)
 
 
-def test_channel_list_lock_twice(dci_with_list):
+def test_channel_list_lock_twice(dci_with_list) -> None:
     channels = dci_with_list.channels
     channels.lock()
     # locking twice should be a no op
     channels.lock()
 
 
-def test_remove_tupled_channel(dci_with_list):
+def test_remove_tupled_channel(dci_with_list) -> None:
     channel_tuple = tuple(
         DummyChannel(dci_with_list, f"Chan{C}", C)
         for C in ("A", "B", "C", "D", "E", "F")
@@ -412,7 +412,7 @@ def test_remove_tupled_channel(dci_with_list):
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(setpoints=hst.lists(hst.floats(0, 300), min_size=4, max_size=4))
-def test_combine_channels(dci, setpoints):
+def test_combine_channels(dci, setpoints) -> None:
     assert len(dci.channels) == 6
 
     mychannels = dci.channels[0:2] + dci.channels[4:]
@@ -433,7 +433,7 @@ def test_combine_channels(dci, setpoints):
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,))
 @given(start=hst.integers(-8, 7), stop=hst.integers(-8, 7),
        step=hst.integers(1, 7))
-def test_access_channels_by_slice(dci, start, stop, step):
+def test_access_channels_by_slice(dci, start, stop, step) -> None:
     names = ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H')
     channels = tuple(DummyChannel(dci,
                                   'Chan'+name, name) for name in names)
@@ -450,7 +450,7 @@ def test_access_channels_by_slice(dci, start, stop, step):
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,), deadline=1000)
 @given(myindexs=hst.lists(elements=hst.integers(-8, 7), min_size=1))
-def test_access_channels_by_tuple(dci, myindexs):
+def test_access_channels_by_tuple(dci, myindexs) -> None:
     names = ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H')
     mytuple = tuple(myindexs)
     channels = tuple(DummyChannel(dci,
@@ -463,13 +463,13 @@ def test_access_channels_by_tuple(dci, myindexs):
         assert chan.name == f"dci_Chan{names[chanindex]}"
 
 
-def test_access_channels_by_name_empty_raises(dci):
+def test_access_channels_by_name_empty_raises(dci) -> None:
     # todo this should raise a less generic error type
     with pytest.raises(Exception, match="one or more names must be given"):
         dci.channels.get_channel_by_name()
 
 
-def test_delete_from_channel_list(dci_with_list):
+def test_delete_from_channel_list(dci_with_list) -> None:
     n_channels = len(dci_with_list.channels)
     chan0 = dci_with_list.channels[0]
     del dci_with_list.channels[0]
@@ -496,13 +496,13 @@ def test_delete_from_channel_list(dci_with_list):
     assert len(dci_with_list.channels) == n_channels - 3
 
 
-def test_set_element_by_int(dci_with_list):
+def test_set_element_by_int(dci_with_list) -> None:
 
     dci_with_list.channels[0] = dci_with_list.channels[1]
     assert dci_with_list.channels[0] is dci_with_list.channels[1]
 
 
-def test_set_element_by_slice(dci_with_list):
+def test_set_element_by_slice(dci_with_list) -> None:
     foo = DummyChannel(dci_with_list, name="foo", channel="foo")
     bar = DummyChannel(dci_with_list, name="bar", channel="bar")
     dci_with_list.channels[0:2] = [foo, bar]
@@ -517,7 +517,7 @@ def test_set_element_by_slice(dci_with_list):
     )
 
 
-def test_set_element_locked_raises(dci_with_list):
+def test_set_element_locked_raises(dci_with_list) -> None:
 
     dci_with_list.channels.lock()
 
@@ -530,7 +530,7 @@ def test_set_element_locked_raises(dci_with_list):
 
 @settings(suppress_health_check=(HealthCheck.function_scoped_fixture,), deadline=1000)
 @given(myindexs=hst.lists(elements=hst.integers(0, 7), min_size=2))
-def test_access_channels_by_name(dci, myindexs):
+def test_access_channels_by_name(dci, myindexs) -> None:
     names = ("A", "B", "C", "D", "E", "F", "G", "H")
     channels = tuple(DummyChannel(dci, "Chan" + name, name) for name in names)
     chlist = ChannelList(dci, "channels", DummyChannel, channels)
@@ -541,7 +541,7 @@ def test_access_channels_by_name(dci, myindexs):
         assert chan.name == f'dci_Chan{names[chanindex]}'
 
 
-def test_channels_contain(dci):
+def test_channels_contain(dci) -> None:
     names = ("A", "B", "C", "D", "E", "F", "G", "H")
     channels = tuple(DummyChannel(dci, "Chan" + name, name) for name in names)
     chlist = ChannelList(dci, "channels", DummyChannel, channels)
@@ -549,7 +549,7 @@ def test_channels_contain(dci):
         assert chan in chlist
 
 
-def test_channels_reverse(dci):
+def test_channels_reverse(dci) -> None:
     names = ("A", "B", "C", "D", "E", "F", "G", "H")
     channels = tuple(DummyChannel(dci, name, name) for name in names)
     chlist = ChannelList(dci, "channels", DummyChannel, channels)
@@ -558,7 +558,7 @@ def test_channels_reverse(dci):
         assert chan.short_name == name
 
 
-def test_channels_count(dci):
+def test_channels_count(dci) -> None:
     names = ("A", "B", "C", "D", "E", "F", "G", "H")
     channels = tuple(DummyChannel(dci, name, name) for name in names)
     chlist = ChannelList(dci, "channels", DummyChannel, channels)
@@ -567,7 +567,7 @@ def test_channels_count(dci):
         assert chlist.count(channel) == 1
 
 
-def test_channels_is_sequence(dci):
+def test_channels_is_sequence(dci) -> None:
     names = ("A", "B", "C", "D", "E", "F", "G", "H")
     channels = tuple(DummyChannel(dci, name, name) for name in names)
     chlist = ChannelList(dci, "channels", DummyChannel, channels)
@@ -576,7 +576,7 @@ def test_channels_is_sequence(dci):
     assert issubclass(ChannelList, Sequence)
 
 
-def test_names(dci):
+def test_names(dci) -> None:
     ex_inst_name = 'dci'
     for channel in dci.channels:
         sub_channel = DummyChannel(channel, 'subchannel', 'subchannel')
@@ -625,7 +625,7 @@ def test_names(dci):
                [ex_inst_name, ex_chan_name, ex_subchan_name, ex_param_name]
 
 
-def test_root_instrument(dci):
+def test_root_instrument(dci) -> None:
     assert dci.root_instrument is dci
     for channel in dci.channels:
         assert channel.root_instrument is dci
@@ -633,7 +633,7 @@ def test_root_instrument(dci):
             assert parameter.root_instrument is dci
 
 
-def test_get_attr_on_empty_channellist_works_as_expected(empty_instrument):
+def test_get_attr_on_empty_channellist_works_as_expected(empty_instrument) -> None:
     channels = ChannelTuple(empty_instrument, "channels", chan_type=DummyChannel)
     empty_instrument.add_submodule("channels", channels)
 
@@ -643,12 +643,12 @@ def test_get_attr_on_empty_channellist_works_as_expected(empty_instrument):
         _ = empty_instrument.channels.temperature
 
 
-def test_channel_tuple_call_method_basic_test(dci):
+def test_channel_tuple_call_method_basic_test(dci) -> None:
     result = dci.channels.turn_on()
     assert result is None
 
 
-def test_channel_tuple_call_method_called_as_expected(dci, mocker):
+def test_channel_tuple_call_method_called_as_expected(dci, mocker) -> None:
 
     for channel in dci.channels:
         channel.turn_on = mocker.MagicMock(return_value=1)

--- a/qcodes/tests/test_command.py
+++ b/qcodes/tests/test_command.py
@@ -1,3 +1,5 @@
+from typing import Any, NoReturn
+
 import pytest
 
 from qcodes.parameters.command import Command, NoCommandError
@@ -29,19 +31,19 @@ def test_bad_calls() -> None:
         )
 
 
-def test_no_cmd():
+def test_no_cmd() -> None:
     with pytest.raises(NoCommandError):
         Command(0)
 
-    def no_cmd_function():
+    def no_cmd_function() -> NoReturn:
         raise CustomError('no command')
 
-    no_cmd = Command(0, no_cmd_function=no_cmd_function)
+    no_cmd: Command[Any, Any] = Command(0, no_cmd_function=no_cmd_function)
     with pytest.raises(CustomError):
         no_cmd()
 
 
-def test_cmd_str():
+def test_cmd_str() -> None:
     def f_now(x):
         return x + ' now'
 
@@ -55,17 +57,16 @@ def test_cmd_str():
         return b, a
 
     # basic exec_str
-    cmd = Command(0, 'pickles', exec_str=f_now)
-    assert cmd() == 'pickles now'
+    cmd: Command[Any, Any] = Command(0, "pickles", exec_str=f_now)
+    assert cmd() == "pickles now"
 
     # with output parsing
     cmd = Command(0, 'blue', exec_str=f_now, output_parser=upper)
     assert cmd() == 'BLUE NOW'
 
     # parameter insertion
-    cmd = Command(3, '{} is {:.2f}% better than {}', exec_str=f_now)
-    assert cmd('ice cream', 56.2, 'cake') == \
-                     'ice cream is 56.20% better than cake now'
+    cmd = Command(3, "{} is {:.2f}% better than {}", exec_str=f_now)
+    assert cmd("ice cream", 56.2, "cake") == "ice cream is 56.20% better than cake now"
     with pytest.raises(ValueError):
         cmd('cake', 'a whole lot', 'pie')
 

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -192,18 +192,16 @@ def _make_mock_config(mocker):
     yield load_config
 
 
-def test_missing_config_file(config):
+def test_missing_config_file(config) -> None:
     with pytest.raises(FileNotFoundError):
         config.load_config("./missing.json")
 
 
-@pytest.mark.skipif(Path.cwd() == Path.home(),
-                    reason="This test requires that "
-                           "working dir is different from homedir.")
-def test_default_config_files(
-        config,
-        load_config
-):
+@pytest.mark.skipif(
+    Path.cwd() == Path.home(),
+    reason="This test requires that " "working dir is different from homedir.",
+)
+def test_default_config_files(config, load_config) -> None:
     load_config.side_effect = partial(side_effect, GOOD_CONFIG_MAP)
     # don't try to load custom schemas
     config.schema_cwd_file_name = None
@@ -217,7 +215,7 @@ def test_default_config_files(
 @pytest.mark.skipif(Path.cwd() == Path.home(),
                     reason="This test requires that "
                            "working dir is different from homedir.")
-def test_bad_config_files(config, load_config):
+def test_bad_config_files(config, load_config) -> None:
 
     load_config.side_effect = partial(side_effect, BAD_CONFIG_MAP)
     # don't try to load custom schemas
@@ -232,7 +230,7 @@ def test_bad_config_files(config, load_config):
 @pytest.mark.skipif(Path.cwd() == Path.home(),
                     reason="This test requires that "
                            "working dir is different from homedir.")
-def test_user_schema(config, load_config, mocker):
+def test_user_schema(config, load_config, mocker) -> None:
     mocker.patch("builtins.open", mock_open(read_data=USER_SCHEMA))
     load_config.side_effect = partial(side_effect, GOOD_CONFIG_MAP)
     config.defaults, _ = config.load_default()
@@ -240,7 +238,7 @@ def test_user_schema(config, load_config, mocker):
     assert config == CONFIG
 
 
-def test_bad_user_schema(config, load_config, mocker):
+def test_bad_user_schema(config, load_config, mocker) -> None:
     mocker.patch("builtins.open", mock_open(read_data=USER_SCHEMA))
     load_config.side_effect = partial(side_effect, BAD_CONFIG_MAP)
     with pytest.raises(jsonschema.exceptions.ValidationError):
@@ -248,7 +246,7 @@ def test_bad_user_schema(config, load_config, mocker):
         config.update_config()
 
 
-def test_update_user_config(config, mocker):
+def test_update_user_config(config, mocker) -> None:
 
     myconfig = mocker.patch.object(
         Config,
@@ -262,7 +260,7 @@ def test_update_user_config(config, mocker):
     assert config.current_config == UPDATED_CONFIG
 
 
-def test_update_and_validate_user_config(config, mocker):
+def test_update_and_validate_user_config(config, mocker) -> None:
 
     myconfig = mocker.patch.object(
         Config,
@@ -283,7 +281,7 @@ def test_update_and_validate_user_config(config, mocker):
 
 
 @pytest.mark.usefixtures("default_config")
-def test_update_from_path(path_to_config_file_on_disk):
+def test_update_from_path(path_to_config_file_on_disk) -> None:
     cfg = qcodes.config
 
     # check that the default is still the default
@@ -301,7 +299,7 @@ def test_update_from_path(path_to_config_file_on_disk):
     assert cfg.current_config_path == expected_path
 
 
-def test_repr():
+def test_repr() -> None:
     cfg = qcodes.config
     rep = cfg.__repr__()
 
@@ -313,7 +311,7 @@ def test_repr():
 
 
 @pytest.mark.usefixtures("default_config")
-def test_add_and_describe():
+def test_add_and_describe() -> None:
     """
     Test that a key can be added and described
     """

--- a/qcodes/tests/test_deprecate.py
+++ b/qcodes/tests/test_deprecate.py
@@ -12,7 +12,7 @@ from qcodes.utils.deprecate import (
 )
 
 
-def test_assert_deprecated_raises():
+def test_assert_deprecated_raises() -> None:
     with assert_deprecated(
             'The use of this function is deprecated, because '
             'of this being a test. Use \"a real function\" as an '
@@ -24,31 +24,31 @@ def test_assert_deprecated_raises():
         )
 
 
-def test_assert_deprecated_does_not_raise_wrong_msg():
+def test_assert_deprecated_does_not_raise_wrong_msg() -> None:
     with pytest.raises(AssertionError):
         with assert_deprecated('entirely different message'):
             issue_deprecation_warning('warning')
 
 
-def test_assert_deprecated_does_not_raise_wrong_type():
+def test_assert_deprecated_does_not_raise_wrong_type() -> None:
     with pytest.raises(AssertionError):
         with assert_deprecated('entirely different message'):
             warnings.warn('warning')
 
 
-def test_assert_not_deprecated_raises():
+def test_assert_not_deprecated_raises() -> None:
     with pytest.raises(AssertionError):
         with assert_not_deprecated():
             issue_deprecation_warning('something')
 
 
-def test_assert_not_deprecated_does_not_raise():
+def test_assert_not_deprecated_does_not_raise() -> None:
     with assert_not_deprecated():
         warnings.warn('some other warning')
 
 
 @pytest.mark.filterwarnings('ignore:The function "add_one" is deprecated,')
-def test_similar_output():
+def test_similar_output() -> None:
 
     def _add_one(x):
         return 1 + x
@@ -63,17 +63,17 @@ def test_similar_output():
         assert add_one(1) == _add_one(1)
 
 
-def test_deprecated_context_manager():
+def test_deprecated_context_manager() -> None:
     with _catch_deprecation_warnings() as ws:
         issue_deprecation_warning('something')
         issue_deprecation_warning('something more')
         warnings.warn('Some other warning')
     assert len(ws) == 2
 
-    with pytest.warns(expected_warning=QCoDeSDeprecationWarning) as ws:
+    with pytest.warns(expected_warning=QCoDeSDeprecationWarning) as ws_2:
         issue_deprecation_warning('something')
         warnings.warn('Some other warning')
-    assert len(ws) == 2
+    assert len(ws_2) == 2
 
 
 @deprecate(reason='this is a test')
@@ -101,27 +101,27 @@ class C:
         self.a = val + '_prop'
 
 
-def test_init_uninhibited():
+def test_init_uninhibited() -> None:
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         c = C('pristine')
     assert c.a == 'pristine'
 
 
-def test_init_raises():
+def test_init_raises() -> None:
     with assert_deprecated(
             'The class <C> is deprecated, because '
             'this is a test.'):
         C('pristine')
 
 
-def test_method_uninhibited():
+def test_method_uninhibited() -> None:
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         c = C('pristine')
         c.method()
     assert c.a == 'last called by method'
 
 
-def test_method_raises():
+def test_method_raises() -> None:
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         c = C('pristine')
 
@@ -131,7 +131,7 @@ def test_method_raises():
         c.method()
 
 
-def test_static_method_uninhibited():
+def test_static_method_uninhibited() -> None:
     assert C.static_method(1) == 2
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         c = C('pristine')
@@ -139,7 +139,7 @@ def test_static_method_uninhibited():
 
 
 @pytest.mark.xfail(reason="This is not implemented yet.")
-def test_static_method_raises(self):
+def test_static_method_raises(self) -> None:
     with assert_deprecated(
             'The function <static_method> is deprecated, because '
             'this is a test.'):
@@ -153,7 +153,7 @@ def test_static_method_raises(self):
 
 
 @pytest.mark.xfail(reason="This is not implemented yet.")
-def test_class_method_uninhibited():
+def test_class_method_uninhibited() -> None:
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         assert C.class_method(1) == 2
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
@@ -163,7 +163,7 @@ def test_class_method_uninhibited():
 
 
 @pytest.mark.xfail(reason="This is not implemented yet.")
-def test_class_method_raises():
+def test_class_method_raises() -> None:
     with assert_deprecated(
             'The function <static_method> is deprecated, because '
             'this is a test.'):
@@ -176,14 +176,14 @@ def test_class_method_raises():
         c.class_method(1)
 
 
-def test_property_uninhibited():
+def test_property_uninhibited() -> None:
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         c = C('pristine')
         assert c.prop == 'pristine'
 
 
 @pytest.mark.xfail(reason="This is not implemented yet.")
-def test_property_raises():
+def test_property_raises() -> None:
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         c = C('pristine')
         with assert_deprecated(
@@ -192,7 +192,7 @@ def test_property_raises():
             _ = c.prop  # pylint: disable=pointless-statement
 
 
-def test_setter_uninhibited():
+def test_setter_uninhibited() -> None:
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         c = C('pristine')
         c.prop = 'changed'
@@ -200,7 +200,7 @@ def test_setter_uninhibited():
 
 
 @pytest.mark.xfail(reason="This is not implemented yet.")
-def test_setter_raises(self):
+def test_setter_raises(self) -> None:
     with pytest.warns(expected_warning=QCoDeSDeprecationWarning):
         c = C('pristine')
 

--- a/qcodes/tests/test_field_vector.py
+++ b/qcodes/tests/test_field_vector.py
@@ -32,7 +32,7 @@ random_coordinates = {
 
 @given(random_coordinates["spherical"])
 @settings(max_examples=10)
-def test_spherical_properties(spherical0):
+def test_spherical_properties(spherical0) -> None:
     """
     If the cartesian to spherical transform has been correctly implemented
     then we expect certain symmetrical properties
@@ -74,7 +74,7 @@ def test_spherical_properties(spherical0):
 
 @given(random_coordinates["cylindrical"])
 @settings(max_examples=10)
-def test_cylindrical_properties(cylindrical0):
+def test_cylindrical_properties(cylindrical0) -> None:
     """
     If the cartesian to cylindrical transform has been correctly implemented
     then we expect certain symmetrical properties
@@ -96,7 +96,7 @@ def test_cylindrical_properties(cylindrical0):
     random_coordinates["spherical"]
 )
 @settings(max_examples=10)
-def test_triangle_inequality(cylindrical0, spherical0):
+def test_triangle_inequality(cylindrical0, spherical0) -> None:
     cylindrical0 = FieldVector(**dict(zip(["rho", "phi", "z"], cylindrical0)))
     spherical0 = FieldVector(**dict(zip(["r", "phi", "theta"], spherical0)))
 
@@ -108,7 +108,7 @@ def test_triangle_inequality(cylindrical0, spherical0):
 
 @given(random_coordinates["cartesian"])
 @settings(max_examples=10)
-def test_homogeneous_roundtrip(cartesian0):
+def test_homogeneous_roundtrip(cartesian0) -> None:
     vec = FieldVector(**dict(zip("xyz", cartesian0)))
     h_vec = 13 * vec.as_homogeneous()
 
@@ -120,7 +120,7 @@ def test_homogeneous_roundtrip(cartesian0):
 
 @given(random_coordinates["spherical"])
 @settings(max_examples=10)
-def test_json_dump(spherical0):
+def test_json_dump(spherical0) -> None:
     vec = FieldVector(**dict(zip(["r", "phi", "theta"], spherical0)))
     dump = json.dumps(vec, cls=NumpyJSONEncoder)
 
@@ -130,7 +130,7 @@ def test_json_dump(spherical0):
     }
 
 
-def test_all_attributes_are_floats():
+def test_all_attributes_are_floats() -> None:
     cartesian0 = (400, 200, 300)
     cylindrical0 = (1, 52, 0)
     spherical0 = (1, 78, 145)

--- a/qcodes/tests/test_interactive_widget.py
+++ b/qcodes/tests/test_interactive_widget.py
@@ -16,35 +16,35 @@ def _create_tab():
     yield interactive_widget.create_tab()
 
 
-def test_snapshot_browser():
+def test_snapshot_browser() -> None:
     dct = {"a": {"b": "c", "d": {"e": "f"}}}
     interactive_widget.nested_dict_browser(dct)
     interactive_widget.nested_dict_browser(dct, ["a"])
 
 
 @pytest.mark.usefixtures("empty_temp_db")
-def test_full_widget_on_empty_db():
+def test_full_widget_on_empty_db() -> None:
     interactive_widget.experiments_widget()
 
 
 @pytest.mark.usefixtures("experiment")
-def test_full_widget_on_empty_experiment():
+def test_full_widget_on_empty_experiment() -> None:
     interactive_widget.experiments_widget()
 
 
 @pytest.mark.usefixtures("dataset")
-def test_full_widget_on_empty_dataset():
+def test_full_widget_on_empty_dataset() -> None:
     interactive_widget.experiments_widget()
 
 
 @pytest.mark.usefixtures("standalone_parameters_dataset")
-def test_full_widget_on_one_dataset():
+def test_full_widget_on_one_dataset() -> None:
     interactive_widget.experiments_widget()
 
 
 def test_button_to_text(
     standalone_parameters_dataset,
-):  # pylint: disable=redefined-outer-name
+) -> None:  # pylint: disable=redefined-outer-name
     box = interactive_widget.button_to_text("title", "body")
     (button,) = box.children
     button.click()
@@ -58,7 +58,7 @@ def test_button_to_text(
 
 def test_snapshot_button(
     tab, standalone_parameters_dataset
-):  # pylint: disable=redefined-outer-name
+) -> None:  # pylint: disable=redefined-outer-name
     ds = standalone_parameters_dataset
     snapshot_button = interactive_widget._get_snapshot_button(ds, tab)
     snapshot_button.click()
@@ -70,7 +70,7 @@ def test_snapshot_button(
 @patch("matplotlib.pyplot.show")
 def test_plot_button(
     tab, standalone_parameters_dataset
-):  # pylint: disable=redefined-outer-name
+) -> None:  # pylint: disable=redefined-outer-name
     ds = standalone_parameters_dataset
     plot_button = interactive_widget._get_plot_button(ds, tab)
     plot_button.click()
@@ -88,7 +88,7 @@ def test_plot_button(
 )
 def test_get_experiment_button(
     get_button_function, standalone_parameters_dataset,
-):  # pylint: disable=redefined-outer-name
+) -> None:  # pylint: disable=redefined-outer-name
     ds = standalone_parameters_dataset
     box = get_button_function(ds)
     snapshot_button = box.children[0]
@@ -97,7 +97,7 @@ def test_get_experiment_button(
     assert len(box.children) == 2
 
 
-def test_get_parameters(standalone_parameters_dataset):
+def test_get_parameters(standalone_parameters_dataset) -> None:
     parameters = interactive_widget._get_parameters(
         standalone_parameters_dataset
     )
@@ -107,7 +107,7 @@ def test_get_parameters(standalone_parameters_dataset):
 
 def test_editable_metadata(
     standalone_parameters_dataset,
-):  # pylint: disable=redefined-outer-name
+) -> None:  # pylint: disable=redefined-outer-name
     ds = standalone_parameters_dataset
     box = interactive_widget.editable_metadata(ds)
     button = box.children[0]
@@ -127,7 +127,7 @@ def test_editable_metadata(
     assert box.children[0].description == test_test
 
 
-def test_experiments_widget(standalone_parameters_dataset):
+def test_experiments_widget(standalone_parameters_dataset) -> None:
     dss = [standalone_parameters_dataset]
     widget = interactive_widget.experiments_widget(data_sets=dss)
     assert len(widget.children) == 3
@@ -139,7 +139,7 @@ def test_experiments_widget(standalone_parameters_dataset):
 
 
 @pytest.mark.parametrize('sort_by', [None, "run_id", "timestamp"])
-def test_experiments_widget_sorting(standalone_parameters_dataset, sort_by):
+def test_experiments_widget_sorting(standalone_parameters_dataset, sort_by) -> None:
     dss = [standalone_parameters_dataset]
     widget = interactive_widget.experiments_widget(
         data_sets=dss, sort_by=sort_by

--- a/qcodes/tests/test_logger.py
+++ b/qcodes/tests/test_logger.py
@@ -9,6 +9,7 @@ import pytest
 
 import qcodes as qc
 import qcodes.logger as logger
+from qcodes.instrument import Instrument
 from qcodes.logger.log_analysis import capture_dataframe
 
 TEST_LOG_MESSAGE = 'test log message'
@@ -107,7 +108,7 @@ def AMI430_3D():
         mag_z.close()
 
 
-def test_get_log_file_name():
+def test_get_log_file_name() -> None:
     fp = logger.logger.get_log_file_name().split(os.sep)
     assert str(os.getpid()) in fp[-1]
     assert logger.logger.PYTHON_LOG_NAME in fp[-1]
@@ -116,7 +117,7 @@ def test_get_log_file_name():
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_start_logger():
+def test_start_logger() -> None:
     # remove all Handlers
     logger.start_logger()
     assert isinstance(logger.get_console_handler(), logging.Handler)
@@ -135,7 +136,7 @@ def test_start_logger():
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_start_logger_twice():
+def test_start_logger_twice() -> None:
     logger.start_logger()
     logger.start_logger()
     handlers = logging.getLogger().handlers
@@ -146,7 +147,7 @@ def test_start_logger_twice():
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_set_level_without_starting_raises():
+def test_set_level_without_starting_raises() -> None:
     with pytest.raises(RuntimeError):
         with logger.console_level('DEBUG'):
             pass
@@ -156,7 +157,7 @@ def test_set_level_without_starting_raises():
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_handler_level():
+def test_handler_level() -> None:
     with logger.LogCapture(level=logging.INFO) as logs:
         logging.debug(TEST_LOG_MESSAGE)
     assert logs.value == ''
@@ -170,7 +171,7 @@ def test_handler_level():
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_filter_instrument(AMI430_3D):
+def test_filter_instrument(AMI430_3D) -> None:
 
     driver, mag_x, mag_y, mag_z = AMI430_3D
 
@@ -209,7 +210,7 @@ def test_filter_instrument(AMI430_3D):
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_filter_without_started_logger_raises(AMI430_3D):
+def test_filter_without_started_logger_raises(AMI430_3D) -> None:
 
     driver, mag_x, mag_y, mag_z = AMI430_3D
 
@@ -221,7 +222,7 @@ def test_filter_without_started_logger_raises(AMI430_3D):
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_capture_dataframe():
+def test_capture_dataframe() -> None:
     root_logger = logging.getLogger()
     with capture_dataframe() as (_, cb):
         root_logger.debug(TEST_LOG_MESSAGE)
@@ -231,7 +232,7 @@ def test_capture_dataframe():
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_channels(model372):
+def test_channels(model372) -> None:
     """
     Test that messages logged in a channel are propagated to the
     main instrument.
@@ -248,42 +249,44 @@ def test_channels(model372):
     # reset without capturing
     inst.sample_heater.set_range_from_temperature(1)
     # rerun with instrument filter
-    with logger.LogCapture(level=logging.DEBUG) as logs_filtered,\
-            logger.filter_instrument(inst,
-                                     handler=logs_filtered.string_handler):
+    with logger.LogCapture(
+        level=logging.DEBUG
+    ) as logs_filtered, logger.filter_instrument(
+        inst, handler=logs_filtered.string_handler
+    ):
         inst.sample_heater.set_range_from_temperature(0.1)
 
-    logs_filtered = [
+    logs_filtered_2 = [
         log for log in logs_filtered.value.splitlines() if "[lakeshore" in log
     ]
-    logs_unfiltered = [
+    logs_unfiltered_2 = [
         log for log in logs_unfiltered.value.splitlines() if "[lakeshore" in log
     ]
 
-    for f, u in zip(logs_filtered, logs_unfiltered):
+    for f, u in zip(logs_filtered_2, logs_unfiltered_2):
         assert f == u
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_channels_nomessages(model372):
+def test_channels_nomessages(model372) -> None:
     """
     Test that messages logged in a channel are not propagated to
     any instrument.
     """
     inst = model372
     # test with wrong instrument
-    mock = qc.Instrument('mock')
+    mock = Instrument("mock")
     inst.sample_heater.set_range_from_temperature(1)
     with logger.LogCapture(level=logging.DEBUG) as logs,\
             logger.filter_instrument(mock, handler=logs.string_handler):
         inst.sample_heater.set_range_from_temperature(0.1)
-    logs = [log for log in logs.value.splitlines() if "[lakeshore" in log]
-    assert len(logs) == 0
+    logs_2 = [log for log in logs.value.splitlines() if "[lakeshore" in log]
+    assert len(logs_2) == 0
     mock.close()
 
 
 @pytest.mark.usefixtures("remove_root_handlers", "awg5208")
-def test_instrument_connect_message():
+def test_instrument_connect_message() -> None:
     """
     Test that the connect_message method logs as expected
 
@@ -308,7 +311,7 @@ def test_instrument_connect_message():
 
 
 @pytest.mark.usefixtures("remove_root_handlers")
-def test_installation_info_logging():
+def test_installation_info_logging() -> None:
     """
     Test that installation information is logged upon starting the logging
     """

--- a/qcodes/tests/test_metadata.py
+++ b/qcodes/tests/test_metadata.py
@@ -1,4 +1,6 @@
-from typing import Optional
+from __future__ import annotations
+
+from typing import Any
 
 import pytest
 
@@ -16,11 +18,11 @@ class HasSnapshotBase(Metadatable):
 class HasSnapshot(Metadatable):
     # Users shouldn't do this... but we'll test its behavior
     # for completeness
-    def snapshot(self, update: Optional[bool] = False) -> Snapshot:  # type: ignore[misc]
+    def snapshot(self, update: bool | None = False) -> Snapshot:  # type: ignore[misc]
         return {"fruit": "kiwi"}
 
 
-DATASETLEFT = {
+DATASETLEFT: dict[str, dict[str, dict[str, Any]]] = {
     "station": {
         "parameters": {
             "apple": {
@@ -44,7 +46,7 @@ DATASETLEFT = {
         }
     }
 }
-DATASETRIGHT = {
+DATASETRIGHT: dict[str, dict[str, dict[str, Any]]] = {
     "station": {
         "parameters": {
             "apple": {
@@ -143,7 +145,7 @@ def test_station_diff() -> None:
         }
 
 
-def test_instrument_diff():
+def test_instrument_diff() -> None:
     left = DATASETLEFT["station"]["instruments"]["another"]
     right = DATASETRIGHT["station"]["instruments"]["another"]
 

--- a/qcodes/tests/test_monitor.py
+++ b/qcodes/tests/test_monitor.py
@@ -59,7 +59,7 @@ def _make_channel_instr_monitor(channel_instr, request):
         m.stop()
 
 
-def test_setup_teardown(request):
+def test_setup_teardown(request) -> None:
     """
     Check that monitor starts up and closes correctly
     """
@@ -76,7 +76,7 @@ def test_setup_teardown(request):
     assert monitor.Monitor.running is None
 
 
-def test_monitor_replace(request):
+def test_monitor_replace(request) -> None:
     """
     Check that monitors get correctly replaced
     """
@@ -93,7 +93,7 @@ def test_monitor_replace(request):
     m2.stop()
 
 
-def test_double_join(request):
+def test_double_join(request) -> None:
     """
     Check that a double join doesn't cause a hang
     """

--- a/qcodes/tests/test_plot_utils.py
+++ b/qcodes/tests/test_plot_utils.py
@@ -35,7 +35,7 @@ def dataset_with_outliers(dataset):
                                            background_noise=False)
 
 
-def test_extend(dataset_with_outliers):
+def test_extend(dataset_with_outliers) -> None:
     # this one should clipp the upper values
     run_id = dataset_with_outliers.run_id
     _, cb = plot_by_id(run_id, auto_color_scale=False)
@@ -51,7 +51,7 @@ def test_extend(dataset_with_outliers):
 
 
 @pytest.mark.usefixtures("default_config")
-def test_defaults(dataset_with_outliers):
+def test_defaults(dataset_with_outliers) -> None:
     run_id = dataset_with_outliers.run_id
 
     _, cb = plot_by_id(run_id)

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -13,7 +13,7 @@ from qcodes.tests.instrument_mocks import SnapShotTestInstrument
                           (['v1', 'v2', 'v3', 'v4'], ['v3']),
                           (['v1', 'v2', 'v3', 'v4'], ['v4']),
                           (['v1', 'v2', 'v3', 'v4'], [])])
-def test_snapshot_skip_params_update(request, params, params_to_skip):
+def test_snapshot_skip_params_update(request, params, params_to_skip) -> None:
     """
     Test that params_to_skip_update works as expected, in particular that only
     the parameters given by that variable are skipped.
@@ -52,7 +52,7 @@ def test_snapshot_skip_params_update(request, params, params_to_skip):
                           (['v1', 'v2', 'v3', 'v4'], ['v4']),
                           (['v1', 'v2', 'v3', 'v4'], ['v1', 'v2']),
                           (['v1', 'v2', 'v3', 'v4'], [])])
-def test_snapshot_exclude_params(request, params, params_to_exclude):
+def test_snapshot_exclude_params(request, params, params_to_exclude) -> None:
     """
     Test that params_to_exclude works as expected, in particular that only
     the parameters given by that variable are excluded from the snapshot.

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -51,7 +51,7 @@ def treat_validation_warning_as_error():
     warnings.simplefilter("default", ValidationWarning)
 
 
-def test_station():
+def test_station() -> None:
     bob = DummyInstrument('bob', gates=['one'])
     station = Station(bob)
 
@@ -62,7 +62,7 @@ def test_station():
     assert station == Station.default
 
 
-def test_station_getitem():
+def test_station_getitem() -> None:
     bob = DummyInstrument('bob', gates=['one'])
     station = Station(bob)
 
@@ -72,7 +72,7 @@ def test_station_getitem():
         _ = station.components['bobby']
 
 
-def test_station_delegated_attributes():
+def test_station_delegated_attributes() -> None:
     bob = DummyInstrument('bob', gates=['one'])
     station = Station(bob)
 
@@ -84,7 +84,7 @@ def test_station_delegated_attributes():
         _ = station.bobby
 
 
-def test_add_component():
+def test_add_component() -> None:
     bob = DummyInstrument('bob', gates=['one'])
     station = Station()
     station.add_component(bob, 'bob')
@@ -93,7 +93,7 @@ def test_add_component():
     assert bob == station.components['bob']
 
 
-def test_add_component_without_specifying_name():
+def test_add_component_without_specifying_name() -> None:
     """
     Test that station looks for 'name' attribute in the component and uses it
     """
@@ -127,7 +127,7 @@ def test_add_component_with_no_name() -> None:
     assert jay == station.components["component1"]  # type: ignore[comparison-overlap]
 
 
-def test_remove_component():
+def test_remove_component() -> None:
     bob = DummyInstrument('bob', gates=['one'])
     station = Station()
     station.add_component(bob, 'bob')
@@ -146,7 +146,7 @@ def test_remove_component():
         _ = station.remove_component('bobby')
 
 
-def test_close_all_registered_instruments():
+def test_close_all_registered_instruments() -> None:
     names = [f'some_name_{i}' for i in range(10)]
     instrs = [Instrument(name=name) for name in names]
     st = Station(*instrs)
@@ -203,7 +203,7 @@ def test_snapshot() -> None:
     assert component_snapshot == snapshot['components']['component']
 
 
-def test_station_after_instrument_is_closed():
+def test_station_after_instrument_is_closed() -> None:
     """
     Test that station is aware of the fact that its components could be
     removed within the lifetime of the station. Here we instantiate an
@@ -244,7 +244,7 @@ def test_station_after_instrument_is_closed():
         station.remove_component('bob')
 
 
-def test_update_config_schema():
+def test_update_config_schema() -> None:
     update_config_schema()
     with open(SCHEMA_PATH) as f:
         schema = json.load(f)
@@ -301,7 +301,7 @@ instruments:
         yield filename
 
 
-def test_dynamic_reload_of_file(example_station_config):
+def test_dynamic_reload_of_file(example_station_config) -> None:
     st = Station(config_file=example_station_config)
     mock_dac = st.load_instrument('mock_dac')
     assert 'ch1' in mock_dac.parameters
@@ -330,7 +330,7 @@ def _make_example_station(example_station_config):
 
 
 # instrument loading related tests
-def test_station_config_path_resolution(example_station_config):
+def test_station_config_path_resolution(example_station_config) -> None:
     config = qcodes.config["station"]
 
     # There is no default yaml file present that defines a station
@@ -386,11 +386,11 @@ def test_station_config_path_resolution(example_station_config):
     assert station_config_has_been_loaded(Station(config_file=str(path)))
 
 
-def test_station_configuration_is_a_component_of_station(example_station):
+def test_station_configuration_is_a_component_of_station(example_station) -> None:
     assert station_config_has_been_loaded(example_station)
 
 
-def test_station_config_can_be_loaded_from_snapshot(example_station):
+def test_station_config_can_be_loaded_from_snapshot(example_station) -> None:
     assert station_config_has_been_loaded(example_station)
     # ensure that we can correctly dump config which is a subclass of UserDict
     configdump = json.dumps(example_station.config, cls=NumpyJSONEncoder)
@@ -419,7 +419,7 @@ instruments:
         """)
 
 
-def test_simple_mock_config(simple_mock_station):
+def test_simple_mock_config(simple_mock_station) -> None:
     st = simple_mock_station
     assert station_config_has_been_loaded(st)
     assert hasattr(st, 'load_mock')
@@ -429,7 +429,7 @@ def test_simple_mock_config(simple_mock_station):
     assert 'mock' in st.config['instruments']
 
 
-def test_simple_mock_load_mock(simple_mock_station):
+def test_simple_mock_load_mock(simple_mock_station) -> None:
     st = simple_mock_station
     mock = st.load_mock()
     assert isinstance(mock, DummyInstrument)
@@ -437,7 +437,7 @@ def test_simple_mock_load_mock(simple_mock_station):
     assert st.components['mock'] is mock
 
 
-def test_simple_mock_load_instrument(simple_mock_station):
+def test_simple_mock_load_instrument(simple_mock_station) -> None:
     st = simple_mock_station
     mock = st.load_instrument('mock')
     assert isinstance(mock, DummyInstrument)
@@ -493,7 +493,7 @@ instruments:
                         expect_failure=True)
 
 
-def test_revive_instance():
+def test_revive_instance() -> None:
     st = station_from_config_str("""
 instruments:
   mock:
@@ -513,7 +513,7 @@ instruments:
     assert mock3 == st.mock
 
 
-def test_init_parameters():
+def test_init_parameters() -> None:
     st = station_from_config_str(
         """
 instruments:
@@ -548,7 +548,7 @@ instruments:
     st.load_instrument('lakeshore')
 
 
-def test_name_init_kwarg(simple_mock_station):
+def test_name_init_kwarg(simple_mock_station) -> None:
     # special case of `name` as kwarg
     st = simple_mock_station
     mock = st.load_instrument('mock', name='test')
@@ -556,7 +556,7 @@ def test_name_init_kwarg(simple_mock_station):
     assert st.components['test'] is mock
 
 
-def test_name_specified_in_init_in_yaml_is_used():
+def test_name_specified_in_init_in_yaml_is_used() -> None:
     st = station_from_config_str(
         """
 instruments:
@@ -578,7 +578,7 @@ class InstrumentWithNameAsNotFirstArgument(Instrument):
         self._first_arg = first_arg
 
 
-def test_able_to_load_instrument_with_name_argument_not_being_the_first():
+def test_able_to_load_instrument_with_name_argument_not_being_the_first() -> None:
     st = station_from_config_str(
         """
 instruments:
@@ -592,7 +592,7 @@ instruments:
     assert st.components['name_goes_second'] is instr
 
 
-def test_setup_alias_parameters():
+def test_setup_alias_parameters() -> None:
     st = station_from_config_str("""
 instruments:
   mock:
@@ -613,7 +613,7 @@ instruments:
     """)
     mock = st.load_instrument('mock')
     p = getattr(mock, 'gate_a')
-    assert isinstance(p, qcodes.Parameter)
+    assert isinstance(p, Parameter)
     assert p.unit == 'mV'
     assert p.label == 'main gate'
     assert p.scale == 2
@@ -629,7 +629,7 @@ instruments:
     assert mock.ch1.raw_value == 7
 
 
-def test_setup_delegate_parameters():
+def test_setup_delegate_parameters() -> None:
     st = station_from_config_str("""
 instruments:
   mock:
@@ -680,7 +680,7 @@ instruments:
             json.dumps(p.snapshot()['source_parameter']))
 
 
-def test_channel_instrument():
+def test_channel_instrument() -> None:
     """Test that parameters from instrument's submodule also get configured correctly"""
     st = station_from_config_str("""
 instruments:
@@ -702,7 +702,7 @@ instruments:
     assert mock.A.voltage.source is mock.A.temperature
 
 
-def test_setting_channel_parameter():
+def test_setting_channel_parameter() -> None:
     st = station_from_config_str("""
 instruments:
   mock:
@@ -715,13 +715,13 @@ instruments:
     assert mock.channels.temperature() == (10,) * 6
 
 
-def test_monitor_not_loaded_by_default(example_station_config):
+def test_monitor_not_loaded_by_default(example_station_config) -> None:
     st = Station(config_file=example_station_config)
     st.load_instrument('mock_dac')
     assert Monitor.running is None
 
 
-def test_monitor_loaded_if_specified(example_station_config):
+def test_monitor_loaded_if_specified(example_station_config) -> None:
     st = Station(config_file=example_station_config, use_monitor=True)
     st.load_instrument('mock_dac')
     assert Monitor.running is not None
@@ -730,7 +730,7 @@ def test_monitor_loaded_if_specified(example_station_config):
     Monitor.running.stop()
 
 
-def test_monitor_loaded_by_default_if_in_config(example_station_config):
+def test_monitor_loaded_by_default_if_in_config(example_station_config) -> None:
     qcodes.config["station"]['use_monitor'] = True
     st = Station(config_file=example_station_config)
     st.load_instrument('mock_dac')
@@ -740,13 +740,13 @@ def test_monitor_loaded_by_default_if_in_config(example_station_config):
     Monitor.running.stop()
 
 
-def test_monitor_not_loaded_if_specified(example_station_config):
+def test_monitor_not_loaded_if_specified(example_station_config) -> None:
     st = Station(config_file=example_station_config, use_monitor=False)
     st.load_instrument('mock_dac')
     assert Monitor.running is None
 
 
-def test_deprecated_driver_keyword():
+def test_deprecated_driver_keyword() -> None:
     st = station_from_config_str("""
 instruments:
   mock:
@@ -761,7 +761,7 @@ instruments:
         st.load_instrument('mock')
 
 
-def test_deprecated_limits_keyword_as_string():
+def test_deprecated_limits_keyword_as_string() -> None:
     st = station_from_config_str("""
 instruments:
   mock:
@@ -780,7 +780,7 @@ instruments:
         st.load_instrument('mock')
 
 
-def test_config_validation_failure():
+def test_config_validation_failure() -> None:
     with pytest.raises(ValidationWarning):
         station_from_config_str("""
 instruments:
@@ -791,7 +791,7 @@ invalid_keyword:
         """)
 
 
-def test_config_validation_failure_on_file():
+def test_config_validation_failure_on_file() -> None:
     with pytest.raises(ValidationWarning):
         test_config = """
 instruments:
@@ -804,7 +804,7 @@ invalid_keyword:
             Station(config_file=filename)
 
 
-def test_config_validation_comprehensive_config():
+def test_config_validation_comprehensive_config() -> None:
     Station(config_file=os.path.join(
         get_qcodes_path(), 'dist', 'tests', 'station', 'example.station.yaml')
     )
@@ -812,7 +812,7 @@ def test_config_validation_comprehensive_config():
 
 def test_load_all_instruments_raises_on_both_only_names_and_only_types_passed(
         example_station
-):
+) -> None:
     with pytest.raises(
         ValueError,
         match="It is an error to supply both ``only_names`` "
@@ -821,7 +821,7 @@ def test_load_all_instruments_raises_on_both_only_names_and_only_types_passed(
         example_station.load_all_instruments(only_names=(), only_types=())
 
 
-def test_load_all_instruments_no_args(example_station):
+def test_load_all_instruments_no_args(example_station) -> None:
     all_instruments_in_config = {"lakeshore", "mock_dac", "mock_dac2"}
 
     loaded_instruments = example_station.load_all_instruments()
@@ -833,7 +833,7 @@ def test_load_all_instruments_no_args(example_station):
         assert Instrument.exist(instrument)
 
 
-def test_load_all_instruments_only_types(example_station):
+def test_load_all_instruments_only_types(example_station) -> None:
     all_dummy_instruments = {"mock_dac", "mock_dac2"}
 
     loaded_instruments = example_station.load_all_instruments(
@@ -856,7 +856,7 @@ def test_load_all_instruments_only_types(example_station):
         assert not Instrument.exist(instrument)
 
 
-def test_load_all_instruments_only_names(example_station):
+def test_load_all_instruments_only_names(example_station) -> None:
     instruments_to_load = {"lakeshore", "mock_dac"}
 
     loaded_instruments = example_station.load_all_instruments(
@@ -885,7 +885,7 @@ def test_load_all_instruments_without_config_raises() -> None:
         station.load_all_instruments()  # type: ignore[call-overload]
 
 
-def test_station_config_created_with_multiple_config_files():
+def test_station_config_created_with_multiple_config_files() -> None:
 
     test_config1 = """
         instruments:

--- a/qcodes/tests/test_sweep_values.py
+++ b/qcodes/tests/test_sweep_values.py
@@ -23,7 +23,7 @@ def _make_c2():
     yield c2
 
 
-def test_errors(c0, c1, c2):
+def test_errors(c0, c1, c2) -> None:
 
     # only complete 3-part slices are valid
     with pytest.raises(TypeError):
@@ -37,13 +37,13 @@ def test_errors(c0, c1, c2):
 
     # fails if the parameter has no setter
     with pytest.raises(TypeError):
-        c2[0:0.1:0.01]
+        c2[0:0.1:0.01]  # type: ignore[misc]
 
     # validates every step value against the parameter's Validator
     with pytest.raises(ValueError):
         c0[5:15:1]
     with pytest.raises(ValueError):
-        c0[5.0:15.0:1.0]
+        c0[5.0:15.0:1.0]  # type: ignore[misc]
     with pytest.raises(ValueError):
         c0[-12]
     with pytest.raises(ValueError):
@@ -64,7 +64,7 @@ def test_errors(c0, c1, c2):
         c0[0.1].get
 
 
-def test_valid(c0):
+def test_valid(c0) -> None:
 
     c0_sv = c0[1]
     # setter gets mapped
@@ -76,7 +76,7 @@ def test_valid(c0):
     assert 2 not in c0_sv
 
     # in-place and copying addition
-    c0_sv += c0[1.5:1.8:0.1]
+    c0_sv += c0[1.5:1.8:0.1]  # type: ignore[misc]
     c0_sv2 = c0_sv + c0[2]
     assert list(c0_sv) == [1, 1.5, 1.6, 1.7]
     assert list(c0_sv2) == [1, 1.5, 1.6, 1.7, 2]
@@ -113,25 +113,18 @@ def test_valid(c0):
     assert c0_sv6 is not c0_sv7
 
 
-def test_base():
+def test_base() -> None:
     p = Parameter('p', get_cmd=None, set_cmd=None)
     with pytest.raises(NotImplementedError):
         iter(SweepValues(p))
 
 
-def test_snapshot(c0):
+def test_snapshot(c0) -> None:
+    assert c0[0].snapshot() == {"parameter": c0.snapshot(), "values": [{"item": 0}]}
 
-    assert c0[0].snapshot() == {
-        'parameter': c0.snapshot(),
-        'values': [{'item': 0}]
-    }
-
-    assert c0[0:5:0.3].snapshot()['values'] == [{
-        'first': 0,
-        'last': 4.8,
-        'num': 17,
-        'type': 'linear'
-    }]
+    assert c0[0:5:0.3].snapshot()["values"] == [  # type: ignore[misc]
+        {"first": 0, "last": 4.8, "num": 17, "type": "linear"}
+    ]
 
     sv = c0.sweep(start=2, stop=4, num=5)
     assert sv.snapshot()['values'] == [{
@@ -164,7 +157,7 @@ def test_snapshot(c0):
         ]
 
 
-def test_repr(c0):
+def test_repr(c0) -> None:
     sv = c0[0]
     assert repr(sv) == (
         f"<qcodes.parameters.sweep_values.SweepFixedValues: c0 at {id(sv)}>"

--- a/qcodes/tests/test_testutils.py
+++ b/qcodes/tests/test_testutils.py
@@ -3,7 +3,7 @@ import pytest
 from .common import error_caused_by
 
 
-def test_error_caused_by_simple():
+def test_error_caused_by_simple() -> None:
     """
     Test that `error_caused_by` will only match the root error and not
     the error raised. For errors raised directly from other errors
@@ -16,7 +16,7 @@ def test_error_caused_by_simple():
     assert not error_caused_by(execinfo, "KeyError: foo")
 
 
-def test_error_caused_by_try_catch():
+def test_error_caused_by_try_catch() -> None:
     """
     Test that `error_caused_by` will only match the root error and not
     the error raised for errors. For errors reraised in a try except chain.
@@ -31,7 +31,7 @@ def test_error_caused_by_try_catch():
     assert not error_caused_by(execinfo, "KeyError: foo")
 
 
-def test_error_caused_by_3_level():
+def test_error_caused_by_3_level() -> None:
     """
     Test that error caused by does not match the middle element in a chain
     of 3 exceptions

--- a/qcodes/tests/test_threading.py
+++ b/qcodes/tests/test_threading.py
@@ -57,7 +57,7 @@ def _dummy_dac2():
         instrument.close()
 
 
-def test_call_params_threaded(dummy_1, dummy_2):
+def test_call_params_threaded(dummy_1, dummy_2) -> None:
 
     params_output = call_params_threaded((dummy_1.voltage_1,
                                           dummy_1.voltage_2,
@@ -78,7 +78,7 @@ def test_call_params_threaded(dummy_1, dummy_2):
     } == expected_params_per_thread
 
 
-def test_thread_pool_params_caller(dummy_1, dummy_2):
+def test_thread_pool_params_caller(dummy_1, dummy_2) -> None:
     params = (
         dummy_1.voltage_1,
         dummy_1.voltage_2,

--- a/qcodes/tests/test_visa.py
+++ b/qcodes/tests/test_visa.py
@@ -108,7 +108,7 @@ def _make_mock_visa():
         mv.close()
 
 
-def test_ask_write_local(mock_visa):
+def test_ask_write_local(mock_visa) -> None:
 
     # test normal ask and write behavior
     mock_visa.state.set(2)
@@ -123,20 +123,20 @@ def test_ask_write_local(mock_visa):
         assert arg in str(e.value)
     assert mock_visa.state.get() == -10  # set still happened
 
-    with pytest.raises(pyvisa.VisaIOError) as e:
+    with pytest.raises(pyvisa.VisaIOError) as ee:
         mock_visa.state.set(0)
     for arg in args2:
-        assert arg in str(e.value)
+        assert arg in str(ee.value)
     assert mock_visa.state.get() == 0
 
     mock_visa.state.set(15)
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(ValueError) as eee:
         mock_visa.state.get()
     for arg in args3:
-        assert arg in str(e.value)
+        assert arg in str(eee.value)
 
 
-def test_visa_backend(mocker, request):
+def test_visa_backend(mocker, request) -> None:
 
     rm_mock = mocker.patch("qcodes.instrument.visa.pyvisa.ResourceManager")
 
@@ -174,14 +174,14 @@ def test_visa_backend(mocker, request):
     inst3.close()
 
 
-def test_visa_instr_metadata(request):
+def test_visa_instr_metadata(request) -> None:
     metadatadict = {'foo': 'bar'}
     mv = MockVisa('Joe', 'none_adress', metadata=metadatadict)
     request.addfinalizer(mv.close)
     assert mv.metadata == metadatadict
 
 
-def test_both_visahandle_and_pyvisa_sim_file_raises():
+def test_both_visahandle_and_pyvisa_sim_file_raises() -> None:
 
     with pytest.raises(
         RuntimeError,
@@ -197,7 +197,7 @@ def test_both_visahandle_and_pyvisa_sim_file_raises():
         )
 
 
-def test_load_pyvisa_sim_file_implict_module(request):
+def test_load_pyvisa_sim_file_implict_module(request) -> None:
     from qcodes.instrument_drivers.AimTTi import AimTTiPL601
 
     driver = AimTTiPL601(
@@ -212,7 +212,7 @@ def test_load_pyvisa_sim_file_implict_module(request):
     assert path.match("qcodes/instrument/sims/AimTTi_PL601P.yaml")
 
 
-def test_load_pyvisa_sim_file_explicit_module(request):
+def test_load_pyvisa_sim_file_explicit_module(request) -> None:
     from qcodes.instrument_drivers.AimTTi import AimTTiPL601
 
     driver = AimTTiPL601(
@@ -229,7 +229,7 @@ def test_load_pyvisa_sim_file_explicit_module(request):
     assert path.match("qcodes/instrument/sims/AimTTi_PL601P.yaml")
 
 
-def test_load_pyvisa_sim_file_invalid_file_raises(request):
+def test_load_pyvisa_sim_file_invalid_file_raises(request) -> None:
     from qcodes.instrument_drivers.AimTTi import AimTTiPL601
 
     with pytest.raises(
@@ -245,7 +245,7 @@ def test_load_pyvisa_sim_file_invalid_file_raises(request):
         )
 
 
-def test_load_pyvisa_sim_file_invalid_module_raises(request):
+def test_load_pyvisa_sim_file_invalid_module_raises(request) -> None:
     from qcodes.instrument_drivers.AimTTi import AimTTiPL601
 
     with pytest.raises(

--- a/qcodes/tests/utils/test_isfunction.py
+++ b/qcodes/tests/utils/test_isfunction.py
@@ -5,7 +5,7 @@ import pytest
 from qcodes.utils import is_function
 
 
-def test_non_function():
+def test_non_function() -> None:
     assert not is_function(0, 0)
     assert not is_function("hello!", 0)
     assert not is_function(None, 0)

--- a/qcodes/tests/utils/test_partial_with_docstring.py
+++ b/qcodes/tests/utils/test_partial_with_docstring.py
@@ -1,7 +1,7 @@
 from qcodes.utils import partial_with_docstring
 
 
-def test_partial_with_docstring():
+def test_partial_with_docstring() -> None:
     def f():
         pass
 
@@ -10,7 +10,7 @@ def test_partial_with_docstring():
     assert g.__doc__ == docstring
 
 
-def test_partial_with_docstring_pass_args():
+def test_partial_with_docstring_pass_args() -> None:
     """
     When one uses partial to bind the last argument
     it should be possible to provide arguments before
@@ -28,7 +28,7 @@ def test_partial_with_docstring_pass_args():
     assert g(2) == 3
 
 
-def test_partial_with_docstring_returns_value():
+def test_partial_with_docstring_returns_value() -> None:
     def f(a: int, b: int):
         return a + b
 


### PR DESCRIPTION
This is done with a libcst transformer like the following

```python
class TypingTransformer(cst.CSTTransformer):
    def __init__(self):
        # stack for storing the canonical name of the current function
        self.stack: List[str] = []
        # store the annotations

    def visit_ClassDef(self, node: cst.ClassDef) -> Optional[bool]:
        self.stack.append(node.name.value)
        print(node.name.value)

    def leave_ClassDef(
        self, original_node: cst.ClassDef, updated_node: cst.ClassDef
    ) -> cst.CSTNode:
        self.stack.pop()
        return updated_node

    def visit_FunctionDef(self, node: cst.FunctionDef) -> Optional[bool]:
        self.stack.append(node.name.value)
        return (
            False
        )  # we are not changing the code

    def leave_FunctionDef(
        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
    ) -> cst.CSTNode:
        key = self.stack[-1]
        print(key)
        
        self.stack.pop()
        if key.startswith("test") and original_node.returns == None:
            return updated_node.with_changes(returns=Annotation(annotation=Name(
                value='None',
                lpar=[],
                rpar=[],
            )))
        else:
            return updated_node
```

executed on all files in tests

```python
for mypath in Path('./qcodes/tests').glob("**/*.py"):
    with open(mypath) as f:
        source = f.read()
    source_tree = cst.parse_module(source)
    modified_tree = source_tree.visit(transformer)
    with open(mypath, "w") as f:
        f.write(modified_tree.code)
```
