### PR TITLE
Add explicit dependency on ipykernel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
     "h5py>=3.0.0",
     "importlib-metadata>=4.4; python_version < '3.10'",
     "importlib-resources>=2.0.0; python_version < '3.9'",
-    "ipywidgets>=7.5.0,<8.0.5",  # https://github.com/jupyter-widgets/ipywidgets/issues/3731
+    "ipywidgets>=7.5.0,<9.0.0",
+    "ipykernel>=6.0.0", # implicitly required by ipywidgets >=8.0.5
     "jsonschema>=3.2.0",
     "matplotlib>=3.3.0",
     "numpy>=1.21.0",

--- a/qcodes/tests/test_interactive_widget.py
+++ b/qcodes/tests/test_interactive_widget.py
@@ -1,12 +1,12 @@
 import time
 from unittest.mock import patch
 
-import matplotlib
-import pytest
 # importing ipykernel has the side effect
 # of registering that as a kernel backend
 # making the tests runnable
-import ipykernel.ipkernel # noqa  F401
+import ipykernel.ipkernel  # noqa  F401
+import matplotlib
+import pytest
 from ipywidgets import HTML, Button, GridspecLayout, Tab, Textarea
 
 from qcodes import interactive_widget

--- a/qcodes/tests/test_interactive_widget.py
+++ b/qcodes/tests/test_interactive_widget.py
@@ -3,6 +3,10 @@ from unittest.mock import patch
 
 import matplotlib
 import pytest
+# importing ipykernel has the side effect
+# of registering that as a kernel backend
+# making the tests runnable
+import ipykernel.ipkernel # noqa  F401
 from ipywidgets import HTML, Button, GridspecLayout, Tab, Textarea
 
 from qcodes import interactive_widget


### PR DESCRIPTION
Ipywidgets from 8.0.5 no longer officially depends on it but the features we use requires it for now

https://github.com/jupyter-widgets/ipywidgets/issues/3731
