### PR TITLE
Use weakref finalize to close visa connections

### DIFF
--- a/docs/changes/newsfragments/5341.improved
+++ b/docs/changes/newsfragments/5341.improved
@@ -1,0 +1,4 @@
+The `pyvisa.ResourceManager` of a VISA instrument is now exposed
+as `instr.resource_manager`. All VISA instruments will now use `weakref.finalize`
+to close the visa resource on shutdown of the instrument. This should reduce the
+chance that an instrument resource is not cleanup correctly on exit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,7 +243,9 @@ markers = "serial"
 filterwarnings = [
     "ignore:The distutils package is deprecated and slated for removal in Python 3.12:DeprecationWarning",
     "ignore:distutils Version classes are deprecated:DeprecationWarning",
-    "ignore:SelectableGroups dict interface is deprecated:DeprecationWarning"
+    "ignore:SelectableGroups dict interface is deprecated:DeprecationWarning",
+    'ignore:Deprecated call to `pkg_resources\.declare_namespace:DeprecationWarning',
+    'ignore:pkg_resources is deprecated as an API',
 ]
 
 [tool.ruff]

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -140,7 +140,6 @@ class VisaInstrument(Instrument):
         self.set_terminator(terminator)
         self.timeout.set(timeout)
 
-
     def _connect_and_handle_error(
         self, address: str, visalib: str | None
     ) -> tuple[pyvisa.resources.MessageBasedResource, str, pyvisa.ResourceManager]:

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -27,7 +27,9 @@ def _close_visa_handle(
     handle: pyvisa.resources.MessageBasedResource, name: str
 ) -> None:
     log.info(
-        f"Closing VISA handle to {name} as there are no non weak references to the instrument."
+        "Closing VISA handle to %s as there are no non weak "
+        "references to the instrument.",
+        name,
     )
     handle.close()
 
@@ -114,6 +116,7 @@ class VisaInstrument(Instrument):
                 )
         else:
             visa_handle, visabackend = self._connect_and_handle_error(address, visalib)
+        finalize(self, _close_visa_handle, visa_handle, str(self.name))
 
         self.visabackend: str = visabackend
         self.visa_handle: pyvisa.resources.MessageBasedResource = visa_handle
@@ -128,7 +131,7 @@ class VisaInstrument(Instrument):
 
         self.set_terminator(terminator)
         self.timeout.set(timeout)
