### PR TITLE
Instrument tests: Avoid leaking state between tests

### DIFF
--- a/qcodes/instrument/ip_to_visa.py
+++ b/qcodes/instrument/ip_to_visa.py
@@ -93,7 +93,9 @@ class IPToVisa(VisaInstrument, IPInstrument):  # type: ignore[misc]
         if getattr(self, "visabackend", None) == "sim" and getattr(
             self, "resource_manager", None
         ):
-            # work around for https://github.com/QCoDeS/Qcodes/issues/5356 and
+            # work around for https://github.com/pyvisa/pyvisa-sim/issues/83
+            # see other issues for more context
+            # https://github.com/QCoDeS/Qcodes/issues/5356 and
             # https://github.com/pyvisa/pyvisa-sim/issues/82
             self.resource_manager.visalib._init()
 

--- a/qcodes/instrument/ip_to_visa.py
+++ b/qcodes/instrument/ip_to_visa.py
@@ -106,7 +106,6 @@ class IPToVisa(VisaInstrument, IPInstrument):  # type: ignore[misc]
                 # https://github.com/QCoDeS/Qcodes/issues/5356 and
                 # https://github.com/pyvisa/pyvisa-sim/issues/82
                 self.resource_manager.visalib._init()
-        super().close()
 
         # Instrument close
         if hasattr(self, 'connection') and hasattr(self.connection, 'close'):

--- a/qcodes/instrument/ip_to_visa.py
+++ b/qcodes/instrument/ip_to_visa.py
@@ -90,6 +90,13 @@ class IPToVisa(VisaInstrument, IPInstrument):  # type: ignore[misc]
         if getattr(self, 'visa_handle', None):
             self.visa_handle.close()
 
+        if getattr(self, "visabackend", None) == "sim" and getattr(
+            self, "resource_manager", None
+        ):
+            # work around for https://github.com/QCoDeS/Qcodes/issues/5356 and
+            # https://github.com/pyvisa/pyvisa-sim/issues/82
+            self.resource_manager.visalib._init()
+
         # Instrument close
         if hasattr(self, 'connection') and hasattr(self.connection, 'close'):
             self.connection.close()

--- a/qcodes/instrument/ip_to_visa.py
+++ b/qcodes/instrument/ip_to_visa.py
@@ -93,12 +93,12 @@ class IPToVisa(VisaInstrument, IPInstrument):  # type: ignore[misc]
         if getattr(self, "visabackend", None) == "sim" and getattr(
             self, "resource_manager", None
         ):
-            session_found = (
-                self.resource_manager.session in self.resource_manager.visalib.sessions  # type: ignore[attr-defined]
-            )
             # The pyvisa-sim visalib has a session attribute but the resource manager is not generic in the
-            # visalib type so we need to use ignore[attr-defined] to avoid errors on session not being defined.
-            n_sessions = len(self.resource_manager.visalib.sessions)  # type: ignore[attr-defined]
+            # visalib type so we cannot get it in a type safe way
+            known_sessions = getattr(self.resource_manager.visalib, "sessions", ())
+            session_found = self.resource_manager.session in known_sessions
+
+            n_sessions = len(known_sessions)
             # if this instrument is the last one or there are no connected instruments its safe to reset the device
             if (session_found and n_sessions == 1) or n_sessions == 0:
                 # work around for https://github.com/pyvisa/pyvisa-sim/issues/83

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from collections.abc import Sequence
 from importlib.resources import as_file, files
 from typing import Any
@@ -272,7 +273,15 @@ class VisaInstrument(Instrument):
                 # see other issues for more context
                 # https://github.com/QCoDeS/Qcodes/issues/5356 and
                 # https://github.com/pyvisa/pyvisa-sim/issues/82
