### PR TITLE
Drop wheel as a build time dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
     "setuptools >= 61.2",
-    "wheel >= 0.29.0",
     "versioningit ~= 2.0.1",
 ]
 build-backend = 'setuptools.build_meta'


### PR DESCRIPTION
As documented here this is not needed
https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use

