### PR TITLE
fix typo in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ The modules ``qcodes.data``, ``qcodes.plots``, ``qcodes.actions``,
 ``qcodes.loops``, ``qcodes.measure``, ``qcodes.extensions.slack``
 and ``qcodes.utils.magic`` that were part of QCoDeS until version 0.37.0.
 have been moved into an independent package called qcodes_loop.
-Please see it's `repository <https://github.com/QCoDeS/Qcodes_loop`_ and
+Please see it's `repository <https://github.com/QCoDeS/Qcodes_loop/>`_ and
 `documentation <https://qcodes.github.io/Qcodes_loop/>`_ for more information.
 
 For the time being it is possible to automatically install the qcodes_loop

--- a/docs/changes/0.38.1.rst
+++ b/docs/changes/0.38.1.rst
@@ -1,0 +1,7 @@
+QCoDeS 0.38.1 (2023-04-26)
+==========================
+
+Improved:
+---------
+
+- Fixed a typo in the readme preventing release to pypi (:pr:`5132`)

--- a/docs/changes/index.rst
+++ b/docs/changes/index.rst
@@ -3,6 +3,7 @@ Changelogs
 
 .. toctree::
    Unreleased <unreleased>
+   0.38.1 <0.38.1>
    0.38.0 <0.38.0>
    0.37.0 <0.37.0>
    0.36.1 <0.36.1>


### PR DESCRIPTION
Since the readme is used as long description this breaks the rendering of the released package on pypi and prevents the release 