### PR TITLE
Silence warnings during docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,6 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sys
 from abc import ABCMeta
 from importlib import reload
 
@@ -55,8 +54,6 @@ import qcodes  # noqa F402
 os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
 
 matplotlib.use('Agg')
-
-sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,13 @@ reload(qcodes.instrument)
 
 import qcodes  # noqa F402
 
+# sphinx 6.2 -> 7.1 produces a warning
+# Debugger warning: It seems that frozen modules are being used, which may
+# make the debugger miss breakpoints. Please pass -Xfrozen_modules=off
+# to python to disable frozen modules.
+# Since we are not debugging we disable it here
+os.environ["PYDEVD_DISABLE_FILE_VALIDATION"] = "1"
+
 matplotlib.use('Agg')
 
 sys.path.insert(0, os.path.abspath('..'))


### PR DESCRIPTION
Also remove a not needed and error prone path modification in the docs build. 