### PR TITLE
Slight improvements to docs build

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -75,6 +75,7 @@ jobs:
         cache-dependency-path: |
           pyproject.toml
           requirements.txt
+          docs/conf.py
     - name: upgrade pip setuptools wheel
       run: python -m pip install --upgrade pip setuptools wheel
       shell: bash

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -51,7 +51,7 @@ jobs:
         fetch-depth: '0'
     - name: set-sphinx-opts
       run: |
-        echo "SPHINX_OPTS=-W -v" >> $GITHUB_ENV
+        echo "SPHINX_OPTS=-W -v --keep-going" >> $GITHUB_ENV
       if: ${{ fromJSON(env.SPHINX_WARNINGS_AS_ERROR) }}
     - name: install pandoc linux
       run: |


### PR DESCRIPTION
* Keep going on errors so we can see all errors on failures.
* Hash docs package cache including docs/conf.py this will ensure that the cache is different for docs and test jobs which correctly reflects that the two jobs install different packages
