### PR TITLE
Mark snapshot method as final

### DIFF
--- a/qcodes/metadatable/metadatable_base.py
+++ b/qcodes/metadatable/metadatable_base.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Dict, Mapping, Optional, Sequence
+from typing import Any, Dict, Mapping, Optional, Sequence, final
 
 from qcodes.utils import deep_update
 
@@ -29,6 +29,7 @@ class Metadatable:
         """
         deep_update(self.metadata, metadata)
 
+    @final
     def snapshot(self, update: Optional[bool] = False) -> Snapshot:
         """
         Decorate a snapshot dictionary with metadata.

--- a/qcodes/tests/test_metadata.py
+++ b/qcodes/tests/test_metadata.py
@@ -1,6 +1,9 @@
+from typing import Optional
+
 import pytest
 
 from qcodes.metadatable import Metadatable
+from qcodes.metadatable.metadatable_base import Snapshot
 from qcodes.utils import diff_param_values
 
 
@@ -13,8 +16,8 @@ class HasSnapshotBase(Metadatable):
 class HasSnapshot(Metadatable):
     # Users shouldn't do this... but we'll test its behavior
     # for completeness
-    def snapshot(self, update=False):
-        return {'fruit': 'kiwi'}
+    def snapshot(self, update: Optional[bool] = False) -> Snapshot:  # type: ignore[misc]
+        return {"fruit": "kiwi"}
 
 
 DATASETLEFT = {


### PR DESCRIPTION
This communicates via the typesystem what was always documented in the docstring of the method

Also ignore the error in the single test that actually does this.

