### PR TITLE
Revert "Update ipykernel requirement from ~=6.26.0 to ~=6.27.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ importlib-metadata~=6.8.0
 importlib-resources~=6.1.0
 incremental~=22.10.0
 iniconfig~=2.0.0
-ipykernel~=6.27.0
+ipykernel~=6.26.0
 ipython~=8.17.1
 ipython-genutils==0.2.0
 ipywidgets~=8.1.0


### PR DESCRIPTION
This reverts commit 6db80ffb159dcf87546e2f1e4926e7484f1ac2d9.

6.27 way yanked 