### PR TITLE
InstrumentLoggerAdaptor store instrument_name and type in record

### DIFF
--- a/docs/changes/newsfragments/5297.improved
+++ b/docs/changes/newsfragments/5297.improved
@@ -1,0 +1,3 @@
+The InstrumentLoggerAdapter has been updated to store the `instrument_name` and `instrument_type`
+as fields on log records rather than the instrument it self. This enables opentelemetry to attache
+the fields to a transmitted LogRecord for better filtering.

--- a/qcodes/logger/instrument_logger.py
+++ b/qcodes/logger/instrument_logger.py
@@ -41,13 +41,14 @@ class InstrumentLoggerAdapter(logging.LoggerAdapter):
         Returns the message and the kwargs for the handlers.
         """
         assert self.extra is not None
-        inst = self.extra['instrument']
-        kwargs["extra"] = {}
-        kwargs["extra"]["instrument_name"] = str(getattr(inst, "full_name", ""))
-        kwargs["extra"]["instrument_type"] = str(type(inst))
+        extra = dict(self.extra)
+        inst = extra.pop("instrument")
+
         full_name = getattr(inst, "full_name", None)
-        kwargs["extra"]["instrument_name"] = full_name
         instr_type = str(type(inst).__name__)
+
+        kwargs["extra"] = extra
+        kwargs["extra"]["instrument_name"] = str(full_name)
         kwargs["extra"]["instrument_type"] = instr_type
         return f"[{full_name}({instr_type})] {msg}", kwargs
 

--- a/qcodes/logger/instrument_logger.py
+++ b/qcodes/logger/instrument_logger.py
@@ -67,13 +67,13 @@ class InstrumentFilter(logging.Filter):
                                           Sequence['InstrumentBase']]):
         super().__init__()
         if not isinstance(instruments, collections.abc.Sequence):
-            instrument_seq: Sequence["str"] = (instruments.full_name,)
+            instrument_seq: Sequence[str] = (instruments.full_name,)
         else:
             instrument_seq = [inst.full_name for inst in instruments]
         self.instrument_set = set(instrument_seq)
 
     def filter(self, record: logging.LogRecord) -> bool:
-        inst: Optional["str"] = getattr(record, "instrument_name", None)
+        inst: Optional[str] = getattr(record, "instrument_name", None)
         if inst is None:
             return False
 


### PR DESCRIPTION
This enables opentelemetry to consume these fields as extras on the log record which it cannot do for the instrument itself since that is not a natively supported type.

