### PR TITLE
Cleanup logging and str formatting

### DIFF
--- a/docs/examples/writing_drivers/Creating-Instrument-Drivers.ipynb
+++ b/docs/examples/writing_drivers/Creating-Instrument-Drivers.ipynb
@@ -424,7 +424,7 @@
     "        self._handle = self._ATS_dll.AlazarGetBoardBySystemID(system_id, board_id)\n",
     "        if not self._handle:\n",
     "            raise Exception(\n",
-    "                f\"AlazarTech_ATS not found at \" f\"system {system_id}, board {board_id}\"\n",
+    "                f\"AlazarTech_ATS not found at system {system_id}, board {board_id}\"\n",
     "            )\n",
     "\n",
     "        self.buffer_list = []\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,8 +252,8 @@ filterwarnings = [
 # PT025 invalid use of pytest fixtures in other fixtures
 # RUF200 validate pyproject.toml
 # I isort
-# ISC001: single-line-implicit-string-concatenation
-select = ["E", "F", "PT025", "UP", "RUF200", "I", "G", "ISC001", "ISC003"]
+# ISC flake8-implicit-str-concat
+select = ["E", "F", "PT025", "UP", "RUF200", "I", "G", "ISC"]
 # darker will fix this as code is
 # reformatted when it is changed.
 # We have a lot of use of f strings in log messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,7 @@ ignore = ["E501", "G004"]
 
 extend-include = ["*.ipynb"]
 
