### PR TITLE
Optional blocking in Keithley 2450

### DIFF
--- a/docs/changes/newsfragments/improved_driver.5547
+++ b/docs/changes/newsfragments/improved_driver.5547
@@ -1,0 +1,2 @@
+Keithley 2450s by default don't block when setting their output level, differing in behavior from the keithley 2400. 
+I added a manual boolian parameter 'block_during_ramp' which forces a check that the ramp command has been completed when True.

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -475,20 +475,17 @@ class Keithley2450Source(InstrumentChannel):
 
         self.add_parameter(
             "block_during_ramp",
-            get_cmd=self._block,
-            set_cmd=self._set_block,
+            get_cmd=None,
+            set_cmd=None,
             vals=Bool(),
             docstring="Setting the source output level alone cannot block the "
             "execution of subsequent code. This parameter allows _proper_function"
             "to either block or not.",
         )
 
-    def _set_block(self, value: bool) -> None:
-        self._block = value
-
     def _set_proper_function(self, value: float) -> None:
         self.write(f"SOUR:{self._proper_function} {value}")
-        if self._block:
+        if self.block_during_ramp():
             self.ask('*OPC?')
 
     def get_sweep_axis(self) -> np.ndarray:

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -474,9 +474,9 @@ class Keithley2450Source(InstrumentChannel):
 
         self.add_parameter(
             "block_during_ramp",
+            initial_value=False,
             get_cmd=None,
             set_cmd=None,
-            initial_value=False,
             vals=Bool(),
             docstring="Setting the source output level alone cannot block the "
             "execution of subsequent code. This parameter allows _proper_function"

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -424,7 +424,7 @@ class Keithley2450Source(InstrumentChannel):
 
         self.add_parameter(
             self._proper_function,
-            set_cmd=f"SOUR:{self._proper_function} {{}}",
+            set_cmd=self._set_proper_function,
             get_cmd=f"SOUR:{self._proper_function}?",
             get_parser=float,
             unit=unit,
@@ -471,6 +471,11 @@ class Keithley2450Source(InstrumentChannel):
             "measured source value or the configured source value "
             "when making a measurement.",
         )
+
+    def _set_proper_function(self, value: float, block: bool = True) -> None:
+        self.write(f"SOUR:{self._proper_function} {value}")
+        if block:
+            self.ask('*OPC?')
 
     def get_sweep_axis(self) -> np.ndarray:
         if self._sweep_arguments is None:

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -385,7 +385,6 @@ class Keithley2450Source(InstrumentChannel):
     def __init__(self, parent: "Keithley2450", name: str, proper_function: str) -> None:
         super().__init__(parent, name)
         self._proper_function = proper_function
-        self._block = False
         range_vals = self.function_modes[self._proper_function]["range_vals"]
         unit = self.function_modes[self._proper_function]["unit"]
 
@@ -477,6 +476,7 @@ class Keithley2450Source(InstrumentChannel):
             "block_during_ramp",
             get_cmd=None,
             set_cmd=None,
+            initial_value=False,
             vals=Bool(),
             docstring="Setting the source output level alone cannot block the "
             "execution of subsequent code. This parameter allows _proper_function"

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -486,7 +486,7 @@ class Keithley2450Source(InstrumentChannel):
     def _set_proper_function(self, value: float) -> None:
         self.write(f"SOUR:{self._proper_function} {value}")
         if self.block_during_ramp():
-            self.ask('*OPC?')
+            self.ask("*OPC?")
 
     def get_sweep_axis(self) -> np.ndarray:
         if self._sweep_arguments is None:


### PR DESCRIPTION
Added a parameter to control whether or not ramp commands sent to Keithley 2450s block<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
