### PR TITLE
Typecheck with pyright 1.1.339

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -77,7 +77,7 @@ jobs:
       if: ${{ !matrix.min-version }}
     - uses: jakebailey/pyright-action@v1.8.0
       with:
-        version: 1.1.337
+        version: 1.1.339
       if: ${{ !matrix.min-version }}
     - name: Run Mypy
       run: mypy -p qcodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,6 +204,9 @@ ignore = [
     ]
 reportMissingTypeStubs = true
 stubPath = "typings/stubs"
+# we would like to move this to at least standard
+# eventually. From 1.1.339 onwards standard is the default
+typeCheckingMode = "basic"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/qcodes/instrument/instrument.py
+++ b/src/qcodes/instrument/instrument.py
@@ -307,7 +307,7 @@ class Instrument(InstrumentBase, metaclass=InstrumentMeta):
         return ins
 
     @staticmethod
-    def exist(name: str, instrument_class: type | None = None) -> bool:
+    def exist(name: str, instrument_class: type[Instrument] | None = None) -> bool:
         """
         Check if an instrument with a given names exists (i.e. is already
         instantiated).


### PR DESCRIPTION
Mainly interesting because pyright has added a new default mode that we opt out of until we have fixed typing issues in that mode