### PR TITLE
get_component: In InstrumentBase fall back to a longer name  when not matching a last part of a name

### DIFF
--- a/qcodes/instrument/instrument_base.py
+++ b/qcodes/instrument/instrument_base.py
@@ -288,10 +288,6 @@ class InstrumentBase(MetadatableWithName, DelegateAttributes):
                 return component
 
             remaining_name_parts.reverse()
-            raise KeyError(
-                f"Found component {component.full_name} but could not match "
-                f"{'_'.join(remaining_name_parts)} part."
-            )
 
         if len(remaining_name_parts) == 0:
             raise KeyError(

--- a/qcodes/tests/drivers/test_yokogawa_gs200.py
+++ b/qcodes/tests/drivers/test_yokogawa_gs200.py
@@ -1,10 +1,12 @@
+from typing import Iterator
+
 import pytest
 
 from qcodes.instrument_drivers.yokogawa import YokogawaGS200
 
 
 @pytest.fixture(scope="function", name="gs200")
-def _make_gs200():
+def _make_gs200() -> Iterator[YokogawaGS200]:
     gs200 = YokogawaGS200(
         "GS200", address="GPIB0::1::INSTR", pyvisa_sim_file="Yokogawa_GS200.yaml"
     )
@@ -13,13 +15,13 @@ def _make_gs200():
     gs200.close()
 
 
-def test_basic_init(gs200) -> None:
+def test_basic_init(gs200: YokogawaGS200) -> None:
 
     idn = gs200.get_idn()
     assert idn["vendor"] == "QCoDeS Yokogawa Mock"
 
 
-def test_current_raises_in_voltage_mode(gs200) -> None:
+def test_current_raises_in_voltage_mode(gs200: YokogawaGS200) -> None:
     gs200.source_mode("VOLT")
 
     with pytest.raises(
@@ -33,7 +35,7 @@ def test_current_raises_in_voltage_mode(gs200) -> None:
         gs200.current(1)
 
 
-def test_voltage_raises_in_current_mode(gs200) -> None:
+def test_voltage_raises_in_current_mode(gs200: YokogawaGS200) -> None:
     gs200.source_mode("CURR")
 
     with pytest.raises(

--- a/qcodes/tests/drivers/test_yokogawa_gs200.py
+++ b/qcodes/tests/drivers/test_yokogawa_gs200.py
@@ -45,3 +45,8 @@ def test_voltage_raises_in_current_mode(gs200) -> None:
         ValueError, match="Cannot get/set VOLT settings while in CURR mode"
     ):
         gs200.voltage(1)
+
+
+def test_get_parameters_as_components(gs200: YokogawaGS200) -> None:
+    assert gs200.get_component("voltage_range") is gs200.voltage_range
+    assert gs200.get_component("voltage") is gs200.voltage

--- a/qcodes/tests/test_station.py
+++ b/qcodes/tests/test_station.py
@@ -939,8 +939,8 @@ def test_get_wrong_component_by_name_raises() -> None:
     with pytest.raises(
         KeyError,
         match=(
-            "Found component dummy_ChanA_temperature but could "
-            "not match parameter part"
+            "Found component dummy_ChanA but could "
+            "not match temperature_parameter part"
         ),
     ):
         _ = station.get_component("dummy_ChanA_temperature_parameter")


### PR DESCRIPTION
This makes it possible to get `voltage_range` on the Yokogawa gs200 as shown in the relevant test.

It does perhaps make the error message a little less clear in the context that you try to get `foo_bar` where `foo` is a component but `bar` is not but I think we can live with that 