### PR TITLE
Update run_id when adding ds in mem to db

### DIFF
--- a/docs/changes/newsfragments/5209.improved
+++ b/docs/changes/newsfragments/5209.improved
@@ -1,0 +1,3 @@
+When writing a `DataSetInMem` back to a database the exp_id, counter and run_id are correctly updated
+to reflect the sate of the new database. `write_metadata_to_db` has also been fixed to use
+the database passed to init of the `DataSetInMem` class if no path is provided.

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -153,7 +153,10 @@ class DataSetInMem(BaseDataSet):
                     sample_name=self.sample_name,
                     load_last_duplicate=True,
                 )
-                _add_run_to_runs_table(self, aconn, exp.exp_id, create_run_table=False)
+                run_id = _add_run_to_runs_table(
+                    self, aconn, exp.exp_id, create_run_table=False
+                )
+            self._run_id = run_id
             self._path_to_db = conn.path_to_dbfile
 
     @classmethod

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -156,10 +156,12 @@ class DataSetInMem(BaseDataSet):
                     sample_name=self.sample_name,
                     load_last_duplicate=True,
                 )
-                _, run_id = _add_run_to_runs_table(
+                counter, run_id, _ = _add_run_to_runs_table(
                     self, aconn, exp.exp_id, create_run_table=False
                 )
+            self._exp_id = exp.exp_id
             self._run_id = run_id
+            self._counter = counter
             self._path_to_db = conn.path_to_dbfile
 
     @classmethod

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -153,7 +153,7 @@ class DataSetInMem(BaseDataSet):
                     sample_name=self.sample_name,
                     load_last_duplicate=True,
                 )
