### PR TITLE
Calculate new run_id/counter from run_id/counter

### DIFF
--- a/docs/changes/newsfragments/5329.improved
+++ b/docs/changes/newsfragments/5329.improved
@@ -1,0 +1,3 @@
+In the QCoDeS DataSetProtocol newly created dataset now always have a captured_run_id / captured_counter
+that matches the run_id / result_counter that they are assigned on creation. Previously these could be
+out of sync if datasets measured elsewhere had been inserted into the database.

--- a/qcodes/tests/dataset/test_database_extract_runs.py
+++ b/qcodes/tests/dataset/test_database_extract_runs.py
@@ -704,9 +704,9 @@ def test_copy_datasets_and_add_new(
         ds.mark_completed()
 
     expected_run_ids = [4, 5, 6]
-    expected_captured_run_ids = [11, 12, 13]
+    expected_captured_run_ids = expected_run_ids
     expected_counter = [4, 5, 6]
-    expected_captured_counter = [6, 7, 8]
+    expected_captured_counter = expected_counter
 
     for ds, eri, ecri, ec, ecc in zip(new_datasets,
                                       expected_run_ids,


### PR DESCRIPTION
This fixes #5328 by ensuring that new runs are inserted with a captured counter/runid that matches the assigned run_id / counter