### PR TITLE
remove a few no longer needed type ignores

### DIFF
--- a/src/qcodes/dataset/dond/do_nd.py
+++ b/src/qcodes/dataset/dond/do_nd.py
@@ -722,7 +722,7 @@ def dond(
             for set_events in tqdm(sweeper, disable=not show_progress):
                 LOG.debug("Processing set events: %s", set_events)
                 results: dict[ParameterBase, Any] = {}
-                for set_event in set_events:  # pyright: ignore[reportGeneralTypeIssues]
+                for set_event in set_events:
                     if set_event.should_set:
                         set_event.parameter(set_event.new_value)
                         for act in set_event.actions:

--- a/src/qcodes/dataset/measurement_extensions.py
+++ b/src/qcodes/dataset/measurement_extensions.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Generator, Sequence
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 from opentelemetry import trace
 
@@ -130,7 +130,7 @@ def parse_dond_into_args(
             raise ValueError("dond_into does not support multiple datasets")
         elif isinstance(par, ParameterBase) and par.gettable:
             params_meas.append(par)
-        elif isinstance(par, Callable):  # type: ignore [arg-type]
+        elif callable(par):
             params_meas.append(par)
     return sweep_instances, params_meas
 


### PR DESCRIPTION
One is no longer needed with newer pyright and the other one can be fixed by using buildin callable rather than isinstance checking against typing callable