### PR TITLE
CI don't fail all jobs on one job failure

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,6 +19,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      # don't stop other jobs if one fails
+      # this is often due to network issues
+      # and or flaky tests
+      # and the time lost in such cases
+      # is bigger than the gain from canceling the job
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11"]

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,6 +19,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      # don't stop other jobs if one fails
+      # this is often due to network issues
+      # and or flaky tests
+      # and the time lost in such cases
+      # is bigger than the gain from canceling the job
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ["3.9", "3.10", "3.11"]


### PR DESCRIPTION
In jobs such as https://github.com/QCoDeS/Qcodes/pull/5348 one matrix job failed due to network issues making all the jobs fail. It seems better to just let all the jobs run to the end