### PR TITLE
Use Dask delayed to export large datasets to NetCDF

### DIFF
--- a/docs/changes/newsfragments/5391.new
+++ b/docs/changes/newsfragments/5391.new
@@ -1,2 +1,3 @@
 Large datasets are now exported to NetCDF4 using Dask delayed writer.
 This avoids allocating a large amount of memory to process the whole dataset at the same time.
+Size threshold at the moment is set to approximately 1 GB.

--- a/docs/changes/newsfragments/5391.new
+++ b/docs/changes/newsfragments/5391.new
@@ -1,0 +1,2 @@
+Large datasets are now exported to NetCDF4 using Dask delayed writer.
+This avoids allocating a large amount of memory to process the whole dataset at the same time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "xarray>=2022.06.0",
     "cf_xarray>=0.8.4",
     "opentelemetry-api>=1.15.0",
-    "dask>=2022.1.0",
+    "dask>=2022.1.0", # we are making use of xarray features that requires dask implicitly
     # transitive dependencies. We list these explicitly to",
     # ensure that we always use versions that do not have",
     # known security vulnerabilities",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "ruamel.yaml>=0.16.0,!=0.16.6",
     "tabulate>=0.8.0",
     "typing_extensions>=4.1.1",
-    "tqdm>=4.32.2",
+    "tqdm>=4.59.0",
     "uncertainties>=3.1.4",
     "versioningit>=2.0.1",
     "websockets>=9.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "xarray>=2022.06.0",
     "cf_xarray>=0.8.4",
     "opentelemetry-api>=1.15.0",
+    "dask>=2022.1.0",
     # transitive dependencies. We list these explicitly to",
     # ensure that we always use versions that do not have",
     # known security vulnerabilities",

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1504,7 +1504,6 @@ class DataSet(BaseDataSet):
         return row_size * len(self) / 1024 / 1024
 
 
-
 # public api
 def load_by_run_spec(
     *,

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1471,10 +1471,12 @@ class DataSet(BaseDataSet):
                     "qcodes_guid": self.guid,
                     "ds_name": self.name,
                     "exp_name": self.exp_name,
+                    "_export_limit": self._export_limit,
+                    "_estimated_ds_size": self._estimate_ds_size(),
                 },
             )
             print(
-                "Large dataset detected. Will write to individual files and combine to reduce memory overhead."
+                "Large dataset detected. Will write to multiple files first and combine after, to reduce memory overhead."
             )
             with tempfile.TemporaryDirectory() as temp_dir:
                 temp_path = Path(temp_dir)
@@ -1523,7 +1525,7 @@ class DataSet(BaseDataSet):
         Give an estimated size of the dataset as the size of a single row
         times the len of the dataset. Result is returned in Mega Bytes.
 
