### PR TITLE
pin importlib_resources to 5 series

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,8 @@ h5py~=3.9.0
 hypothesis~=6.80.0
 idna==3.4
 imagesize~=1.4.1
-importlib-metadata~=5.0.0; python_version < '3.10'
+importlib-metadata~=5.0.0
+importlib-resources~=5.13.0
 incremental~=22.10.0
 iniconfig~=2.0.0
 ipykernel~=6.24.0


### PR DESCRIPTION
version 6.0.0 removed various deprecated functions but these are still used by towncrier which we use to build the docs.
This is fixed in https://github.com/twisted/towncrier/pull/529/ but not yet in a release

Also remove env marker from importlib_metadata. This file is only used to constrain requirements so there is no need
to use the env marker here. That is done in pyproject.toml and having it here prevents dependabot from bumping the version

