### PR TITLE
Better treshold calculation for chunked output

### DIFF
--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib
 import json
 import logging
-import sys
 import tempfile
 import time
 import uuid
@@ -1530,15 +1529,15 @@ class DataSet(BaseDataSet):
         Give an estimated size of the dataset as the size of a single row
         times the len of the dataset. Result is returned in Mega Bytes.
 
-        Note that this does not take overhead into account so it is more accurate
-        if the row size is "large"
+        Note that this does not take overhead from storing the array into account
+        so it is assumed that the total array is large compared to the overhead.
         """
         sample_data = self.get_parameter_data(start=1, end=1)
         row_size = 0.0
 
         for param_data in sample_data.values():
             for array in param_data.values():
-                row_size += sys.getsizeof(array)
+                row_size += array.size * array.dtype.itemsize
         return row_size * len(self) / 1024 / 1024
 
 

--- a/src/qcodes/dataset/data_set.py
+++ b/src/qcodes/dataset/data_set.py
@@ -1467,7 +1467,7 @@ class DataSet(BaseDataSet):
             log.info(
                 "Dataset is expected to be larger that threshold. Using distributed export.",
                 extra={
-                    "file_name": file_path,
+                    "file_name": str(file_path),
                     "qcodes_guid": self.guid,
                     "ds_name": self.name,
                     "exp_name": self.exp_name,
@@ -1483,7 +1483,7 @@ class DataSet(BaseDataSet):
                 log.info(
                     "Writing individual files to temp dir.",
                     extra={
-                        "file_name": file_path,
+                        "file_name": str(file_path),
                         "qcodes_guid": self.guid,
                         "ds_name": self.name,
                         "exp_name": self.exp_name,
@@ -1504,7 +1504,7 @@ class DataSet(BaseDataSet):
                     log.info(
                         "Combining temp files into one file.",
                         extra={
-                            "file_name": file_path,
+                            "file_name": str(file_path),
                             "qcodes_guid": self.guid,
                             "ds_name": self.name,
                             "exp_name": self.exp_name,


### PR DESCRIPTION
Rather than using sys.getsizeof which has a huge overhead when the row size is small.
E.g. a dataset with many small rows. 

```
In [2]: import numpy as np
In [3]: d = np.array([[1,2,3],[4,5,6]])
In [4]: import sys
In [5]: sys.getsizeof(d)
Out[5]: 152
In [6]: d.dtype.itemsize * d.size
Out[6]: 24
```


Also add a test for exporting pure numeric datasets which was previously not covered.
And correct a warning from opentelemetry due to non str attributes on log messages 