-        Note that this does not take overhead into account so it works best
+        Note that this does not take overhead into account so it is more accurate
         if the row size is "large"
         """
         sample_data = self.get_parameter_data(start=1, end=1)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1477,10 +1477,15 @@ class DataSet(BaseDataSet):
                     )
                 files = tuple(temp_path.glob("*.nc"))
                 data = xr.open_mfdataset(files)
-                write_job = data.to_netcdf(file_path, compute=False, engine="h5netcdf")
-                with ProgressBar():
-                    print(f"Writing to {file_path}")
-                    write_job.compute()
+                try:
+                    write_job = data.to_netcdf(
+                        file_path, compute=False, engine="h5netcdf"
+                    )
+                    with ProgressBar():
+                        print(f"Writing to {file_path}")
+                        write_job.compute()
+                finally:
+                    data.close()
         else:
             file_path = super()._export_as_netcdf(path=path, file_name=file_name)
         return file_path

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1506,7 +1506,9 @@ class DataSet(BaseDataSet):
                             "temp_dir": temp_dir,
                         },
                     )
-                    xarray_to_h5netcdf_with_complex_numbers(data, file_path)
+                    xarray_to_h5netcdf_with_complex_numbers(
+                        data, file_path, compute=False
+                    )
                 finally:
                     data.close()
         else:

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1488,10 +1488,13 @@ class DataSet(BaseDataSet):
                         "temp_dir": temp_dir,
                     },
                 )
-                for i in trange(len(self), desc="Writing individual files"):
+                num_files = len(self)
+                num_digits = len(str(num_files))
+                file_name_template = f"ds_{{:0{num_digits}d}}.nc"
+                for i in trange(num_files, desc="Writing individual files"):
                     xarray_to_h5netcdf_with_complex_numbers(
                         self.to_xarray_dataset(start=i + 1, end=i + 1),
-                        temp_path / f"ds_{i:03d}.nc",
+                        temp_path / file_name_template.format(i),
                     )
                 files = tuple(temp_path.glob("*.nc"))
                 data = xr.open_mfdataset(files)

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1474,7 +1474,7 @@ class DataSet(BaseDataSet):
                 self.to_xarray_dataset(start=i + 1, end=i + 1).to_netcdf(
                     str(temp_dir / f"ds_{i:03d}.nc"), engine="h5netcdf"
                 )
-            files = [f for f in temp_dir.glob("*.nc")]
+            files = tuple(temp_dir.glob("*.nc"))
             data = xr.open_mfdataset(files)
             write_job = data.to_netcdf(file_path, compute=False, engine="h5netcdf")
             with ProgressBar():

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -81,7 +81,6 @@ from qcodes.dataset.sqlite.query_helpers import (
 )
 from qcodes.utils import (
     NumpyJSONEncoder,
-    QCoDeSDeprecationWarning,
     deprecate,
     issue_deprecation_warning,
 )
@@ -865,7 +864,6 @@ class DataSet(BaseDataSet):
             a column and a indexed by a :py:class:`pandas.MultiIndex` formed
             by the dependencies.
         """
-        self._warn_if_set(*params, start=start, end=end)
         datadict = self.get_parameter_data(*params,
                                            start=start,
                                            end=end)
@@ -964,7 +962,6 @@ class DataSet(BaseDataSet):
             Return a pandas DataFrame with
                 df = ds.to_pandas_dataframe()
         """
-        self._warn_if_set(*params, start=start, end=end)
         datadict = self.get_parameter_data(*params,
                                            start=start,
                                            end=end)
@@ -1016,7 +1013,6 @@ class DataSet(BaseDataSet):
 
                 dataarray_dict = ds.to_xarray_dataarray_dict()
         """
-        self._warn_if_set(*params, start=start, end=end)
         data = self.get_parameter_data(*params,
                                        start=start,
                                        end=end)
