### PR TITLE
load_by_id optionally loads data from exported file

### DIFF
--- a/docs/changes/newsfragments/5320.improved
+++ b/docs/changes/newsfragments/5320.improved
@@ -1,3 +1,3 @@
 `load_by_run_spec` and `load_by_id` may now optionally load the dataset as a DataSetInMem from an exported netcdf file. This avoids reading
-from the database potentially resulting in better performance. This option is off by default at the moment but can be turned on by experiment_setting
+from the database potentially resulting in better performance. This option is off by default at the moment but can be turned on by setting
 `qcodes.config.dataset.load_from_exported_file` to True.

--- a/docs/changes/newsfragments/5320.improved
+++ b/docs/changes/newsfragments/5320.improved
@@ -1,0 +1,3 @@
+`load_by_run_spec` and `load_by_id` may now optionally load the dataset as a DataSetInMem from an exported netcdf file. This avoids reading
+from the database potentially resulting in better performance. This option is off by default at the moment but can be turned on by experiment_setting
+`qcodes.config.dataset.load_from_exported_file` to True.

--- a/src/qcodes/configuration/qcodesrc.json
+++ b/src/qcodes/configuration/qcodesrc.json
@@ -79,7 +79,7 @@
         "export_chunked_export_of_large_files_enabled": false,
         "export_chunked_threshold": 1000,
         "in_memory_cache": true,
-        "load_from_file": false
+        "load_from_exported_file": false
     },
     "telemetry":
     {

--- a/src/qcodes/configuration/qcodesrc.json
+++ b/src/qcodes/configuration/qcodesrc.json
@@ -78,7 +78,8 @@
         "export_name_elements": ["captured_run_id", "guid"],
         "export_chunked_export_of_large_files_enabled": false,
         "export_chunked_threshold": 1000,
-        "in_memory_cache": true
+        "in_memory_cache": true,
+        "load_from_file": false
     },
     "telemetry":
     {

--- a/src/qcodes/configuration/qcodesrc_schema.json
+++ b/src/qcodes/configuration/qcodesrc_schema.json
@@ -373,7 +373,7 @@
                     "default": 1000,
                     "description": "Estimated size in MB above which the dataset will be exported in chuncks and recombined."
                 },
