### PR TITLE
Fix over broad regex in test

### DIFF
--- a/qcodes/tests/validators/test_arrays.py
+++ b/qcodes/tests/validators/test_arrays.py
@@ -218,6 +218,9 @@ def test_repr() -> None:
     c = Arrays(shape=(2, 2))
     assert str(c) == '<Arrays, shape: (2, 2)>'
     c = Arrays(shape=(lambda: 2, 2))
-    assert re.match(r"<Arrays, shape: \(<function "
-                    r"test_repr.<locals>.<lambda> "
-                    r"at 0x[a-fA-f0-9]*>, 2\)>", str(c))
+    assert re.match(
+        r"<Arrays, shape: \(<function "
+        r"test_repr.<locals>.<lambda> "
+        r"at 0x[a-fA-F0-9]*>, 2\)>",
+        str(c),
+    )


### PR DESCRIPTION
Resolves https://github.com/QCoDeS/Qcodes/security/code-scanning/5

This does not have any security implication but the regex is clearly not as intended