-                self.resource_manager.visalib._init()
+                try:
+                    self.resource_manager.visalib._init()
+                except AttributeError:
+                    warnings.warn(
+                        "The installed version of pyvisa-sim does not have an `_init` method "
+                        "in its visa library implementation. Cannot reset simulated instrument state. "
+                        "On reconnect the instrument may retain settings set in this session."
+                    )
+
         super().close()
 
     def write_raw(self, cmd: str) -> None:

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -261,9 +261,11 @@ class VisaInstrument(Instrument):
             self, "resource_manager", None
         ):
             session_found = (
-                self.resource_manager.session in self.resource_manager.visalib.sessions
+                self.resource_manager.session in self.resource_manager.visalib.sessions  # type: ignore[attr-defined]
             )
-            n_sessions = len(self.resource_manager.visalib.sessions)
+            # The pyvisa-sim visalib has a session attribute but the resource manager is not generic in the
+            # visalib type so we need to use ignore[attr-defined] to avoid errors on session not being defined.
+            n_sessions = len(self.resource_manager.visalib.sessions)  # type: ignore[attr-defined]
             # if this instrument is the last one its safe to reset the device
             if session_found and n_sessions == 1:
                 # work around for https://github.com/pyvisa/pyvisa-sim/issues/83

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -260,7 +260,9 @@ class VisaInstrument(Instrument):
         if getattr(self, "visabackend", None) == "sim" and getattr(
             self, "resource_manager", None
         ):
-            # work around for https://github.com/QCoDeS/Qcodes/issues/5356 and
+            # work around for https://github.com/pyvisa/pyvisa-sim/issues/83
+            # see other issues for more context
+            # https://github.com/QCoDeS/Qcodes/issues/5356 and
             # https://github.com/pyvisa/pyvisa-sim/issues/82
             self.resource_manager.visalib._init()
         super().close()

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -260,12 +260,12 @@ class VisaInstrument(Instrument):
         if getattr(self, "visabackend", None) == "sim" and getattr(
             self, "resource_manager", None
         ):
-            session_found = (
-                self.resource_manager.session in self.resource_manager.visalib.sessions  # type: ignore[attr-defined]
-            )
             # The pyvisa-sim visalib has a session attribute but the resource manager is not generic in the
-            # visalib type so we need to use ignore[attr-defined] to avoid errors on session not being defined.
-            n_sessions = len(self.resource_manager.visalib.sessions)  # type: ignore[attr-defined]
+            # visalib type so we cannot get it in a type safe way
+            known_sessions = getattr(self.resource_manager.visalib, "sessions", ())
+            session_found = self.resource_manager.session in known_sessions
+
+            n_sessions = len(known_sessions)
             # if this instrument is the last one or there are no connected instruments its safe to reset the device
             if (session_found and n_sessions == 1) or n_sessions == 0:
                 # work around for https://github.com/pyvisa/pyvisa-sim/issues/83

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -266,8 +266,8 @@ class VisaInstrument(Instrument):
             # The pyvisa-sim visalib has a session attribute but the resource manager is not generic in the
             # visalib type so we need to use ignore[attr-defined] to avoid errors on session not being defined.
             n_sessions = len(self.resource_manager.visalib.sessions)  # type: ignore[attr-defined]
-            # if this instrument is the last one its safe to reset the device
-            if session_found and n_sessions == 1:
+            # if this instrument is the last one or there are no connected instruments its safe to reset the device
+            if (session_found and n_sessions == 1) or n_sessions == 0:
                 # work around for https://github.com/pyvisa/pyvisa-sim/issues/83
                 # see other issues for more context
                 # https://github.com/QCoDeS/Qcodes/issues/5356 and

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -257,6 +257,12 @@ class VisaInstrument(Instrument):
         if getattr(self, 'visa_handle', None):
             self.visa_handle.close()
 
+        if getattr(self, "visabackend", None) == "sim" and getattr(
+            self, "resource_manager", None
+        ):
+            # work around for https://github.com/QCoDeS/Qcodes/issues/5356 and
+            # https://github.com/pyvisa/pyvisa-sim/issues/82
+            self.resource_manager.visalib._init()
         super().close()
 
     def write_raw(self, cmd: str) -> None:

--- a/qcodes/instrument/visa.py
+++ b/qcodes/instrument/visa.py
@@ -260,11 +260,17 @@ class VisaInstrument(Instrument):
         if getattr(self, "visabackend", None) == "sim" and getattr(
             self, "resource_manager", None
         ):
-            # work around for https://github.com/pyvisa/pyvisa-sim/issues/83
-            # see other issues for more context
-            # https://github.com/QCoDeS/Qcodes/issues/5356 and
-            # https://github.com/pyvisa/pyvisa-sim/issues/82
-            self.resource_manager.visalib._init()
+            session_found = (
+                self.resource_manager.session in self.resource_manager.visalib.sessions
+            )
+            n_sessions = len(self.resource_manager.visalib.sessions)
+            # if this instrument is the last one its safe to reset the device
+            if session_found and n_sessions == 1:
+                # work around for https://github.com/pyvisa/pyvisa-sim/issues/83
+                # see other issues for more context
+                # https://github.com/QCoDeS/Qcodes/issues/5356 and
+                # https://github.com/pyvisa/pyvisa-sim/issues/82
+                self.resource_manager.visalib._init()
         super().close()
 
     def write_raw(self, cmd: str) -> None:

--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -23,7 +23,7 @@ def test_aliases_dict() -> None:
     ])
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="function")
 def s46_six():
     """
     A six channel-per-relay instrument
@@ -38,7 +38,7 @@ def s46_six():
         driver.close()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="function")
 def s46_four():
     """
     A four channel-per-relay instrument

--- a/qcodes/tests/drivers/test_keithley_s46.py
+++ b/qcodes/tests/drivers/test_keithley_s46.py
@@ -126,51 +126,6 @@ def test_init_four(s46_four: S46) -> None:
             assert not hasattr(s46_four, alias)
 
 
-def test_init_four_and_six(
-    s46_four: S46, s46_six: S46, caplog: LogCaptureFixture
-) -> None:
-    """
-    Test that we can use one both instruments and close one of them
-    and still use the other.
-    """
-    assert len(s46_four.available_channels) == 18
-
-    closed_channel_numbers = [1, 8]
-    assert s46_four.closed_channels() == [
-        S46.aliases[i] for i in closed_channel_numbers
-    ]
-
-    # A four channel instrument will have channels missing
-    for relay in ["A", "B", "C", "D"]:
-        for index in [5, 6]:
-            alias = f"{relay}{index}"
-            assert not hasattr(s46_four, alias)
-
-    assert len(s46_six.available_channels) == 26
-
-    closed_channel_numbers = [1, 8, 13]
-    assert s46_six.closed_channels() == [S46.aliases[i] for i in closed_channel_numbers]
-
-    with caplog.at_level(logging.DEBUG):
-        s46_six.open_all_channels()
-        assert ":open (@1)" in caplog.text
-        assert ":open (@8)" in caplog.text
-        assert ":open (@13)" in caplog.text
-
-        assert s46_six.A1._lock._locked_by is None
-        assert s46_six.B1._lock._locked_by is None
-        assert s46_six.C1._lock._locked_by is None
-
-    assert s46_six.A1() == "close"
-    s46_six.A1("open")
-    assert s46_six.A1() == "open"
-
-    s46_four.close()
-
-    assert s46_six.A1() == "close"
-    s46_six.A1("open")
-    assert s46_six.A1() == "open"
-
 def test_channel_number_invariance(s46_four: S46, s46_six: S46) -> None:
     """
     Regardless of the channel layout (that is, number of channels per relay),


### PR DESCRIPTION
When all pyvisa-sim instruments defined by a yaml file is closed reset the instruments. This in practice will ensure that every test will reset the state of pyvisa-sim instruments on exit since the test must close instruments anyway.

closes https://github.com/QCoDeS/Qcodes/issues/5356

See https://github.com/pyvisa/pyvisa-sim/issues/83 for details