-                run_id = _add_run_to_runs_table(
+                _, run_id = _add_run_to_runs_table(
                     self, aconn, exp.exp_id, create_run_table=False
                 )
             self._run_id = run_id

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -138,6 +138,9 @@ class DataSetInMem(BaseDataSet):
     def write_metadata_to_db(self, path_to_db: str | Path | None = None) -> None:
         from .experiment_container import load_or_create_experiment
 
+        if path_to_db is None:
+            path_to_db = self.path_to_db
+
         if self._dataset_is_in_runs_table(path_to_db=path_to_db):
             return
         if isinstance(path_to_db, Path):

--- a/qcodes/dataset/database_extract_runs.py
+++ b/qcodes/dataset/database_extract_runs.py
@@ -146,7 +146,9 @@ def _extract_single_dataset_into_db(dataset: DataSet,
     if run_id is not None:
         return
 
-    target_table_name, _ = _add_run_to_runs_table(dataset, target_conn, target_exp_id)
+    _, _, target_table_name = _add_run_to_runs_table(
+        dataset, target_conn, target_exp_id
+    )
     assert target_table_name is not None
     _populate_results_table(
         source_conn, target_conn, dataset.table_name, target_table_name

--- a/qcodes/dataset/database_extract_runs.py
+++ b/qcodes/dataset/database_extract_runs.py
@@ -146,7 +146,7 @@ def _extract_single_dataset_into_db(dataset: DataSet,
     if run_id is not None:
         return
 
-    target_table_name = _add_run_to_runs_table(dataset, target_conn, target_exp_id)
+    target_table_name, _ = _add_run_to_runs_table(dataset, target_conn, target_exp_id)
     assert target_table_name is not None
     _populate_results_table(
         source_conn, target_conn, dataset.table_name, target_table_name

--- a/qcodes/dataset/dataset_helpers.py
+++ b/qcodes/dataset/dataset_helpers.py
@@ -15,13 +15,13 @@ def _add_run_to_runs_table(
     target_conn: ConnectionPlus,
     target_exp_id: int,
     create_run_table: bool = True,
-) -> str | None:
+) -> int:
     metadata = dataset.metadata
     snapshot_raw = dataset._snapshot_raw
     captured_run_id = dataset.captured_run_id
     captured_counter = dataset.captured_counter
     parent_dataset_links = links_to_str(dataset.parent_dataset_links)
-    _, target_run_id, target_table_name = create_run(
+    _, target_run_id, _ = create_run(
         target_conn,
         target_exp_id,
         name=dataset.name,
@@ -41,4 +41,4 @@ def _add_run_to_runs_table(
         dataset.run_timestamp_raw,
         dataset.completed_timestamp_raw,
     )
-    return target_table_name
+    return target_run_id

--- a/qcodes/dataset/dataset_helpers.py
+++ b/qcodes/dataset/dataset_helpers.py
@@ -15,13 +15,13 @@ def _add_run_to_runs_table(
     target_conn: ConnectionPlus,
     target_exp_id: int,
     create_run_table: bool = True,
-) -> int:
+) -> tuple[str | None, int]:
     metadata = dataset.metadata
     snapshot_raw = dataset._snapshot_raw
     captured_run_id = dataset.captured_run_id
     captured_counter = dataset.captured_counter
     parent_dataset_links = links_to_str(dataset.parent_dataset_links)
-    _, target_run_id, _ = create_run(
+    _, target_run_id, target_table_name = create_run(
         target_conn,
         target_exp_id,
         name=dataset.name,
@@ -41,4 +41,4 @@ def _add_run_to_runs_table(
         dataset.run_timestamp_raw,
         dataset.completed_timestamp_raw,
     )
-    return target_run_id
+    return target_table_name, target_run_id

--- a/qcodes/dataset/dataset_helpers.py
+++ b/qcodes/dataset/dataset_helpers.py
@@ -15,13 +15,13 @@ def _add_run_to_runs_table(
     target_conn: ConnectionPlus,
     target_exp_id: int,
     create_run_table: bool = True,
-) -> tuple[str | None, int]:
+) -> tuple[int, int, str | None]:
     metadata = dataset.metadata
     snapshot_raw = dataset._snapshot_raw
     captured_run_id = dataset.captured_run_id
     captured_counter = dataset.captured_counter
     parent_dataset_links = links_to_str(dataset.parent_dataset_links)
-    _, target_run_id, target_table_name = create_run(
+    target_counter, target_run_id, target_table_name = create_run(
         target_conn,
         target_exp_id,
         name=dataset.name,
@@ -41,4 +41,4 @@ def _add_run_to_runs_table(
         dataset.run_timestamp_raw,
         dataset.completed_timestamp_raw,
     )
-    return target_table_name, target_run_id
+    return target_counter, target_run_id, target_table_name

--- a/qcodes/tests/dataset/test_dataset_in_mem_import.py
+++ b/qcodes/tests/dataset/test_dataset_in_mem_import.py
@@ -1,0 +1,307 @@
+import json
+
+import numpy as np
+import pytest
+
+from qcodes.dataset import load_by_guid, load_from_netcdf
+from qcodes.dataset.data_set import DataSet
+from qcodes.dataset.data_set_in_memory import DataSetInMem
+from qcodes.dataset.experiment_container import Experiment
+from qcodes.dataset.sqlite.connection import path_to_dbfile
+
+
+@pytest.mark.usefixtures("default_config")
+def test_basic_roundtrip(
+    two_empty_temp_db_connections, some_interdeps, tmp_path
+) -> None:
+    """
+    Test that we can export from one db and import into another in
+    the most basic form.
+    """
+    source_conn, target_conn = two_empty_temp_db_connections
+
+    source_exp_1 = Experiment(conn=source_conn)
+
+    source_path = path_to_dbfile(source_conn)
+    target_path = path_to_dbfile(target_conn)
+
+    # make 5 runs in first experiment
+    source_datasets = []
+
+    for i in range(5):
+        source_dataset = DataSetInMem._create_new_run(
+            name=f"ds{i}",
+            exp_id=source_exp_1.exp_id,
+            path_to_db=source_path,
+        )
+        source_datasets.append(source_dataset)
+        source_dataset._set_interdependencies(some_interdeps[1])
+
+        source_dataset._perform_start_actions()
+
+        for val in range(10):
+            source_dataset._enqueue_results(
+                {name: np.array([val]) for name in some_interdeps[1].names}
+            )
+        source_dataset.mark_completed()
+        source_dataset.export(export_type="netcdf", path=str(tmp_path))
+
+    loaded_datasets = [
+        load_from_netcdf(
+            json.loads(ds.metadata["export_info"])["export_paths"]["nc"], target_path
+        )
+        for ds in source_datasets
+    ]
+    _assert_before_writing_metadata(source_datasets, loaded_datasets)
+
+    for loaded_ds in loaded_datasets:
+        loaded_ds.write_metadata_to_db()
+
+    reloaded_ds = [load_by_guid(ds.guid, target_conn) for ds in loaded_datasets]
+
+    _assert_after_writing_metadata(
+        source_datasets,
+        loaded_datasets,
+        reloaded_ds,
+        offset_total_ds=0,
+        offset_ds_in_exp=0,
+        offset_exps=0,
+    )
+
+
+@pytest.mark.usefixtures("default_config")
+def test_roundtrip_to_db_with_existing_meas(
+    two_empty_temp_db_connections, some_interdeps, tmp_path
+) -> None:
+    """
+    Test that we can export from one db and import into another in
+    the most basic form.
+    """
+
+    n_extra_runs = 4
+    n_extra_experiments = 1
+
+    source_conn, target_conn = two_empty_temp_db_connections
+
+    source_exp_1 = Experiment(conn=source_conn)
+    target_exp_1 = Experiment(
+        conn=target_conn, name="some_other_exp", sample_name="some_other_sample"
+    )
+
+    source_path = path_to_dbfile(source_conn)
+    target_path = path_to_dbfile(target_conn)
+
+    # make 5 runs in first experiment
+    source_datasets = []
+
+    # write datasets to test on
+
+    for i in range(5):
+        source_dataset = DataSetInMem._create_new_run(
+            name=f"ds{i}",
+            exp_id=source_exp_1.exp_id,
+            path_to_db=source_path,
+        )
+        source_datasets.append(source_dataset)
+        source_dataset._set_interdependencies(some_interdeps[1])
+
+        source_dataset._perform_start_actions()
+
+        for val in range(10):
+            source_dataset._enqueue_results(
+                {name: np.array([val]) for name in some_interdeps[1].names}
+            )
+        source_dataset.mark_completed()
+        source_dataset.export(export_type="netcdf", path=str(tmp_path))
+
+    extra_datasets = []
+
+    for i in range(n_extra_runs):
+        extra_dataset = DataSet(conn=target_conn, exp_id=target_exp_1.exp_id)
+
+        extra_datasets.append(extra_dataset)
+        extra_dataset.set_interdependencies(some_interdeps[1])
+
+        extra_dataset.mark_started()
+
+        for val in range(10):
+            extra_dataset._enqueue_results(
+                {name: np.array([val]) for name in some_interdeps[1].names}
+            )
+        extra_dataset.mark_completed()
+
+    loaded_datasets = [
+        load_from_netcdf(
+            json.loads(ds.metadata["export_info"])["export_paths"]["nc"], target_path
+        )
+        for ds in source_datasets
+    ]
+
+    _assert_before_writing_metadata(source_datasets, loaded_datasets)
+
+    for loaded_ds in loaded_datasets:
+        loaded_ds.write_metadata_to_db()
+
+    reloaded_ds = [load_by_guid(ds.guid, target_conn) for ds in loaded_datasets]
+
+    _assert_after_writing_metadata(
+        source_datasets,
+        loaded_datasets,
+        reloaded_ds,
+        offset_total_ds=n_extra_runs,
+        offset_ds_in_exp=0,
+        offset_exps=n_extra_experiments,
+    )
+
+
+@pytest.mark.usefixtures("default_config")
+def test_roundtrip_to_db_with_existing_meas_in_same_exp(
+    two_empty_temp_db_connections, some_interdeps, tmp_path
+) -> None:
+    """
+    Test that we can export from one db and import into another in
+    the most basic form.
+    """
+
+    n_extra_runs = 4
+
+    source_conn, target_conn = two_empty_temp_db_connections
+
+    source_exp_1 = Experiment(conn=source_conn)
+    target_exp_1 = Experiment(conn=target_conn)
+
+    source_path = path_to_dbfile(source_conn)
+    target_path = path_to_dbfile(target_conn)
+
+    # make 5 runs in first experiment
+    source_datasets = []
+
+    # write datasets to test on
+
+    for i in range(5):
+        source_dataset = DataSetInMem._create_new_run(
+            name=f"ds{i}",
+            exp_id=source_exp_1.exp_id,
+            path_to_db=source_path,
+        )
+        source_datasets.append(source_dataset)
+        source_dataset._set_interdependencies(some_interdeps[1])
+
+        source_dataset._perform_start_actions()
+
+        for val in range(10):
+            source_dataset._enqueue_results(
+                {name: np.array([val]) for name in some_interdeps[1].names}
+            )
+        source_dataset.mark_completed()
+        source_dataset.export(export_type="netcdf", path=str(tmp_path))
+
+    extra_datasets = []
+
+    for i in range(n_extra_runs):
+        extra_dataset = DataSet(conn=target_conn, exp_id=target_exp_1.exp_id)
+
+        extra_datasets.append(extra_dataset)
+        extra_dataset.set_interdependencies(some_interdeps[1])
+
+        extra_dataset.mark_started()
+
+        for val in range(10):
+            extra_dataset._enqueue_results(
+                {name: np.array([val]) for name in some_interdeps[1].names}
+            )
+        extra_dataset.mark_completed()
+
+    loaded_datasets = [
+        load_from_netcdf(
+            json.loads(ds.metadata["export_info"])["export_paths"]["nc"], target_path
+        )
+        for ds in source_datasets
+    ]
+
+    _assert_before_writing_metadata(source_datasets, loaded_datasets)
+
+    for loaded_ds in loaded_datasets:
+        loaded_ds.write_metadata_to_db()
+
+    reloaded_ds = [load_by_guid(ds.guid, target_conn) for ds in loaded_datasets]
+
+    _assert_after_writing_metadata(
+        source_datasets,
+        loaded_datasets,
+        reloaded_ds,
+        offset_total_ds=n_extra_runs,
+        offset_ds_in_exp=n_extra_runs,
+        offset_exps=0,
+    )
+
+
+def _assert_before_writing_metadata(source_datasets, loaded_datasets) -> None:
+    for ds, lds in zip(source_datasets, loaded_datasets):
+        # these should always be equal
+        assert ds.guid == lds.guid
+
+        assert ds.captured_run_id == lds.captured_run_id
+
+        assert ds.captured_counter == lds.captured_counter
+
+        assert ds.exp_name == lds.exp_name
+
+        assert ds.sample_name == lds.sample_name
+
+        # these are effectively counters and should be equal
+        # in this case since we are inserting all runs in order
+        # into an empty db
+
+        # when loaded run_id/counter will be the captured run_id/counter e.g.
+        # the original run_id/counter
+        # after writing metadata to db it will be updated to match
+        # see below
+        assert ds.run_id == lds.run_id
+        assert ds.counter == lds.counter
+
+        # at this stage the exp_id is not set since
+        # the dataset has not been written to a db
+        # and exp_id is not a persistent attribute
+        # this will be updated to the exp_id of the experiment
+        # in the target db once written to the db
+        assert lds.exp_id == 0
+
+
+def _assert_after_writing_metadata(
+    source_datasets,
+    loaded_datasets,
+    reloaded_ds,
+    offset_total_ds,
+    offset_ds_in_exp,
+    offset_exps,
+) -> None:
+    for ds, lds, rlds in zip(source_datasets, loaded_datasets, reloaded_ds):
+        # these should always be equal
+        assert ds.guid == lds.guid
+        assert ds.guid == rlds.guid
+
+        assert ds.captured_run_id == lds.captured_run_id
+        assert ds.captured_run_id == rlds.captured_run_id
+
+        assert ds.captured_counter == lds.captured_counter
+        assert ds.captured_counter == rlds.captured_counter
+
+        assert ds.exp_name == lds.exp_name
+        assert ds.exp_name == rlds.exp_name
+
+        assert ds.sample_name == lds.sample_name
+        assert ds.exp_name == rlds.exp_name
+
+        # these are effectively counters and should be offset
+        # since we are inserting all runs in order into a db with
+        # existing runs and experiment
+
+        assert ds.exp_id + offset_exps == lds.exp_id
+        assert ds.exp_id + offset_exps == rlds.exp_id
+
+        assert ds.run_id + offset_total_ds == lds.run_id
+        assert ds.run_id + offset_total_ds == rlds.run_id
+
+        assert ds.counter + offset_ds_in_exp == lds.counter
+        assert ds.counter + offset_ds_in_exp == rlds.counter


### PR DESCRIPTION
This should fix the issue of run_ids not getting incremented when importing netcdf datasets or datasets in memory in general.
Addressing the issue we have talked about @jenshnielsen .

I have replaced the table name return value, as I could not find it used anywhere and it is not a part of a public API.

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