@@ -1067,7 +1063,6 @@ class DataSet(BaseDataSet):
 
                 xds = ds.to_xarray_dataset()
         """
-        self._warn_if_set(*params, start=start, end=end)
         data = self.get_parameter_data(*params,
                                        start=start,
                                        end=end)
@@ -1511,19 +1506,6 @@ class DataSet(BaseDataSet):
                 row_size += sys.getsizeof(array)
         return row_size * len(self) / 1024 / 1024
 
-    @staticmethod
-    def _warn_if_set(
-        *params: str | ParamSpec | ParameterBase,
-        start: int | None = None,
-        end: int | None,
-    ) -> None:
-        if len(params) > 0 or start is not None or end is not None:
-            QCoDeSDeprecationWarning(
-                "Passing params, start or stop to to_xarray_... and "
-                "to_pandas_... methods is deprecated "
-                "This will be an error in the future. "
-                "If you need to sub-select use `dataset.get_parameter_data`"
-            )
 
 
 # public api

--- a/qcodes/dataset/data_set.py
+++ b/qcodes/dataset/data_set.py
@@ -1462,8 +1462,8 @@ class DataSet(BaseDataSet):
         """Export data as netcdf to a given path with file prefix"""
         import xarray as xr
 
+        file_path = path / file_name
         if self._estimate_ds_size() > self._export_limit:
-            file_path = path / file_name
             log.info(
                 "Dataset is expected to be larger that threshold. Using distributed export.",
                 extra={
@@ -1517,6 +1517,11 @@ class DataSet(BaseDataSet):
                 finally:
                     data.close()
         else:
+            log.info(
+                "Writing netcdf file directly.",
+                extra={"file_name": file_path},
+            )
+
             file_path = super()._export_as_netcdf(path=path, file_name=file_name)
         return file_path
 

--- a/qcodes/dataset/data_set_protocol.py
+++ b/qcodes/dataset/data_set_protocol.py
@@ -1,19 +1,8 @@
 from __future__ import annotations
 
-import sys
-
-from dask.diagnostics.progress import ProgressBar
-from tqdm import tqdm
-
-if sys.version_info >= (3, 10):
-    # new entrypoints api was added in 3.10
-    from importlib.metadata import entry_points
-else:
-    # 3.9 and earlier
-    from importlib_metadata import entry_points
-
 import logging
 import os
+import sys
 import warnings
 from collections.abc import Mapping, Sequence
 from enum import Enum
@@ -41,6 +30,13 @@ from .exporters.export_info import ExportInfo
 from .exporters.export_to_csv import dataframe_to_csv
 from .exporters.export_to_xarray import xarray_to_h5netcdf_with_complex_numbers
 from .sqlite.queries import raw_time_to_str_time
+
+if sys.version_info >= (3, 10):
+    # new entrypoints api was added in 3.10
+    from importlib.metadata import entry_points
+else:
+    # 3.9 and earlier
+    from importlib_metadata import entry_points
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -245,21 +241,6 @@ class DataSetProtocol(Protocol):
     ) -> ParameterData:
         ...
 
-    def _estimate_ds_size(self) -> float:
-        """
-        Give an estimated size of the dataset as the size of a single row
-        times the len of the dataset. Result is returned in Mega Bytes.
-
-        Note that this does not take overhead into account so it works best
-        if the row size is "large"
-        """
-        sample_data = self.get_parameter_data(start=1, end=1)
-        row_size = 0.0
-
-        for param_data in sample_data.values():
-            for array in param_data.values():
-                row_size += sys.getsizeof(array)
-        return row_size * len(self) / 1024 / 1024
 
     def get_parameters(self) -> SPECS:
         # used by plottr
@@ -484,25 +465,9 @@ class BaseDataSet(DataSetProtocol, Protocol):
 
     def _export_as_netcdf(self, path: Path, file_name: str) -> Path:
         """Export data as netcdf to a given path with file prefix"""
-        import xarray as xr
         file_path = path / file_name
-        if self._estimate_ds_size() > 1000:
-            print("large dataset export.")
-            temp_dir = Path(f"./temp_export_{self.guid}/")
-            temp_dir.mkdir(exist_ok=True)
-            for i in tqdm(range(len(self))):
-                self.to_xarray_dataset(start=i + 1, end=i + 1).to_netcdf(
-                    str(temp_dir / f"ds_{i:03d}.nc"), engine="h5netcdf"
-                )
-            files = [f for f in temp_dir.glob("*.nc")]
-            data = xr.open_mfdataset(files)
-            write_job = data.to_netcdf(file_path, compute=False, engine="h5netcdf")
-            with ProgressBar():
-                print(f"Writing to {file_path}")
-                write_job.compute()
-        else:
-            xarr_dataset = self.to_xarray_dataset()
-            xarray_to_h5netcdf_with_complex_numbers(xarr_dataset, file_path)
+        xarr_dataset = self.to_xarray_dataset()
+        xarray_to_h5netcdf_with_complex_numbers(xarr_dataset, file_path)
         return file_path
 
     def _export_as_csv(self, path: Path, file_name: str) -> Path:

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -256,7 +256,7 @@ def xarray_to_h5netcdf_with_complex_numbers(
         if not compute and maybe_write_job is not None:
             with TqdmCallback(desc="Combining files"):
                 _LOG.info(
-                    "Writing netcdf file using Dask delayed writer",
+                    "Writing netcdf file using Dask delayed writer.",
                     extra={"file_name": file_path},
                 )
                 maybe_write_job.compute()

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -243,6 +243,7 @@ def xarray_to_h5netcdf_with_complex_numbers(
             )
             # pyright 1.1.329 for some reason pyright does not allow a bool here
             # the function is typed to take both True and False in overload
+            # https://github.com/microsoft/pyright/issues/6069
             maybe_write_job = internal_ds.to_netcdf(
                 path=file_path,
                 engine="h5netcdf",

--- a/qcodes/dataset/exporters/export_to_xarray.py
+++ b/qcodes/dataset/exporters/export_to_xarray.py
@@ -241,12 +241,17 @@ def xarray_to_h5netcdf_with_complex_numbers(
                 message="You are writing invalid netcdf features",
                 category=UserWarning,
             )
+            # pyright 1.1.329 for some reason pyright does not allow a bool here
+            # the function is typed to take both True and False in overload
             maybe_write_job = internal_ds.to_netcdf(
-                path=file_path, engine="h5netcdf", invalid_netcdf=True, compute=compute
+                path=file_path,
+                engine="h5netcdf",
+                invalid_netcdf=True,
+                compute=compute,  # pyright: ignore
             )
     else:
         maybe_write_job = internal_ds.to_netcdf(
-            path=file_path, engine="h5netcdf", compute=compute
+            path=file_path, engine="h5netcdf", compute=compute  # pyright: ignore
         )
 
     if not compute and maybe_write_job is not None:

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -726,6 +726,10 @@ def test_export_numpy_dataset(
         "Dataset is expected to be larger that threshold. Using distributed export."
         in caplog.records[0].msg
     )
+    assert "Writing individual files to temp dir" in caplog.records[1].msg
+    assert "Combining temp files into one file" in caplog.records[2].msg
+    assert "Writing netcdf file using Dask delayed writer" in caplog.records[3].msg
+
     loaded_ds = xr.load_dataset(mock_dataset_numpy.export_info.export_paths["nc"])
     assert loaded_ds.x.shape == (10,)
     assert_allclose(loaded_ds.x, np.arange(10))
@@ -757,6 +761,10 @@ def test_export_numpy_dataset_complex(
         "Dataset is expected to be larger that threshold. Using distributed export."
         in caplog.records[0].msg
     )
+    assert "Writing individual files to temp dir" in caplog.records[1].msg
+    assert "Combining temp files into one file" in caplog.records[2].msg
+    assert "Writing netcdf file using Dask delayed writer" in caplog.records[3].msg
+
     loaded_ds = xr.load_dataset(
         mock_dataset_numpy_complex.export_info.export_paths["nc"]
     )

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -714,7 +714,20 @@ def test_export_2d_dataset(
     assert xr_ds.identical(xr_ds_reimported)
 
 
-def test_export_numpy_dataset(
+def test_export_dataset_small_no_delated(
+    tmp_path_factory: TempPathFactory, mock_dataset_numpy: DataSet, caplog
+) -> None:
+    """
+    Test that a 'small' dataset does not use the delayed export.
+    """
+    tmp_path = tmp_path_factory.mktemp("export_netcdf")
+    with caplog.at_level(logging.INFO):
+        mock_dataset_numpy.export(export_type="netcdf", path=tmp_path, prefix="qcodes_")
+
+    assert "Writing netcdf file directly" in caplog.records[0].msg
+
+
+def test_export_dataset_delayed(
     tmp_path_factory: TempPathFactory, mock_dataset_numpy: DataSet, caplog
 ) -> None:
     tmp_path = tmp_path_factory.mktemp("export_netcdf")
@@ -747,7 +760,7 @@ def test_export_numpy_dataset(
     _assert_xarray_metadata_is_as_expected(loaded_ds, mock_dataset_numpy)
 
 
-def test_export_numpy_dataset_complex(
+def test_export_dataset_delayed_complex(
     tmp_path_factory: TempPathFactory, mock_dataset_numpy_complex: DataSet, caplog
 ) -> None:
     tmp_path = tmp_path_factory.mktemp("export_netcdf")

--- a/qcodes/tests/dataset/test_dataset_export.py
+++ b/qcodes/tests/dataset/test_dataset_export.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -128,7 +130,7 @@ def _make_mock_dataset_numpy(experiment) -> DataSet:
     y = np.arange(10, 21, 1)
     dataset.mark_started()
     for x in range(10):
-        results = [{"x": x, "y": y, "z": x + y}]
+        results: list[dict[str, int | np.ndarray]] = [{"x": x, "y": y, "z": x + y}]
         dataset.add_results(results)
     dataset.mark_completed()
     return dataset


### PR DESCRIPTION
Avoid loading a potentially huge dataset into memory just to be able to rewrite it to disk. 

This writes each row of a dataset to disk individually and then uses dask/xarray to lazily merge the dataset into one file
