### PR TITLE
Remove initial value for output of Keithley 2450

### DIFF
--- a/docs/changes/newsfragments/improved_driver.5572
+++ b/docs/changes/newsfragments/improved_driver.5572
@@ -1,2 +1,2 @@
-Previously, the keithley 2450 driver had an initial value for the output. This is particularly dangerous when reinitializing/recovering from a kernal crash. 
+Previously, the keithley 2450 driver had an initial value for the output. This is particularly dangerous when reinitializing/recovering from a kernal crash.
 Initializing the instrument should leave all parameters unchanged. This PR removes the initial value for the output.

--- a/docs/changes/newsfragments/improved_driver.5572
+++ b/docs/changes/newsfragments/improved_driver.5572
@@ -1,0 +1,2 @@
+Previously, the keithley 2450 driver had an initial value for the output. This is particularly dangerous when reinitializing/recovering from a kernal crash. 
+Initializing the instrument should leave all parameters unchanged. This PR removes the initial value for the output.

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -607,7 +607,6 @@ class Keithley2450(VisaInstrument):
 
         self.add_parameter(
             "output_enabled",
-            initial_value="0",
             set_cmd=":OUTP {}",
             get_cmd=":OUTP?",
             val_mapping=create_on_off_val_mapping(on_val="1", off_val="0"),

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -485,7 +485,7 @@ class Keithley2450Source(InstrumentChannel):
 
     def _set_proper_function(self, value: float) -> None:
         self.write(f"SOUR:{self._proper_function} {value}")
-        if self.block_during_ramp():
+        if self.block_during_ramp:
             self.ask("*OPC?")
 
     def get_sweep_axis(self) -> np.ndarray:

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -485,7 +485,7 @@ class Keithley2450Source(InstrumentChannel):
 
     def _set_proper_function(self, value: float) -> None:
         self.write(f"SOUR:{self._proper_function} {value}")
-        if self.block_during_ramp:
+        if self.block_during_ramp():
             self.ask("*OPC?")
 
     def get_sweep_axis(self) -> np.ndarray:

--- a/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
+++ b/src/qcodes/instrument_drivers/Keithley/Keithley_2450.py
@@ -486,7 +486,7 @@ class Keithley2450Source(InstrumentChannel):
     def _set_proper_function(self, value: float) -> None:
         self.write(f"SOUR:{self._proper_function} {value}")
         if self.block_during_ramp():
-            self.ask('*OPC?')
+            self.ask("*OPC?")
 
     def get_sweep_axis(self) -> np.ndarray:
         if self._sweep_arguments is None:


### PR DESCRIPTION
Setting an initial value for the keithley output is quite dangerous, especially when recovering from a kernel crash. Initializing the instrument should leave the output state unchanged<!--

Thanks for submitting a pull request against QCoDeS.

To help us effectively merge your pr please consider the following check list.

- [ ] Make sure that the pull request contains a short description of the changes made.
- [ ] If you are submitting a new feature please document it. This can be in the form of inline
      docstrings, an example notebook or restructured text files.
- [ ] Please include automatic tests for the changes made when possible.

Unless your change is a small or trivial fix please add a small changelog entry:

- [ ] Create a file in the docs\changes\newsfragments folder with a short description of the change.

This file should be in the format number.categoryofcontribution. Here the number should either be the number
of the pull request. To get the number of the pull request one must
first the pull request and then subsequently update the number. The category of contribution should be
one of ``breaking``, ``new``, ``improved``, ``new_driver`` ``improved_driver``, ``underthehood``.

If this fixes a known bug reported against QCoDeS:

- [ ] Please include a string in the following form ``closes #xxx`` where ``xxx``` is the number of the bug fixed.

Please have a look at [the contributing guide](https://qcodes.github.io/Qcodes/community/contributing.html)
for more information.

If you are in doubt about any of this please ask and we will be happy to help.

-->
