### PR TITLE
upgrade type stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,7 @@ ignore = [
     "qcodes/instrument_drivers/Harvard/Decadac.py",
     ]
 reportMissingTypeStubs = true
+stubPath = "typings/stubs"
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
rebased against main of ms/typing-stubs and removed matplotlib as matplotlib is now typed.
