### PR TITLE
Deprecate `parameter.__getitem__`

### DIFF
--- a/qcodes/parameters/parameter.py
+++ b/qcodes/parameters/parameter.py
@@ -7,6 +7,8 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
+from qcodes.utils import deprecate
+
 from .command import Command
 from .parameter_base import ParamDataType, ParameterBase, ParamRawDataType
 from .sweep_values import SweepFixedValues
@@ -367,6 +369,10 @@ class Parameter(ParameterBase):
     def label(self, label: str) -> None:
         self._label = label
 
+    @deprecate(
+        "the ability to sweep a parameter using [start:step:stop] will be removed",
+        alternative="Parameter.sweep for qcodes_loop support",
+    )
     def __getitem__(self, keys: Any) -> SweepFixedValues:
         """
         Slice a Parameter to get a SweepValues object

--- a/qcodes/tests/test_sweep_values.py
+++ b/qcodes/tests/test_sweep_values.py
@@ -1,7 +1,10 @@
+import warnings
+
 import pytest
 
 from qcodes.parameters import Parameter
 from qcodes.parameters.sweep_values import SweepValues
+from qcodes.utils import QCoDeSDeprecationWarning
 from qcodes.validators import Numbers
 
 
@@ -25,92 +28,98 @@ def _make_c2():
 
 def test_errors(c0, c1, c2):
 
-    # only complete 3-part slices are valid
-    with pytest.raises(TypeError):
-        c0[1:2]  # For Int params this could be defined as step=1
-    with pytest.raises(TypeError):
-        c0[:2:3]
-    with pytest.raises(TypeError):
-        c0[1::3]
-    with pytest.raises(TypeError):
-        c0[:]  # For Enum params we *could* define this one too...
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=QCoDeSDeprecationWarning)
 
-    # fails if the parameter has no setter
-    with pytest.raises(TypeError):
-        c2[0:0.1:0.01]
+        # only complete 3-part slices are valid
+        with pytest.raises(TypeError):
+            c0[1:2]  # For Int params this could be defined as step=1
+        with pytest.raises(TypeError):
+            c0[:2:3]
+        with pytest.raises(TypeError):
+            c0[1::3]
+        with pytest.raises(TypeError):
+            c0[:]  # For Enum params we *could* define this one too...
 
-    # validates every step value against the parameter's Validator
-    with pytest.raises(ValueError):
-        c0[5:15:1]
-    with pytest.raises(ValueError):
-        c0[5.0:15.0:1.0]
-    with pytest.raises(ValueError):
-        c0[-12]
-    with pytest.raises(ValueError):
-        c0[-5, 12, 5]
-    with pytest.raises(ValueError):
-        c0[-5, 12:8:1, 5]
+        # fails if the parameter has no setter
+        with pytest.raises(TypeError):
+            c2[0:0.1:0.01]
 
-    # cannot combine SweepValues for different parameters
-    with pytest.raises(TypeError):
-        _ = c0[0.1] + c1[0.2]
+        # validates every step value against the parameter's Validator
+        with pytest.raises(ValueError):
+            c0[5:15:1]
+        with pytest.raises(ValueError):
+            c0[5.0:15.0:1.0]
+        with pytest.raises(ValueError):
+            c0[-12]
+        with pytest.raises(ValueError):
+            c0[-5, 12, 5]
+        with pytest.raises(ValueError):
+            c0[-5, 12:8:1, 5]
 
-    # improper use of extend
-    with pytest.raises(TypeError):
-        c0[0.1].extend(5)
+        # cannot combine SweepValues for different parameters
+        with pytest.raises(TypeError):
+            _ = c0[0.1] + c1[0.2]
 
-    # SweepValue object has no getter, even if the parameter does
-    with pytest.raises(AttributeError):
-        c0[0.1].get
+        # improper use of extend
+        with pytest.raises(TypeError):
+            c0[0.1].extend(5)
+
+        # SweepValue object has no getter, even if the parameter does
+        with pytest.raises(AttributeError):
+            c0[0.1].get
 
 
 def test_valid(c0):
 
-    c0_sv = c0[1]
-    # setter gets mapped
-    assert c0_sv.set == c0.set
-    # normal sequence operations access values
-    assert list(c0_sv) == [1]
-    assert c0_sv[0] == 1
-    assert 1 in c0_sv
-    assert 2 not in c0_sv
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=QCoDeSDeprecationWarning)
 
-    # in-place and copying addition
-    c0_sv += c0[1.5:1.8:0.1]
-    c0_sv2 = c0_sv + c0[2]
-    assert list(c0_sv) == [1, 1.5, 1.6, 1.7]
-    assert list(c0_sv2) == [1, 1.5, 1.6, 1.7, 2]
+        c0_sv = c0[1]
+        # setter gets mapped
+        assert c0_sv.set == c0.set
+        # normal sequence operations access values
+        assert list(c0_sv) == [1]
+        assert c0_sv[0] == 1
+        assert 1 in c0_sv
+        assert 2 not in c0_sv
 
-    # append and extend
-    c0_sv3 = c0[2]
-    # append only works with straight values
-    c0_sv3.append(2.1)
-    # extend can use another SweepValue, (even if it only has one value)
-    c0_sv3.extend(c0[2.2])
-    # extend can also take a sequence
-    c0_sv3.extend([2.3])
-    # as can addition
-    c0_sv3 += [2.4]
-    c0_sv4 = c0_sv3 + [2.5, 2.6]
-    assert list(c0_sv3) == [2, 2.1, 2.2, 2.3, 2.4]
-    assert list(c0_sv4) == [2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6]
+        # in-place and copying addition
+        c0_sv += c0[1.5:1.8:0.1]
+        c0_sv2 = c0_sv + c0[2]
+        assert list(c0_sv) == [1, 1.5, 1.6, 1.7]
+        assert list(c0_sv2) == [1, 1.5, 1.6, 1.7, 2]
 
-    # len
-    assert len(c0_sv3) == 5
+        # append and extend
+        c0_sv3 = c0[2]
+        # append only works with straight values
+        c0_sv3.append(2.1)
+        # extend can use another SweepValue, (even if it only has one value)
+        c0_sv3.extend(c0[2.2])
+        # extend can also take a sequence
+        c0_sv3.extend([2.3])
+        # as can addition
+        c0_sv3 += [2.4]
+        c0_sv4 = c0_sv3 + [2.5, 2.6]
+        assert list(c0_sv3) == [2, 2.1, 2.2, 2.3, 2.4]
+        assert list(c0_sv4) == [2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6]
 
-    # in-place and copying reverse
-    c0_sv.reverse()
-    c0_sv5 = reversed(c0_sv)
-    assert list(c0_sv) == [1.7, 1.6, 1.5, 1]
-    assert list(c0_sv5) == [1, 1.5, 1.6, 1.7]
+        # len
+        assert len(c0_sv3) == 5
 
-    # multi-key init, where first key is itself a list
-    c0_sv6 = c0[[1, 3], 4]
-    # copying
-    c0_sv7 = c0_sv6.copy()
-    assert list(c0_sv6) == [1, 3, 4]
-    assert list(c0_sv7) == [1, 3, 4]
-    assert c0_sv6 is not c0_sv7
+        # in-place and copying reverse
+        c0_sv.reverse()
+        c0_sv5 = reversed(c0_sv)
+        assert list(c0_sv) == [1.7, 1.6, 1.5, 1]
+        assert list(c0_sv5) == [1, 1.5, 1.6, 1.7]
+
+        # multi-key init, where first key is itself a list
+        c0_sv6 = c0[[1, 3], 4]
+        # copying
+        c0_sv7 = c0_sv6.copy()
+        assert list(c0_sv6) == [1, 3, 4]
+        assert list(c0_sv7) == [1, 3, 4]
+        assert c0_sv6 is not c0_sv7
 
 
 def test_base():
@@ -121,51 +130,46 @@ def test_base():
 
 def test_snapshot(c0):
 
-    assert c0[0].snapshot() == {
-        'parameter': c0.snapshot(),
-        'values': [{'item': 0}]
-    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=QCoDeSDeprecationWarning)
 
-    assert c0[0:5:0.3].snapshot()['values'] == [{
-        'first': 0,
-        'last': 4.8,
-        'num': 17,
-        'type': 'linear'
-    }]
+        assert c0[0].snapshot() == {"parameter": c0.snapshot(), "values": [{"item": 0}]}
 
-    sv = c0.sweep(start=2, stop=4, num=5)
-    assert sv.snapshot()['values'] == [{
-        'first': 2,
-        'last': 4,
-        'num': 5,
-        'type': 'linear'
-    }]
-
-    # mixture of bare items, nested lists, and slices
-    sv = c0[1, 7, 3.2, [1, 2, 3], 6:9:1, -4.5, 5.3]
-    assert sv.snapshot()['values'] == [{
-        'first': 1,
-        'last': 5.3,
-        'min': -4.5,
-        'max': 8,
-        'num': 11,
-        'type': 'sequence'
-        }]
-
-    assert (c0[0] + c0[1]).snapshot()['values'] == [
-        {'item': 0},
-        {'item': 1}
+        assert c0[0:5:0.3].snapshot()["values"] == [
+            {"first": 0, "last": 4.8, "num": 17, "type": "linear"}
         ]
 
-    assert (c0[0:3:1] + c0[4, 6, 9]).snapshot()['values'] == [
-        {'first': 0, 'last': 2, 'num': 3, 'type': 'linear'},
-        {'first': 4, 'last': 9, 'min': 4, 'max': 9, 'num': 3,
-         'type': 'sequence'}
+        sv = c0.sweep(start=2, stop=4, num=5)
+        assert sv.snapshot()["values"] == [
+            {"first": 2, "last": 4, "num": 5, "type": "linear"}
+        ]
+
+        # mixture of bare items, nested lists, and slices
+        sv = c0[1, 7, 3.2, [1, 2, 3], 6:9:1, -4.5, 5.3]
+        assert sv.snapshot()["values"] == [
+            {
+                "first": 1,
+                "last": 5.3,
+                "min": -4.5,
+                "max": 8,
+                "num": 11,
+                "type": "sequence",
+            }
+        ]
+
+        assert (c0[0] + c0[1]).snapshot()["values"] == [{"item": 0}, {"item": 1}]
+
+        assert (c0[0:3:1] + c0[4, 6, 9]).snapshot()["values"] == [
+            {"first": 0, "last": 2, "num": 3, "type": "linear"},
+            {"first": 4, "last": 9, "min": 4, "max": 9, "num": 3, "type": "sequence"},
         ]
 
 
 def test_repr(c0):
-    sv = c0[0]
-    assert repr(sv) == (
-        f"<qcodes.parameters.sweep_values.SweepFixedValues: c0 at {id(sv)}>"
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=QCoDeSDeprecationWarning)
+
+        sv = c0[0]
+        assert repr(sv) == (
+            f"<qcodes.parameters.sweep_values.SweepFixedValues: c0 at {id(sv)}>"
+        )


### PR DESCRIPTION
And therefor the ability to sweep a parameter using the syntax
param[0,1.0,10]

* This syntax is confusing since its not really indexing the parameter
* The implementation requires the input to be floats which is not
pytonic
* It does nothing that cannot be done with param.sweep