### PR TITLE
Update qcodes to support numpy 2.0

### DIFF
--- a/docs/changes/newsfragments/5399.breaking
+++ b/docs/changes/newsfragments/5399.breaking
@@ -1,0 +1,3 @@
+Update QCoDeS to work with the upcoming release of numpy 2.0.
+The unused attributes `qcodes.utils.types.numpy_non_concrete_floats_instantiable` and
+`qcodes.utils.types.numpy_non_concrete_complex_instantiable` have been removed from QCoDeS.

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -159,7 +159,7 @@ def connect(name: str | Path, debug: bool = False, version: int = -1) -> Connect
         sqlite3.register_adapter(numpy_float, _adapt_float)
 
     for complex_type in complex_types:
-        sqlite3.register_adapter(complex_type, _adapt_complex)
+        sqlite3.register_adapter(complex_type, _adapt_complex)  # type: ignore
     sqlite3.register_converter("complex", _convert_complex)
 
     if debug:

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -159,7 +159,7 @@ def connect(name: str | Path, debug: bool = False, version: int = -1) -> Connect
         sqlite3.register_adapter(numpy_float, _adapt_float)
 
     for complex_type in complex_types:
-        sqlite3.register_adapter(complex_type, _adapt_complex)  # type: ignore
+        sqlite3.register_adapter(complex_type, _adapt_complex)  # type: ignore[arg-type]
     sqlite3.register_converter("complex", _convert_complex)
 
     if debug:

--- a/qcodes/dataset/sqlite/database.py
+++ b/qcodes/dataset/sqlite/database.py
@@ -159,7 +159,7 @@ def connect(name: str | Path, debug: bool = False, version: int = -1) -> Connect
         sqlite3.register_adapter(numpy_float, _adapt_float)
 
     for complex_type in complex_types:
-        sqlite3.register_adapter(complex_type, _adapt_complex)  # type: ignore[arg-type]
+        sqlite3.register_adapter(complex_type, _adapt_complex)
     sqlite3.register_converter("complex", _convert_complex)
 
     if debug:

--- a/qcodes/instrument_drivers/tektronix/AWG5014.py
+++ b/qcodes/instrument_drivers/tektronix/AWG5014.py
@@ -1525,11 +1525,11 @@ class TektronixAWG5014(VisaInstrument):
             raise TypeError(
                 "Waveform values out of bonds. Allowed values: -1 to 1 (inclusive)"
             )
-        if not np.all(np.in1d(m1, np.array([0, 1]))):
+        if not np.all(np.isin(m1, np.array([0, 1]))):
             raise TypeError(
                 "Marker 1 contains invalid values. Only 0 and 1 are allowed"
             )
-        if not np.all(np.in1d(m2, np.array([0, 1]))):
+        if not np.all(np.isin(m2, np.array([0, 1]))):
             raise TypeError(
                 "Marker 2 contains invalid values. Only 0 and 1 are allowed"
             )

--- a/qcodes/tests/drivers/test_ami430.py
+++ b/qcodes/tests/drivers/test_ami430.py
@@ -21,9 +21,8 @@ from qcodes.instrument_drivers.american_magnetics.AMI430 import (
 )
 from qcodes.math_utils import FieldVector
 from qcodes.utils.types import (
-    numpy_concrete_floats,
     numpy_concrete_ints,
-    numpy_non_concrete_floats_instantiable,
+    numpy_floats,
     numpy_non_concrete_ints_instantiable,
 )
 
