### PR TITLE
Add quote to escape sqlite keywords (Fixing #5217)

### DIFF
--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -588,7 +588,7 @@ def get_parameter_tree_values(
     # Create the base sql query
     columns = [toplevel_param_name] + list(other_param_names)
     sql = f"""
-           SELECT {','.join(columns)} FROM "{result_table_name}"
+           SELECT "{'","'.join(columns)}" FROM "{result_table_name}"
            WHERE {toplevel_param_name} IS NOT NULL
            LIMIT ? OFFSET ?
            """


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
This PR add quotes around column names in sqlite query.
Closes #5217 