-                "load_from_file": {
+                "load_from_exported_file": {
                     "description": "Flag to load metadata and raw data from exported file of type specified in export_type. If set to true, qcodes will try to import from file first, if it exists.",
                     "type": "boolean",
                     "default": false

--- a/src/qcodes/configuration/qcodesrc_schema.json
+++ b/src/qcodes/configuration/qcodesrc_schema.json
@@ -373,6 +373,11 @@
                     "default": 1000,
                     "description": "Estimated size in MB above which the dataset will be exported in chuncks and recombined."
                 },
+                "load_from_file": {
+                    "description": "Flag to load metadata and raw data from exported file of type specified in export_type. If set to true, qcodes will try to import from file first, if it exists.",
+                    "type": "boolean",
+                    "default": false
+                },
                 "in_memory_cache": {
                     "type": "boolean",
                     "default": true,

--- a/src/qcodes/dataset/__init__.py
+++ b/src/qcodes/dataset/__init__.py
@@ -10,7 +10,7 @@ from .data_set import (
     load_by_run_spec,
     new_data_set,
 )
-from .data_set_in_memory import load_from_netcdf
+from .data_set_in_memory import load_from_file, load_from_netcdf
 from .data_set_protocol import DataSetProtocol, DataSetType
 from .database_extract_runs import extract_runs_into_db
 from .descriptions.dependencies import InterDependencies_, ParamSpecTree
@@ -103,6 +103,7 @@ __all__ = [
     "load_by_run_spec",
     "load_experiment",
     "load_experiment_by_name",
+    "load_from_file",
     "load_from_netcdf",
     "load_last_experiment",
     "load_or_create_experiment",

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -34,7 +34,7 @@ from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
 from qcodes.dataset.descriptions.versioning.v0 import InterDependencies
 from qcodes.dataset.experiment_settings import get_default_experiment_id
 from qcodes.dataset.export_config import (
-    get_data_export_type,
+    DataExportType,
 )
 from qcodes.dataset.guids import filter_guids_by_parts, generate_guid, parse_guid
 from qcodes.dataset.linked_datasets.links import Link, links_to_str, str_to_links
@@ -1834,11 +1834,11 @@ def _get_datasetprotocol_from_guid(guid: str, conn: ConnectionPlus) -> DataSetPr
 
     if qcodes.config.dataset.load_from_exported_file:
         export_info = _get_datasetprotocol_export_info(run_id=run_id, conn=conn)
-        export_type = get_data_export_type()
-        if export_type is not None:
-            export_file_path = export_info.export_paths.get(export_type.value)
-        else:
-            export_file_path = None
+
+        export_file_path = export_info.export_paths.get(
+            DataExportType.NETCDF.value, None
+        )
+
         if export_file_path is not None:
             try:
                 d: DataSetProtocol = load_from_file(export_file_path)

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -1791,11 +1791,11 @@ def load_by_counter(
     data to another db file. We recommend using :func:`.load_by_run_spec` which
     does not have this issue and is significantly more flexible.
 
+    If the raw data is in the database this will be loaded as a
+    :class:`qcodes.dataset.data_set.DataSet`.
     If the raw data is exported to netcdf this will be loaded from file
     as a :class:`DataSetInMemory`.
-    If the raw data is in the database this will be loaded as a
-    :class:`qcodes.dataset.data_set.DataSet`
-    otherwise it will be loaded as a :class:`.DataSetInMemory`
+    In other cases, it will be loaded as a :class:`.DataSetInMemory`
 
     Args:
         counter: counter of the dataset within the given experiment

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -38,7 +38,6 @@ from qcodes.dataset.export_config import (
 )
 from qcodes.dataset.guids import filter_guids_by_parts, generate_guid, parse_guid
 from qcodes.dataset.linked_datasets.links import Link, links_to_str, str_to_links
-from qcodes.dataset.load_config import get_data_load_from_file
 from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic, atomic_transaction
 from qcodes.dataset.sqlite.database import (
     conn_from_dbpath_or_conn,
@@ -1827,9 +1826,9 @@ def load_by_counter(
 def _get_datasetprotocol_from_guid(guid: str, conn: ConnectionPlus) -> DataSetProtocol:
     run_id = get_runid_from_guid(conn, guid)
     if run_id is None:
-        raise NameError(f"No run with GUID: {guid} found in database.")
+        raise NameError("No run with GUID: %s found in database.", guid)
 
-    if get_data_load_from_file():
+    if qcodes.config.dataset.load_from_file:
         export_info = _get_datasetprotocol_export_info(run_id=run_id, conn=conn)
         export_type = get_data_export_type()
         if export_type is not None:
@@ -1841,7 +1840,7 @@ def _get_datasetprotocol_from_guid(guid: str, conn: ConnectionPlus) -> DataSetPr
                 d: DataSetProtocol = load_from_file(export_file_path)
 
             except (ValueError, FileNotFoundError) as e:
-                log.warning(f"Cannot load data from file: {e!s}")
+                log.warning("Cannot load data from file: %s", e)
 
             else:
                 return d

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -1832,10 +1832,13 @@ def _get_datasetprotocol_from_guid(guid: str, conn: ConnectionPlus) -> DataSetPr
     if get_data_load_from_file():
         export_info = _get_datasetprotocol_export_info(run_id=run_id, conn=conn)
         export_type = get_data_export_type()
-        export_file_path = export_info.export_paths.get(export_type.value)
+        if export_type is not None:
+            export_file_path = export_info.export_paths.get(export_type.value)
+        else:
+            export_file_path = None
         if export_file_path is not None:
             try:
-                d: DataSetInMem = load_from_file(export_file_path)
+                d: DataSetProtocol = load_from_file(export_file_path)
 
             except (ValueError, FileNotFoundError) as e:
                 log.warning(f"Cannot load data from file: {e!s}")
@@ -1845,14 +1848,14 @@ def _get_datasetprotocol_from_guid(guid: str, conn: ConnectionPlus) -> DataSetPr
 
     result_table_name = _get_result_table_name_by_guid(conn, guid)
     if _check_if_table_found(conn, result_table_name):
-        d: DataSetProtocol = DataSet(conn=conn, run_id=run_id)
+        d = DataSet(conn=conn, run_id=run_id)
     else:
         d = DataSetInMem._load_from_db(conn=conn, guid=guid)
 
     return d
 
 
-def _get_datasetprotocol_export_info(run_id: str, conn: ConnectionPlus) -> ExportInfo:
+def _get_datasetprotocol_export_info(run_id: int, conn: ConnectionPlus) -> ExportInfo:
     metadata = get_metadata_from_run_id(conn=conn, run_id=run_id)
     export_info_str = metadata.get("export_info", "")
     export_info = ExportInfo.from_str(export_info_str)

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -1828,7 +1828,7 @@ def _get_datasetprotocol_from_guid(guid: str, conn: ConnectionPlus) -> DataSetPr
     if run_id is None:
         raise NameError("No run with GUID: %s found in database.", guid)
 
-    if qcodes.config.dataset.load_from_file:
+    if qcodes.config.dataset.load_from_exported_file:
         export_info = _get_datasetprotocol_export_info(run_id=run_id, conn=conn)
         export_type = get_data_export_type()
         if export_type is not None:

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -1592,8 +1592,9 @@ def load_by_run_spec(
     specs of the runs found will be printed.
 
     If the raw data is in the database this will be loaded as a
-    :class:`qcodes.dataset.data_set.DataSet`
-    otherwise it will be loaded as a :class:`.DataSetInMemory`
+    :class:`DataSet`. Otherwise it will be loaded as a :class:`.DataSetInMemory`
+    If the raw data is exported to netcdf and ``qcodes.config.dataset.load_from_exported_file`` is
+    set to True. this will be loaded from file as a :class:`DataSetInMemory`. regardless.
 
     Args:
         captured_run_id: The ``run_id`` that was originally assigned to this
@@ -1712,9 +1713,11 @@ def load_by_id(run_id: int, conn: ConnectionPlus | None = None) -> DataSetProtoc
     data to another db file. We recommend using :func:`.load_by_run_spec` which
     does not have this issue and is significantly more flexible.
 
+
     If the raw data is in the database this will be loaded as a
-    :class:`qcodes.dataset.data_set.DataSet` otherwise it will be
-    loaded as a :class:`.DataSetInMemory`
+    :class:`DataSet`. Otherwise it will be loaded as a :class:`.DataSetInMemory`
+    If the raw data is exported to netcdf and ``qcodes.config.dataset.load_from_exported_file`` is
+    set to True. this will be loaded from file as a :class:`DataSetInMemory`. regardless.
 
     Args:
         run_id: run id of the dataset
@@ -1750,8 +1753,9 @@ def load_by_guid(guid: str, conn: ConnectionPlus | None = None) -> DataSetProtoc
     is specified in the config.
 
     If the raw data is in the database this will be loaded as a
-    :class:`qcodes.dataset.data_set.DataSet`
-    otherwise it will be loaded as a :class:`.DataSetInMemory`
+    :class:`DataSet`. Otherwise it will be loaded as a :class:`.DataSetInMemory`
+    If the raw data is exported to netcdf and ``qcodes.config.dataset.load_from_exported_file`` is
+    set to True. this will be loaded from file as a :class:`DataSetInMemory`. regardless.
 
     Args:
         guid: guid of the dataset
@@ -1791,11 +1795,11 @@ def load_by_counter(
     data to another db file. We recommend using :func:`.load_by_run_spec` which
     does not have this issue and is significantly more flexible.
 
+
     If the raw data is in the database this will be loaded as a
-    :class:`qcodes.dataset.data_set.DataSet`.
-    If the raw data is exported to netcdf this will be loaded from file
-    as a :class:`DataSetInMemory`.
-    In other cases, it will be loaded as a :class:`.DataSetInMemory`
+    :class:`DataSet`. Otherwise it will be loaded as a :class:`.DataSetInMemory`
+    If the raw data is exported to netcdf and ``qcodes.config.dataset.load_from_exported_file`` is
+    set to True. this will be loaded from file as a :class:`DataSetInMemory`. regardless.
 
     Args:
         counter: counter of the dataset within the given experiment
@@ -1804,7 +1808,7 @@ def load_by_counter(
           connection to the DB file specified in the config is made
 
     Returns:
-        :class:`qcodes.dataset.data_set.DataSet` or
+        :class:`DataSet` or
         :class:`.DataSetInMemory` of the given counter in
         the given experiment
     """

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -23,6 +23,7 @@ from qcodes.dataset.descriptions.param_spec import ParamSpec, ParamSpecBase
 from qcodes.dataset.descriptions.rundescriber import RunDescriber
 from qcodes.dataset.descriptions.versioning.converters import new_to_old
 from qcodes.dataset.descriptions.versioning.rundescribertypes import Shapes
+from qcodes.dataset.export_config import DataExportType
 from qcodes.dataset.guids import generate_guid
 from qcodes.dataset.linked_datasets.links import Link, links_to_str
 from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic
@@ -41,7 +42,6 @@ from qcodes.dataset.sqlite.queries import (
     update_parent_datasets,
     update_run_description,
 )
-from qcodes.dataset.export_config import DataExportType
 from qcodes.utils import NumpyJSONEncoder
 
 from .data_set_cache import DataSetCacheInMem
@@ -934,5 +934,15 @@ def load_from_file(
     Returns:
         The loaded dataset.
     """
+    if not path.is_file():
+        raise FileNotFoundError(f"File {path} not found.")
+
     if DataExportType.NETCDF.value == path.suffix:
         return DataSetInMem._load_from_netcdf(path=path, path_to_db=path_to_db)
+
+    else:
+        raise ValueError(
+            f"Loading file of type {path.suffix} is not supported."
+            "Please refer to https://github.com/QCoDeS/Qcodes/issues"
+            "to find existing or create a new feature request."
+        )

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -41,6 +41,7 @@ from qcodes.dataset.sqlite.queries import (
     update_parent_datasets,
     update_run_description,
 )
+from qcodes.dataset.export_config import DataExportType
 from qcodes.utils import NumpyJSONEncoder
 
 from .data_set_cache import DataSetCacheInMem
@@ -913,3 +914,25 @@ def load_from_netcdf(
         The loaded dataset.
     """
     return DataSetInMem._load_from_netcdf(path=path, path_to_db=path_to_db)
+
+
+def load_from_file(
+    path: Path | str, path_to_db: Path | str | None = None
+) -> DataSetInMem:
+    """
+    Create an in-memory dataset from a file.
+    The file is expected to contain a QCoDeS dataset that
+    has been exported using the QCoDeS export functions.
+    Currently, this only supports loading from netcdf files.
+
+    Args:
+        path: Path to the file to import.
+        path_to_db: Optional path to a database where this dataset may be
+            exported to. If not supplied the path can be given at export time
+            or the dataset exported to the default db as set in the QCoDeS config.
+
+    Returns:
+        The loaded dataset.
+    """
+    if DataExportType.NETCDF.value == path.suffix:
+        return DataSetInMem._load_from_netcdf(path=path, path_to_db=path_to_db)

--- a/src/qcodes/dataset/data_set_in_memory.py
+++ b/src/qcodes/dataset/data_set_in_memory.py
@@ -934,10 +934,11 @@ def load_from_file(
     Returns:
         The loaded dataset.
     """
+    path = Path(path)
     if not path.is_file():
         raise FileNotFoundError(f"File {path} not found.")
 
-    if DataExportType.NETCDF.value == path.suffix:
+    if DataExportType.NETCDF.value == path.suffix.replace(".", ""):
         return DataSetInMem._load_from_netcdf(path=path, path_to_db=path_to_db)
 
     else:

--- a/src/qcodes/dataset/load_config.py
+++ b/src/qcodes/dataset/load_config.py
@@ -1,9 +1,0 @@
-import qcodes
-
-DATASET_CONFIG_SECTION = "dataset"
-LOAD_FROM_FILE = "load_from_file"
-
-
-def get_data_load_from_file() -> bool:
-    """Get the flag to import data from sqlite db."""
-    return qcodes.config[DATASET_CONFIG_SECTION][LOAD_FROM_FILE]

--- a/src/qcodes/dataset/load_config.py
+++ b/src/qcodes/dataset/load_config.py
@@ -1,0 +1,9 @@
+import qcodes
+
+DATASET_CONFIG_SECTION = "dataset"
+LOAD_FROM_FILE = "load_from_file"
+
+
+def get_data_load_from_file() -> bool:
+    """Get the flag to import data from sqlite db."""
+    return qcodes.config[DATASET_CONFIG_SECTION][LOAD_FROM_FILE]

--- a/tests/dataset/test_dataset_in_memory.py
+++ b/tests/dataset/test_dataset_in_memory.py
@@ -469,6 +469,7 @@ def test_load_from_file(meas_with_registered_param, DMM, DAC, tmp_path) -> None:
     ds.add_metadata("metadata_added_after_export", "42")
 
     export_file_path = ds.export_info.export_paths.get("nc")
+    assert export_file_path is not None
     loaded_ds: DataSetInMem = load_from_file(export_file_path)
 
     assert isinstance(loaded_ds, DataSetInMem)

--- a/tests/dataset/test_dataset_in_memory.py
+++ b/tests/dataset/test_dataset_in_memory.py
@@ -15,9 +15,9 @@ import qcodes
 from qcodes.dataset import load_by_id, load_by_run_spec
 from qcodes.dataset.data_set_in_memory import DataSetInMem, load_from_file
 from qcodes.dataset.data_set_protocol import DataSetType
+from qcodes.dataset.load_config import get_data_load_from_file
 from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic_transaction
 from qcodes.station import Station
-from qcodes.dataset.load_config import get_data_load_from_file
 
 
 def test_dataset_in_memory_reload_from_db(
@@ -503,7 +503,7 @@ def test_load_from_file_by_id(meas_with_registered_param, DMM, DAC, tmp_path) ->
     ds: DataSetInMem = datasaver.dataset
     assert not isinstance(ds, DataSetInMem)
     ds.export(path=tmp_path)
-    
+
     # Load from file
     loaded_ds_from_file = load_by_id(ds.run_id)
     assert isinstance(loaded_ds_from_file, DataSetInMem)

--- a/tests/dataset/test_dataset_in_memory.py
+++ b/tests/dataset/test_dataset_in_memory.py
@@ -451,7 +451,6 @@ def test_load_from_db(meas_with_registered_param, DMM, DAC, tmp_path) -> None:
     compare_datasets(ds, loaded_ds)
 
 
-@pytest.mark.usefixtures("default_config")
 def test_load_from_file(meas_with_registered_param, DMM, DAC, tmp_path) -> None:
     qcodes.config["dataset"]["export_prefix"] = "my_export_prefix"
     qcodes.config["dataset"]["export_type"] = "netcdf"
@@ -486,7 +485,6 @@ def test_load_from_file(meas_with_registered_param, DMM, DAC, tmp_path) -> None:
     compare_datasets(ds, loaded_ds)
 
 
-@pytest.mark.usefixtures("default_config")
 def test_load_from_file_by_id(meas_with_registered_param, DMM, DAC, tmp_path) -> None:
     qcodes.config["dataset"]["export_prefix"] = "my_export_prefix"
     qcodes.config["dataset"]["export_type"] = "netcdf"

--- a/tests/dataset/test_dataset_in_memory.py
+++ b/tests/dataset/test_dataset_in_memory.py
@@ -488,8 +488,8 @@ def test_load_from_file(meas_with_registered_param, DMM, DAC, tmp_path) -> None:
 def test_load_from_file_by_id(meas_with_registered_param, DMM, DAC, tmp_path) -> None:
     qcodes.config["dataset"]["export_prefix"] = "my_export_prefix"
     qcodes.config["dataset"]["export_type"] = "netcdf"
-    qcodes.config["dataset"]["load_from_file"] = True
-    assert qcodes.config.dataset.load_from_file is True
+    qcodes.config["dataset"]["load_from_exported_file"] = True
+    assert qcodes.config.dataset.load_from_exported_file is True
 
     Station(DAC, DMM)
     with meas_with_registered_param.run() as datasaver:
@@ -507,8 +507,8 @@ def test_load_from_file_by_id(meas_with_registered_param, DMM, DAC, tmp_path) ->
     assert isinstance(loaded_ds_from_file, DataSetInMem)
 
     # Load from db
-    qcodes.config["dataset"]["load_from_file"] = False
-    assert qcodes.config.dataset.load_from_file is False
+    qcodes.config["dataset"]["load_from_exported_file"] = False
+    assert qcodes.config.dataset.load_from_exported_file is False
     loaded_ds_from_db = load_by_id(ds.run_id)
     assert not isinstance(loaded_ds_from_db, DataSetInMem)
 

--- a/tests/dataset/test_dataset_in_memory.py
+++ b/tests/dataset/test_dataset_in_memory.py
@@ -15,7 +15,6 @@ import qcodes
 from qcodes.dataset import load_by_id, load_by_run_spec
 from qcodes.dataset.data_set_in_memory import DataSetInMem, load_from_file
 from qcodes.dataset.data_set_protocol import DataSetType
-from qcodes.dataset.load_config import get_data_load_from_file
 from qcodes.dataset.sqlite.connection import ConnectionPlus, atomic_transaction
 from qcodes.station import Station
 
@@ -489,7 +488,7 @@ def test_load_from_file_by_id(meas_with_registered_param, DMM, DAC, tmp_path) ->
     qcodes.config["dataset"]["export_prefix"] = "my_export_prefix"
     qcodes.config["dataset"]["export_type"] = "netcdf"
     qcodes.config["dataset"]["load_from_file"] = True
-    assert get_data_load_from_file()
+    assert qcodes.config.dataset.load_from_file is True
 
     Station(DAC, DMM)
     with meas_with_registered_param.run() as datasaver:
@@ -508,7 +507,7 @@ def test_load_from_file_by_id(meas_with_registered_param, DMM, DAC, tmp_path) ->
 
     # Load from db
     qcodes.config["dataset"]["load_from_file"] = False
-    assert get_data_load_from_file() is False
+    assert qcodes.config.dataset.load_from_file is False
     loaded_ds_from_db = load_by_id(ds.run_id)
     assert not isinstance(loaded_ds_from_db, DataSetInMem)
 


### PR DESCRIPTION
<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
We've been having issues using Plottr in tandem with measurements because they access the sqlite database at the same time. We think that simultaneous read/write operations from both processes have been causing either one of them to crash. A potential solution I came up with is to have load_by_id load the dataset from an exported netcdf file, if it exists.
Please take a look and let me know if you think this is a reasonable solution, I'm currently testing it to see if it actually solves the problem.