+extend-exclude = ["typings"]
 
 [tool.ruff.per-file-ignores]
 # deprecated modules left

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,10 +252,12 @@ filterwarnings = [
 # PT025 invalid use of pytest fixtures in other fixtures
 # RUF200 validate pyproject.toml
 # I isort
-select = ["E", "F", "PT025", "UP", "RUF200", "I"]
+select = ["E", "F", "PT025", "UP", "RUF200", "I", "G"]
 # darker will fix this as code is
 # reformatted when it is changed.
-ignore = ["E501"]
+# We have a lot of use of f strings in log messages
+# so disable that lint for now
+ignore = ["E501", "G004"]
 
 extend-include = ["*.ipynb"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -253,7 +253,7 @@ filterwarnings = [
 # RUF200 validate pyproject.toml
 # I isort
 # ISC001: single-line-implicit-string-concatenation
-select = ["E", "F", "PT025", "UP", "RUF200", "I", "G", "ISC001"]
+select = ["E", "F", "PT025", "UP", "RUF200", "I", "G", "ISC001", "ISC003"]
 # darker will fix this as code is
 # reformatted when it is changed.
 # We have a lot of use of f strings in log messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,8 @@ filterwarnings = [
 # PT025 invalid use of pytest fixtures in other fixtures
 # RUF200 validate pyproject.toml
 # I isort
-select = ["E", "F", "PT025", "UP", "RUF200", "I", "G"]
+# ISC001: single-line-implicit-string-concatenation
+select = ["E", "F", "PT025", "UP", "RUF200", "I", "G", "ISC001"]
 # darker will fix this as code is
 # reformatted when it is changed.
 # We have a lot of use of f strings in log messages

--- a/qcodes/dataset/data_set_in_memory.py
+++ b/qcodes/dataset/data_set_in_memory.py
@@ -718,7 +718,7 @@ class DataSetInMem(BaseDataSet):
         """
         if not isinstance(interdeps, InterDependencies_):
             raise TypeError(
-                "Wrong input type. Expected InterDepencies_, " f"got {type(interdeps)}"
+                f"Wrong input type. Expected InterDepencies_, got {type(interdeps)}"
             )
 
         if not self.pristine:
@@ -772,7 +772,7 @@ class DataSetInMem(BaseDataSet):
             )
         if self.completed:
             raise CompletedError(
-                "This DataSet is complete, no further " "results can be added to it."
+                "This DataSet is complete, no further results can be added to it."
             )
 
     def __len__(self) -> int:

--- a/qcodes/dataset/experiment_container.py
+++ b/qcodes/dataset/experiment_container.py
@@ -347,7 +347,7 @@ def load_experiment_by_name(
             e = exp  # pyright: ignore
         else:
             raise ValueError(
-                f"Many experiments matching your request" f" found:\n{_repr_str}"
+                f"Many experiments matching your request found:\n{_repr_str}"
             )
     else:
         e = Experiment(exp_id=exp_ids[0], conn=conn)

--- a/qcodes/dataset/sqlite/queries.py
+++ b/qcodes/dataset/sqlite/queries.py
@@ -1668,7 +1668,7 @@ def set_run_timestamp(
             if timestamp is None:
                 timestamp = time.time()
             c.execute(cmd, (timestamp, run_id))
-            log.info(f"Set the run_timestamp of run_id {run_id} to " f"{timestamp}")
+            log.info(f"Set the run_timestamp of run_id {run_id} to {timestamp}")
 
 
 def add_parameter(
@@ -1772,7 +1772,7 @@ def _validate_table_name(table_name: str) -> bool:
     for i in table_name:
         if unicodedata.category(i) not in _unicode_categories:
             valid = False
-            raise RuntimeError("Invalid table name " f"{table_name} starting at {i}")
+            raise RuntimeError(f"Invalid table name {table_name} starting at {i}")
     return valid
 
 

--- a/qcodes/instrument/channel.py
+++ b/qcodes/instrument/channel.py
@@ -447,7 +447,7 @@ class ChannelTuple(MetadatableWithName, Sequence[InstrumentModuleType]):
         # to construct a multiparameter from a list of multi parameters
         if isinstance(self._channels[0].parameters[name], MultiParameter):
             raise NotImplementedError(
-                "Slicing is currently not " "supported for MultiParameters"
+                "Slicing is currently not supported for MultiParameters"
             )
         parameters = cast(
             list[Union[Parameter, ArrayParameter]],

--- a/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -177,7 +177,7 @@ class AimTTiChannel(InstrumentChannel):
         store specified by the numbers 0-9.
         """
         if slot not in self.set_up_store_slots:
-            raise RuntimeError("Slote number should be an integer between" "0 adn 9.")
+            raise RuntimeError("Slote number should be an integer between 0 and 9.")
 
         channel_id = self.channel
         self.write(f"SAV{channel_id} {slot}")
@@ -188,7 +188,7 @@ class AimTTiChannel(InstrumentChannel):
         store specified by the numbers 0-9.
         """
         if slot not in self.set_up_store_slots:
-            raise RuntimeError("Slote number should be an integer between" "0 adn 9.")
+            raise RuntimeError("Slote number should be an integer between 0 and 9.")
 
         channel_id = self.channel
         self.write(f"RCL{channel_id} {slot}")
@@ -237,7 +237,7 @@ class AimTTi(VisaInstrument):
         _model = self.get_idn()["model"]
 
         if (_model not in self._numOutputChannels.keys()) or (_model is None):
-            raise NotKnownModel("Unknown model, connection cannot be " "established.")
+            raise NotKnownModel("Unknown model, connection cannot be established.")
 
         self.numOfChannels = self._numOutputChannels[_model]
         for i in range(1, self.numOfChannels + 1):

--- a/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
+++ b/qcodes/instrument_drivers/AimTTi/_AimTTi_PL_P.py
@@ -177,18 +177,18 @@ class AimTTiChannel(InstrumentChannel):
         store specified by the numbers 0-9.
         """
         if slot not in self.set_up_store_slots:
-            raise RuntimeError("Slote number should be an integer between 0 and 9.")
+            raise RuntimeError("Slot number should be an integer between 0 and 9.")
 
         channel_id = self.channel
         self.write(f"SAV{channel_id} {slot}")
 
     def load_setup(self, slot: int) -> None:
         """
-        A bound function that loadss the output setup from the internal
+        A bound function that loads the output setup from the internal
         store specified by the numbers 0-9.
         """
         if slot not in self.set_up_store_slots:
-            raise RuntimeError("Slote number should be an integer between 0 and 9.")
+            raise RuntimeError("Slot number should be an integer between 0 and 9.")
 
         channel_id = self.channel
         self.write(f"RCL{channel_id} {slot}")

--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -576,7 +576,7 @@ class AlazarTech_ATS(Instrument):
                 records_per_sec,
             )
             self.log.debug(
-                "Transferred %d bytes (%f " "bytes per sec)",
+                "Transferred %d bytes (%f bytes per sec)",
                 bytes_transferred,
                 bytes_per_sec,
             )

--- a/qcodes/instrument_drivers/AlazarTech/ATS.py
+++ b/qcodes/instrument_drivers/AlazarTech/ATS.py
@@ -565,14 +565,21 @@ class AlazarTech_ATS(Instrument):
             records_per_sec = (records_per_buffer *
                                buffers_completed / transfer_time_sec)
         if self.log.isEnabledFor(logging.DEBUG):
-            self.log.debug("Captured %d buffers (%f buffers per sec)" %
-                           (buffers_completed, buffers_per_sec))
-            self.log.debug("Captured %d records (%f records per sec)" %
-                           (records_per_buffer * buffers_completed,
-                            records_per_sec))
-            self.log.debug("Transferred {:g} bytes ({:g} "
-                           "bytes per sec)".format(bytes_transferred,
-                                                   bytes_per_sec))
+            self.log.debug(
+                "Captured %d buffers (%f buffers per sec)",
+                buffers_completed,
+                buffers_per_sec,
+            )
+            self.log.debug(
+                "Captured %d records (%f records per sec)",
+                records_per_buffer * buffers_completed,
+                records_per_sec,
+            )
+            self.log.debug(
+                "Transferred %d bytes (%f " "bytes per sec)",
+                bytes_transferred,
+                bytes_per_sec,
+            )
             self.log.debug(f"Pre setup took {presetup_time}")
             self.log.debug(f"Pre capture setup took {setup_time}")
             self.log.debug(f"Capture took {capture_time}")

--- a/qcodes/instrument_drivers/AlazarTech/constants.py
+++ b/qcodes/instrument_drivers/AlazarTech/constants.py
@@ -114,9 +114,7 @@ ERROR_CODES: dict[ReturnCode, str] = {
         ),
         587: "ApiWaitAbandoned",
         588: "ApiWaitFailed",
-        589: (
-            "ApiTransferComplete: This buffer is last in the current " "acquisition."
-        ),
+        589: ("ApiTransferComplete: This buffer is last in the current acquisition."),
         590: "ApiPllNotLocked: hardware error, contact AlazarTech",
         591: (
             "ApiNotSupportedInDualChannelMode:Requested number of samples "

--- a/qcodes/instrument_drivers/Galil/dmc_41x3.py
+++ b/qcodes/instrument_drivers/Galil/dmc_41x3.py
@@ -464,7 +464,7 @@ class GalilDMC4133Controller(GalilMotionController):
             get_cmd=None,
             set_cmd="PF 10.{}",
             vals=Ints(0, 4),
-            docstring="sets number of decimals in the format " "of the position",
+            docstring="sets number of decimals in the format of the position",
         )
 
         self.add_parameter(
@@ -472,7 +472,7 @@ class GalilDMC4133Controller(GalilMotionController):
             get_cmd=self._get_absolute_position,
             set_cmd=None,
             unit="quadrature counts",
-            docstring="gets absolute position of the motors " "from the set origin",
+            docstring="gets absolute position of the motors from the set origin",
         )
 
         self.add_parameter(

--- a/qcodes/instrument_drivers/HP/HP_8753D.py
+++ b/qcodes/instrument_drivers/HP/HP_8753D.py
@@ -254,7 +254,7 @@ class HP8753D(VisaInstrument):
         with self.timeout.set_to(new_timeout):
             log.debug(
                 f"Making {N} blocking sweeps."
-                + f" Setting VISA timeout to {new_timeout} s."
+                f" Setting VISA timeout to {new_timeout} s."
             )
 
             self.ask(f"OPC?;NUMG{N}")

--- a/qcodes/instrument_drivers/Harvard/Decadac.py
+++ b/qcodes/instrument_drivers/Harvard/Decadac.py
@@ -150,7 +150,7 @@ class DacReader:
         val = int(val)
         if val < 0 or val >= 2**32:
             raise HarvardDecadacException(
-                f"Writing invalid value " f"({val}) to address {addr}."
+                f"Writing invalid value ({val}) to address {addr}."
             )
 
         # Choose a poke command depending on whether we are querying a

--- a/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -170,7 +170,7 @@ class Keithley2450Buffer(InstrumentChannel):
         """
         if (not self.elements()) or readings_only:
             raw_data = self.ask(
-                f":TRACe:DATA? {start_idx}, {end_idx}, " f"'{self.buffer_name}'"
+                f":TRACe:DATA? {start_idx}, {end_idx}, '{self.buffer_name}'"
             )
             return [float(i) for i in raw_data.split(",")]
         elements = [self.buffer_elements[element] for element in self.elements()]
@@ -347,12 +347,12 @@ class Keithley2450Sense(InstrumentChannel):
         self.write(f":TRACe:CLEar '{buffer_name}'")
 
     def _get_user_delay(self) -> str:
-        get_cmd = f":SENSe:{self._proper_function}:DELay:USER" f"{self.user_number()}?"
+        get_cmd = f":SENSe:{self._proper_function}:DELay:USER{self.user_number()}?"
         return self.ask(get_cmd)
 
     def _set_user_delay(self, value: float) -> None:
         set_cmd = (
-            f":SENSe:{self._proper_function}:DELay:USER" f"{self.user_number()} {value}"
+            f":SENSe:{self._proper_function}:DELay:USER{self.user_number()} {value}"
         )
         self.write(set_cmd)
 
@@ -527,7 +527,7 @@ class Keithley2450Source(InstrumentChannel):
         self._sweep_arguments = None
 
     def _get_user_delay(self) -> float:
-        get_cmd = f":SOURce:{self._proper_function}:DELay:USER" f"{self.user_number()}?"
+        get_cmd = f":SOURce:{self._proper_function}:DELay:USER{self.user_number()}?"
         return float(self.ask(get_cmd))
 
     def _set_user_delay(self, value: float) -> None:

--- a/qcodes/instrument_drivers/Keithley/Keithley_6500.py
+++ b/qcodes/instrument_drivers/Keithley/Keithley_6500.py
@@ -174,7 +174,7 @@ class Keithley6500(VisaInstrument):
         for trigger in range(1, 5):
             self.add_parameter(
                 "trigger%i_delay" % trigger,
-                docstring="Set and read trigger delay for " "timer %i." % trigger,
+                docstring="Set and read trigger delay for timer %i." % trigger,
                 get_parser=float,
                 get_cmd="TRIG:TIM%i:DEL?" % trigger,
                 set_cmd="TRIG:TIM%i:DEL {}" % trigger,
@@ -184,7 +184,7 @@ class Keithley6500(VisaInstrument):
 
             self.add_parameter(
                 "trigger%i_source" % trigger,
-                docstring="Set the trigger source for " "timer %i." % trigger,
+                docstring="Set the trigger source for timer %i." % trigger,
                 get_cmd="TRIG:TIM%i:STAR:STIM?" % trigger,
                 set_cmd="TRIG:TIM%i:STAR:STIM {}" % trigger,
                 val_mapping={

--- a/qcodes/instrument_drivers/Keithley/Keithley_7510.py
+++ b/qcodes/instrument_drivers/Keithley/Keithley_7510.py
@@ -148,7 +148,7 @@ class Keithley7510Buffer(InstrumentChannel):
             "first_index",
             get_cmd=f":TRACe:ACTual:STARt? '{self.short_name}'",
             get_parser=int,
-            docstring="Get the starting index of readings in the reading " "buffer.",
+            docstring="Get the starting index of readings in the reading buffer.",
         )
 
         self.add_parameter(
@@ -564,12 +564,12 @@ class Keithley7510Sense(InstrumentChannel):
         )
 
     def _get_user_delay(self) -> str:
-        get_cmd = f":SENSe:{self._proper_function}:DELay:USER" f"{self.user_number()}?"
+        get_cmd = f":SENSe:{self._proper_function}:DELay:USER{self.user_number()}?"
         return self.ask(get_cmd)
 
     def _set_user_delay(self, value: float) -> None:
         set_cmd = (
-            f":SENSe:{self._proper_function}:DELay:USER" f"{self.user_number()} {value}"
+            f":SENSe:{self._proper_function}:DELay:USER{self.user_number()} {value}"
         )
         self.write(set_cmd)
 

--- a/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
+++ b/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
@@ -615,7 +615,7 @@ class Keithley2600Channel(InstrumentChannel):
         """
         self.write(f"{self.channel}.reset()")
         # remember to update all the metadata
-        log.debug(f"Reset channel {self.channel}." + "Updating settings...")
+        log.debug(f"Reset channel {self.channel}. Updating settings...")
         self.snapshot(update=True)
 
     def doFastSweep(self, start: float, stop: float, steps: int, mode: str) -> DataSet:

--- a/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
+++ b/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
@@ -132,9 +132,9 @@ class TimeTrace(ParameterWithSetpoints):
         if nplc * plc > dt:
             warnings.warn(
                 f"Integration time of {nplc*plc*1000:.1f} "
-                + f"ms is longer than {dt*1000:.1f} ms set "
-                + "as measurement interval. Consider lowering "
-                + "NPLC or increasing interval.",
+                f"ms is longer than {dt*1000:.1f} ms set "
+                "as measurement interval. Consider lowering "
+                "NPLC or increasing interval.",
                 UserWarning,
                 2,
             )

--- a/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
+++ b/qcodes/instrument_drivers/Keithley/_Keithley_2600.py
@@ -425,7 +425,7 @@ class Keithley2600Channel(InstrumentChannel):
             set_cmd=f"{channel}.measure.nplc={{}}",
             get_cmd=f"{channel}.measure.nplc",
             get_parser=float,
-            docstring="Number of power line cycles, used " "to perform measurements",
+            docstring="Number of power line cycles, used to perform measurements",
             vals=vals.Numbers(0.001, 25),
         )
         # volt range

--- a/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
+++ b/qcodes/instrument_drivers/Keysight/KeysightAgilent_33XXX.py
@@ -232,18 +232,20 @@ class Keysight33xxxOutputChannel(InstrumentChannel):
                            vals=vals.Enum('NORM', 'INV')
                            )
 
-        self.add_parameter('burst_int_period',
-                           label=(f'Channel {channum}' +
-                                  ' burst internal period'),
-                           set_cmd=f'SOURce{channum}:BURSt:INTernal:PERiod {{}}',
-                           get_cmd=f'SOURce{channum}:BURSt:INTernal:PERiod?',
-                           unit='s',
-                           vals=vals.Numbers(1e-6, 8e3),
-                           get_parser=float,
-                           docstring=('The burst period is the time '
-                                      'between the starts of consecutive '
-                                      'bursts when trigger is immediate.')
-                           )
+        self.add_parameter(
+            "burst_int_period",
+            label=(f"Channel {channum} burst internal period"),
+            set_cmd=f"SOURce{channum}:BURSt:INTernal:PERiod {{}}",
+            get_cmd=f"SOURce{channum}:BURSt:INTernal:PERiod?",
+            unit="s",
+            vals=vals.Numbers(1e-6, 8e3),
+            get_parser=float,
+            docstring=(
+                "The burst period is the time "
+                "between the starts of consecutive "
+                "bursts when trigger is immediate."
+            ),
+        )
 
 
 OutputChannel = Keysight33xxxOutputChannel

--- a/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
+++ b/qcodes/instrument_drivers/Keysight/Keysight_N9030B.py
@@ -269,7 +269,7 @@ class KeysightN9030BSpectrumAnalyzerMode(InstrumentChannel):
             timeout = self.sweep_time() + self.root_instrument._additional_wait
             with self.root_instrument.timeout.set_to(timeout):
                 data_str = self.ask(
-                    f":READ:" f"{self.root_instrument.measurement()}" f"{trace_num}?"
+                    f":READ:{self.root_instrument.measurement()}{trace_num}?"
                 )
                 data = np.array(data_str.rstrip().split(",")).astype("float64")
         except TimeoutError as e:
@@ -409,7 +409,7 @@ class KeysightN9030BPhaseNoiseMode(InstrumentChannel):
 
         if abs(val - start_offset) >= 1:
             self.log.warning(
-                f"Could not set start offset to {val} setting it to " f"{start_offset}"
+                f"Could not set start offset to {val} setting it to {start_offset}"
             )
         if val >= stop_offset or abs(val - stop_offset) < 10:
             self.log.warning(
@@ -430,7 +430,7 @@ class KeysightN9030BPhaseNoiseMode(InstrumentChannel):
 
         if abs(val - stop_offset) >= 1:
             self.log.warning(
-                f"Could not set stop offset to {val} setting it to " f"{stop_offset}"
+                f"Could not set stop offset to {val} setting it to {stop_offset}"
             )
 
         if val <= start_offset or abs(val - start_offset) < 10:
@@ -457,7 +457,7 @@ class KeysightN9030BPhaseNoiseMode(InstrumentChannel):
 
         try:
             data_str = self.ask(
-                f":READ:{self.root_instrument.measurement()}" f"{trace_num}?"
+                f":READ:{self.root_instrument.measurement()}{trace_num}?"
             )
             data = np.array(data_str.rstrip().split(",")).astype("float64")
         except TimeoutError as e:

--- a/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -84,9 +84,7 @@ class FormattedSweep(ParameterWithSetpoints):
         Overwrite setpoint parameter to ask the PNA what type of sweep
         """
         if self.instrument is None:
-            raise RuntimeError(
-                "Cannot return setpoints if not attached " "to instrument"
-            )
+            raise RuntimeError("Cannot return setpoints if not attached to instrument")
         root_instrument: "PNABase" = self.root_instrument  # type: ignore[assignment]
         sweep_type = root_instrument.sweep_type()
         if sweep_type == "LIN":

--- a/qcodes/instrument_drivers/Keysight/N52xx.py
+++ b/qcodes/instrument_drivers/Keysight/N52xx.py
@@ -310,12 +310,16 @@ class KeysightPNATrace(InstrumentChannel):
             msg = "User abort detected. "
             source = root_instr.trigger_source()
             if source == "MAN":
-                msg += "The trigger source is manual. Are you sure this is " \
-                       "correct? Please set the correct source with the " \
-                       "'trigger_source' parameter"
+                msg += (
+                    "The trigger source is manual. Are you sure this is "
+                    "correct? Please set the correct source with the "
+                    "'trigger_source' parameter"
+                )
             elif source == "EXT":
-                msg += "The trigger source is external. Is the trigger " \
-                       "source functional?"
+                msg += (
+                    "The trigger source is external. Is the trigger "
+                    "source functional?"
+                )
             self.log.warning(msg)
             raise
 

--- a/qcodes/instrument_drivers/Keysight/keysight_34934a.py
+++ b/qcodes/instrument_drivers/Keysight/keysight_34934a.py
@@ -25,22 +25,21 @@ class Keysight34934A(KeysightSwitchMatrixSubModule):
 
         super().__init__(parent, name, slot)
 
-        self.add_parameter(name='protection_mode',
-                           get_cmd=self._get_relay_protection_mode,
-                           set_cmd=self._set_relay_protection_mode,
-                           vals=validators.Enum('AUTO100',
-                                                 'AUTO0',
-                                                 'FIX',
-                                                 'ISO'),
-                           docstring='get and set the relay protection mode.'
-                                     'The fastest switching speeds for relays'
-                                     'in a given signal path are achieved using'
-                                     'the FIXed or ISOlated modes, followed'
-                                     'by the AUTO100 and AUTO0 modes.'
-                                     'There may be a maximum of 200 Ohm of'
-                                     'resistance, which can only be bypassed'
-                                     'by "AUTO0" mode. See manual and'
-                                     'programmer''s reference for detail.')
+        self.add_parameter(
+            name="protection_mode",
+            get_cmd=self._get_relay_protection_mode,
+            set_cmd=self._set_relay_protection_mode,
+            vals=validators.Enum("AUTO100", "AUTO0", "FIX", "ISO"),
+            docstring="get and set the relay protection mode."
+            "The fastest switching speeds for relays"
+            "in a given signal path are achieved using"
+            "the FIXed or ISOlated modes, followed"
+            "by the AUTO100 and AUTO0 modes."
+            "There may be a maximum of 200 Ohm of"
+            "resistance, which can only be bypassed"
+            'by "AUTO0" mode. See manual and'
+            "programmer's reference for detail.",
+        )
 
         layout = self.ask(f'SYSTEM:MODule:TERMinal:TYPE? {self.slot}')
         self._is_locked = (layout == 'NONE')

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1500_module.py
@@ -199,11 +199,11 @@ def format_dcorr_response(r: _DCORRResponse) -> str:
     primary = labels_units['primary']
     secondary = labels_units['secondary']
 
-    result_str = \
-        f"Mode: {r.mode.name}, " \
-        f"Primary {primary['label']}: {r.primary} {primary['unit']}, " \
+    result_str = (
+        f"Mode: {r.mode.name}, "
+        f"Primary {primary['label']}: {r.primary} {primary['unit']}, "
         f"Secondary {secondary['label']}: {r.secondary} {secondary['unit']}"
-
+    )
     return result_str
 
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/KeysightB1520A.py
@@ -1119,8 +1119,10 @@ class KeysightB1500Correction(InstrumentChannel):
         self.enable(corr=corr)
 
         is_enabled = self.is_enabled(corr=corr)
-        response_out = f'Correction status {correction_status.name} and ' \
-                       f'Enable {is_enabled.name}'
+        response_out = (
+            f"Correction status {correction_status.name} and "
+            f"Enable {is_enabled.name}"
+        )
         return response_out
 
 

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/constants.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/constants.py
@@ -49,31 +49,40 @@ class MeasurementStatus(StrEnum):
     Contains the meanings of possible compliance errors. One may look at
     this list to figure out the reason for the non-compliant data.
     """
-    C = 'Reached compliance limit.'
-    N = 'No status error occurred.'
-    T = 'Another channel reached compliance limit.'
-    V = 'Measurement data is over the measurement range.' \
-        ' Or the sweep measurement was aborted by the automatic' \
-        ' stop function or power compliance.' \
-        ' D will be 199.999E+99 (no meaning).'
-    X = 'One or more channels are oscillating. ' \
-        'Or source output did not settle before measurement.'
-    U = 'CMU is in the NULL loop unbalance condition.'
-    D = 'CMU is in the IV amplifier saturation condition.'
-    G = 'For linear or binary search measurement, ' \
-        'the target value was not found within the search range.' \
-        ' Returns the source output value. ' \
-        'For quasi-pulsed spot measurement, ' \
-        'the detection time was over the limit ' \
-        '(3 s for Short mode, 12 s for Long mode).'
-    S = 'For linear or binary search measurement, ' \
-        'the search measurement was stopped. ' \
-        'Returns the source output value. ' \
-        'See status of Data_sense.' \
-        'For quasi-pulsed spot measurement, ' \
-        'output slew rate was too slow to perform the settling detection.' \
-        'Or quasi-pulsed source channel reached the current compliance' \
-        ' before the source output voltage changed 10 V from the start voltage.'
+
+    C = "Reached compliance limit."
+    N = "No status error occurred."
+    T = "Another channel reached compliance limit."
+    V = (
+        "Measurement data is over the measurement range."
+        " Or the sweep measurement was aborted by the automatic"
+        " stop function or power compliance."
+        " D will be 199.999E+99 (no meaning)."
+    )
+    X = (
+        "One or more channels are oscillating. "
+        "Or source output did not settle before measurement."
+    )
+    U = "CMU is in the NULL loop unbalance condition."
+    D = "CMU is in the IV amplifier saturation condition."
+    G = (
+        "For linear or binary search measurement, "
+        "the target value was not found within the search range."
+        " Returns the source output value. "
+        "For quasi-pulsed spot measurement, "
+        "the detection time was over the limit "
+        "(3 s for Short mode, 12 s for Long mode)."
+    )
+    S = (
+        "For linear or binary search measurement, "
+        "the search measurement was stopped. "
+        "Returns the source output value. "
+        "See status of Data_sense."
+        "For quasi-pulsed spot measurement, "
+        "output slew rate was too slow to perform the settling detection."
+        "Or quasi-pulsed source channel reached the current compliance"
+        " before the source output voltage changed 10 V from the start voltage."
+    )
 
 
 class ModuleKind(StrEnum):

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
@@ -3682,7 +3682,7 @@ class MessageBuilder:
             _abort = abort
         else:
             raise TypeError(
-                "`abort` argument has to be of type `bool` or " "`constants.Abort`."
+                "`abort` argument has to be of type `bool` or `constants.Abort`."
             )
 
         cmd = f'WM {_abort}'
@@ -3704,7 +3704,7 @@ class MessageBuilder:
             _abort = abort
         else:
             raise TypeError(
-                "`abort` argument has to be of type `bool` or " "`constants.Abort`."
+                "`abort` argument has to be of type `bool` or `constants.Abort`."
             )
 
         cmd = f'WMACV {_abort}'
@@ -3753,7 +3753,7 @@ class MessageBuilder:
             _abort = abort
         else:
             raise TypeError(
-                "`abort` argument has to be of type `bool` or " "`constants.Abort`."
+                "`abort` argument has to be of type `bool` or `constants.Abort`."
             )
 
         cmd = f'WMDCV {_abort}'
@@ -3775,7 +3775,7 @@ class MessageBuilder:
             _abort = abort
         else:
             raise TypeError(
-                "`abort` argument has to be of type `bool` or " "`constants.Abort`."
+                "`abort` argument has to be of type `bool` or `constants.Abort`."
             )
 
         cmd = f'WMFC {_abort}'

--- a/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
+++ b/qcodes/instrument_drivers/Keysight/keysightb1500/message_builder.py
@@ -1276,18 +1276,21 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def corrdt(self,
-               chnum: Union[constants.ChNr, int],
-               freq: float,
-               open_r: float,
-               open_i: float,
-               short_r: float,
-               short_i: float,
-               load_r: float,
-               load_i: float
-               ) -> 'MessageBuilder':
-        cmd = f'CORRDT {chnum},{freq},{open_r},{open_i},{short_r},' \
-              f'{short_i},{load_r},{load_i}'
+    def corrdt(
+        self,
+        chnum: Union[constants.ChNr, int],
+        freq: float,
+        open_r: float,
+        open_i: float,
+        short_r: float,
+        short_i: float,
+        load_r: float,
+        load_i: float,
+    ) -> "MessageBuilder":
+        cmd = (
+            f"CORRDT {chnum},{freq},{open_r},{open_i},{short_r},"
+            f"{short_i},{load_r},{load_i}"
+        )
 
         self._msg.append(cmd)
         return self
@@ -1321,15 +1324,15 @@ class MessageBuilder:
         return self
 
     @final_command
-    def corrser_query(self,
-                      chnum: Union[constants.ChNr, int],
-                      use_immediately: bool,
-                      delay: float,
-                      interval: float,
-                      count: int
-                      ) -> 'MessageBuilder':
-        cmd = f'CORRSER? {chnum},{int(use_immediately)},{delay},{interval},' \
-              f'{count}'
+    def corrser_query(
+        self,
+        chnum: Union[constants.ChNr, int],
+        use_immediately: bool,
+        delay: float,
+        interval: float,
+        count: int,
+    ) -> "MessageBuilder":
+        cmd = f"CORRSER? {chnum},{int(use_immediately)},{delay},{interval},{count}"
 
         self._msg.append(cmd)
         return self
@@ -2744,12 +2747,13 @@ class MessageBuilder:
         self._msg.append(cmd)
         return self
 
-    def qsl(self,
-            enable_data_output: bool,
-            enable_leakage_current_compensation: bool
-            ) -> 'MessageBuilder':
-        cmd = f'QSL {int(enable_data_output)},' \
-              f'{int(enable_leakage_current_compensation)}'
+    def qsl(
+        self, enable_data_output: bool, enable_leakage_current_compensation: bool
+    ) -> "MessageBuilder":
+        cmd = (
+            f"QSL {int(enable_data_output)},"
+            f"{int(enable_leakage_current_compensation)}"
+        )
 
         self._msg.append(cmd)
         return self

--- a/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_325.py
+++ b/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_325.py
@@ -151,7 +151,7 @@ class LakeshoreModel325Curve(InstrumentChannel):
         """
         if cls.temperature_key not in data_dict:
             raise ValueError(
-                f"At least {cls.temperature_key} needed in the " f"data dictionary"
+                f"At least {cls.temperature_key} needed in the data dictionary"
             )
 
         sensor_units = [i for i in data_dict.keys() if i != cls.temperature_key]

--- a/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_372.py
+++ b/qcodes/instrument_drivers/Lakeshore/Lakeshore_model_372.py
@@ -52,14 +52,14 @@ class LakeshoreModel372Output(BaseOutput):
         self.add_parameter(
             "polarity",
             label="Output polarity",
-            docstring="Specifies output polarity (not " "applicable to warm-up heater)",
+            docstring="Specifies output polarity (not applicable to warm-up heater)",
             val_mapping=self.POLARITIES,
             parameter_class=GroupParameter,
         )
         self.add_parameter(
             "use_filter",
             label="Use filter for readings",
-            docstring="Specifies controlling on unfiltered or " "filtered readings",
+            docstring="Specifies controlling on unfiltered or filtered readings",
             val_mapping={True: 1, False: 0},
             parameter_class=GroupParameter,
         )
@@ -67,7 +67,7 @@ class LakeshoreModel372Output(BaseOutput):
             "delay",
             label="Delay",
             unit="s",
-            docstring="Delay in seconds for setpoint change " "during Autoscanning",
+            docstring="Delay in seconds for setpoint change during Autoscanning",
             vals=vals.Ints(0, 255),
             get_parser=int,
             parameter_class=GroupParameter,
@@ -129,7 +129,7 @@ class LakeshoreModel372Channel(BaseSensorChannel):
         self.add_parameter(
             "dwell",
             label="Dwell",
-            docstring="Specifies a value for the autoscanning " "dwell time.",
+            docstring="Specifies a value for the autoscanning dwell time.",
             unit="s",
             get_parser=int,
             vals=vals.Numbers(1, 200),
@@ -138,7 +138,7 @@ class LakeshoreModel372Channel(BaseSensorChannel):
         self.add_parameter(
             "pause",
             label="Change pause time",
-            docstring="Specifies a value for " "the change pause time",
+            docstring="Specifies a value for the change pause time",
             unit="s",
             get_parser=int,
             vals=vals.Numbers(3, 200),

--- a/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
+++ b/qcodes/instrument_drivers/Minicircuits/Base_SPDT.py
@@ -82,9 +82,12 @@ class SPDT_Base(Instrument):
     def __getattr__(self, key: str) -> Any:
         if key in self._deprecated_attributes:
             warnings.warn(
-                ("Using '{}' is deprecated and will be removed in future" +
-                 "releases. Use '{}' instead").
-                format(key, self._deprecated_attributes[key]), UserWarning)
+                (
+                    f"Using '{key}' is deprecated and will be removed in future"
+                    f"releases. Use '{self._deprecated_attributes[key]}' instead"
+                ),
+                UserWarning,
+            )
         return super().__getattr__(key)
 
     def get_number_of_channels(self) -> int:
@@ -97,23 +100,24 @@ class SPDT_Base(Instrument):
         model_parts = model.split('-')
         if len(model_parts) < 2:
             raise RuntimeError(
-                ('The driver could not determine the number of channels of ' +
-                 'the model \'{}\', it might not be supported').format(model)
+                "The driver could not determine the number of channels of "
+                f"the model '{model}', it might not be supported"
             )
         if model_parts[0] not in ('RC', 'USB'):
             log.warning(
-                ('The model with the name \'{}\' might not be supported by' +
-                 ' the driver').format(model))
-        match = re.match('^[0-9]*', model_parts[1])
+                f"The model with the name '{model}' might not be supported by"
+                " the driver"
+            )
+        match = re.match("^[0-9]*", model_parts[1])
         if match is None:
             raise RuntimeError(
-                'The driver could not determine the number of channels of' +
-                f' the model \'{model}\', it might not be supported'
+                "The driver could not determine the number of channels of"
+                f" the model '{model}', it might not be supported"
             )
         channels = match[0]
         if not channels:
             raise RuntimeError(
-                'The driver could not determine the number of channels of' +
-                f' the model \'{model}\', it might not be supported'
+                "The driver could not determine the number of channels of"
+                f" the model '{model}', it might not be supported"
             )
         return int(channels)

--- a/qcodes/instrument_drivers/QDev/QDac_channels.py
+++ b/qcodes/instrument_drivers/QDev/QDac_channels.py
@@ -582,8 +582,8 @@ class QDevQDac(VisaInstrument):
             rampchans = ", ".join(str(c[0]) for c in self._slopes)
             raise ValueError(
                 "Can not assign finite slope to more than "
-                + "8 channels. Assign 'Inf' to at least one of "
-                + f"the following channels: {rampchans}"
+                "8 channels. Assign 'Inf' to at least one of "
+                f"the following channels: {rampchans}"
             )
 
         self._slopes.append((chan, slope))

--- a/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
+++ b/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
@@ -850,9 +850,11 @@ class QDac(VisaInstrument):
                 self.channels[ii].slope.cache(), self.channels[ii].slope.unit
             )
             if self.channels[ii].sync.cache() > 0:
-                line += f"    Sync Out: {self.channels[ii].sync.cache()}, "
-                "Delay: {self.channels[ii].sync_delay.cache()} ({self.channels[ii].sync_delay.unit}), "
-                "Duration: {self.channels[ii].sync_duration.cache()} ({self.channels[ii].sync_duration.unit}).\n"
+                line += (
+                    f"    Sync Out: {self.channels[ii].sync.cache()}, "
+                    "Delay: {self.channels[ii].sync_delay.cache()} ({self.channels[ii].sync_delay.unit}), "
+                    "Duration: {self.channels[ii].sync_duration.cache()} ({self.channels[ii].sync_duration.unit}).\n"
+                )
 
             print(line)
 

--- a/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
+++ b/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
@@ -850,14 +850,9 @@ class QDac(VisaInstrument):
                 self.channels[ii].slope.cache(), self.channels[ii].slope.unit
             )
             if self.channels[ii].sync.cache() > 0:
-                line += '    Sync Out: {}, Delay: {} ({}), '\
-                        'Duration: {} ({}).\n'.format(
-                            self.channels[ii].sync.cache(),
-                            self.channels[ii].sync_delay.cache(),
-                            self.channels[ii].sync_delay.unit,
-                            self.channels[ii].sync_duration.cache(),
-                            self.channels[ii].sync_duration.unit,
-                        )
+                line += f"    Sync Out: {self.channels[ii].sync.cache()}, "
+                "Delay: {self.channels[ii].sync_delay.cache()} ({self.channels[ii].sync_delay.unit}), "
+                "Duration: {self.channels[ii].sync_duration.cache()} ({self.channels[ii].sync_duration.unit}).\n"
 
             print(line)
 

--- a/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
+++ b/qcodes/instrument_drivers/QDevil/QDevil_QDAC.py
@@ -1006,8 +1006,10 @@ class QDac(VisaInstrument):
         step_length_ms = int(step_length*1000)
 
         if step_length < 0.001:
-            LOG.warning('step_length too short: {:.3f} s. \nstep_length set to'
-                        .format(step_length_ms) + ' minimum (1ms).')
+            LOG.warning(
+                f"step_length too short: {step_length_ms:.3f} s. \n"
+                "step_length set to minimum (1ms)."
+            )
             step_length_ms = 1
 
         if any([ch in fast_chans for ch in slow_chans]):

--- a/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
+++ b/qcodes/instrument_drivers/QuantumDesign/DynaCoolPPMS/private/server.py
@@ -56,8 +56,9 @@ def run_server() -> None:
             if sock == server_socket:
                 sock_fd, address = server_socket.accept()
                 socket_dict[sock_fd] = address
-                print('Client ({}, {}) connected.'.format(*address))
-                log.info('Client ({}, {}) connected.'.format(*address))
+                msg_str = f"Client ({address[0]}, {address[1]}) connected."
+                print(msg_str)
+                log.info(msg_str)
 
             # Incoming message from existing connection
             else:
@@ -82,8 +83,9 @@ def run_server() -> None:
                     # send an error code, since the driver expects that for all
                     # commands
                     sock.send(b'0')
-                    print('Client ({}, {}) disconnected.'.format(*socket_dict[sock]))
-                    log.info('Client ({}, {}) disconnected.'.format(*socket_dict[sock]))
+                    msg_str = f"Client ({socket_dict[sock][0]}, {socket_dict[sock][1]}) disconnected."
+                    print(msg_str)
+                    log.info(msg_str)
                     socket_dict.pop(sock, None)
                     sock.close()
                 else:

--- a/qcodes/instrument_drivers/american_magnetics/AMI430.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430.py
@@ -283,11 +283,11 @@ class AMI430(IPInstrument):
         Check the current state of the magnet to see if we can start ramping
         """
         if self.is_quenched():
-            logging.error(__name__ + ': Could not ramp because of quench')
+            logging.error(f"{__name__}: Could not ramp because of quench")
             return False
 
         if self.switch_heater.in_persistent_mode():
-            logging.error(__name__ + ': Could not ramp because persistent')
+            logging.error(f"{__name__}: Could not ramp because persistent")
             return False
 
         state = self.ramping_state()
@@ -300,7 +300,7 @@ class AMI430(IPInstrument):
         elif state in ['holding', 'paused', 'at zero current']:
             return True
 
-        logging.error(__name__ + f': Could not ramp, state: {state}')
+        logging.error(f"{__name__}: Could not ramp, state: {state}")
         return False
 
     def set_field(self,

--- a/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -335,11 +335,11 @@ class AMIModel430(VisaInstrument):
         Check the current state of the magnet to see if we can start ramping
         """
         if self.is_quenched():
-            logging.error(__name__ + ": Could not ramp because of quench")
+            logging.error(f"{__name__}: Could not ramp because of quench")
             return False
 
         if self.switch_heater.in_persistent_mode():
-            logging.error(__name__ + ": Could not ramp because persistent")
+            logging.error(f"{__name__}: Could not ramp because persistent")
             return False
 
         state = self.ramping_state()
@@ -352,7 +352,7 @@ class AMIModel430(VisaInstrument):
         elif state in ["holding", "paused", "at zero current"]:
             return True
 
-        logging.error(__name__ + f": Could not ramp, state: {state}")
+        logging.error(f"{__name__}: Could not ramp, state: {state}")
         return False
 
     def set_field(

--- a/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
+++ b/qcodes/instrument_drivers/american_magnetics/AMI430_visa.py
@@ -382,7 +382,7 @@ class AMIModel430(VisaInstrument):
         # Check we can ramp
         if not self._can_start_ramping():
             raise AMI430Exception(
-                f"Cannot ramp in current state: " f"state is {self.ramping_state()}"
+                f"Cannot ramp in current state: state is {self.ramping_state()}"
             )
 
         # Then, do the actual ramp

--- a/qcodes/instrument_drivers/oxford/triton.py
+++ b/qcodes/instrument_drivers/oxford/triton.py
@@ -3,7 +3,6 @@ import logging
 import re
 from functools import partial
 from time import sleep
-from traceback import format_exc
 from typing import Any, Optional, Union
 
 from qcodes.instrument import IPInstrument
@@ -233,7 +232,7 @@ class OxfordTriton(IPInstrument):
         try:
             self._get_named_channels()
         except Exception:
-            logging.warning("Ignored an error in _get_named_channels\n" + format_exc())
+            logging.warning("Ignored an error in _get_named_channels\n", exc_info=True)
 
         self.connect_message()
 

--- a/qcodes/instrument_drivers/rigol/Rigol_DG1062.py
+++ b/qcodes/instrument_drivers/rigol/Rigol_DG1062.py
@@ -293,9 +293,7 @@ class RigolDG1062Channel(InstrumentChannel):
         if param in params_dict:
             params_dict[param] = value
         else:
-            log.warning(
-                f"Warning, unable to set '{param}' for the current " f"waveform"
-            )
+            log.warning(f"Warning, unable to set '{param}' for the current waveform")
             return
 
         return self._set_waveform_params(**params_dict)
@@ -318,7 +316,7 @@ class RigolDG1062Channel(InstrumentChannel):
 
         if not set(param_names).issubset(params_dict.keys()):
             raise ValueError(
-                f"Waveform {waveform} needs at least parameters " f"{param_names}"
+                f"Waveform {waveform} needs at least parameters {param_names}"
             )
 
         string = f":SOUR{self.channel}:APPL:{waveform} "

--- a/qcodes/instrument_drivers/rigol/Rigol_DG4000.py
+++ b/qcodes/instrument_drivers/rigol/Rigol_DG4000.py
@@ -247,13 +247,13 @@ class RigolDG4000(VisaInstrument):
             # to implement in here
             self.add_function(
                 ch + "custom",
-                call_cmd=source + "APPL:CUST " "{:.6e},{:.6e},{:.6e},{:.6e}",
+                call_cmd=source + "APPL:CUST {:.6e},{:.6e},{:.6e},{:.6e}",
                 args=[Numbers(1e-6, arb_freq), Numbers(), Numbers(), Numbers(0, 360)],
             )
 
             self.add_function(
                 ch + "harmonic",
-                call_cmd=source + "APPL:HARM " "{:.6e},{:.6e},{:.6e},{:.6e}",
+                call_cmd=source + "APPL:HARM {:.6e},{:.6e},{:.6e},{:.6e}",
                 args=[
                     Numbers(1e-6, harmonic_freq),
                     Numbers(),
@@ -270,25 +270,25 @@ class RigolDG4000(VisaInstrument):
 
             self.add_function(
                 ch + "pulse",
-                call_cmd=source + "APPL:PULS " "{:.6e},{:.6e},{:.6e},{:.6e}",
+                call_cmd=source + "APPL:PULS {:.6e},{:.6e},{:.6e},{:.6e}",
                 args=[Numbers(1e-6, pulse_freq), Numbers(), Numbers(), Numbers(0)],
             )
 
             self.add_function(
                 ch + "ramp",
-                call_cmd=source + "APPL:RAMP " "{:.6e},{:.6e},{:.6e},{:.6e}",
+                call_cmd=source + "APPL:RAMP {:.6e},{:.6e},{:.6e},{:.6e}",
                 args=[Numbers(1e-6, ramp_freq), Numbers(), Numbers(), Numbers(0, 360)],
             )
 
             self.add_function(
                 ch + "sinusoid",
-                call_cmd=source + "APPL:SIN " "{:.6e},{:.6e},{:.6e},{:.6e}",
+                call_cmd=source + "APPL:SIN {:.6e},{:.6e},{:.6e},{:.6e}",
                 args=[Numbers(1e-6, sine_freq), Numbers(), Numbers(), Numbers(0, 360)],
             )
 
             self.add_function(
                 ch + "square",
-                call_cmd=source + "APPL:SQU " "{:.6e},{:.6e},{:.6e},{:.6e}",
+                call_cmd=source + "APPL:SQU {:.6e},{:.6e},{:.6e},{:.6e}",
                 args=[
                     Numbers(1e-6, square_freq),
                     Numbers(),
@@ -299,7 +299,7 @@ class RigolDG4000(VisaInstrument):
 
             self.add_function(
                 ch + "user",
-                call_cmd=source + "APPL:USER " "{:.6e},{:.6e},{:.6e},{:.6e}",
+                call_cmd=source + "APPL:USER {:.6e},{:.6e},{:.6e},{:.6e}",
                 args=[Numbers(1e-6, arb_freq), Numbers(), Numbers(), Numbers(0, 360)],
             )
 

--- a/qcodes/instrument_drivers/rigol/Rigol_DS4000.py
+++ b/qcodes/instrument_drivers/rigol/Rigol_DS4000.py
@@ -110,7 +110,7 @@ class ScopeArray(ArrayParameter):
                     # Wait some time to have the buffer re-filled
                     time.sleep(0.3)
                 log.info(
-                    "chucks read: %d, last chuck points: " "%g, total read size: %g",
+                    "chucks read: %d, last chuck points: %g, total read size: %g",
                     i,
                     len(data_chuck),
                     len(data_bin),

--- a/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
+++ b/qcodes/instrument_drivers/rohde_schwarz/RTO1000.py
@@ -60,7 +60,7 @@ class ScopeTrace(ArrayParameter):
 
         # now get setpoints
 
-        hdr = self.root_instrument.ask(f"CHANnel{self.channum}:" "DATA:HEADER?")
+        hdr = self.root_instrument.ask(f"CHANnel{self.channum}:DATA:HEADER?")
         hdr_vals = list(map(float, hdr.split(",")))
         t_start = hdr_vals[0]
         t_stop = hdr_vals[1]

--- a/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
@@ -29,7 +29,7 @@ class TraceParameter(Parameter):
     def set_raw(self, value: Any) -> None:  # pylint: disable=method-hidden
         if not isinstance(self.instrument, SignalHoundUSBSA124B):
             raise RuntimeError(
-                "TraceParameter only works with " "'SignalHound_USB_SA124B'"
+                "TraceParameter only works with 'SignalHound_USB_SA124B'"
             )
         self.instrument._parameters_synced = False
 
@@ -64,7 +64,7 @@ class ScaleParameter(TraceParameter):
     def set_raw(self, value: str) -> None:  # pylint: disable=method-hidden
         if not isinstance(self.instrument, SignalHoundUSBSA124B):
             raise RuntimeError(
-                "ScaleParameter only works with " "'SignalHound_USB_SA124B'"
+                "ScaleParameter only works with 'SignalHound_USB_SA124B'"
             )
         if value in ("log-scale", "log-full-scale"):
             unit = "dBm"
@@ -89,7 +89,7 @@ class SweepTraceParameter(TraceParameter):
     def set_raw(self, value: Any) -> None:  # pylint: disable=method-hidden
         if not isinstance(self.instrument, SignalHoundUSBSA124B):
             raise RuntimeError(
-                "SweepTraceParameter only works with " "'SignalHound_USB_SA124B'"
+                "SweepTraceParameter only works with 'SignalHound_USB_SA124B'"
             )
         self.instrument._trace_updated = False
         super().set_raw(value)
@@ -148,7 +148,7 @@ class FrequencySweep(ArrayParameter):
         """
         if not isinstance(self.instrument, SignalHoundUSBSA124B):
             raise RuntimeError(
-                "'FrequencySweep' is only implemented" "for 'SignalHound_USB_SA124B'"
+                "'FrequencySweep' is only implementedfor 'SignalHound_USB_SA124B'"
             )
         end_freq = start_freq + stepsize * (sweep_len - 1)
         freq_points = tuple(np.linspace(start_freq, end_freq, sweep_len))
@@ -158,10 +158,10 @@ class FrequencySweep(ArrayParameter):
 
     def get_raw(self) -> np.ndarray:
         if self.instrument is None:
-            raise RuntimeError("No instrument is attached to" "'FrequencySweep'")
+            raise RuntimeError("No instrument is attached to'FrequencySweep'")
         if not isinstance(self.instrument, SignalHoundUSBSA124B):
             raise RuntimeError(
-                "'FrequencySweep' is only implemented" "for 'SignalHound_USB_SA124B'"
+                "'FrequencySweep' is only implementedfor 'SignalHound_USB_SA124B'"
             )
         if not self.instrument._trace_updated:
             raise RuntimeError("trace not updated, run configure to update")
@@ -321,7 +321,7 @@ class SignalHoundUSBSA124B(Instrument):
             initial_value=True,
             parameter_class=TraceParameter,
             get_cmd=None,
-            docstring="Apply software filter to remove " "undersampling mirroring",
+            docstring="Apply software filter to remove undersampling mirroring",
             vals=vals.Bool(),
         )
         self.add_parameter(
@@ -567,7 +567,7 @@ class SignalHoundUSBSA124B(Instrument):
         """
         Close connection to the instrument.
         """
-        log.info("Closing Device with handle num: " f"{self.deviceHandle.value}")
+        log.info(f"Closing Device with handle num: {self.deviceHandle.value}")
 
         try:
             self.abort()

--- a/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
@@ -148,7 +148,7 @@ class FrequencySweep(ArrayParameter):
         """
         if not isinstance(self.instrument, SignalHoundUSBSA124B):
             raise RuntimeError(
-                "'FrequencySweep' is only implementedfor 'SignalHound_USB_SA124B'"
+                "'FrequencySweep' is only implemented for 'SignalHound_USB_SA124B'"
             )
         end_freq = start_freq + stepsize * (sweep_len - 1)
         freq_points = tuple(np.linspace(start_freq, end_freq, sweep_len))

--- a/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
+++ b/qcodes/instrument_drivers/signal_hound/SignalHound_USB_SA124B.py
@@ -158,10 +158,10 @@ class FrequencySweep(ArrayParameter):
 
     def get_raw(self) -> np.ndarray:
         if self.instrument is None:
-            raise RuntimeError("No instrument is attached to'FrequencySweep'")
+            raise RuntimeError("No instrument is attached to 'FrequencySweep'")
         if not isinstance(self.instrument, SignalHoundUSBSA124B):
             raise RuntimeError(
-                "'FrequencySweep' is only implementedfor 'SignalHound_USB_SA124B'"
+                "'FrequencySweep' is only implemented for 'SignalHound_USB_SA124B'"
             )
         if not self.instrument._trace_updated:
             raise RuntimeError("trace not updated, run configure to update")

--- a/qcodes/instrument_drivers/stahl/stahl.py
+++ b/qcodes/instrument_drivers/stahl/stahl.py
@@ -107,8 +107,10 @@ class StahlChannel(InstrumentChannel):
             [0, 1]
         )
 
-        send_string = f"{self.parent.identifier} CH{self._channel_string} " \
+        send_string = (
+            f"{self.parent.identifier} CH{self._channel_string} "
             f"{voltage_normalized:.5f}"
+        )
         response = self.ask(send_string)
 
         if response != self.acknowledge_reply:

--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -548,17 +548,15 @@ class TektronixAWG5014(VisaInstrument):
         dircheck = '%s, DIR' % folder
         if dircheck in self.get_folder_contents():
             self.change_folder(folder)
-            log.debug('Directory already exists')
-            log.warning(('Directory already exists, ' +
-                         'changed path to {}').format(folder))
-            log.info('Contents of folder is ' +
-                     '{}'.format(self.ask('MMEMory:cat?')))
+            log.debug("Directory already exists")
+            log.warning(f"Directory already exists, changed path to {folder}")
+            content = self.ask("MMEMory:cat?")
+            log.info("Contents of folder is %s", content)
         elif self.get_current_folder_name() == f'"\\{folder}"':
-            log.info('Directory already set to ' +
-                     f'{folder}')
+            log.info(f"Directory already set to {folder}")
         else:
-            self.write('MMEMory:MDIRectory "%s"' % folder)
-            self.write('MMEMory:CDIRectory "%s"' % folder)
+            self.write(f'MMEMory:MDIRectory "{folder}"')
+            self.write(f'MMEMory:CDIRectory "{folder}"')
 
         return self.get_folder_contents()
 
@@ -646,8 +644,10 @@ class TektronixAWG5014(VisaInstrument):
         """
         allowed_states = [0, 1]
         if goto_state not in allowed_states:
-            log.warning(('{} not recognized as a valid goto' +
-                         ' state. Setting to 0 (OFF).').format(goto_state))
+            log.warning(
+                f"{goto_state} not recognized as a valid goto"
+                " state. Setting to 0 (OFF)."
+            )
             goto_state = 0
         self.write(f"SEQuence:ELEMent{element_no}:GOTO:STATe {int(goto_state)}")
 
@@ -667,8 +667,9 @@ class TektronixAWG5014(VisaInstrument):
         """
         allowed_states = [0, 1]
         if state not in allowed_states:
-            log.warning(('{} not recognized as a valid loop' +
-                         '  state. Setting to 0 (OFF).').format(state))
+            log.warning(
+                f"{state} not recognized as a valid loop state. Setting to 0 (OFF)."
+            )
             state = 0
 
         self.write(f"SEQuence:ELEMent{element_no}:LOOP:INFinite {int(state)}")
@@ -1128,8 +1129,7 @@ class TektronixAWG5014(VisaInstrument):
                 head_str.write(self._pack_record(k, sequence_cfg[k],
                                                  self.AWG_FILE_FORMAT_HEAD[k]))
             else:
-                log.warning('AWG: ' + k +
-                            ' not recognized as valid AWG setting')
+                log.warning(f"AWG: {k} not recognized as valid AWG setting")
         # channel settings
         ch_record_str = BytesIO()
         for k in list(channel_cfg.keys()):
@@ -1140,8 +1140,7 @@ class TektronixAWG5014(VisaInstrument):
                 ch_record_str.write(pack)
 
             else:
-                log.warning('AWG: ' + k +
-                            ' not recognized as valid AWG channel setting')
+                log.warning(f"AWG: {k} not recognized as valid AWG channel setting")
 
         # waveforms
         ii = 21

--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -368,11 +368,9 @@ class TektronixAWG5014(VisaInstrument):
 
             # Marker channels
             for j in range(1, 3):
-                m_del_cmd = f'SOURce{i}:MARKer{j}:DELay'
-                m_high_cmd = ('SOURce{}:MARKer{}:VOLTage:' +
-                              'LEVel:IMMediate:HIGH').format(i, j)
-                m_low_cmd = ('SOURce{}:MARKer{}:VOLTage:' +
-                             'LEVel:IMMediate:LOW').format(i, j)
+                m_del_cmd = f"SOURce{i}:MARKer{j}:DELay"
+                m_high_cmd = f"SOURce{i}:MARKer{j}:VOLTage:LEVel:IMMediate:HIGH"
+                m_low_cmd = f"SOURce{i}:MARKer{j}:VOLTage:LEVel:IMMediate:LOW"
 
                 self.add_parameter(
                     f'ch{i}_m{j}_del',
@@ -440,8 +438,7 @@ class TektronixAWG5014(VisaInstrument):
         elif state.startswith('2'):
             return 'Running'
         else:
-            raise ValueError(__name__ + (' : AWG in undefined ' +
-                                         'state "{}"').format(state))
+            raise ValueError(f'__name__ : AWG in undefined state "{state}"')
 
     def start(self) -> str:
         """Convenience function, identical to self.run()"""
@@ -604,8 +601,7 @@ class TektronixAWG5014(VisaInstrument):
             element_no: The sequence element number
             index: The index to set the target to
         """
-        self.write('SEQuence:' +
-                   f'ELEMent{element_no}:JTARGet:INDex {index}')
+        self.write(f"SEQuence:ELEMent{element_no}:JTARGet:INDex {index}")
 
     def set_sqel_goto_target_index(
             self,
@@ -890,24 +886,28 @@ class TektronixAWG5014(VisaInstrument):
             'TRIGGER_SOURCE':   1 if
             self.get('trigger_source').startswith('EXT') else 2,
             # External | Internal
-            'TRIGGER_INPUT_IMPEDANCE': (1 if self.get('trigger_impedance') ==
-                                        50. else 2),  # 50 ohm | 1 kohm
-            'TRIGGER_INPUT_SLOPE': (1 if self.get('trigger_slope').startswith(
-                                    'POS') else 2),  # Positive | Negative
-            'TRIGGER_INPUT_POLARITY': (1 if self.ask('TRIGger:' +
-                                                     'POLarity?').startswith(
-                                       'POS') else 2),  # Positive | Negative
-            'TRIGGER_INPUT_THRESHOLD':  self.get('trigger_level'),  # V
-            'EVENT_INPUT_IMPEDANCE':   (1 if self.get('event_impedance') ==
-                                        50. else 2),  # 50 ohm | 1 kohm
-            'EVENT_INPUT_POLARITY':  (1 if self.get('event_polarity').startswith(
-                                      'POS') else 2),  # Positive | Negative
-            'EVENT_INPUT_THRESHOLD':   self.get('event_level'),  # V
-            'JUMP_TIMING':   (1 if
-                              self.get('event_jump_timing').startswith('SYNC')
-                              else 2),  # Sync | Async
-            'RUN_MODE':   4,  # Continuous | Triggered | Gated | Sequence
-            'RUN_STATE':  0,  # On | Off
+            "TRIGGER_INPUT_IMPEDANCE": (
+                1 if self.get("trigger_impedance") == 50.0 else 2
+            ),  # 50 ohm | 1 kohm
+            "TRIGGER_INPUT_SLOPE": (
+                1 if self.get("trigger_slope").startswith("POS") else 2
+            ),  # Positive | Negative
+            "TRIGGER_INPUT_POLARITY": (
+                1 if self.ask("TRIGger:POLarity?").startswith("POS") else 2
+            ),  # Positive | Negative
+            "TRIGGER_INPUT_THRESHOLD": self.get("trigger_level"),  # V
+            "EVENT_INPUT_IMPEDANCE": (
+                1 if self.get("event_impedance") == 50.0 else 2
+            ),  # 50 ohm | 1 kohm
+            "EVENT_INPUT_POLARITY": (
+                1 if self.get("event_polarity").startswith("POS") else 2
+            ),  # Positive | Negative
+            "EVENT_INPUT_THRESHOLD": self.get("event_level"),  # V
+            "JUMP_TIMING": (
+                1 if self.get("event_jump_timing").startswith("SYNC") else 2
+            ),  # Sync | Async
+            "RUN_MODE": 4,  # Continuous | Triggered | Gated | Sequence
+            "RUN_STATE": 0,  # On | Off
         }
         return AWG_sequence_cfg
 
@@ -1401,8 +1401,7 @@ class TektronixAWG5014(VisaInstrument):
             preservechannelsettings=preservechannelsettings)
 
         # by default, an unusable directory is targeted on the AWG
-        self.visa_handle.write('MMEMory:CDIRectory ' +
-                               '"C:\\Users\\OEM\\Documents"')
+        self.visa_handle.write('MMEMory:CDIRectory "C:\\Users\\OEM\\Documents"')
 
         self.send_awg_file(filename, awg_file)
         currentdir = self.visa_handle.query('MMEMory:CDIRectory?')
@@ -1523,14 +1522,17 @@ class TektronixAWG5014(VisaInstrument):
         if (not((len(wf) == len(m1)) and (len(m1) == len(m2)))):
             raise Exception('error: sizes of the waveforms do not match')
         if np.min(wf) < -1 or np.max(wf) > 1:
-            raise TypeError('Waveform values out of bonds.' +
-                            ' Allowed values: -1 to 1 (inclusive)')
+            raise TypeError(
+                "Waveform values out of bonds. Allowed values: -1 to 1 (inclusive)"
+            )
         if not np.all(np.in1d(m1, np.array([0, 1]))):
-            raise TypeError('Marker 1 contains invalid values.' +
-                            ' Only 0 and 1 are allowed')
+            raise TypeError(
+                "Marker 1 contains invalid values. Only 0 and 1 are allowed"
+            )
         if not np.all(np.in1d(m2, np.array([0, 1]))):
-            raise TypeError('Marker 2 contains invalid values.' +
-                            ' Only 0 and 1 are allowed')
+            raise TypeError(
+                "Marker 2 contains invalid values. Only 0 and 1 are allowed"
+            )
 
         # Note: we use np.trunc here rather than np.round
         # as it is an order of magnitude faster
@@ -1661,14 +1663,17 @@ class TektronixAWG5014(VisaInstrument):
         if (not((len(w) == len(m1)) and (len(m1) == len(m2)))):
             raise Exception('error: sizes of the waveforms do not match')
         if min(w) < -1 or max(w) > 1:
-            raise TypeError('Waveform values out of bonds.' +
-                            ' Allowed values: -1 to 1 (inclusive)')
+            raise TypeError(
+                "Waveform values out of bonds. Allowed values: -1 to 1 (inclusive)"
+            )
         if (list(m1).count(0) + list(m1).count(1)) != len(m1):
-            raise TypeError('Marker 1 contains invalid values.' +
-                            ' Only 0 and 1 are allowed')
+            raise TypeError(
+                "Marker 1 contains invalid values. Only 0 and 1 are allowed"
+            )
         if (list(m2).count(0) + list(m2).count(1)) != len(m2):
-            raise TypeError('Marker 2 contains invalid values.' +
-                            ' Only 0 and 1 are allowed')
+            raise TypeError(
+                "Marker 2 contains invalid values. Only 0 and 1 are allowed"
+            )
 
         self._values['files'][wfmname] = self._file_dict(w, m1, m2, None)
 

--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -438,7 +438,7 @@ class TektronixAWG5014(VisaInstrument):
         elif state.startswith('2'):
             return 'Running'
         else:
-            raise ValueError(f'__name__ : AWG in undefined state "{state}"')
+            raise ValueError(f'{__name__} : AWG in undefined state "{state}"')
 
     def start(self) -> str:
         """Convenience function, identical to self.run()"""

--- a/qcodes/instrument_drivers/tektronix/AWG70000A.py
+++ b/qcodes/instrument_drivers/tektronix/AWG70000A.py
@@ -794,11 +794,16 @@ class AWG70000A(VisaInstrument):
         dsc = ET.SubElement(hdr, 'DataSetsCollection')
         dsc.set("xmlns", "http://www.tektronix.com")
         dsc.set("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
-        dsc.set("xsi:schemaLocation", (r"http://www.tektronix.com file:///" +
-                                       r"C:\Program%20Files\Tektronix\AWG70000" +
-                                       r"\AWG\Schemas\awgDataSets.xsd"))
-        datasets = ET.SubElement(dsc, 'DataSets')
-        datasets.set('version', '1')
+        dsc.set(
+            "xsi:schemaLocation",
+            (
+                r"http://www.tektronix.com file:///"
+                r"C:\Program%20Files\Tektronix\AWG70000"
+                r"\AWG\Schemas\awgDataSets.xsd"
+            ),
+        )
+        datasets = ET.SubElement(dsc, "DataSets")
+        datasets.set("version", "1")
         datasets.set("xmlns", "http://www.tektronix.com")
 
         # Description of the data
@@ -1327,11 +1332,16 @@ class AWG70000A(VisaInstrument):
         dsc = ET.SubElement(datafile, 'DataSetsCollection')
         dsc.set("xmlns", "http://www.tektronix.com")
         dsc.set("xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance")
-        dsc.set("xsi:schemaLocation", (r"http://www.tektronix.com file:///" +
-                                       r"C:\Program%20Files\Tektronix\AWG70000" +
-                                       r"\AWG\Schemas\awgSeqDataSets.xsd"))
-        datasets = ET.SubElement(dsc, 'DataSets')
-        datasets.set('version', '1')
+        dsc.set(
+            "xsi:schemaLocation",
+            (
+                r"http://www.tektronix.com file:///"
+                r"C:\Program%20Files\Tektronix\AWG70000"
+                r"\AWG\Schemas\awgSeqDataSets.xsd"
+            ),
+        )
+        datasets = ET.SubElement(dsc, "DataSets")
+        datasets.set("version", "1")
         datasets.set("xmlns", "http://www.tektronix.com")
 
         # Description of the data

--- a/qcodes/instrument_drivers/tektronix/AWG70000A.py
+++ b/qcodes/instrument_drivers/tektronix/AWG70000A.py
@@ -892,12 +892,12 @@ class AWG70000A(VisaInstrument):
             binary_marker = struct.pack(fmt, *markers)
 
         if wfm.max() > channel_max or wfm.min() < channel_min:
-            log.warning('Waveform exceeds specified channel range.'
-                        ' The resulting waveform will be clipped. '
-                        'Waveform min.: {} (V), waveform max.: {} (V),'
-                        'Channel min.: {} (V), channel max.: {} (V)'
-                        ''.format(wfm.min(), wfm.max(), channel_min,
-                                  channel_max))
+            log.warning(
+                f"Waveform exceeds specified channel range."
+                f" The resulting waveform will be clipped. "
+                f"Waveform min.: {wfm.min()} (V), waveform max.: {wfm.max()} (V),"
+                f"Channel min.: {channel_min} (V), channel max.: {channel_max} (V)"
+            )
 
         # the data must be such that channel_max becomes 1 and
         # channel_min becomes -1

--- a/qcodes/instrument_drivers/tektronix/AWGFileParser.py
+++ b/qcodes/instrument_drivers/tektronix/AWGFileParser.py
@@ -385,11 +385,11 @@ def _getendingnumber(string: str) -> tuple[int, str]:
     return int(num[::-1]), string[:-len(num)]
 
 
-awgfilepath = ('/Users/william/AuxiliaryQCoDeS/AWGhelpers/awgfiles/' +
-               'customawgfile.awg')
+awgfilepath = "/Users/william/AuxiliaryQCoDeS/AWGhelpers/awgfiles/customawgfile.awg"
 
-awgfilepath2 = ('/Users/william/AuxiliaryQCoDeS/AWGhelpers/awgfiles/' +
-                'machinemadefortest.awg')
+awgfilepath2 = (
+    "/Users/william/AuxiliaryQCoDeS/AWGhelpers/awgfiles/machinemadefortest.awg"
+)
 
 
 def _parser1(

--- a/qcodes/instrument_drivers/tektronix/TPS2012.py
+++ b/qcodes/instrument_drivers/tektronix/TPS2012.py
@@ -350,13 +350,12 @@ class TektronixTPS2012(VisaInstrument):
         self.add_submodule("channels", channels.to_channel_tuple())
 
         # Necessary settings for parsing the binary curve data
-        self.visa_handle.encoding = 'latin-1'
-        log.info('Set VISA encoding to latin-1')
-        self.write('DATa:ENCdg RPBinary')
-        log.info('Set TPS2012 data encoding to RPBinary' +
-                 ' (Positive Integer Binary)')
-        self.write('DATa:WIDTh 2')
-        log.info('Set TPS2012 data width to 2')
+        self.visa_handle.encoding = "latin-1"
+        log.info("Set VISA encoding to latin-1")
+        self.write("DATa:ENCdg RPBinary")
+        log.info("Set TPS2012 data encoding to RPBinary (Positive Integer Binary)")
+        self.write("DATa:WIDTh 2")
+        log.info("Set TPS2012 data width to 2")
         # Note: using data width 2 has been tested to not add
         # significantly to transfer times. The maximal length
         # of an array in one transfer is 2500 points.

--- a/qcodes/instrument_drivers/yokogawa/GS200.py
+++ b/qcodes/instrument_drivers/yokogawa/GS200.py
@@ -220,14 +220,14 @@ class GS200Program(InstrumentChannel):
         self.add_parameter(
             "save",
             set_cmd=":PROG:SAVE '{}'",
-            docstring="save the program to the system memory " "(.csv file)",
+            docstring="save the program to the system memory (.csv file)",
         )
 
         self.add_parameter(
             "load",
             get_cmd=":PROG:LOAD?",
             set_cmd=":PROG:LOAD '{}'",
-            docstring="load the program (.csv file) from the " "system memory",
+            docstring="load the program (.csv file) from the system memory",
         )
 
         self.add_parameter(
@@ -546,7 +546,7 @@ class GS200(VisaInstrument):
             self_range = self.range()
             if self_range is None:
                 raise RuntimeError(
-                    "Trying to set output but not in" " auto mode and range is unknown."
+                    "Trying to set output but not in auto mode and range is unknown."
                 )
         else:
             mode = self.source_mode.get_latest()

--- a/qcodes/instrument_drivers/yokogawa/Yokogawa_GS200.py
+++ b/qcodes/instrument_drivers/yokogawa/Yokogawa_GS200.py
@@ -215,14 +215,14 @@ class YokogawaGS200Program(InstrumentChannel):
         self.add_parameter(
             "save",
             set_cmd=":PROG:SAVE '{}'",
-            docstring="save the program to the system memory " "(.csv file)",
+            docstring="save the program to the system memory (.csv file)",
         )
 
         self.add_parameter(
             "load",
             get_cmd=":PROG:LOAD?",
             set_cmd=":PROG:LOAD '{}'",
-            docstring="load the program (.csv file) from the " "system memory",
+            docstring="load the program (.csv file) from the system memory",
         )
 
         self.add_parameter(

--- a/qcodes/parameters/array_parameter.py
+++ b/qcodes/parameters/array_parameter.py
@@ -136,7 +136,7 @@ class ArrayParameter(ParameterBase):
 
         if self.settable:
             # TODO (alexcjohnson): can we support, ala Combine?
-            raise AttributeError("ArrayParameters do not support set " "at this time.")
+            raise AttributeError("ArrayParameters do not support set at this time.")
 
         self._meta_attrs.extend(
             ["setpoint_names", "setpoint_labels", "setpoint_units", "label", "unit"]

--- a/qcodes/parameters/group_parameter.py
+++ b/qcodes/parameters/group_parameter.py
@@ -54,7 +54,7 @@ class GroupParameter(Parameter):
 
         if "set_cmd" in kwargs or "get_cmd" in kwargs:
             raise ValueError(
-                "A GroupParameter does not use 'set_cmd' or " "'get_cmd' kwarg"
+                "A GroupParameter does not use 'set_cmd' or 'get_cmd' kwarg"
             )
 
         self._group: Group | None = None

--- a/qcodes/parameters/multi_parameter.py
+++ b/qcodes/parameters/multi_parameter.py
@@ -176,7 +176,7 @@ class MultiParameter(ParameterBase):
 
         if not is_sequence_of(shapes, int, depth=2) or len(shapes) != len(names):
             raise ValueError(
-                "shapes must be a tuple of tuples of ints, not " + repr(shapes)
+                f"shapes must be a tuple of tuples of ints, not {shapes!r}"
             )
         self.shapes = shapes
 

--- a/qcodes/parameters/multi_parameter.py
+++ b/qcodes/parameters/multi_parameter.py
@@ -176,7 +176,7 @@ class MultiParameter(ParameterBase):
 
         if not is_sequence_of(shapes, int, depth=2) or len(shapes) != len(names):
             raise ValueError(
-                "shapes must be a tuple of tuples " "of ints, not " + repr(shapes)
+                "shapes must be a tuple of tuples of ints, not " + repr(shapes)
             )
         self.shapes = shapes
 

--- a/qcodes/parameters/parameter_base.py
+++ b/qcodes/parameters/parameter_base.py
@@ -560,7 +560,7 @@ class ParameterBase(MetadatableWithName):
         @wraps(get_function)
         def get_wrapper(*args: Any, **kwargs: Any) -> ParamDataType:
             if not self.gettable:
-                raise TypeError("Trying to get a parameter" " that is not gettable.")
+                raise TypeError("Trying to get a parameter that is not gettable.")
             if self.abstract:
                 raise NotImplementedError(
                     f"Trying to get an abstract parameter: {self.full_name}"
@@ -589,9 +589,7 @@ class ParameterBase(MetadatableWithName):
         def set_wrapper(value: ParamDataType, **kwargs: Any) -> None:
             try:
                 if not self.settable:
-                    raise TypeError(
-                        "Trying to set a parameter" " that is not settable."
-                    )
+                    raise TypeError("Trying to set a parameter that is not settable.")
                 if self.abstract:
                     raise NotImplementedError(
                         f"Trying to set an abstract parameter: {self.full_name}"

--- a/qcodes/parameters/scaled_paramter.py
+++ b/qcodes/parameters/scaled_paramter.py
@@ -118,7 +118,7 @@ class ScaledParameter(Parameter):
     def _multiplier(self) -> Parameter:
         if self._multiplier_parameter is None:
             raise RuntimeError(
-                "Cannot get multiplier when multiplier " "parameter in unknown."
+                "Cannot get multiplier when multiplier parameter in unknown."
             )
         return self._multiplier_parameter
 

--- a/qcodes/parameters/specialized_parameters.py
+++ b/qcodes/parameters/specialized_parameters.py
@@ -34,7 +34,7 @@ class ElapsedTimeParameter(Parameter):
 
         for hck in hardcoded_kwargs:
             if hck in kwargs:
-                raise ValueError(f'Can not set "{hck}" for an ' "ElapsedTimeParameter.")
+                raise ValueError(f'Can not set "{hck}" for an ElapsedTimeParameter.')
 
         super().__init__(name=name, label=label, unit="s", set_cmd=False, **kwargs)
 

--- a/qcodes/sphinx_extensions/parse_parameter_attr.py
+++ b/qcodes/sphinx_extensions/parse_parameter_attr.py
@@ -89,7 +89,7 @@ def parse_init_function_from_str(
     init_funcs = find_init_func(classes[0])
     if len(init_funcs) > 1:
         LOGGER.warning(
-            f"Found more than one init function for {classname}: " f"Found {init_funcs}"
+            f"Found more than one init function for {classname}: Found {init_funcs}"
         )
         return None
     if len(init_funcs) == 0:

--- a/qcodes/tests/dataset/test_database_creation_and_upgrading.py
+++ b/qcodes/tests/dataset/test_database_creation_and_upgrading.py
@@ -880,8 +880,10 @@ def test_cannot_connect_to_newer_db() -> None:
     current_version = get_user_version(conn)
     set_user_version(conn, current_version+1)
     conn.close()
-    err_msg = f'is version {current_version + 1} but this version of QCoDeS ' \
-        f'supports up to version {current_version}'
+    err_msg = (
+        f"is version {current_version + 1} but this version of QCoDeS "
+        f"supports up to version {current_version}"
+    )
     with pytest.raises(RuntimeError, match=err_msg):
         conn = connect(qc.config["core"]["db_location"],
                        qc.config["core"]["db_debug"])

--- a/qcodes/tests/dataset/test_experiment_container.py
+++ b/qcodes/tests/dataset/test_experiment_container.py
@@ -299,11 +299,13 @@ def test_load_experiment_by_name_duplicate_name_and_sample_name(empty_temp_db) -
     exp1 = Experiment(exp_id=None, name='exp', sample_name='sss')
     exp2 = Experiment(exp_id=None, name='exp', sample_name='sss')
 
-    repr_str = f"Many experiments matching your request found:\n" \
-               f"exp_id:{exp1.exp_id} ({exp1.name}-{exp1.sample_name}) " \
-               f"started at ({exp1.started_at})\n" \
-               f"exp_id:{exp2.exp_id} ({exp2.name}-{exp2.sample_name}) " \
-               f"started at ({exp2.started_at})"
+    repr_str = (
+        f"Many experiments matching your request found:\n"
+        f"exp_id:{exp1.exp_id} ({exp1.name}-{exp1.sample_name}) "
+        f"started at ({exp1.started_at})\n"
+        f"exp_id:{exp2.exp_id} ({exp2.name}-{exp2.sample_name}) "
+        f"started at ({exp2.started_at})"
+    )
     repr_str_regex = re.escape(repr_str)
 
     with pytest.raises(ValueError, match=repr_str_regex):

--- a/qcodes/tests/dataset/test_sqlite_base.py
+++ b/qcodes/tests/dataset/test_sqlite_base.py
@@ -494,11 +494,11 @@ def test_set_run_timestamp_explicit(dataset) -> None:
     assert dataset.completed_timestamp_raw is None
 
     with pytest.raises(
-        RuntimeError, match="Rolling back due to unhandled " "exception"
+        RuntimeError, match="Rolling back due to unhandled exception"
     ) as ei:
         mut_queries.set_run_timestamp(dataset.conn, dataset.run_id)
 
-    assert error_caused_by(ei, "Can not set run_timestamp; it has already " "been set")
+    assert error_caused_by(ei, "Can not set run_timestamp; it has already been set")
 
 
 def test_mark_run_complete(dataset) -> None:

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1500.py
@@ -274,7 +274,9 @@ def test_error_message_is_called_after_setting_a_parameter(b1500) -> None:
     mock_ask.return_value = '+200, "Output channel not enabled"'
     with pytest.raises(Exception) as e_info:
         b1500.enable_smu_filters(True)
-    mock_ask.assert_called_once_with('ERRX?')
-    error_string = 'While setting this parameter received error: +200, ' \
-                  '"Output channel not enabled"'
+    mock_ask.assert_called_once_with("ERRX?")
+    error_string = (
+        "While setting this parameter received error: +200, "
+        '"Output channel not enabled"'
+    )
     assert e_info.value.args[0] == error_string

--- a/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
+++ b/qcodes/tests/drivers/keysight_b1500/b1500_driver_tests/test_b1520a_cmu.py
@@ -103,8 +103,9 @@ def test_get_capacitance(cmu) -> None:
 
     assert pytest.approx((-1.45713E-06, -3.05845E-03)) == cmu.capacitance()
 
-    mainframe.ask.return_value = "NCC-1.55713E-06,NCD-3.15845E-03," \
-                                 "NCV-1.52342E-03,NCV+0.14235E-03"
+    mainframe.ask.return_value = (
+        "NCC-1.55713E-06,NCD-3.15845E-03,NCV-1.52342E-03,NCV+0.14235E-03"
+    )
 
     assert pytest.approx((-1.55713E-06, -3.15845E-03)) == cmu.capacitance()
 
@@ -234,9 +235,11 @@ def test_run_sweep(cmu) -> None:
     end = 1.0
     steps = 5
 
-    return_string = f'WMDCV2,2;WTDCV0.00,0.0000,0.2250,0.0000,' \
-                    f'0.0000;WDCV3,' \
-                    f'1,{start},{end},{steps};ACT0,1'
+    return_string = (
+        f"WMDCV2,2;WTDCV0.00,0.0000,0.2250,0.0000,"
+        f"0.0000;WDCV3,"
+        f"1,{start},{end},{steps};ACT0,1"
+    )
     mainframe.ask.return_value = return_string
     cmu.setup_fnc_already_run = True
     cmu.impedance_model(constants.IMP.MeasurementMode.G_X)
@@ -420,10 +423,12 @@ def test_perform_and_enable_correction(cmu) -> None:
     response = cmu.correction.perform_and_enable(
         constants.CalibrationType.OPEN)
 
-    expected_response = f'Correction status ' \
-                        f'{constants.CORR.Response.SUCCESSFUL.name} and ' \
-                        f'Enable ' \
-                        f'{constants.CORRST.Response.ON.name}'
+    expected_response = (
+        f"Correction status "
+        f"{constants.CORR.Response.SUCCESSFUL.name} and "
+        f"Enable "
+        f"{constants.CORRST.Response.ON.name}"
+    )
     assert response == expected_response
 
 

--- a/qcodes/tests/drivers/test_lakeshore_335.py
+++ b/qcodes/tests/drivers/test_lakeshore_335.py
@@ -96,7 +96,7 @@ class LakeshoreModel335Mock(MockVisaInstrument, LakeshoreModel335):
     @query("OUTMODE?")
     def outmodeq(self, arg):
         heater = self.heaters[arg]
-        return f"{heater.mode},{heater.input_channel}," f"{heater.powerup_enable}"
+        return f"{heater.mode},{heater.input_channel},{heater.powerup_enable}"
 
     @command("OUTMODE")
     @split_args()

--- a/qcodes/tests/drivers/test_lakeshore_336_legacy.py
+++ b/qcodes/tests/drivers/test_lakeshore_336_legacy.py
@@ -116,7 +116,7 @@ class Model_336_Mock(MockVisaInstrument, Model_336):
     @query("OUTMODE?")
     def outmodeq(self, arg):
         heater = self.heaters[arg]
-        return f"{heater.mode},{heater.input_channel}," f"{heater.powerup_enable}"
+        return f"{heater.mode},{heater.input_channel},{heater.powerup_enable}"
 
     @command("OUTMODE")
     @split_args()

--- a/qcodes/tests/helpers/test_compare_dictionaries.py
+++ b/qcodes/tests/helpers/test_compare_dictionaries.py
@@ -68,10 +68,10 @@ def test_val_diff_seq() -> None:
     match, err = compare_dictionaries(a, b)
 
     assert not match
-    assert 'Value of "d1[a]" ("[1, {2: 3}, 4]", ' \
-           'type"<class \'list\'>") not same' in err
-    assert '"d2[a]" ("[1, {5: 6}, 4]", type"<class \'list\'>")' in \
-           err
+    assert (
+        'Value of "d1[a]" ("[1, {2: 3}, 4]", type"<class \'list\'>") not same'
+    ) in err
+    assert '"d2[a]" ("[1, {5: 6}, 4]", type"<class \'list\'>")' in err
 
 
 def test_nested_key_diff() -> None:

--- a/qcodes/tests/test_config.py
+++ b/qcodes/tests/test_config.py
@@ -199,7 +199,7 @@ def test_missing_config_file(config) -> None:
 
 @pytest.mark.skipif(
     Path.cwd() == Path.home(),
-    reason="This test requires that " "working dir is different from homedir.",
+    reason="This test requires that working dir is different from homedir.",
 )
 def test_default_config_files(config, load_config) -> None:
     load_config.side_effect = partial(side_effect, GOOD_CONFIG_MAP)

--- a/qcodes/tests/test_snapshot.py
+++ b/qcodes/tests/test_snapshot.py
@@ -89,9 +89,12 @@ def test_snapshot_exclude_params(
     snap_params = [x for x in snap["parameters"]]
     params = [x for x in params if x not in params_to_exclude]
 
-    assert all(elem not in snap_params for elem in params_to_exclude), \
-        f"Parameter(s) is not excluded from the snapshot. expected: " \
-        f"{params}, actual: {snap_params}"\
+    assert all(elem not in snap_params for elem in params_to_exclude), (
+        f"Parameter(s) is not excluded from the snapshot. expected: "
+        f"{params}, actual: {snap_params}"
+    )
 
-    assert snap_params == params, f"Snapshot does not contain the expected " \
+    assert snap_params == params, (
+        f"Snapshot does not contain the expected "
         f"parameters expected: {params}, actual: {snap_params}"
+    )

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -38,8 +38,8 @@ from .spyder_utils import add_to_spyder_UMR_excludelist
 # module is removed.
 def warn_units(class_name: str, instance: object) -> None:
     logging.warning(
-        f"`units` is deprecated for the ` {class_name} "
-        f"` class, use `unit` instead. {repr(instance)}"
+        f"`units` is deprecated for the `{class_name}` "
+        f"class, use `unit` instead. {instance!r}"
     )
 
 

--- a/qcodes/utils/helpers.py
+++ b/qcodes/utils/helpers.py
@@ -37,8 +37,10 @@ from .spyder_utils import add_to_spyder_UMR_excludelist
 # on longer in used but left for backwards compatibility until
 # module is removed.
 def warn_units(class_name: str, instance: object) -> None:
-    logging.warning('`units` is deprecated for the `' + class_name +
-                    '` class, use `unit` instead. ' + repr(instance))
+    logging.warning(
+        f"`units` is deprecated for the ` {class_name} "
+        f"` class, use `unit` instead. {repr(instance)}"
+    )
 
 
 @deprecate("Internal function no longer part of the public qcodes api")

--- a/qcodes/validators/validators.py
+++ b/qcodes/validators/validators.py
@@ -197,7 +197,7 @@ class Strings(Validator[str]):
             self._max_length = max_length
         else:
             raise TypeError(
-                "max_length must be a positive integer " "no smaller than min_length"
+                "max_length must be a positive integer no smaller than min_length"
             )
         self._valid_values = ("." * min_length,)
 
@@ -411,7 +411,7 @@ class PermissiveInts(Ints):
                 castvalue = intrepr
             else:
                 raise TypeError(
-                    f"{repr(value)} is not an int or close to an int" f"; {context}"
+                    f"{repr(value)} is not an int or close to an int; {context}"
                 )
         else:
             castvalue = value
@@ -604,7 +604,7 @@ class PermissiveMultiples(Validator[numbertypes]):
                 raise ValueError(f"{value} is not a multiple" + f" of {self._divisor}.")
 
     def __repr__(self) -> str:
-        repr_str = "<PermissiveMultiples, Multiples of " "{} to within {}>".format(
+        repr_str = "<PermissiveMultiples, Multiples of {} to within {}>".format(
             self._divisor, self._precision
         )
         return repr_str
@@ -896,7 +896,7 @@ class Arrays(Validator[np.ndarray]):
 
         if not isinstance(shape, abc.Sequence) and shape is not None:
             raise ValueError(
-                f"Shape must be a sequence (List, Tuple ...) " f"got a {type(shape)}"
+                f"Shape must be a sequence (List, Tuple ...) got a {type(shape)}"
             )
         self._shape: shape_tuple_type = None
         if shape is not None:


### PR DESCRIPTION
Only use logformatting or f strings to format logs. Ideally we should only use log formatting and not f strings for performance but this is at least a step in the right direction.

Use ruff to enforce this.

Also fix and enforce [implicit-str-concat-isc](https://beta.ruff.rs/docs/rules/#flake8-implicit-str-concat-isc)