### PR TITLE
Lakeshore 335 Output: Add parameter mapping for input=None

### DIFF
--- a/docs/changes/newsfragments/5520.improved
+++ b/docs/changes/newsfragments/5520.improved
@@ -1,0 +1,1 @@
+Lakeshore 335 Output: Add parameter mapping for input=None

--- a/src/qcodes/instrument_drivers/Lakeshore/_lakeshore_model_335.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/_lakeshore_model_335.py
@@ -21,7 +21,7 @@ _channel_name_to_outmode_command_map: dict[str, int] = {
     ch_name: num_for_cmd + 1
     for num_for_cmd, ch_name in enumerate(_channel_name_to_command_map.keys())
 }
-_channel_name_to_outmode_command_map.update({'None':0})
+_channel_name_to_outmode_command_map.update({"None": 0})
 
 
 class LakeshoreModel335Channel(BaseSensorChannel):

--- a/src/qcodes/instrument_drivers/Lakeshore/_lakeshore_model_335.py
+++ b/src/qcodes/instrument_drivers/Lakeshore/_lakeshore_model_335.py
@@ -21,6 +21,7 @@ _channel_name_to_outmode_command_map: dict[str, int] = {
     ch_name: num_for_cmd + 1
     for num_for_cmd, ch_name in enumerate(_channel_name_to_command_map.keys())
 }
+_channel_name_to_outmode_command_map.update({'None':0})
 
 
 class LakeshoreModel335Channel(BaseSensorChannel):


### PR DESCRIPTION
According to the manual (https://www.lakeshore.com/docs/default-source/product-downloads/335_manual.pdf?sfvrsn=9f5c5b7f_7) , page 121:

> `input` Specifies which input to use for control: 0 = None, 1 = A, 2 = B

Here, we add the parameter mapping for the value 0.