### PR TITLE
Fix incorrect step logic in validator.

### DIFF
--- a/.github/workflows/darker.yaml
+++ b/.github/workflows/darker.yaml
@@ -21,5 +21,5 @@ jobs:
         with:
           options: "--check --diff"
           src: "./qcodes"
-          revision: "origin/master..."
+          revision: "origin/main..."
           version: "@e3c210b5c1b91400c3f317b2474c10ab23bec1cf"

--- a/docs/changes/0.41.1.rst
+++ b/docs/changes/0.41.1.rst
@@ -1,0 +1,8 @@
+QCoDeS 0.41.1 (2023-10-19)
+==========================
+
+Improved:
+---------
+
+- Corrected a bug where non integer step sizes were incorrectly rejected
+  from parameters without integer validators. (:pr:`5446`)

--- a/docs/changes/index.rst
+++ b/docs/changes/index.rst
@@ -3,6 +3,7 @@ Changelogs
 
 .. toctree::
    Unreleased <unreleased>
+   0.41.1 <0.41.1>
    0.41.0 <0.41.0>
    0.40.0 <0.40.0>
    0.39.1 <0.39.1>

--- a/qcodes/parameters/parameter_base.py
+++ b/qcodes/parameters/parameter_base.py
@@ -838,7 +838,7 @@ class ParameterBase(MetadatableWithName):
             self._step = None
         elif step <= 0:
             raise ValueError("step must be positive")
-        elif not all(isinstance(vals, Ints) for vals in self._vals) and not isinstance(
+        elif any(isinstance(vals, Ints) for vals in self._vals) and not isinstance(
             step, int
         ):
             raise TypeError("step must be a positive int for an Ints parameter")

--- a/qcodes/tests/parameter/test_validators.py
+++ b/qcodes/tests/parameter/test_validators.py
@@ -194,3 +194,12 @@ def test_validators_step_int() -> None:
     param = Parameter("a", get_cmd=False, set_cmd=False, vals=Numbers(0, 10))
 
     param.step = 0.1
+    param.step = 1.0
+
+    param.add_validator(Ints(0, 10))
+
+    # but once we add an integer validator we no longer can set a step size as a float
+    with pytest.raises(
+        TypeError, match="step must be a positive int for an Ints parameter"
+    ):
+        param.step = 0.1

--- a/qcodes/tests/parameter/test_validators.py
+++ b/qcodes/tests/parameter/test_validators.py
@@ -3,7 +3,7 @@ import pytest
 from hypothesis import given
 
 from qcodes.parameters import Parameter
-from qcodes.validators import Ints
+from qcodes.validators import Ints, Numbers
 
 
 def test_add_ints_validator_to_parameter():
@@ -187,3 +187,10 @@ def test_replace_vals():
     p.remove_validator()
     p.vals = None
     assert len(p.validators) == 0
+
+
+def test_validators_step_int() -> None:
+    # this parameter should allow step to be set as a float since the parameter is in it self a float
+    param = Parameter("a", get_cmd=False, set_cmd=False, vals=Numbers(0, 10))
+
+    param.step = 0.1


### PR DESCRIPTION
The intent was that it should not be possible to set a float step size if any of the validators was an Int validator. That was however not correctly implemented.

Adding changelog directly to save a bit of time on towncrier since I am going to cut a new release just after merging this