### PR TITLE
Dataset: Fix quoted str when getting length of dataset and handle that users could have passed a list of floats as shape

### DIFF
--- a/src/qcodes/dataset/sqlite/queries.py
+++ b/src/qcodes/dataset/sqlite/queries.py
@@ -254,6 +254,9 @@ def get_shaped_parameter_data_for_one_paramtree(
         shape = rundescriber.shapes.get(output_param)
 
         if shape is not None:
+            # if the user calculates shape its very easy to end up putting in a
+            # float such as 100.0 rather than 100 so to be safe we cast to int here
+            shape = tuple(int(s) for s in shape)
             total_len_shape = np.prod(shape)
             for name, paramdata in one_param_output.items():
                 total_data_shape = np.prod(paramdata.shape)

--- a/src/qcodes/dataset/sqlite/query_helpers.py
+++ b/src/qcodes/dataset/sqlite/query_helpers.py
@@ -387,7 +387,12 @@ def length(conn: ConnectionPlus,
     Returns:
         the length of the table
     """
-    query = f"select MAX(id) from '{formatted_name}'"
+    # we replace ' in the table name to '' to make sure that
+    # if the formatted name contains ' that will not cause the ' '
+    # around formatted name to be ended
+    # https://stackoverflow.com/questions/603572/escape-single-quote-character-for-use-in-an-sqlite-query
+    escaped_formatted_name = formatted_name.replace("'", "''")
+    query = f"select MAX(id) from '{escaped_formatted_name}'"
     c = atomic_transaction(conn, query)
     _len = c.fetchall()[0][0]
     if _len is None:

--- a/tests/dataset/test_dataset_basic.py
+++ b/tests/dataset/test_dataset_basic.py
@@ -352,6 +352,7 @@ def test_add_experiments(experiment_name, sample_name, dataset_name) -> None:
     assert loaded_dataset.table_name == "{}-{}-{}".format(
         "results", exp.exp_id, loaded_dataset.counter
     )
+    assert len(loaded_dataset) == 0
     expected_ds_counter += 1
     dataset = new_data_set(dataset_name)
     dsid = dataset.run_id


### PR DESCRIPTION
Historically it has been possible to create a arbitrary table name. Such a name could contain `'` which would escape the quotes around the table name in length. This resolves that by replacing quotes internal to the str with their escaped form.