-        finalize(self, _close_visa_handle, self.visa_handle, str(self.name))
+
 
     def _connect_and_handle_error(
         self, address: str, visalib: str | None

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -256,6 +256,13 @@ class VisaInstrument(Instrument):
         """Disconnect and irreversibly tear down the instrument."""
         if getattr(self, 'visa_handle', None):
             self.visa_handle.close()
+
+        if getattr(self, "visabackend", None) == "sim" and getattr(
+            self, "resource_manager", None
+        ):
+            # work around for https://github.com/QCoDeS/Qcodes/issues/5356 and
+            # https://github.com/pyvisa/pyvisa-sim/issues/82
+            self.resource_manager.close()
         super().close()
 
     def write_raw(self, cmd: str) -> None:

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -191,10 +191,13 @@ class VisaInstrument(Instrument):
                 change the backend for VISA, use the self.visalib attribute
                 (and then call this function).
         """
-        resource, visabackend = self._open_resource(address, self.visalib)
+        resource, visabackend, resource_manager = self._open_resource(
+            address, self.visalib
+        )
         self.visa_handle = resource
         self._address = address
         self.visabackend = visabackend
+        self.resource_manager = resource_manager
 
     def device_clear(self) -> None:
         """Clear the buffers of the device"""

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -4,6 +4,7 @@ Test suite for Instrument and InstrumentBase
 from __future__ import annotations
 
 import contextlib
+import gc
 import io
 import re
 import weakref
@@ -424,6 +425,19 @@ def test_instrument_label(cls, request: FixtureRequest) -> None:
         request.addfinalizer(instrument.close)
     assert instrument.label == label
 
+
+def test_instrument_without_ref_is_gced():
+    # When there are no active references to an instrument and it is
+    # gced there should be no live references to the instrument
+
+    def use_some_instrument() -> None:
+        _ = Instrument("SomeInstrument")
+        assert list(Instrument._all_instruments.keys()) == ["SomeInstrument"]
+
+    assert list(Instrument._all_instruments.keys()) == []
+    use_some_instrument()
+    gc.collect()
+    assert list(Instrument._all_instruments.keys()) == []
 
 def test_snapshot_and_meta_attrs() -> None:
     """Test snapshot of InstrumentBase contains _meta_attrs attributes"""

--- a/qcodes/tests/test_instrument.py
+++ b/qcodes/tests/test_instrument.py
@@ -434,10 +434,10 @@ def test_instrument_without_ref_is_gced():
         _ = Instrument("SomeInstrument")
         assert list(Instrument._all_instruments.keys()) == ["SomeInstrument"]
 
-    assert list(Instrument._all_instruments.keys()) == []
+    assert len(Instrument._all_instruments) == 0
     use_some_instrument()
     gc.collect()
-    assert list(Instrument._all_instruments.keys()) == []
+    assert len(Instrument._all_instruments) == 0
 
 def test_snapshot_and_meta_attrs() -> None:
     """Test snapshot of InstrumentBase contains _meta_attrs attributes"""

--- a/qcodes/tests/test_visa.py
+++ b/qcodes/tests/test_visa.py
@@ -129,7 +129,7 @@ def test_visa_gc_closes_connection(caplog) -> None:
         use_magnet()
         gc.collect()
     # at this stage the instrument created in use_magnet has gone out of scope
-    # and we have triggered an explicit gc so the finalize method has been triggered/
+    # and we have triggered an explicit gc so the weakref.finalize function has been triggered
     # We test this
     # and the instrument should no longer be in the instrument registry
     assert list(Instrument._all_instruments.keys()) == []

--- a/qcodes/tests/test_visa.py
+++ b/qcodes/tests/test_visa.py
@@ -129,13 +129,13 @@ def test_visa_gc_closes_connection(caplog) -> None:
         use_magnet()
         gc.collect()
     # at this stage the instrument created in use_magnet has gone out of scope
-    # and we have triggered an explicit gc so the weakref.finalize function has been triggered
-    # We test this
+    # and we have triggered an explicit gc so the weakref.finalize function
+    # has been triggered. We test this
     # and the instrument should no longer be in the instrument registry
-    assert list(Instrument._all_instruments.keys()) == []
+    assert len(Instrument._all_instruments) == 0
     assert (
-        caplog.records[-1].message
-        == "Closing VISA handle to x as there are no non weak references to the instrument."
+        caplog.records[-1].message == "Closing VISA handle to x as there are no non "
+        "weak references to the instrument."
     )
 
 

--- a/qcodes/tests/test_visa.py
+++ b/qcodes/tests/test_visa.py
@@ -22,7 +22,7 @@ class MockVisa(VisaInstrument):
                            vals=Numbers(-20, 20))
 
     def _open_resource(self, address: str, visalib):
-        return MockVisaHandle(), visalib
+        return MockVisaHandle(), visalib, pyvisa.ResourceManager("@sim")
 
 
 class MockVisaHandle(pyvisa.resources.MessageBasedResource):


### PR DESCRIPTION
Partial fix for #3774 it's tricky to do this generally since the finalizer cannot take a reference to the instrument it self and therefore also not a method on this such as `self.close`. 

For visa instruments this is possible to implement since we only need a reference to the visa_handle to close the connection. This could also be implemented more generally if we created a handle/closer class on all instruments. 

This also adds tests that confirms that visa instruments are closed once the instrument is out of scope and gc'ed. 

Closes https://github.com/QCoDeS/Qcodes/issues/5356 by closing the resource_manager in close if the backend is sim. Since this only applies to simulated instruments we don't add it to the finalizer but assume as always that a test must cleanup after it self. 