### PR TITLE
Typecheck with pyright 1.1.310

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -55,7 +55,7 @@ jobs:
         pip install .[test] -c requirements.txt
     - uses: jakebailey/pyright-action@v1.5.1
       with:
-        version: 1.1.303
+        version: 1.1.310
     - name: Run Mypy
       run: mypy -p qcodes
     - name: Run parallel tests

--- a/qcodes/dataset/dond/do_nd.py
+++ b/qcodes/dataset/dond/do_nd.py
@@ -707,7 +707,7 @@ def dond(
             for set_events in tqdm(sweeper, disable=not show_progress):  # type: ignore[call-overload]
                 LOG.debug("Processing set events: %s", set_events)
                 results: dict[ParameterBase, Any] = {}
-                for set_event in set_events:
+                for set_event in set_events:  # pyright: ignore[reportGeneralTypeIssues]
                     if set_event.should_set:
                         set_event.parameter(set_event.new_value)
                         for act in set_event.actions:

--- a/qcodes/instrument_drivers/Keithley/Keithley_6500.py
+++ b/qcodes/instrument_drivers/Keithley/Keithley_6500.py
@@ -28,7 +28,7 @@ def _parse_output_string(string_value: str) -> str:
     return s
 
 
-def _parse_output_bool(numeric_value: float) -> bool:
+def _parse_output_bool(numeric_value: Union[float, str]) -> bool:
     """Parses and converts the value to boolean type. True is 1.
 
     Args:

--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -1108,9 +1108,9 @@ class TektronixAWG5014(VisaInstrument):
         self.available_channels = (self.available_waveform_channels +
                                    self.available_marker_channels)
 
-        waveforms = []
-        m1s = []
-        m2s = []
+        waveforms: List[List[Any]] = []
+        m1s: List[List[Any]] = []
+        m2s: List[List[Any]] = []
         # unfortunately the definitions of the sequence elements in terms of
         # channel and step in :meth:`make_and_send_awg_file` and the forged
         # sequence definition are transposed. Start by filling out after schema

--- a/qcodes/tests/delegate/conftest.py
+++ b/qcodes/tests/delegate/conftest.py
@@ -3,7 +3,7 @@ import pathlib
 
 import pytest
 
-import qcodes as qc
+from qcodes.station import Station
 from qcodes.tests.instrument_mocks import MockDAC, MockField, MockLockin
 
 PARENT_DIR = pathlib.Path(__file__).parent.absolute()
@@ -29,7 +29,7 @@ def lockin():
 
 @pytest.fixture(scope="function")
 def station(dac, lockin, field_x):
-    _station = qc.Station()
+    _station = Station()
     _station.add_component(dac)
     _station.add_component(lockin)
     _station.add_component(field_x)


### PR DESCRIPTION
* Upgrade the version of pyright that we use in CI to the latest version and fix a few issues that were now raised.
* Pyright now realized that you cannot pass a function from int to bool to a method that expects a function from str to bool so update the type to reflect that.
* Clarify that some types in the awg5014c driver are always lists of lists so its safe to index into them twice
* Silence an error about the output from tqdm being NoReturn, I did not look into why that is