@@ -1057,16 +1056,18 @@ def _parametrization_kwargs() -> PDict:
     kwargs: PDict = {"argvalues": [], "ids": []}
 
     for type_constructor, type_name in zip(
-        ((int, float)
-         + numpy_concrete_ints
-         + numpy_non_concrete_ints_instantiable
-         + numpy_concrete_floats
-         + numpy_non_concrete_floats_instantiable),
-        (['int', 'float']
-         + [str(t) for t in numpy_concrete_ints]
-         + [str(t) for t in numpy_non_concrete_ints_instantiable]
-         + [str(t) for t in numpy_concrete_floats]
-         + [str(t) for t in numpy_non_concrete_floats_instantiable])
+        (
+            (int, float)
+            + numpy_concrete_ints
+            + numpy_non_concrete_ints_instantiable
+            + numpy_floats
+        ),
+        (
+            ["int", "float"]
+            + [str(t) for t in numpy_concrete_ints]
+            + [str(t) for t in numpy_non_concrete_ints_instantiable]
+            + [str(t) for t in numpy_floats]
+        ),
     ):
         kwargs['argvalues'].append(type_constructor(2.2))
         kwargs['ids'].append(type_name)

--- a/qcodes/tests/drivers/test_ami430_visa.py
+++ b/qcodes/tests/drivers/test_ami430_visa.py
@@ -23,7 +23,6 @@ from qcodes.math_utils import FieldVector
 from qcodes.utils.types import (
     numpy_concrete_floats,
     numpy_concrete_ints,
-    numpy_non_concrete_floats_instantiable,
     numpy_non_concrete_ints_instantiable,
 )
 
@@ -1142,14 +1141,12 @@ def _parametrization_kwargs() -> PDict:
             + numpy_concrete_ints
             + numpy_non_concrete_ints_instantiable
             + numpy_concrete_floats
-            + numpy_non_concrete_floats_instantiable
         ),
         (
             ["int", "float"]
             + [str(t) for t in numpy_concrete_ints]
             + [str(t) for t in numpy_non_concrete_ints_instantiable]
             + [str(t) for t in numpy_concrete_floats]
-            + [str(t) for t in numpy_non_concrete_floats_instantiable]
         ),
     ):
         kwargs["argvalues"].append(type_constructor(2.2))

--- a/qcodes/tests/validators/test_arrays.py
+++ b/qcodes/tests/validators/test_arrays.py
@@ -86,7 +86,7 @@ def test_real_subtypes() -> None:
     Test that validating a concrete real type into an array that
     only support other concrete types raises as expected
     """
-    types = list(numpy_concrete_ints + numpy_floats)
+    types = set(numpy_concrete_ints + numpy_floats)
     randint = np.random.randint(0, len(types))
     mytype = types.pop(randint)
 

--- a/qcodes/tests/validators/test_arrays.py
+++ b/qcodes/tests/validators/test_arrays.py
@@ -7,9 +7,8 @@ from hypothesis.extra.numpy import complex_number_dtypes
 
 from qcodes.utils.types import (
     concrete_complex_types,
-    numpy_concrete_floats,
     numpy_concrete_ints,
-    numpy_non_concrete_floats_instantiable,
+    numpy_floats,
     numpy_non_concrete_ints_instantiable,
 )
 from qcodes.validators import Arrays
@@ -87,7 +86,7 @@ def test_real_subtypes() -> None:
     Test that validating a concrete real type into an array that
     only support other concrete types raises as expected
     """
-    types = list(numpy_concrete_ints + numpy_concrete_floats)
+    types = list(numpy_concrete_ints + numpy_floats)
     randint = np.random.randint(0, len(types))
     mytype = types.pop(randint)
 
@@ -140,10 +139,7 @@ def test_default_types() -> None:
     for mytype in integer_types:
         a.validate(np.arange(10, dtype=mytype))
 
-    float_types = (
-            (float,)
-            + numpy_non_concrete_floats_instantiable
-            + numpy_concrete_floats)
+    float_types = (float,) + numpy_floats
     for mytype in float_types:
         a.validate(np.arange(10, dtype=mytype))
 

