### PR TITLE
remove slack and qtplot extra install targets

### DIFF
--- a/docs/changes/newsfragments/5425.breaking
+++ b/docs/changes/newsfragments/5425.breaking
@@ -1,0 +1,2 @@
+The extra install targets qcodes[slack] and qcodes[qtplot] have been removed.
+All dependencies on slack and pyqtgraph have moved to qcodes_loop.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,10 +71,6 @@ Tracker = "https://github.com/QCoDeS/Qcodes/issues"
 Changelog = "https://qcodes.github.io/Qcodes/changes/index.html"
 
 [project.optional-dependencies]
-qtplot = ["pyqtgraph>=0.11.0"]
-# can be removed once deprecated pyqtgraph module is removed
-slack = ["slack-sdk>=3.4.2"]
-# can be removed once deprecated slack are removed
 zurichinstruments = ["zhinst-qcodes>=0.3"]
 loop = ["qcodes_loop>=0.1.2"]
 test = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,6 @@ pyparsing~=3.1.0
 PyQt5~=5.15.7
 PyQt5-Qt5~=5.15.2
 PyQt5-sip~=12.12.0
-pyqtgraph==0.13.3
 pyrsistent==0.19.3
 pytest~=7.4.0
 pytest-asyncio==0.21.1
@@ -134,7 +133,6 @@ schema==0.7.5
 scipy~=1.11.2
 Send2Trash~=1.8.0
 six~=1.16.0
-slack-sdk~=3.23.0
 snowballstemmer~=2.2.0
 sortedcontainers~=2.4.0
 soupsieve~=2.4


### PR DESCRIPTION
They no longer have an effect since that code was only used in modules that are now part of the qcodes-loop package