### PR TITLE
don't upload coverage from merge groups

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -92,3 +92,6 @@ jobs:
       with:
         file: ./coverage.xml
         env_vars: OS,PYTHON
+      if: ${{ github.event_name != 'merge_group' }}
+      # we don't trigger coverage from merge groups since that would
+      # make twice the number of coverage reports be uploded from a given commit


### PR DESCRIPTION
Otherwise codecov gets confused by the number of jobs in a branch build compared to pr