### PR TITLE
Add finalizer to ensure that Monitor is always stopped in tests that create a monitor

### DIFF
--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -733,23 +733,27 @@ def test_monitor_not_loaded_by_default(example_station_config) -> None:
     assert Monitor.running is None
 
 
-def test_monitor_loaded_if_specified(example_station_config) -> None:
+def test_monitor_loaded_if_specified(
+    example_station_config, request: pytest.FixtureRequest
+) -> None:
     st = Station(config_file=example_station_config, use_monitor=True)
     st.load_instrument("mock_dac")
     assert Monitor.running is not None
+    request.addfinalizer(Monitor.running.stop)
     assert len(Monitor.running._parameters) == 1
     assert Monitor.running._parameters[0].name == "ch1"
-    Monitor.running.stop()
 
 
-def test_monitor_loaded_by_default_if_in_config(example_station_config) -> None:
+def test_monitor_loaded_by_default_if_in_config(
+    example_station_config, request: pytest.FixtureRequest
+) -> None:
     qcodes.config["station"]["use_monitor"] = True
     st = Station(config_file=example_station_config)
     st.load_instrument("mock_dac")
     assert Monitor.running is not None
+    request.addfinalizer(Monitor.running.stop)
     assert len(Monitor.running._parameters) == 1
     assert Monitor.running._parameters[0].name == "ch1"
-    Monitor.running.stop()
 
 
 def test_monitor_not_loaded_if_specified(example_station_config) -> None:


### PR DESCRIPTION
There tests occasionally fail with a error about failing to bind a socket. I doubt this is enough to fix the issue but its a step in the right direction. 