--- a/qcodes/tests/validators/test_arrays.py
+++ b/qcodes/tests/validators/test_arrays.py
@@ -86,7 +86,7 @@ def test_real_subtypes() -> None:
     Test that validating a concrete real type into an array that
     only support other concrete types raises as expected
     """
-    types = set(numpy_concrete_ints + numpy_floats)
+    types = list(set(numpy_concrete_ints + numpy_floats))
     randint = np.random.randint(0, len(types))
     mytype = types.pop(randint)
 

--- a/qcodes/utils/numpy_utils.py
+++ b/qcodes/utils/numpy_utils.py
@@ -5,7 +5,12 @@ from collections.abc import Sequence
 from typing import Any
 
 import numpy as np
-from numpy import VisibleDeprecationWarning
+
+try:
+    from numpy.exceptions import VisibleDeprecationWarning
+except ImportError:
+    # numpy < 2.0
+    from numpy import VisibleDeprecationWarning
 
 
 def list_of_data_to_maybe_ragged_nd_array(

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -7,9 +7,7 @@ from typing import Union
 
 import numpy as np
 
-complex_type_union = Union[
-    np.complex64, np.complex128, np.complex_, np.complexfloating, complex
-]
+complex_type_union = Union[np.complex64, np.complex128, np.complexfloating, complex]
 
 
 numpy_concrete_ints = (np.int8, np.int16, np.int32, np.int64,
@@ -46,7 +44,7 @@ numpy_c_floats = (np.half, np.single, np.double)
 """
 Floating point types that matches C types.
 """
-numpy_non_concrete_floats_instantiable = (np.float_, )
+numpy_non_concrete_floats_instantiable = tuple()
 """
 Default floating point types. The size may be platform dependent.
 """
@@ -68,7 +66,7 @@ numpy_c_complex = (np.csingle, np.cdouble)
 """
 Complex types that matches C types.
 """
-numpy_non_concrete_complex_instantiable = (np.complex_, )
+numpy_non_concrete_complex_instantiable = tuple()
 """
 Default complex types. The size may be platform dependent.
 """

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -44,7 +44,7 @@ numpy_c_floats = (np.half, np.single, np.double)
 """
 Floating point types that matches C types.
 """
-numpy_non_concrete_floats_instantiable = tuple()
+numpy_non_concrete_floats_instantiable: tuple[type, ...] = tuple()
 """
 Default floating point types. The size may be platform dependent.
 """
@@ -66,7 +66,7 @@ numpy_c_complex = (np.csingle, np.cdouble)
 """
 Complex types that matches C types.
 """
-numpy_non_concrete_complex_instantiable = tuple()
+numpy_non_concrete_complex_instantiable: tuple[type, ...] = tuple()
 """
 Default complex types. The size may be platform dependent.
 """

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -72,9 +72,9 @@ Default complex types. The size may be platform dependent.
 """
 
 numpy_complex: tuple[type[complex_type_union], ...] = (
-        numpy_concrete_complex +
-        numpy_c_complex +
-        numpy_non_concrete_complex_instantiable
+    numpy_concrete_complex
+    + numpy_c_complex  # type: ignore[assignment]
+    + numpy_non_concrete_complex_instantiable
 )
 """
 All numpy complex types

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -66,7 +66,7 @@ numpy_c_complex = (np.csingle, np.cdouble)
 """
 Complex types that matches C types.
 """
-numpy_non_concrete_complex_instantiable: tuple[type, ...] = tuple()
+numpy_non_concrete_complex_instantiable: tuple[type[complex_type_union], ...] = tuple()
 """
 Default complex types. The size may be platform dependent.
 """

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -44,16 +44,8 @@ numpy_c_floats = (np.half, np.single, np.double)
 """
 Floating point types that matches C types.
 """
-numpy_non_concrete_floats_instantiable: tuple[type, ...] = tuple()
-"""
-Default floating point types. The size may be platform dependent.
-"""
 
-numpy_floats: tuple[type, ...] = (
-        numpy_concrete_floats +
-        numpy_c_floats +
-        numpy_non_concrete_floats_instantiable
-)
+numpy_floats: tuple[type, ...] = numpy_concrete_floats + numpy_c_floats
 """
 All numpy float types
 """
@@ -66,15 +58,10 @@ numpy_c_complex = (np.csingle, np.cdouble)
 """
 Complex types that matches C types.
 """
-numpy_non_concrete_complex_instantiable: tuple[type[complex_type_union], ...] = tuple()
-"""
-Default complex types. The size may be platform dependent.
-"""
 
 numpy_complex: tuple[type[complex_type_union], ...] = (
     numpy_concrete_complex
     + numpy_c_complex  # type: ignore[assignment]
-    + numpy_non_concrete_complex_instantiable
 )
 """
 All numpy complex types
