### PR TITLE
Change R&S ZNB timeout calculation

### DIFF
--- a/docs/changes/newsfragments/5201.improved_driver
+++ b/docs/changes/newsfragments/5201.improved_driver
@@ -1,0 +1,1 @@
+Increase default timeout on R&S ZNB and allow the instrument to overwrite default timeout

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -350,6 +350,7 @@ class RohdeSchwarzZNBChannel(InstrumentChannel):
         channel: int,
         vna_parameter: Optional[str] = None,
         existing_trace_to_bind_to: Optional[str] = None,
+        additional_wait: int = 0,
     ) -> None:
         """
         Args:
@@ -362,12 +363,11 @@ class RohdeSchwarzZNBChannel(InstrumentChannel):
             existing_trace_to_bind_to: Name of an existing trace on the VNA.
                 If supplied try to bind to an existing trace with this name
                 rather than creating a new trace.
-
+            additional_time: Additional wait before instrument timeout.
         """
         n = channel
         self._instrument_channel = channel
-        # Additional wait when adjusting instrument timeout to sweep time.
-        self._additional_wait = 1
+        self.additional_wait = additional_wait
 
         if vna_parameter is None:
             vna_parameter = name
@@ -830,7 +830,7 @@ class RohdeSchwarzZNBChannel(InstrumentChannel):
                     data_format_command = "SDAT"
                 else:
                     data_format_command = "FDAT"
-                timeout = self.sweep_time() + self._additional_wait
+                timeout = self.sweep_time() * 1.5 + self._additional_wait
                 with self.root_instrument.timeout.set_to(timeout):
                     # instrument averages over its last 'avg' number of sweeps
                     # need to ensure averaged result is returned

--- a/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/ZNB.py
@@ -350,7 +350,6 @@ class RohdeSchwarzZNBChannel(InstrumentChannel):
         channel: int,
         vna_parameter: Optional[str] = None,
         existing_trace_to_bind_to: Optional[str] = None,
-        additional_wait: int = 0,
     ) -> None:
         """
         Args:


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->

R&S ZNB timeout was set to sweep time, plus a private attribute called `_additional_wait` .
This PR increases timeout to 1.5 * sweep time, and expose `additional_wait` attribute as public (no leading underscore).