### PR TITLE
Darker: remove no longer required workaround

### DIFF
--- a/.github/workflows/darker.yaml
+++ b/.github/workflows/darker.yaml
@@ -22,4 +22,3 @@ jobs:
           options: "--check --diff"
           src: "./qcodes"
           revision: "origin/main..."
-          version: "@e3c210b5c1b91400c3f317b2474c10ab23bec1cf"


### PR DESCRIPTION
This was required due to a bug in darker that has been fixed.