@@ -83,6 +70,5 @@ All numpy complex types
 concrete_complex_types = numpy_concrete_complex + (complex,)
 complex_types = (
         numpy_concrete_complex +
-        numpy_non_concrete_complex_instantiable +
         (complex,)
 )

--- a/qcodes/utils/types.py
+++ b/qcodes/utils/types.py
@@ -60,8 +60,7 @@ Complex types that matches C types.
 """
 
 numpy_complex: tuple[type[complex_type_union], ...] = (
-    numpy_concrete_complex
-    + numpy_c_complex  # type: ignore[assignment]
+    numpy_concrete_complex + numpy_c_complex
 )
 """
 All numpy complex types

--- a/qcodes/validators/validators.py
+++ b/qcodes/validators/validators.py
@@ -814,7 +814,7 @@ class Arrays(Validator[np.ndarray]):
             for mytype in valid_types:
 
                 is_supported = any(
-                    np.issubsctype(mytype, supported_type)
+                    np.issubdtype(mytype, supported_type)
                     for supported_type in self.__supported_types
                 )
                 if not is_supported:
@@ -828,19 +828,17 @@ class Arrays(Validator[np.ndarray]):
             self.valid_types = self.__real_types
 
         supports_complex = any(
-            np.issubsctype(my_type, np.complexfloating) for my_type in self.valid_types
+            np.issubdtype(my_type, np.complexfloating) for my_type in self.valid_types
         )
 
         limits_given = min_value is not None or max_value is not None
 
         min_real = any(
-            np.issubsctype(type(min_value), real_type)
-            for real_type in self.__real_types
+            np.issubdtype(type(min_value), real_type) for real_type in self.__real_types
         )
 
         max_real = any(
-            np.issubsctype(type(max_value), real_type)
-            for real_type in self.__real_types
+            np.issubdtype(type(max_value), real_type) for real_type in self.__real_types
         )
 
         if min_value is not None and not min_real:
@@ -862,12 +860,12 @@ class Arrays(Validator[np.ndarray]):
             )
 
         min_value_is_valid_type = any(
-            np.issubsctype(type(min_value), valid_type)
+            np.issubdtype(type(min_value), valid_type)
             for valid_type in self.valid_types
         )
 
         max_value_is_valid_type = any(
-            np.issubsctype(type(max_value), valid_type)
+            np.issubdtype(type(max_value), valid_type)
             for valid_type in self.valid_types
         )
 
@@ -942,7 +940,7 @@ class Arrays(Validator[np.ndarray]):
             raise TypeError(f"{repr(value)} is not a numpy array; {context}")
 
         if not any(
-            np.issubsctype(value.dtype.type, valid_type)
+            np.issubdtype(value.dtype.type, valid_type)
             for valid_type in self.valid_types
         ):
             raise TypeError(


### PR DESCRIPTION
Numpy 2.0 is scheduled to be released this year (https://github.com/numpy/numpy/issues/24300). In this PR we adapt qcodes to work with numpy 2.0.

The `numpy_non_concrete_floats_instantiable` and `numpy_non_concrete_complex_instantiable` are now empty, perhaps it is better to just remove them. (they are public, but not used in the qcodes codebase)

<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
