### PR TITLE
Fix typo in DummyBase::get_idn

### DIFF
--- a/docs/changes/newsfragments/underthehood.5579
+++ b/docs/changes/newsfragments/underthehood.5579
@@ -1,0 +1,1 @@
+Fix typo: instrument_drivers.mock_instruments.DummyInstrument::get_idn() now returns dict containing key "serial" instead of "seral"

--- a/src/qcodes/instrument_drivers/mock_instruments/__init__.py
+++ b/src/qcodes/instrument_drivers/mock_instruments/__init__.py
@@ -27,7 +27,7 @@ class DummyBase(Instrument):
         return {
             "vendor": "QCoDeS",
             "model": str(self.__class__),
-            "seral": "NA",
+            "serial": "NA",
             "firmware": "NA",
         }
 

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -212,7 +212,7 @@ def test_get_idn(testdummy: DummyInstrument) -> None:
     idn = {
         "vendor": "QCoDeS",
         "model": str(testdummy.__class__),
-        "seral": "NA",
+        "serial": "NA",
         "firmware": "NA",
     }
     assert testdummy.get_idn() == idn


### PR DESCRIPTION
fix typo key of dict returned by get_idn of Dummy instruments.