### PR TITLE
fix coverage links

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,10 +122,9 @@ log_exported_ds = "qcodes.extensions:log_dataset_export_info"
 
 [tool.coverage.run]
 omit = [
-    "qcodes/__init__.py",
+    "src/qcodes/__init__.py",
     "*/__init__.py",
-    "qcodes/tests/*",
-    "qcodes/instrument_drivers/test.py"
+    "src/qcodes/tests/*",
 ]
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
Looks like the tests are no longer correctly excluded from the coverage so change paths to include src dir.

also remove exclusion of a non-existing file.
